### PR TITLE
Add :ping and :pong to Phoenix.Socket.Handler.websocket_handle/3

### DIFF
--- a/lib/phoenix/socket/handler.ex
+++ b/lib/phoenix/socket/handler.ex
@@ -83,6 +83,12 @@ defmodule Phoenix.Socket.Handler do
     |> Socket.set_current_channel(msg.channel, msg.topic)
     |> dispatch(msg.channel, msg.event, msg.message)
   end
+  def websocket_handle({:ping, _}, _req, socket) do
+    {:ok, socket.conn, socket}
+  end
+  def websocket_handle({:pong, _}, _req, socket) do
+    {:ok, socket.conn, socket}
+  end
 
   defp dispatch(socket, "phoenix", "heartbeat", _msg) do
     msg = %Message{channel: "phoenix", topic: "conn", event: "heartbeat", message: %{}}


### PR DESCRIPTION
The `cowboy_websocket` module takes care of sending the reply to WebSocket ping frames, but then immediately crashes the process by invoking `websocket_handle`. This change just adds no-op clauses appropriately.

Some browsers (such as IE 11) send unsolicited pong frames to keep the underlying TCP connection alive. This is allowed per [RFC 6455 § 5.5.3](https://tools.ietf.org/html/rfc6455#section-5.5.3). This causes the handler process to crash and the connection proceeds to time out.

For future reference, Cowboy also provides a `:binary` tag, which I left unhandled.
