### PR TITLE
changed dependency versions due to elixir 0.14.2 problems

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,10 +31,10 @@ defmodule Phoenix.Mixfile do
   defp deps(:prod) do
     [
       {:cowboy, "~> 0.10.0", github: "extend/cowboy", optional: true},
-      {:plug, "0.5.0"},
-      {:inflex, "0.2.3"},
+      {:plug, "~> 0.5.1"},
+      {:inflex, "~> 0.2.4"},
       {:ex_conf, "0.1.2"},
-      {:jazz, "0.1.1"}
+      {:jazz, "~> 0.1.2"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "cowlib": {:git, "git://github.com/extend/cowlib.git", "e2ffefe828b918486e2cd76e44c54ae9b62c616e", [ref: "0.6.2"]},
   "ex_conf": {:package, "0.1.2"},
   "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "ddf1cae6bf331d8cfd5ded61b3b120293b80642d", []},
-  "inflex": {:package, "0.2.3"},
-  "jazz": {:package, "0.1.1"},
-  "plug": {:package, "0.5.0"},
+  "inflex": {:package, "0.2.4"},
+  "jazz": {:package, "0.1.2"},
+  "plug": {:package, "0.5.1"},
   "ranch": {:git, "git://github.com/extend/ranch.git", "3189ef2d47843945efc96c224963380462c33d40", [ref: "0.10.0"]}}


### PR DESCRIPTION
Just wanted to try out the framework a bit and had some issues when following your install manual. I am using Elixir 0.14.2 and there the function atom_to_binary seems to be removed. Due to that some of your dependencies does not work any more. 

Regarding this issue I changed some dependencies. But it came up the question to me why are you using fixed dependency versions? So by using {:plug, "~> 0.5.0"} instead of {:plug, "0.5.0"} I think this problem wouldn't have occured. 

Hope I could help you a bit and (@chrismccord) thanks for your coding session at Railsconv ;-)

here is my console output:

[bstoecker Elixir]$ git clone https://github.com/phoenixframework/phoenix.git && cd phoenix && git checkout v0.2.10 && mix do deps.get, compile
Cloning into 'phoenix'...
remote: Reusing existing pack: 2932, done.
remote: Total 2932 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (2932/2932), 391.97 KiB | 435.00 KiB/s, done.
Resolving deltas: 100% (1700/1700), done.
Checking connectivity... done.
Note: checking out 'v0.2.10'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b new_branch_name

HEAD is now at 39ac7a5... Merge pull request #122 from jni-/test_callbacks
- Getting cowboy (git://github.com/extend/cowboy.git)
  Cloning into '/Users/bstoecker/Elixir/phoenix/deps/cowboy'...
  remote: Reusing existing pack: 6201, done.
  remote: Counting objects: 47, done.
  remote: Compressing objects: 100% (47/47), done.
  remote: Total 6248 (delta 11), reused 0 (delta 0)
  Receiving objects: 100% (6248/6248), 4.77 MiB | 1.50 MiB/s, done.
  Resolving deltas: 100% (3657/3657), done.
  Checking connectivity... done.
- Getting ex_doc (git://github.com/elixir-lang/ex_doc.git)
  Cloning into '/Users/bstoecker/Elixir/phoenix/deps/ex_doc'...
  remote: Reusing existing pack: 2829, done.
  remote: Total 2829 (delta 0), reused 0 (delta 0)
  Receiving objects: 100% (2829/2829), 695.79 KiB | 453.00 KiB/s, done.
  Resolving deltas: 100% (1213/1213), done.
  Checking connectivity... done.
- Getting cowlib (git://github.com/extend/cowlib.git)
  Cloning into '/Users/bstoecker/Elixir/phoenix/deps/cowlib'...
  remote: Reusing existing pack: 185, done.
  remote: Total 185 (delta 0), reused 0 (delta 0)
  Receiving objects: 100% (185/185), 79.84 KiB | 0 bytes/s, done.
  Resolving deltas: 100% (108/108), done.
  Checking connectivity... done.
- Getting ranch (git://github.com/extend/ranch.git)
  Cloning into '/Users/bstoecker/Elixir/phoenix/deps/ranch'...
  remote: Reusing existing pack: 855, done.
  remote: Total 855 (delta 0), reused 0 (delta 0)
  Receiving objects: 100% (855/855), 273.16 KiB | 328.00 KiB/s, done.
  Resolving deltas: 100% (501/501), done.
  Checking connectivity... done.
- Getting plug (package)
  Fetching package (http://s3.hex.pm/tarballs/plug-0.5.0.tar)
  Unpacked package tarball (/Users/bstoecker/.mix/.package-cache/plug-0.5.0.tar)
- Getting inflex (package)
  Fetching package (http://s3.hex.pm/tarballs/inflex-0.2.3.tar)
  Unpacked package tarball (/Users/bstoecker/.mix/.package-cache/inflex-0.2.3.tar)
- Getting ex_conf (package)
  Fetching package (http://s3.hex.pm/tarballs/ex_conf-0.1.2.tar)
  Unpacked package tarball (/Users/bstoecker/.mix/.package-cache/ex_conf-0.1.2.tar)
- Getting jazz (package)
  Fetching package (http://s3.hex.pm/tarballs/jazz-0.1.1.tar)
  Unpacked package tarball (/Users/bstoecker/.mix/.package-cache/jazz-0.1.1.tar)
  ==> inflex
  Compiled lib/inflex/parameterize.ex
  Compiled lib/inflex/underscore.ex
  Compiled lib/inflex/camelize.ex
  Compiled lib/inflex/pluralize.ex

== Compilation error on file lib/inflex.ex ==
*\* (CompileError) lib/inflex.ex:5: function atom_to_binary/1 undefined
    (stdlib) lists.erl:1336: :lists.foreach/2
    (stdlib) erl_eval.erl:657: :erl_eval.do_apply/6
    (elixir) src/elixir.erl:163: :elixir.erl_eval/2
    (elixir) src/elixir.erl:156: :elixir.eval_forms/4
    (elixir) src/elixir_lexical.erl:17: :elixir_lexical.run/2
    (elixir) src/elixir.erl:163: :elixir.erl_eval/2

could not compile dependency inflex, mix compile failed. You can recompile this dependency with `mix deps.compile inflex` or update it with `mix deps.update inflex`
[bstoecker phoenix ((v0.2.10))]$ elixir -v
Elixir 0.14.2
