### PR TITLE
Example of how to override the accept headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ The template format to render is chosen based on the following priority:
  * The request header `accept` field, ie "text/html"
  * Fallback to html as default format, therefore rendering `*.html.eex`
 
+To override the request headers, for example when rendering your sitemap.xml, you would do something like
+
+```elixir
+def sitemap(conn, _params) do
+  conn
+  |> put_resp_content_type("text/xml")
+  |> render "sitemap"
+end
+```
+
 Note that the layout and view templates would be chosen by matching conten types, ie `application.[format].eex` would be used to render `show.[format].eex`.
 
 See [this file](https://github.com/elixir-lang/plug/blob/master/lib/plug/mime.types) for a list of supported mime types.


### PR DESCRIPTION
I ran into a situation where I wanted to override the accept headers to force a file to be rendered as XML, but didn't know how.  After getting insight from the mailing list, I wanted to put it into the documentation for safe keeping.
