### PR TITLE
refactor Phoenix.Router.Path.build_url to take a keyword list as it's third arg

### DIFF
--- a/lib/phoenix/router/mapper.ex
+++ b/lib/phoenix/router/mapper.ex
@@ -114,7 +114,7 @@ defmodule Phoenix.Router.Mapper do
           scheme = if config[:ssl], do: "https", else: "http"
 
           Path.build(unquote(path), params)
-          |> Path.build_url(host, scheme)
+          |> Path.build_url(host, [scheme: scheme])
         end
       end
     end

--- a/lib/phoenix/router/path.ex
+++ b/lib/phoenix/router/path.ex
@@ -153,15 +153,20 @@ defmodule Phoenix.Router.Path do
   Builds a URL based on options passed.
 
   # Examples:
-    iex> Path.build_url("/users", "example.com", "https")
-    "https://example.com/users"
-
     iex> Path.build_url("/users", "example.com")
     "http://example.com/users"
 
+    iex> Path.build_url("/users", "example.com", [scheme: "https"])
+    "https://example.com/users"
+
+    iex> Path.build_url("/users", "example.com", [port: 8080])
+    "http://example.com:8080/users"
+
   """
-  def build_url(path, host, scheme \\ "http") do
-    %URI{scheme: scheme, host: host, path: path} |> to_string
+  def build_url(path, host, options \\ []) do
+    scheme = options[:scheme] || "http"
+    port   = options[:port]
+    %URI{scheme: scheme, host: host, path: path, port: port} |> to_string
   end
 
   @doc """

--- a/test/phoenix/router/path_test.exs
+++ b/test/phoenix/router/path_test.exs
@@ -31,7 +31,7 @@ defmodule Phoenix.Router.PathTest do
 
   test "build_url includes the host and scheme" do
     path = Path.build("users/:id", id: 1)
-    assert Path.build_url(path, "example.com", "https") ==
+    assert Path.build_url(path, "example.com", [scheme: "https"]) ==
       "https://example.com/users/1"
   end
 


### PR DESCRIPTION
When working on #150 I noticed that, based on the way Phoenix.Router.Path.build_url is written, there would be no way to add an optional port. It takes 3 arguments, and the third is an optional string.

This PR converts that third argument to a keyword list, which makes it possible to to pass port and scheme to `%URI{}`. It'd also make it easy add other URI parameters in the future, like query strings.
