### PR TITLE
Ensure temp project path does not exist prior to invoking Phoenix.New.run

### DIFF
--- a/test/mix/tasks/phoenix/new_test.exs
+++ b/test/mix/tasks/phoenix/new_test.exs
@@ -5,6 +5,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
   @destination_path "/tmp"
 
   setup_all do
+    File.rm_rf(project_path)
     Mix.Tasks.Phoenix.New.run([@app_name, @destination_path])
     on_exit fn() -> File.rm_rf(project_path) end
     :ok


### PR DESCRIPTION
While running tests i was getting this error:

```
1) Mix.Tasks.Phoenix.NewTest: failure on setup_all callback, tests invalidated
     ** (RuntimeError) No shell process input given for yes?/1
     stacktrace:
       (mix) lib/mix/shell/process.ex:120: Mix.Shell.Process.yes?/1
       (mix) lib/mix/generator.ex:16: Mix.Generator.create_file/2
       (phoenix) lib/mix/tasks/phoenix/new.ex:30: Mix.Tasks.Phoenix.New."-run/1-lc$^0/1-0-"/4
       test/mix/tasks/phoenix/new_test.exs:8: Mix.Tasks.Phoenix.NewTest.__ex_unit_setup_all_0/1
       test/mix/tasks/phoenix/new_test.exs:1: Mix.Tasks.Phoenix.NewTest.__ex_unit__/2
```

Perhaps i've interrupted the test run before it ended and the `on_exit` fn got the chance to be invoked.
In all subsequent tests the _tmp/@app_name_ existed and it required confirmation to overwrite.
I added `File.rm_rf(project_path)` as the first thing to be invoked in _setup_all_ to ensure the tmp dir doesn't contain a dir with _@app_name_
