### PR TITLE
Fixing `layout: :none` in controller rendering

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -144,7 +144,8 @@ defmodule Phoenix.Controller do
   defp template_name(template, [ext | _]), do: "#{template}.#{ext}"
   defp prepare_for_render(conn, assigns, layout_mod, exts) do
     assigns = Dict.put_new(assigns, :conn, conn)
-    layout = layout(conn)
+    conn    = assign_layout(conn, Dict.get(assigns, :layout))
+    layout  = layout(conn)
     if is_binary layout do
       assigns = Dict.put_new(assigns, :within, {layout_mod, template_name(layout, exts)})
     end

--- a/lib/phoenix/controller/connection.ex
+++ b/lib/phoenix/controller/connection.ex
@@ -41,11 +41,14 @@ defmodule Phoenix.Controller.Connection do
   def assign_layout(conn, :none) do
     assign_private(conn, :phoenix_layout, :none)
   end
+  def assign_layout(conn, _) do
+    assign_layout(conn, "application")
+  end
 
   @doc """
   Retrieve layout from phoenix private assigns
   """
-  def layout(conn), do: Dict.get(conn.private, :phoenix_layout, "application")
+  def layout(conn), do: Dict.get(conn.private, :phoenix_layout)
 
   @doc """
   Assigns the Conn status


### PR DESCRIPTION
Regarding https://github.com/phoenixframework/phoenix/commit/bc2c2899fff7fee7f066d0fecf85a2a3c8dfdfca, `layout: :none` wasn't working. `prepare_for_render/4` wasn't paying attention to the user-provided `assigns`. I changed the default to be assigned by `assign_layout/2` rather than fetched by `layout/1`, hope that's ok.

Foregoing an integration test per https://github.com/phoenixframework/phoenix/pull/178#issuecomment-48829583
