### PR TITLE
Added ability for Phoenix.Channel to send binary data to the client (i.e. not wrapped in the usual %Message{} JSON)

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -104,6 +104,15 @@ defmodule Phoenix.Channel do
     socket
   end
   def reply(_, _, _), do: raise_invalid_message
+  
+  @doc """
+  Sends binary to socket
+  """
+  def reply(socket, data) when is_binary(data) do
+    send socket.pid, data
+    socket
+  end
+  def reply(_, _), do: raise_invalid_binary
 
   @doc """
   Terminates socket connection, including all multiplexed channels
@@ -118,4 +127,5 @@ defmodule Phoenix.Channel do
   defp namespaced(channel, topic), do: "#{channel}:#{topic}"
 
   defp raise_invalid_message, do: raise "Message argument must be a map"
+  defp raise_invalid_binary, do: raise "Data argument must be a binary"
 end

--- a/lib/phoenix/router/cowboy_handler.ex
+++ b/lib/phoenix/router/cowboy_handler.ex
@@ -71,7 +71,12 @@ defmodule Phoenix.Router.CowboyHandler do
   end
 
   def websocket_info({:reply, text}, req, state) do
-    {:reply, {:text, text}, req, state}
+    case String.valid? text do
+      true -> 
+        {:reply, {:text, text}, req, state}
+      false -> 
+        {:reply, {:binary, text}, req, state}
+    end
   end
 
   def websocket_info(:shutdown, req, state) do

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -50,6 +50,14 @@ defmodule Phoenix.Transports.WebSocket do
       {:error, sockets, _reason} -> %{state | sockets: sockets}
     end
   end
+  
+  @doc """
+  Receives binary and sends to client
+  """
+  def ws_info(data, state) when is_binary(data) do
+    reply(self, data)
+    state
+  end
 
   @doc """
   Receives `%Phoenix.Socket.Message{}` and sends encoded message JSON to client


### PR DESCRIPTION
The reason for this is if you wish to send back a binary file to the client, over the web socket connection, such as the following example use case:

The client sends an "image" event to the channel with a specific image_id. In response, the server sends back the binary of the image.

``` Elixir
defmodule MyApp.MyChannel do
  use Phoenix.Channel

  ...

  def event(socket, "image", %{"image_id" => image_id}) do
    {:ok, image_file} = File.open("/path/to/image/with/#{image_id}", [:read])
    image_data = IO.binread(image_file, :all)
    reply socket, image_data
    socket
  end

  ...

end
```

The binary opcode, instead of text, is set in the web socket response frame in cowboy for this type of response

Let me know your thoughts. Should I be discussing this on the phoenix-core list? I'm fairly new to phoenix and elixir, so I appreciate your patience. :-)
