### PR TITLE
Fix syntax error in templated config file.

### DIFF
--- a/template/config/dev.exs
+++ b/template/config/dev.exs
@@ -10,7 +10,7 @@ config :phoenix, <%= application_module %>.Router,
   session_key: "_<%= application_name %>_key",
   session_secret: "<%= session_secret %>"
 
-config :logger, :console
+config :logger, :console,
   level: :debug
 
 


### PR DESCRIPTION
Fixes #271, for a compiler error for newly generated applications.
