### PR TITLE
Testing adding controller filters using plugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 ```elixir
 defmodule YourApp.Router do
   use Phoenix.Router, port: 4000
-  
+
   plug Plug.Static, at: "/static", from: :your_app
 
   get "/pages/:page", Controllers.Pages, :show, as: :page
@@ -93,6 +93,31 @@ from the `priv/static/` directory of your application.
 
 ```elixir
   plug Plug.Static, at: "/static", from: :your_app
+```
+
+### Controller filters
+Controller filters allow to run code and alter the connection record before running a controller action.
+You can do that by adding a stack of plugs ([Plug documentation](http://elixir-lang.org/docs/plug/)) to the
+controller.
+
+```elixir
+defmodule Controllers.Users do
+  use Phoenix.Controller
+  use Plug.Builder
+
+  plug :info, only: :show
+
+  def index(conn), do: text(conn, "running index action")
+  def show(conn), do: text(conn, "running show action")
+
+  def info(conn, options) do
+    action = conn.private[:phoenix_context][:action]
+    if action in List.wrap(options[:only]) do
+      IO.puts "---> running :info plug..."
+    end
+    conn
+  end
+end
 ```
 
 ## Documentation

--- a/lib/phoenix/router/mapper.ex
+++ b/lib/phoenix/router/mapper.ex
@@ -95,9 +95,18 @@ defmodule Phoenix.Router.Mapper do
       def unquote(:match)(conn, unquote(http_method), unquote(path_args)) do
         conn = conn.params(Dict.merge(conn.params, unquote(params_list_with_bindings)))
 
-        apply(unquote(controller), unquote(action), [conn])
+        prepare(conn, unquote(controller), unquote(action))
       end
     end
+  end
+
+  def prepare(conn, controller, action) do
+    if function_exported?(controller, :call, 2) do
+      conn = Plug.Connection.assign_private(conn, :phoenix_context,
+        [ controller: controller, action: action ])
+      conn = controller.call(conn, [])
+    end
+    apply(controller, action, [conn])
   end
 
   defmacro defroute_aliases({_http_method, path, _controller, _action, options}) do

--- a/test/phoenix/router/filter_test.exs
+++ b/test/phoenix/router/filter_test.exs
@@ -1,0 +1,105 @@
+defmodule Phoenix.Router.FilterTest do
+  use ExUnit.Case
+  use PlugHelper
+
+  defmodule Plugs do
+    defmodule ModulePlug do
+      @behaviour Plug
+      def init(opts), do: opts
+      def call(conn, opts), do: Plug.Connection.assign_private(conn, :module_plug_test, opts)
+    end
+
+    defmodule WrapPlug do
+      @behaviour Plug
+      def init(opts), do: opts
+      def wrap(conn, opts, fun) do
+        conn = Plug.Connection.assign_private(conn, :wrap_plug_test, opts)
+        fun.(conn)
+      end
+    end
+  end
+
+  defmodule NoFilterController do
+    use Phoenix.Controller
+    def index(conn), do: text(conn, "NoFilterController")
+  end
+
+  defmodule ModulePlugController do
+    use Phoenix.Controller
+    use Plug.Builder
+    plug Plugs.ModulePlug, metallica: "black album"
+    def index(conn), do: text(conn, "ModulePlugController")
+  end
+
+  defmodule FunctionPlugController do
+    use Phoenix.Controller
+    use Plug.Builder
+    plug :testing, the_cult: "sonic temple"
+    def index(conn), do: text(conn, "FunctionPlugController")
+    def testing(conn, opts), do: Plug.Connection.assign_private(conn, :function_plug_test, opts)
+  end
+
+  defmodule WrapPlugController do
+    use Phoenix.Controller
+    use Plug.Builder
+    plug Plugs.WrapPlug, beck: "odelay"
+    def index(conn), do: text(conn, "WrapPlugController")
+  end
+
+  defmodule ConditionalController do
+    use Phoenix.Controller
+    use Plug.Builder
+    plug :info, only: :show
+    def index(conn), do: text(conn, "index: #{conn.private[:from_plug]}")
+    def show(conn), do: text(conn, "show: #{conn.private[:from_plug]}")
+    def info(conn, options) do
+      action = conn.private[:phoenix_context][:action]
+      if action in List.wrap(options[:only]) do
+        Plug.Connection.assign_private(conn, :from_plug, "code executed")
+      else
+        conn
+      end
+    end
+  end
+
+  defmodule Router do
+    use Phoenix.Router
+    get "/no-filter", NoFilterController, :index
+    get "/module-plug", ModulePlugController, :index
+    get "/function-plug", FunctionPlugController, :index
+    get "/wrap-plug", WrapPlugController, :index
+    get "/conditional/index", ConditionalController, :index
+    get "/conditional/show", ConditionalController, :show
+  end
+
+  test "run successfully without filters" do
+    conn = simulate_request(Router, :get, "/no-filter")
+    assert conn.status == 200
+    assert Enum.empty?(conn.private)
+  end
+
+  test "executes module plug successfully" do
+    conn = simulate_request(Router, :get, "/module-plug")
+    assert conn.status == 200
+    assert conn.private[:module_plug_test] == [ metallica: "black album" ]
+  end
+
+  test "executes function plug successfully" do
+    conn = simulate_request(Router, :get, "/function-plug")
+    assert conn.status == 200
+    assert conn.private[:function_plug_test] == [ the_cult: "sonic temple" ]
+  end
+
+  test "executes wrap plug successfully" do
+    conn = simulate_request(Router, :get, "/wrap-plug")
+    assert conn.status == 200
+    assert conn.private[:wrap_plug_test] == [ beck: "odelay" ]
+  end
+
+  test "use plug option to conditionaly do something" do
+    conn = simulate_request(Router, :get, "/conditional/index")
+    assert conn.resp_body == "index: "
+    conn = simulate_request(Router, :get, "/conditional/show")
+    assert conn.resp_body == "show: code executed"
+  end
+end


### PR DESCRIPTION
Thank you for Phoenix, it looks like such a promising web framework, and the design and code are so clean and simple.

This pull request is more a question around controller filters. Do you intend to add a filter feature similar to Rails before/around/after filters? This pull request is a basic implementation using Plug. Implementing around and after filters would be more complex, but maybe not necessary.

With this implementation you can use `Plug.Builder` in the controllers to add plugs to be executed before the action:

``` elixir
# Router
resources "accounts", Controllers.Accounts

# Account controller
use Phoenix.Controller
use Plug.Builder

plug :authenticate_token, except: [ :index, :show]

# actions
...

def authenticate_token(conn, options) do
  ...
  conn
end
```

We can use regular plugs (function or module) for filters that don't need to break the stack chain, or plug wrappers if we need more flexibility or just stop the chain.

Do you already have different or similar plans? Is it worth spending some time to implement this with tests and maybe a couple macros for a more consistent DSL?
