### PR TITLE
Allow overriding HTML method type using "_method" parameter

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -39,6 +39,8 @@ defmodule Phoenix.Router do
         plug Plugs.SessionFetcher
       end
 
+      plug Plug.MethodOverride
+
       unless Plugs.plugged?(@plugs, :dispatch) do
         plug :dispatch
       end


### PR DESCRIPTION
Since this plug is tested in [plug's tests](https://github.com/elixir-lang/plug/blob/master/test/plug/method_override_test.exs), I didn't think that this needs a test to be integrated. I have manually tested that this is the proper place to put it. See http://guides.rubyonrails.org/form_helpers.html#how-do-forms-with-patch-put-or-delete-methods-work-questionmark for an example usage in Rails.

Let me know if you have any comments/suggestions.
