### PR TITLE
Handle missing arguments for phoenix.new mix task

### DIFF
--- a/lib/mix/tasks/phoenix/new.ex
+++ b/lib/mix/tasks/phoenix/new.ex
@@ -5,15 +5,6 @@ defmodule Mix.Tasks.Phoenix.New do
 
   @template_dir "template"
 
-  def run([]) do
-    Mix.shell.info """
-    Supply application name and destination path.
-
-    e.g.
-      mix phoenix.new photo_blog /home/johndoe/
-    """
-  end
-
   @doc """
   Creates Phoenix application.
   """
@@ -38,6 +29,18 @@ defmodule Mix.Tasks.Phoenix.New do
         Mix.Generator.create_file(destination_path, contents)
       end
     end
+  end
+
+  @doc """
+  Display instructions on how to create a Phoenix application.
+  """
+  def run(_) do
+    Mix.shell.info """
+    Supply application name and destination path.
+
+    e.g.
+      mix phoenix.new photo_blog /home/johndoe/
+    """
   end
 
   defp make_project_path(path, application_name) do

--- a/test/mix/tasks/phoenix/new_test.exs
+++ b/test/mix/tasks/phoenix/new_test.exs
@@ -36,6 +36,11 @@ defmodule Mix.Tasks.Phoenix.NewTest do
     assert Regex.match?(~r/PhotoBlog/, content)
   end
 
+  test "missing name and/or path arguments" do
+    assert :ok == Mix.Tasks.Phoenix.New.run([])
+    assert :ok == Mix.Tasks.Phoenix.New.run([@app_name])
+  end
+
   teardown_all do
     File.rm_rf(project_path)
     :ok


### PR DESCRIPTION
The task was only matching when users passed 0 or 2 arguments. If a
user were to pass only 1 argument, for example the app name, the task would
throw an error. This edit fixes the bug, now it will display
instructions anytime a user misuses the tasks.
