### PR TITLE
looks like we missed adding plug :action in one part of the @doc

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -120,6 +120,8 @@ defmodule Phoenix.Controller do
       defmodule MyApp.UserController do
         use Phoenix.Controller
 
+        plug :action
+
         def show(conn) do
           render conn, "show", name: "José"
         end


### PR DESCRIPTION
- adds `plug :action` to one module definition in the rendering @doc.
