### PR TITLE
Convert port to integer before use

### DIFF
--- a/lib/phoenix/router/router.ex
+++ b/lib/phoenix/router/router.ex
@@ -54,7 +54,8 @@ defmodule Phoenix.Router do
   end
 
   def dispatch_options(options, module) do
-    Dict.merge([port: Config.for(module).router[:port]], options)
+    [port: binary_to_integer(Config.for(module).router[:port]) ]
+    |> Dict.merge(options)
   end
 end
 


### PR DESCRIPTION
Uses `binary_to_integer` to convert port to integer.
