### PR TITLE
Set session cookie store secret to 64 bytes.

### DIFF
--- a/lib/mix/tasks/phoenix/new.ex
+++ b/lib/mix/tasks/phoenix/new.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Phoenix.New do
 
     bindings = [application_name: application_name,
                 application_module: application_module,
-                session_secret: random_string(50, 80)]
+                session_secret: random_string(64, 80)]
 
     Mix.Generator.create_directory(project_path)
 


### PR DESCRIPTION
Plug's session cookie store wants the secret to be at least 64 bytes.

https://github.com/elixir-lang/plug/blob/master/lib/plug/session/cookie.ex#L32
