### PR TITLE
Adding heartbeat, on socket close code and close reason, and refactoring code to use WebSocket enums

### DIFF
--- a/priv/src/static/cs/phoenix.coffee
+++ b/priv/src/static/cs/phoenix.coffee
@@ -48,12 +48,11 @@
     reconnectTimer: null
     reconnectAfterMs: 5000
     heartbeatIntervalMs: 30000
-    heartbeatMessage: "ping"
 
     constructor: (endPoint, opts) ->
-      if opts?
-        @heartbeatMessage = opts.heartbeatMessage if opts.heartbeatMessage?
-        @heartbeatIntervalMs = opts.heartbeatIntervalMs if opts.heartbeatIntervalMs?
+      if opts? && (opts.heartbeatMessage? || opts.sendHeartbeat?)
+        @heartbeatMessage = opts.heartbeatMessage || "heartbeat"
+        @heartbeatIntervalMs = opts.heartbeatIntervalMs || @heartbeatIntervalMs
       @endPoint = @expandEndpoint(endPoint)
       @channels = []
       @sendBuffer = []
@@ -83,7 +82,7 @@
       callback?()
 
     sendHeartbeat: ->
-      socket.send(@heartbeatMessage)
+      @conn.send(@heartbeatMessage)
 
     reconnect: ->
       @close =>

--- a/priv/static/js/phoenix.js
+++ b/priv/static/js/phoenix.js
@@ -104,16 +104,10 @@
 
       Socket.prototype.heartbeatIntervalMs = 30000;
 
-      Socket.prototype.heartbeatMessage = "ping";
-
       function Socket(endPoint, opts) {
-        if (opts != null) {
-          if (opts.heartbeatMessage != null) {
-            this.heartbeatMessage = opts.heartbeatMessage;
-          }
-          if (opts.heartbeatIntervalMs != null) {
-            this.heartbeatIntervalMs = opts.heartbeatIntervalMs;
-          }
+        if ((opts != null) && ((opts.heartbeatMessage != null) || (opts.sendHeartbeat != null))) {
+          this.heartbeatMessage = opts.heartbeatMessage || "heartbeat";
+          this.heartbeatIntervalMs = opts.heartbeatIntervalMs || this.heartbeatIntervalMs;
         }
         this.endPoint = this.expandEndpoint(endPoint);
         this.channels = [];
@@ -160,7 +154,7 @@
       };
 
       Socket.prototype.sendHeartbeat = function() {
-        return socket.send(this.heartbeatMessage);
+        return this.conn.send(this.heartbeatMessage);
       };
 
       Socket.prototype.reconnect = function() {

--- a/template/priv/static/js/phoenix.js
+++ b/template/priv/static/js/phoenix.js
@@ -104,16 +104,10 @@
 
       Socket.prototype.heartbeatIntervalMs = 30000;
 
-      Socket.prototype.heartbeatMessage = "ping";
-
       function Socket(endPoint, opts) {
-        if (opts != null) {
-          if (opts.heartbeatMessage != null) {
-            this.heartbeatMessage = opts.heartbeatMessage;
-          }
-          if (opts.heartbeatIntervalMs != null) {
-            this.heartbeatIntervalMs = opts.heartbeatIntervalMs;
-          }
+        if ((opts != null) && ((opts.heartbeatMessage != null) || (opts.sendHeartbeat != null))) {
+          this.heartbeatMessage = opts.heartbeatMessage || "heartbeat";
+          this.heartbeatIntervalMs = opts.heartbeatIntervalMs || this.heartbeatIntervalMs;
         }
         this.endPoint = this.expandEndpoint(endPoint);
         this.channels = [];
@@ -160,7 +154,7 @@
       };
 
       Socket.prototype.sendHeartbeat = function() {
-        return socket.send(this.heartbeatMessage);
+        return this.conn.send(this.heartbeatMessage);
       };
 
       Socket.prototype.reconnect = function() {


### PR DESCRIPTION
Adding heartbeat to the Phoenix JS socket
Allowing for closing code and closing reason to be passed to the web socket connection as mentioned here http://tools.ietf.org/html/rfc6455#section-7.4.1
Refactoring to use enums instead of hard coded values for connection status
