### PR TITLE
Create query strings when constructing paths from routes.

### DIFF
--- a/test/phoenix/router/named_routing_test.exs
+++ b/test/phoenix/router/named_routing_test.exs
@@ -33,8 +33,8 @@ defmodule Phoenix.Router.NamedRoutingTest do
   test "manual alias generated named route" do
     assert Router.profile_path(id: 5) == "/users/5"
     assert Router.profile_url(id: 5) == "http://example.com/users/5"
-    assert Router.top_path(id: 5) == "/users/top"
-    assert Router.top_url(id: 5) == "http://example.com/users/top"
+    assert Router.top_path(id: 5) == "/users/top?id=5"
+    assert Router.top_url(id: 5) == "http://example.com/users/top?id=5"
   end
 
   test "resources generates named routes for :index, :edit, :show, :new" do

--- a/test/phoenix/router/path_test.exs
+++ b/test/phoenix/router/path_test.exs
@@ -14,6 +14,11 @@ defmodule Phoenix.Router.PathTest do
       "/users/123/comments/1"
   end
 
+  test "build with named params uses extras to construct the query string" do
+    assert Path.build("users/:user_id/comments/:id", user_id: 123, id: 1, highlights: %{red: "abc", yellow: "def"}) ==
+      "/users/123/comments/1?highlights[red]=abc&highlights[yellow]=def"
+  end
+
   test "build ensures leading forward slash" do
     assert Path.build("users/:id", id: 55) == "/users/55"
     assert Path.build("/users/:id", id: 55) == "/users/55"


### PR DESCRIPTION
I ran into the need to construct a path with query parameters, rather than just path parameters. Any parameters passed to `Path.build` that aren't explicit path parameters are assumed to be query parameters.

Hope this is of use, I'm not sure this is the cleanest idiomatic approach, though. Always open to suggestions. :)
