### PR TITLE
Fixed IO.ANSI.format bug

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -73,8 +73,8 @@ defmodule Phoenix.Router do
     protocol = if opts[:ssl], do: :https, else: :http
     case apply(Plug.Adapters.Cowboy, protocol, [module, [], opts]) do
       {:ok, pid} ->
-        "%{green}Running #{module} with Cowboy on port #{inspect opts[:port]}%{reset}"
-        |> IO.ANSI.escape
+        [:green, "Running #{module} with Cowboy on port #{inspect opts[:port]}"]
+        |> IO.ANSI.format
         |> IO.puts
         {:ok, pid}
 


### PR DESCRIPTION
In order to add ANSI codes to a string you have to call IO.ANSI.format.
I suppose the IO.ANSI api in Elixir changed recently
