### PR TITLE
[WIP] permit_params plug

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -86,9 +86,6 @@ defmodule Phoenix.Controller do
         render_view conn, @subview_module, @layout_module, template, assigns
       end
 
-      def permit_params(conn, whitelist) do
-        put_in conn.params, Dict.take(conn.params, whitelist)
-      end
       defoverridable action: 2
     end
   end
@@ -190,5 +187,26 @@ defmodule Phoenix.Controller do
     |> Module.split
     |> Enum.at(0)
     |> Module.concat("LayoutView")
+  end
+
+  @doc """
+  Removes fields in the conn's params that are not included in the whitelist
+
+  ## Examples
+      # Params are filtered according to whitelist
+
+      defmodule MyApp.UserController do
+        use Phoenix.Controller
+
+        plug :permit_params, ["first_name", "last_name"]
+
+        def create(conn, params) do
+          # params will only include first_name and last_name fields
+        end
+      end
+
+  """
+  def permit_params(conn, whitelist) do
+    put_in conn.params, Dict.take(conn.params, whitelist)
   end
 end

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -82,10 +82,6 @@ defmodule Phoenix.Controller do
         apply(__MODULE__, conn.private[:phoenix_action], [conn, conn.params])
       end
 
-      def render(conn, template, assigns \\ []) do
-        render_view conn, @subview_module, @layout_module, template, assigns
-      end
-
       defoverridable action: 2
     end
   end
@@ -129,6 +125,12 @@ defmodule Phoenix.Controller do
 
 
   """
+  defmacro render(conn, template, assigns \\ []) do
+    quote do
+      render_view unquote(conn), @subview_module, @layout_module, unquote(template), unquote(assigns)
+    end
+  end
+
   def render_view(conn, view_mod, layout_mod, template, assigns \\ [])
   def render_view(conn, view_mod, layout_mod, [], assigns) do
     render_view conn, view_mod, layout_mod, action_name(conn), assigns

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -85,6 +85,10 @@ defmodule Phoenix.Controller do
       def render(conn, template, assigns \\ []) do
         render_view conn, @subview_module, @layout_module, template, assigns
       end
+
+      def permit_params(conn, whitelist) do
+        put_in conn.params, Dict.take(conn.params, whitelist)
+      end
       defoverridable action: 2
     end
   end

--- a/test/phoenix/controller/permit_params_test.exs
+++ b/test/phoenix/controller/permit_params_test.exs
@@ -1,30 +1,32 @@
-defmodule MyApp.PermitParamsController do
-  use Phoenix.Controller
-
-  plug :permit_params, ["first_name", "last_name"]
-
-  def test(conn, params), do: conn
-end
-
-defmodule MyApp.Router do
-  use Phoenix.Router
-
-  post "/permit/test", MyApp.PermitParamsController, :test
-end
-
 defmodule Phoenix.Controller.PermitParamsTest do
   use ExUnit.Case
   use PlugHelper
 
+  defmodule PermitParams.Controller do
+    use Phoenix.Controller
+
+    plug :permit_params, ["first_name", "last_name"]
+
+    def test(conn, _params) do
+      conn
+    end
+  end
+
+  defmodule PermitParams.Router do
+    use Phoenix.Router
+
+    post "/permit/test", PermitParams.Controller, :test
+  end
+
   test "permits all whitelisted params" do
     params = %{first_name: "Foo", last_name: "Bar"}
-    conn = simulate_request(MyApp.Router, :post, "permit/test", params)
+    conn = simulate_request(PermitParams.Router, :post, "permit/test", params)
     assert conn.params == %{"first_name" => "Foo", "last_name" => "Bar"}
   end
 
   test "blocks unpermitted params" do
     params = %{first_name: "Foo", username: "foobar", aka: "baz"}
-    conn = simulate_request(MyApp.Router, :post, "permit/test", params)
+    conn = simulate_request(PermitParams.Router, :post, "permit/test", params)
     assert conn.params == %{"first_name" => "Foo"}
   end
 end

--- a/test/phoenix/controller/permit_params_test.exs
+++ b/test/phoenix/controller/permit_params_test.exs
@@ -1,0 +1,30 @@
+defmodule MyApp.PermitParamsController do
+  use Phoenix.Controller
+
+  plug :permit_params, ["first_name", "last_name"]
+
+  def test(conn, params), do: conn
+end
+
+defmodule MyApp.Router do
+  use Phoenix.Router
+
+  post "/permit/test", MyApp.PermitParamsController, :test
+end
+
+defmodule Phoenix.Controller.PermitParamsTest do
+  use ExUnit.Case
+  use PlugHelper
+
+  test "permits all whitelisted params" do
+    params = %{first_name: "Foo", last_name: "Bar"}
+    conn = simulate_request(MyApp.Router, :post, "permit/test", params)
+    assert conn.params == %{"first_name" => "Foo", "last_name" => "Bar"}
+  end
+
+  test "blocks unpermitted params" do
+    params = %{first_name: "Foo", username: "foobar", aka: "baz"}
+    conn = simulate_request(MyApp.Router, :post, "permit/test", params)
+    assert conn.params == %{"first_name" => "Foo"}
+  end
+end

--- a/test/plug_helper.exs
+++ b/test/plug_helper.exs
@@ -4,17 +4,17 @@ defmodule PlugHelper do
     quote do
       use Plug.Test
       import ExUnit.CaptureIO
-      def simulate_request(router, http_method, path) do
+      def simulate_request(router, http_method, path, params_or_body \\ nil, opts \\ []) do
         {conn, _} = capture_log fn ->
-          conn = conn(http_method, path)
+          conn = conn(http_method, path, params_or_body, opts)
           router.call(conn, [])
         end
         conn
       end
 
-      def simulate_request_with_logging(router, http_method, path) do
+      def simulate_request_with_logging(router, http_method, path, params_or_body \\ nil, opts \\ []) do
         capture_log fn ->
-          conn = conn(http_method, path)
+          conn = conn(http_method, path, params_or_body, opts)
           router.call(conn, [])
         end
       end


### PR DESCRIPTION
@chrismccord were you thinking of something like this for https://github.com/phoenixframework/phoenix/issues/297? It's a simple plug that takes only whitelisted params. 

If this is what you had in mind, below are some of the other stuff I was thinking of implementing:
- Raising an error if `:permit_params` isn't plugged so that devs will make sure to explicitly whitelist attributes
- Add a flag to toggle requiring of the permit_params plug.
- Store unfiltered params somewhere in conn

What do you think?