### PR TITLE
Generate correct module name for app names with dashes.

### DIFF
--- a/lib/mix/tasks/phoenix/new.ex
+++ b/lib/mix/tasks/phoenix/new.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.Phoenix.New do
   """
   def run([name, path]) do
     application_name = Mix.Utils.underscore(name)
-    application_module = Mix.Utils.camelize(name)
+    application_module = Mix.Utils.camelize(application_name)
     project_path = make_project_path(path, application_name)
 
     bindings = [application_name: application_name,


### PR DESCRIPTION
Without underscore transformation applied first application generated with name 'your-app' would end up with module name 'Your-app'. With this fix module name will be 'YourApp'.
