### PR TITLE
fix Controller.error_with_trace to show __struct__

### DIFF
--- a/lib/phoenix/controller/controller.ex
+++ b/lib/phoenix/controller/controller.ex
@@ -69,7 +69,7 @@ defmodule Phoenix.Controller do
 
     html conn, status, """
       <html>
-        <h2>(#{inspect exception.__record__(:name)}) #{exception.message}</h2>
+        <h2>(#{inspect exception.__struct__}) #{exception.message}</h2>
         <h4>Stacktrace</h4>
         <body>
           <pre>#{Exception.format_stacktrace stacktrace}</pre>


### PR DESCRIPTION
This was previously showing Record information and it appears Exceptions are now Structs.

This keeps a less-than-clear Ranch listener failure from showing when there inevitably bugs in my controller code (at least it does in my small project)
