### PR TITLE
Missing `alias Poison, as: JSON`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ end
 ```elixir
 defmodule YourApp.UserController do
   use Phoenix.Controller
+  alias Poison, as: JSON
 
   plug :action
 


### PR DESCRIPTION
I caught the following error. It maybe need `alias Poison, as: JSON`.

```
**(UndefinedFunctionError) undefined function: JSON.encode!/1 (module JSON is not available)
```

Thanks!
