### PR TITLE
Print app url at startup

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -1,6 +1,7 @@
 defmodule Phoenix.Router do
   alias Phoenix.Plugs
   alias Phoenix.Router.Options
+  alias Phoenix.Router.Path
   alias Phoenix.Adapters.Cowboy
   alias Phoenix.Plugs.Parsers
   alias Phoenix.Config

--- a/lib/phoenix/router/options.ex
+++ b/lib/phoenix/router/options.ex
@@ -4,6 +4,7 @@ defmodule Phoenix.Router.Options do
   def merge(options, dispatch_options, router_module, adapter) do
     Config.for(router_module).router
     |> map_config
+    |> ensure_host_is_set
     |> Dict.merge(options)
     |> adapter.merge_options(dispatch_options, router_module)
   end
@@ -16,4 +17,12 @@ defmodule Phoenix.Router.Options do
 
   defp convert(:int, val) when is_integer(val), do: val
   defp convert(:int, val), do: String.to_integer(val)
+
+  defp ensure_host_is_set(options) do
+    unless Dict.has_key? options, :host do
+      options ++ [host: "localhost"]
+    else
+      options
+    end
+  end
 end

--- a/test/phoenix/router/options_test.exs
+++ b/test/phoenix/router/options_test.exs
@@ -22,4 +22,9 @@ defmodule Phoenix.Router.OptionsTest do
     assert options[:port] == 71107
     assert options[:ssl] == false
   end
+
+  test "use localhost as the default hostname" do
+    options = Options.merge([], [], PhoenixConfTest.Router, Cowboy)
+    assert options[:host] == "localhost"
+  end
 end


### PR DESCRIPTION
This uses the `Path.build_url` to build the url. Defaults to 'localhost' if `options[:host]` is unset.

The port isn't an argument to `Path.build_url`, so I've left that as is for now. It would be good if it were possible to pass in port & build a full url. (but that's probably a separate issue)

(related to issue #129)
