### PR TITLE
Make it easier to add env specific dependencies/applications

### DIFF
--- a/template/mix.exs
+++ b/template/mix.exs
@@ -6,14 +6,14 @@ defmodule <%= application_module %>.Mixfile do
       version: "0.0.1",
       elixir: "~> 1.0.0",
       elixirc_paths: ["lib", "web"],
-      deps: deps ]
+      deps: deps(Mix.env) ]
   end
 
   # Configuration for the OTP application
   def application do
     [
       mod: { <%= application_module %>, [] },
-      applications: [:phoenix, :cowboy, :logger]
+      applications: app_list(Mix.env)
     ]
   end
 
@@ -22,10 +22,14 @@ defmodule <%= application_module %>.Mixfile do
   #
   # To specify particular versions, regardless of the tag, do:
   # { :barbat, "~> 0.1", github: "elixir-lang/barbat" }
-  defp deps do
+  defp deps(_) do
     [
       {:phoenix, "0.4.1"},
       {:cowboy, "~> 1.0.0"}
     ]
+  end
+
+  defp app_list(_) do
+    [:phoenix, :cowboy, :logger]
   end
 end


### PR DESCRIPTION
I just integrated `dotenv_elixir` into my phoenix project. This made me realise that environment specific dependencies are pretty much standard. It should be even easier to specify them. This is also suggested here: http://elixir-lang.org/getting_started/mix_otp/1.html#1.4-environments

The suggested change allows me to simply add this:

``` elixir
defp deps(:dev), do: [{:dotenv, "~> 0.0.4"} | deps(:prod) ]
```

Similarly:

``` elixir
defp app_list(:dev), do: [:dotenv | app_list(:prod)]
```

I know this is a super minor change and I'm not even sure this warrants a PR but I was desperate to contribute in some way. :smile: 
