### PR TITLE
Make phoenix.start play nicely with non-phoenix siblings

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -26,4 +26,13 @@ defmodule Mix.Phoenix do
   defp beam_to_module(path) do
     path |> Path.basename(".beam") |> String.to_atom()
   end
+
+  @doc """
+  Checks to see if an app has phoenix in its dependency list.
+  """
+  def is_phoenix_app? do
+    Mix.Project.config
+    |> Keyword.fetch!(:deps)
+    |> Keyword.has_key?(:phoenix)
+  end
 end

--- a/lib/mix/tasks/phoenix.start.ex
+++ b/lib/mix/tasks/phoenix.start.ex
@@ -13,8 +13,10 @@ defmodule Mix.Tasks.Phoenix.Start do
   """
   def run([]) do
     Mix.Task.run "app.start", []
-    Mix.Phoenix.router.start
-    no_halt
+    if Mix.Phoenix.is_phoenix_app? do
+      Mix.Phoenix.router.start
+      no_halt
+    end
   end
 
   def run([worker]) do


### PR DESCRIPTION
The `phoenix.start` mix task recursively attempts to start a router on all apps in an umbrella project, which doesn't seem to play nicely with non-phoenix siblings. Having a non-phoenix sibling crashed iex when attempting to start an interactive session, as no such router existed.

This patch adds a check to see if phoenix is listed in the target app's dependency list*, and only attempts to start the router if it is found.

(*) = "Checks to see if the atom `:phoenix` appears as a key in the app's dependency list", which may be a fragile & silly way of checking to see if the app requires phoenix. Any suggestions for a more robust approach are welcome. 
