### PR TITLE
More info for undefined template error

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -68,7 +68,7 @@ defmodule Phoenix.Template do
       unquote(renders_ast)
       def render(undefined_template), do: render(undefined_template, [])
       def render(undefined_template, _assign) do
-        raise %UndefinedError{message: "No such template \"#{undefined_template}\""}
+        raise %UndefinedError{message: "No such template \"#{undefined_template}\" for #{__MODULE__}"}
       end
 
       @doc "Returns true if list of directory files has changed"

--- a/test/phoenix/template/compiler_test.exs
+++ b/test/phoenix/template/compiler_test.exs
@@ -56,14 +56,15 @@ defmodule Phoenix.Template.CompilerTest do
     assert html == "{\n  \"type\":\"script\",\n  \"payload:\"<script>alert('hello!');</script>\"\n}\n"
   end
 
-  test "compiler adds cach-all render/1 that raises UndefinedError" do
+  test "compiler adds catch-all render/1 that raises UndefinedError" do
     assert_raise Phoenix.Template.UndefinedError, fn ->
       View.render(MyApp.Views, "not-exists.html", [])
     end
   end
 
-  test "compiler adds cach-all render/2 that raises UndefinedError" do
-    assert_raise Phoenix.Template.UndefinedError, fn ->
+  test "compiler adds catch-all render/2 that raises UndefinedError" do
+    message = "No such template \"not-exists.html\" for Elixir.Phoenix.Template.CompilerTest.MyApp.Views"
+    assert_raise Phoenix.Template.UndefinedError, message, fn ->
       View.render(MyApp.Views, "not-exists.html", [])
     end
   end


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix/issues/266

This PR does the ff:
1. Adds test case for undefined template error
2. Include Module name of View in undefined template error

Wasn't sure where to put the test case. Was thinking either in `template_test` or in `view_test`. I put it in `view_test` since adding it in `template_test` led to a little more set-up(requiring files and aliases). Let me know if it was unnecessary to add the test case.
