### PR TITLE
log event object to console

### DIFF
--- a/priv/static/js/phoenix.js
+++ b/priv/static/js/phoenix.js
@@ -157,7 +157,7 @@
 
       Socket.prototype.onClose = function(event) {
         if (typeof console.log === "function") {
-          console.log("WS close: " + event);
+          console.log("WS close: ", event);
         }
         clearInterval(this.reconnectTimer);
         return this.reconnectTimer = setInterval(((function(_this) {


### PR DESCRIPTION
By comma separating the string message and the event object, the console will make the object inspectable, rather than printing the string `"WS Close [object] [Object]"`
