### PR TITLE
I believe the :path option is no longer necessary in scope declarations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ defmodule YourApp.Router do
     end
   end
 
-  scope path: "/admin", alias: YourApp.Admin, helper: "admin" do
+  scope "/admin", alias: YourApp.Admin, helper: "admin" do
     resources "/users", UserController
   end
 end

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -70,7 +70,7 @@ defmodule Phoenix.Router do
 
   The router also supports scoping of routes:
 
-      scope path: "/api/v1", as: :api_v1 do
+      scope "/api/v1", as: :api_v1 do
         get "/pages/:id", PageController, :show
       end
 
@@ -125,13 +125,13 @@ defmodule Phoenix.Router do
       defmodule MyApp.Router do
         use Phoenix.Router
 
-        scope path: "/" do
+        scope "/" do
           pipe_through :browser
 
           # browser related routes and resources
         end
 
-        scope path: "/api" do
+        scope "/api" do
           pipe_through :api
 
           # api related routes and resources
@@ -518,7 +518,7 @@ defmodule Phoenix.Router do
 
   A scope may then use this pipeline as:
 
-      scope path: "/" do
+      scope "/" do
         pipe_through :api
       end
 
@@ -659,7 +659,7 @@ defmodule Phoenix.Router do
 
   ## Examples
 
-    scope path: "/api/v1", as: :api_v1, alias: API.V1 do
+    scope "/api/v1", as: :api_v1, alias: API.V1 do
       get "/pages/:id", PageController, :show
     end
 

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -88,11 +88,11 @@ defmodule Phoenix.Router.HelpersTest do
 
     resources "/files", FileController
 
-    scope path: "/admin", alias: Admin do
+    scope "/admin", alias: Admin do
       resources "/messages", MessageController
     end
 
-    scope path: "/admin/new", alias: Admin, as: "admin" do
+    scope "/admin/new", alias: Admin, as: "admin" do
       resources "/messages", MessageController
     end
 

--- a/test/phoenix/router/pipeline_test.exs
+++ b/test/phoenix/router/pipeline_test.exs
@@ -52,17 +52,17 @@ defmodule Phoenix.Router.PipelineTest.Router do
   put "/root/:id", SampleController, :index
   get "/route_that_crashes", SampleController, :crash
 
-  scope path: "/browser" do
+  scope "/browser" do
     pipe_through :browser
     get "/root", SampleController, :index
 
-    scope path: "/api" do
+    scope "/api" do
       pipe_through :api
       get "/root", SampleController, :index
     end
   end
 
-  scope path: "/browser-api" do
+  scope "/browser-api" do
     pipe_through [:browser, :api]
     get "/root", SampleController, :index
   end

--- a/test/phoenix/router/scope_test.exs
+++ b/test/phoenix/router/scope_test.exs
@@ -25,7 +25,7 @@ defmodule Phoenix.Router.ScopedRoutingTest do
     end
 
     scope "/api" do
-      scope path: "/v1" do
+      scope "/v1" do
         get "/users/:id", Api.V1.UserController, :show
       end
     end
@@ -33,12 +33,12 @@ defmodule Phoenix.Router.ScopedRoutingTest do
     scope "/api", Api do
       get "/users/:id", V1.UserController, :show
 
-      scope path: "/v1", alias: V1 do
+      scope "/v1", alias: V1 do
         resources "/users", UserController, only: [:destroy]
       end
     end
 
-    scope path: "/api" do
+    scope "/api" do
       scope "/v1", Api.V1 do
         resources "/venues", VenueController, only: [:show] do
           resources "/users", UserController, only: [:edit]


### PR DESCRIPTION
- removes `path: "<pathname>"` from tests, README.md, and docstrings.
