### PR TITLE
Indicate last known working elixir version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 [![Build Status](https://travis-ci.org/phoenixframework/phoenix.svg)](https://travis-ci.org/phoenixframework/phoenix)
 
+## Elixir
+
+Ensure [Elixir](http://elixir-lang.org/) is installed. Current working version: `0.14.0`
+
 ## Getting started
 
 1. Install Phoenix


### PR DESCRIPTION
With `elixir` changing so frequently, it would be nice to newcomers to the framework (like myself) to know what version of `elixir` they are expected to have installed. Some packages are reliant on elixir master, some further behind. Until the `1.0.0` release, this would help confusing errors like this:

Attempting to install against `0.14.1` (latest stable developer release) or `0.14.1-dev` (master)

```
➜  elixir  git clone https://github.com/phoenixframework/phoenix.git && cd phoenix && mix do deps.get, compile
Cloning into 'phoenix'...

... Removed git cloning output ...  

==> inflex
Compiled lib/inflex/parameterize.ex
Compiled lib/inflex/underscore.ex
Compiled lib/inflex/camelize.ex
Compiled lib/inflex/pluralize.ex

== Compilation error on file lib/inflex/supervisor.ex ==
** (CompileError) lib/inflex/supervisor.ex:2: module Supervisor.Behaviour is not loaded and could not be found
    (elixir) expanding macro: Kernel.use/1
    lib/inflex/supervisor.ex:2: Inflex.Supervisor (module)
    (elixir) src/elixir.erl:156: :elixir.erl_eval/2
    (elixir) src/elixir.erl:149: :elixir.eval_forms/4
    (elixir) src/elixir_lexical.erl:17: :elixir_lexical.run/2
    (elixir) lib/kernel/parallel_compiler.ex:91: anonymous fn/3 in Kernel.ParallelCompiler.spawn_compilers/8


== Compilation error on file lib/inflex.ex ==
** (CompileError) lib/inflex.ex:2: module Application.Behaviour is not loaded and could not be found
    (elixir) expanding macro: Kernel.use/1
    lib/inflex.ex:2: Inflex (module)
    (elixir) src/elixir.erl:156: :elixir.erl_eval/2
    (elixir) src/elixir.erl:149: :elixir.eval_forms/4
    (elixir) src/elixir_lexical.erl:17: :elixir_lexical.run/2
    (elixir) lib/kernel/parallel_compiler.ex:91: anonymous fn/3 in Kernel.ParallelCompiler.spawn_compilers/8

could not compile dependency inflex, mix compile failed. You can recompile this dependency with `mix deps.compile inflex` or update it with `mix deps.update inflex`
```
