### PR TITLE
When json is an array, add to params under _json

### DIFF
--- a/lib/phoenix/plugs/parsers/json.ex
+++ b/lib/phoenix/plugs/parsers/json.ex
@@ -21,6 +21,8 @@ defmodule Phoenix.Plugs.Parsers.JSON do
   def parse(conn, "application", "json", _headers, opts) do
     {:ok, body, conn} = read_body(conn, opts)
     case Jazz.decode(body) do
+      {:ok, terms} when is_list(terms)->
+        {:ok, %{"_json" => terms}, conn}
       {:ok, terms} ->
         {:ok, terms, conn}
       _ ->

--- a/test/phoenix/plugs/parsers/json_test.exs
+++ b/test/phoenix/plugs/parsers/json_test.exs
@@ -14,6 +14,13 @@ defmodule Phoenix.Plugs.Parsers.JSONTest do
     assert conn.params["id"] == 1
   end
 
+  test "parses the request body when it is an array" do
+    headers = [{"content-type", "application/json"}]
+    body = Jazz.encode!([%{id: 2}, %{id: 1}])
+    conn = parse(conn(:post, "/", body, headers: headers))
+    assert length(conn.params["_json"]) == 2
+  end
+
   test "raises ParseError with malformed JSON" do
     exception = assert_raise Phoenix.Plugs.Parsers.JSON.ParseError, fn ->
       headers = [{"content-type", "application/json"}]


### PR DESCRIPTION
Currently we have an issue when we try to merge an array from the request body and the map from the query params. Following the example at: https://github.com/rails/rails/blob/f6746c024531740900d79236944ce11c65608cde/actionpack/lib/action_dispatch/middleware/params_parser.rb#L45
