### PR TITLE
update javascript to log objects unstringified

### DIFF
--- a/priv/src/static/cs/phoenix.coffee
+++ b/priv/src/static/cs/phoenix.coffee
@@ -84,12 +84,12 @@
 
 
     onClose: (event) ->
-      console.log?("WS close: #{event}")
+      console.log?("WS close: ", event)
       clearInterval(@reconnectTimer)
       @reconnectTimer = setInterval (=> @reconnect() ), @reconnectAfterMs
 
 
-    onError: (error) -> console.log?("WS error: #{error}")
+    onError: (error) -> console.log?("WS error: ", error)
 
     connectionState: ->
       switch @conn?.readyState ? 3
@@ -137,7 +137,7 @@
 
 
     onMessage: (rawMessage) ->
-      console.log? rawMessage
+      console.log?("message received: ", rawMessage)
       {channel, topic, event, message} = JSON.parse(rawMessage.data)
       for chan in @channels when chan.isMember(channel, topic)
         chan.trigger(event, message)

--- a/priv/static/js/phoenix.js
+++ b/priv/static/js/phoenix.js
@@ -157,7 +157,7 @@
 
       Socket.prototype.onClose = function(event) {
         if (typeof console.log === "function") {
-          console.log("WS close: " + event);
+          console.log("WS close: ", event);
         }
         clearInterval(this.reconnectTimer);
         return this.reconnectTimer = setInterval(((function(_this) {
@@ -168,7 +168,7 @@
       };
 
       Socket.prototype.onError = function(error) {
-        return typeof console.log === "function" ? console.log("WS error: " + error) : void 0;
+        return typeof console.log === "function" ? console.log("WS error: ", error) : void 0;
       };
 
       Socket.prototype.connectionState = function() {
@@ -277,7 +277,7 @@
       Socket.prototype.onMessage = function(rawMessage) {
         var chan, channel, event, message, topic, _i, _len, _ref, _ref1, _results;
         if (typeof console.log === "function") {
-          console.log(rawMessage);
+          console.log("message received: ", rawMessage);
         }
         _ref = JSON.parse(rawMessage.data), channel = _ref.channel, topic = _ref.topic, event = _ref.event, message = _ref.message;
         _ref1 = this.channels;


### PR DESCRIPTION
Log the actual objects passed to the handlers, rather than the string "[object Object]"
