### PR TITLE
Cleaning up test output

### DIFF
--- a/test/mix/tasks/phoenix/new_test.exs
+++ b/test/mix/tasks/phoenix/new_test.exs
@@ -38,8 +38,8 @@ defmodule Mix.Tasks.Phoenix.NewTest do
   end
 
   test "missing name and/or path arguments" do
-    assert :ok == Mix.Tasks.Phoenix.New.run([])
-    assert :ok == Mix.Tasks.Phoenix.New.run([@app_name])
+    assert Mix.Tasks.Phoenix.New.run([])
+    assert Mix.Tasks.Phoenix.New.run([@app_name])
   end
 
   def project_path do

--- a/test/mix/tasks/phoenix/routes_test.exs
+++ b/test/mix/tasks/phoenix/routes_test.exs
@@ -14,6 +14,6 @@ defmodule Mix.Tasks.Phoenix.RoutesTest do
   end
 
   test "format routes for specific router" do
-    assert(Mix.Tasks.Phoenix.Routes.run(["TestApp.Router"]) == :ok)
+    assert Mix.Tasks.Phoenix.Routes.run(["TestApp.Router"])
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,3 @@
 Code.require_file "plug_helper.exs", __DIR__
+Mix.shell(Mix.Shell.Process)
 ExUnit.start


### PR DESCRIPTION
Silences Mix console output during tests.

Hopefully those assert changes are alright, the previous `:ok` outcome seems to just come from `IO.puts`: https://github.com/elixir-lang/elixir/blob/ef23a3fe395059f0d835d9fef8c3bc4dab5ccb68/lib/mix/lib/mix/shell/io.ex#L32

I originally took a different approach, but the elixir-core mailing list set me straight. https://groups.google.com/forum/#!topic/elixir-lang-core/tRkmXu2DfGg
