### PR TITLE
Remove unused Project alias.

### DIFF
--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -1,5 +1,4 @@
 defmodule Phoenix.View do
-  alias Phoenix.Project
   alias Phoenix.Html
   alias Phoenix.Naming
 


### PR DESCRIPTION
Removing the unused Project alias to resolve a compiler warning.
