### PR TITLE
update required Elixir version in README to reflect actual required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Getting started
 
 ### Requirements
-- Elixir v0.14.1
+- Elixir v0.14.2
 
 ### Setup
 1. Install Phoenix


### PR DESCRIPTION
Just fixes the version in the README. Didn't notice this before submitting the last PR.
