### PR TITLE
Add hal to the list of mime types

### DIFF
--- a/lib/phoenix/mimes.txt
+++ b/lib/phoenix/mimes.txt
@@ -262,6 +262,7 @@ application/java-serialized-object	.ser
 text/x-java-source,java	.java
 application/javascript	.js
 application/json	.json
+application/hal+json	.hal
 application/vnd.joost.joda-archive	.joda
 video/jpm	.jpm
 image/jpeg	.jpeg, .jpg


### PR DESCRIPTION
This just adds [hal](http://tools.ietf.org/html/draft-kelly-json-hal-06) to the list of known mime types.

Cheerio
Björn
