### PR TITLE
Removed .Behaviour from the templates used to generate an application

### DIFF
--- a/template/lib/application_name.ex
+++ b/template/lib/application_name.ex
@@ -1,5 +1,5 @@
 defmodule <%= application_module %> do
-  use Application.Behaviour
+  use Application
 
   # See http://elixir-lang.org/docs/stable/Application.Behaviour.html
   # for more information on OTP Applications

--- a/template/lib/application_name/supervisor.ex
+++ b/template/lib/application_name/supervisor.ex
@@ -1,5 +1,5 @@
 defmodule <%= application_module %>.Supervisor do
-  use Supervisor.Behaviour
+  use Supervisor
 
   def start_link do
     :supervisor.start_link(__MODULE__, [])


### PR DESCRIPTION
In my previous commit i wasn't aware that the templates used to generate a Phoenix app also had the .Behaviour appended to the Supervisor and Application directives.

This (hopefully) fixes it !
