### PR TITLE
Use Hexdocs URL for Docs Link on index.html.eex Template

### DIFF
--- a/priv/template/web/templates/page/index.html.eex
+++ b/priv/template/web/templates/page/index.html.eex
@@ -8,7 +8,7 @@
     <h4>Resources</h4>
     <ul>
       <li>
-        <a href="http://api.phoenixframework.org/">Docs</a>
+        <a href="http://hexdocs.pm/phoenix">Docs</a>
       </li>
       <li>
         <a href="https://github.com/phoenixframework/phoenix">Source</a>


### PR DESCRIPTION
- the current link points to 0.4.1 documentation on http://api.phoenixframework.org/
- the hexdocs link will resolve to the current stable version
