### PR TITLE
Updated to jazz 0.2.0 to update support for elixir 0.15.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Phoenix.Mixfile do
       {:plug, "0.5.3"},
       {:inflex, "0.2.4"},
       {:linguist, "~> 0.1.1"},
-      {:jazz, "0.1.2"},
+      {:jazz, "0.2.0"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "cowlib": {:package, "1.0.0"},
   "ex_doc": {:git, "git://github.com/elixir-lang/ex_doc.git", "b59a08729ad0ee805aabc4f2b4f2d97261a57825", []},
   "inflex": {:package, "0.2.4"},
-  "jazz": {:package, "0.1.2"},
+  "jazz": {:package, "0.2.0"},
   "linguist": {:package, "0.1.1"},
   "plug": {:package, "0.5.3"},
   "ranch": {:package, "1.0.0"}}


### PR DESCRIPTION
Jazz updated to 0.2.0 with support for elixir 0.15.0 to remove the warning about 0.14.2

Ran full testsuite, and everything passed:

Finished in 2.8 seconds (1.9s on load, 0.9s on tests)
237 tests, 0 failures
