### PR TITLE
Fix Code Reloader

### DIFF
--- a/lib/phoenix/code_reloader.ex
+++ b/lib/phoenix/code_reloader.ex
@@ -58,7 +58,7 @@ defmodule Phoenix.CodeReloader do
   def mix_compile({:module, Mix.Task}) do
     touch_modules_for_recompile
     Mix.Task.reenable "compile.elixir"
-    Mix.Task.run "compile.elixir", ["web"]
+    Mix.Task.run "compile.elixir", ["--ignore-module-conflict", "--elixirc-paths", "web"]
   end
 
   defp touch_modules_for_recompile do


### PR DESCRIPTION
The mix task compile.elixir was being called incorrectly according the documentation. I also added the argument to ignore module conflicts since we are reloading all modules that exist. 

https://github.com/elixir-lang/elixir/issues/2557
http://elixir-lang.org/docs/stable/mix/Mix.Tasks.Compile.Elixir.html
