### PR TITLE
Fix Flash Module Doc 

### DIFF
--- a/lib/phoenix/controller/flash.ex
+++ b/lib/phoenix/controller/flash.ex
@@ -9,10 +9,6 @@ defmodule Phoenix.Controller.Flash do
   Messages can be stored in the session and persisted across redirects for
   notices and alerts about request state.
 
-  Plugged automatically by Phoenix.Controller
-
-  A `Flash` alias is automatically injected when using `Phoenix.Controller`
-
   ## Examples
 
       def index(conn, _) do


### PR DESCRIPTION
`Phoenix.Controller.Flash`  is no longer automatically plugged in controllers.
