### PR TITLE
Add requirement of Elixir 0.13.0-dev to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 ## Getting started
 
+> Requires: Elixir 0.13.0-dev 
+
 1. Install Phoenix
 
         git clone https://github.com/phoenixframework/phoenix.git && cd phoenix && mix do deps.get, compile


### PR DESCRIPTION
- Add note about how Phoenix requires Elixir 0.13.0-dev
- I had a couple of issues installing phoenix until I read the closed issues. I hope this helps future users.
