### PR TITLE
fix(gitignore): .gitignore now generated on phoenix.new

### DIFF
--- a/lib/mix/tasks/phoenix/new.ex
+++ b/lib/mix/tasks/phoenix/new.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Phoenix.New do
   defp template_files do
     file_pattern = Path.join(template_path, "**/*")
 
-    Path.wildcard(file_pattern)
+    Path.wildcard(file_pattern, match_dot: true)
   end
 
   defp make_destination_path(project_path, file, application_name) do


### PR DESCRIPTION
In Elixir v0.14.1 `Path.wildcard` no longer looks up dotfiles by default
- the `match_dot` keyword is now required. Since .gitignore in the
  `template` directory is a dotfile it was not being generate when
  calling the `phoenix.new` task

The change was introduced in:

commit:

elixir-lang/elixir@65cf31d32db2b5896b6947b17ef135f5efefd0ee

link:

https://github.com/elixir-lang/elixir/commit/65cf31d32db2b5896b6947b17ef135f5efefd0ee
