### PR TITLE
fix phoenix.start when add MyApp.Router as supervisor's child (in case o...

### DIFF
--- a/lib/phoenix/router/adapter.ex
+++ b/lib/phoenix/router/adapter.ex
@@ -21,6 +21,9 @@ defmodule Phoenix.Router.Adapter do
         |> IO.puts
         {:ok, pid}
 
+      {:error, {:already_started, pid}} ->
+        {:ok, pid}
+
       {:error, :eaddrinuse} ->
         raise "Port #{inspect opts[:port]} is already in use"
     end


### PR DESCRIPTION
When deploy our app use exrm, we should add MyApp.Router to the application's supervisor tree, while running "mix phoenix.start" result in "error, already started....". In this case, we can return the started pid to avoid the error.
