### PR TITLE
the generated path helper for a route "/" returns "/"

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -112,6 +112,7 @@ defmodule Phoenix.Router.Helpers do
     end
   end
 
+  defp optimize_segments([]), do: "/"
   defp optimize_segments(segments) when is_list(segments),
     do: optimize_segments(segments, "")
   defp optimize_segments(segments),

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -95,6 +95,8 @@ defmodule Phoenix.Router.HelpersTest do
     scope path: "/admin/new", alias: Admin, as: "admin" do
       resources "/messages", MessageController
     end
+
+    get "/", PageController, :root, as: :page
   end
 
   setup_all do
@@ -119,6 +121,8 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.top_path(:top) == "/posts/top"
     assert Helpers.top_path(:top, id: 5) == "/posts/top?id=5"
     assert Helpers.top_path(:top, %{"id" => 5}) == "/posts/top?id=5"
+
+    assert Helpers.page_path(:root) == "/"
 
     assert_raise UndefinedFunctionError, fn ->
       Helpers.post_path(:skip)


### PR DESCRIPTION
as discussed in #elixir, the named helper for root was an empty string. this gave me a problem, when redirecting from a controller.
