### PR TITLE
update elixir requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ### Requirements
 
-- Elixir v1.0.0+
+- Elixir v1.0.2+
 
 ### Setup
 


### PR DESCRIPTION
Noticed when I was installing/setting up that the dependency is actually `~> 1.0.`2 (and/or `~> 1.1` it appears).

See also: https://github.com/phoenixframework/phoenix/blob/master/mix.exs#L7
