### PR TITLE
Socket state can be updated when receiving process messages

### DIFF
--- a/lib/phoenix/socket/handler.ex
+++ b/lib/phoenix/socket/handler.ex
@@ -144,11 +144,12 @@ defmodule Phoenix.Socket.Handler do
   Each messages is forward to all socket's authorized channels "info" event
   """
   def websocket_info(data, req, socket) do
-    Enum.each socket.channels, fn {channel, topic} ->
+    socket = Enum.reduce socket.channels, socket, fn {channel, topic}, socket ->
+      {:ok, _conn, socket} = socket
+        |> Socket.set_current_channel(channel, topic)
+        |> socket.router.match(:websocket, channel, "info", data)
+        |> handle_result("info")
       socket
-      |> Socket.set_current_channel(channel, topic)
-      |> socket.router.match(:websocket, channel, "info", data)
-      |> handle_result("info")
     end
     {:ok, req, socket}
   end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -270,5 +270,32 @@ defmodule Phoenix.Channel.ChannelTest do
       Handler.websocket_handle({:text, message}, nil, socket)
     end
   end
+
+  test "socket state can change when receiving regular process messages" do
+    defmodule Chan10 do
+      use Phoenix.Channel
+      def join(socket, _topic, _msg), do: {:ok, socket}
+      def event(socket, "info", _msg) do
+        Socket.assign(socket, :foo, :bar)
+      end
+    end
+    defmodule Router10 do
+      use Phoenix.Router
+      use Phoenix.Router.Socket, mount: "/ws"
+      channel "chan10", Chan10
+    end
+
+    socket = %Socket{pid: self, router: Router10, channel: "chan66"}
+
+    message  = """
+    {"channel": "chan10","topic":"topic","event":"join","message":"{}"}
+    """
+    Topic.create("chan10:topic")
+    {:ok, _req, socket} = Handler.websocket_handle({:text, message}, nil, socket)
+    {:ok, _req, socket} = Handler.websocket_info(:stuff, socket.conn, socket)
+
+    assert Socket.get_assign(socket, socket.channel, "topic", :foo) == :bar
+  end
+
 end
 


### PR DESCRIPTION
The current implementation of `websocket_info/3` ignores the return value of the event handlers, thus disallowing any possible changes to `socket`. This PR changes that behavior and adds a test.
