### PR TITLE
Router.Options to abstract merging router options

### DIFF
--- a/lib/phoenix/router/options.ex
+++ b/lib/phoenix/router/options.ex
@@ -1,0 +1,16 @@
+defmodule Phoenix.Router.Options do
+  alias Phoenix.Config
+
+  def merge(options, module) do
+    Config.for(module).router |> map_config |> Dict.merge(options)
+  end
+
+  defp map_config([]), do: []
+  defp map_config([{k, v}|t]), do: [option(k,v)] ++ map_config(t)
+
+  defp option(:port, val), do: { :port, convert(:int, val) }
+  defp option(key, val), do: { key, val }
+
+  defp convert(:int, val) when is_integer(val), do: val
+  defp convert(:int, val), do: binary_to_integer(val)
+end

--- a/lib/phoenix/router/router.ex
+++ b/lib/phoenix/router/router.ex
@@ -2,7 +2,6 @@ defmodule Phoenix.Router do
   use GenServer.Behaviour
   alias Phoenix.Dispatcher
   alias Phoenix.Controller
-  alias Phoenix.Config
   alias Phoenix.Plugs
 
   defmacro __using__(plug_adapter_options \\ []) do
@@ -27,7 +26,7 @@ defmodule Phoenix.Router do
       end
 
       def start do
-        options = Phoenix.Router.dispatch_options(@options, __MODULE__)
+        options = Phoenix.Router.Options.merge(@options, __MODULE__)
         IO.puts ">> Running #{__MODULE__} with Cowboy with #{inspect options}"
         Plug.Adapters.Cowboy.http __MODULE__, [], options
       end
@@ -52,11 +51,4 @@ defmodule Phoenix.Router do
       {:error, reason} -> Controller.error(conn, reason)
     end
   end
-
-  def dispatch_options(options, module) do
-    [port: binary_to_integer(Config.for(module).router[:port]) ]
-    |> Dict.merge(options)
-  end
 end
-
-

--- a/test/phoenix/router/options_test.exs
+++ b/test/phoenix/router/options_test.exs
@@ -1,0 +1,23 @@
+defmodule PhoenixOptionsTest.Config do
+  use Phoenix.Config.App
+
+  config :router, port: "71107", ssl: false
+end
+
+defmodule PhoenixOptionsTest.Router do
+  use Phoenix.Router
+  get "/pages/:page", Pages, :show, as: :page
+end
+
+defmodule Phoenix.Router.OptionsTest do
+  use ExUnit.Case
+
+  test "merge port number into options" do
+    assert [port: 1234] ==
+      Phoenix.Router.Options.merge([], PhoenixConfTest.Router)
+
+    assert [port: 71107, ssl: false] ==
+      Phoenix.Router.Options.merge([], PhoenixOptionsTest.Router)
+  end
+
+end


### PR DESCRIPTION
The Phoenix.Router.Options module abstracts the merging of config options and handles type conversion as necessary.
