### PR TITLE
Added alias <%= application_module %>.Views to expand the views for alia...

### DIFF
--- a/template/web/views.ex
+++ b/template/web/views.ex
@@ -6,6 +6,8 @@ defmodule <%= application_module %>.Views do
       import unquote(__MODULE__)
 
       # This block is expanded within all views for aliases, imports, etc
+      alias <%= application_module %>.Views
+
       import <%= application_module %>.I18n
     end
   end


### PR DESCRIPTION
The documentation shows:

```
# This block is expanded within all views for aliases, imports, etc
alias App.Views
```

But that line isn't part of the code generation.  Without that line,
I was running into template not found issues.

When added it to the code generation, template/views rendered more
closely to how I expected.

If you need more details, please ask; as I will have more questions about
using templates.
# 

To test it, I updated the generation, created a sample app and it 
created the expected output.

```
mix phoenix.new your_app ../your_app
```

Which generated

```
defmodule YourApp.Views do

  defmacro __using__(_options) do
    quote do
      use Phoenix.View
      import unquote(__MODULE__)

      # This block is expanded within all views for aliases, imports, etc
      alias YourApp.Views

      import YourApp.I18n
    end
  end

  # Functions defined here are available to all other views/templates
end
```
