### PR TITLE
Fixes Teeny Typo in Flash Module pop_all Function Doc

### DIFF
--- a/lib/phoenix/controller/flash.ex
+++ b/lib/phoenix/controller/flash.ex
@@ -88,9 +88,9 @@ defmodule Phoenix.Controller.Flash do
   ## Examples
 
       iex> conn
-      |> Flash.put(:notices, "hello")
-      |> Flash.put(:notices, "world")
-      |> Flash.get_all(:notices)
+      |> Flash.put(:notice, "hello")
+      |> Flash.put(:notice, "world")
+      |> Flash.get_all(:notice)
       ["hello", "world"]
 
   """
@@ -108,9 +108,9 @@ defmodule Phoenix.Controller.Flash do
   ## Examples
 
       iex> %Conn{}
-      |> Flash.put(:notices, "oh noes!")
+      |> Flash.put(:notice, "oh noes!")
       |> Flash.put(:notice, "false alarm!")
-      |> Flash.pop_all(:notices)
+      |> Flash.pop_all(:notice)
       {["oh noes!", "false alarm!"], %Conn{}}
 
   """


### PR DESCRIPTION
- changes singular `:notice` to plural `:notices` for the key

This begs a question, though. Throughout the doc strings, the plural and singular `:notices` and `:notice` are both used. Should we standardize on one or the other within the docs in this module?

I would be happy to make the change if it is deemed necessary.
