### PR TITLE
Raise an error if starting router was not :ok

### DIFF
--- a/lib/phoenix/router/adapter.ex
+++ b/lib/phoenix/router/adapter.ex
@@ -25,8 +25,8 @@ defmodule Phoenix.Router.Adapter do
       {:error, :eaddrinuse} ->
         raise "Port #{inspect opts[:port]} is already in use"
 
-      {:error, _} ->
-        raise "Something went wrong while starting router"
+      {:error, reason} ->
+        raise "Something went wrong while starting router: #{inspect reason}"
     end
   end
 


### PR DESCRIPTION
Just a small clarification, it is useful if you need to run the router manually, for example during integration tests
