### PR TITLE
Show fetch_session/1 in session example

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ defmodule Controllers.Pages do
   use Phoenix.Controller
 
   def show(conn, _params) do
-    conn = put_session(:foo, "bar")
+    conn = fetch_session(conn) |> put_session(:foo, "bar")
     foo = get_session(conn, :foo)
 
     text conn, foo


### PR DESCRIPTION
Update README session example to show `fetch_session/1` prior to `put_session/3` 
