### PR TITLE
Add stop/shutdown task to Router

### DIFF
--- a/lib/phoenix/router/router.ex
+++ b/lib/phoenix/router/router.ex
@@ -35,6 +35,11 @@ defmodule Phoenix.Router do
         IO.puts "Running #{__MODULE__} with Cowboy on port #{inspect options}"
         Plug.Adapters.Cowboy.http __MODULE__, [], options
       end
+
+      def stop do
+        IO.puts "#{__MODULE__} has been stopped"
+        Plug.Adapters.Cowboy.shutdown __MODULE__.HTTP
+      end
     end
   end
 


### PR DESCRIPTION
Not sure if a mix task would be of any use here, so I just implemented the stop function in the router.
#66

Thoughts?

``` text
$ iex -S mix phoenix.start
Erlang/OTP 17 [erts-6.0] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe]
[kernel-poll:false]

...

Running Elixir.PhoenixDev.Router with Cowboy on port [dispatch: [_: [{:_,
Plug.Adapters.Cowboy.Handler, {PhoenixDev.Router, []}}]], port: 4000, ssl:
false, consider_all_requests_local: true]
Interactive Elixir (0.13.2) - press Ctrl+C to exit (type h() ENTER for help)

iex(1)> PhoenixDev.Router.stop
Elixir.PhoenixDev.Router has been stopped
:ok
iex(2)>
```
