### PR TITLE
Fix logo url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![phoenix logo](https://raw.githubusercontent.com/phoenixframework/phoenix/master/priv/static/images/phoenix-logo.png)
+![phoenix logo](https://raw.githubusercontent.com/phoenixframework/phoenix/master/priv/static/images/phoenix.png)
 > Elixir Web Framework targeting full-featured, fault tolerant applications with realtime functionality
 
 [![Build Status](https://api.travis-ci.org/phoenixframework/phoenix.svg)](https://travis-ci.org/phoenixframework/phoenix)


### PR DESCRIPTION
I think the current logo url in README is 404. I've changed it to the correct one. 
