### PR TITLE
Fixed current *.Behaviour deprecations.

### DIFF
--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix do
-  use Application.Behaviour
+  use Application
 
   # See http://elixir-lang.org/docs/stable/Application.Behaviour.html
   # for more information on OTP Applications

--- a/lib/phoenix/supervisor.ex
+++ b/lib/phoenix/supervisor.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.Supervisor do
-  use Supervisor.Behaviour
+  use Supervisor
 
   def start_link do
     :supervisor.start_link(__MODULE__, [])

--- a/lib/phoenix/topic/server.ex
+++ b/lib/phoenix/topic/server.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.Topic.Server do
-  use GenServer.Behaviour
+  use GenServer
   alias Phoenix.Topic
   alias Phoenix.Topic.Server
   alias Phoenix.Topic.GarbageCollector

--- a/lib/phoenix/topic/supervisor.ex
+++ b/lib/phoenix/topic/supervisor.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.Topic.Supervisor do
-  use Supervisor.Behaviour
+  use Supervisor
 
   def start_link do
     :supervisor.start_link({:local, __MODULE__}, __MODULE__, [])

--- a/lib/phoenix/topic/topic.ex
+++ b/lib/phoenix/topic/topic.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.Topic do
-  use GenServer.Behaviour
+  use GenServer
   alias Phoenix.Topic.Server
 
   @server Phoenix.Topic.Server


### PR DESCRIPTION
Just eliminated the *.Behaviour portion in GenServer, Supervisor and Application declarations.
