### PR TITLE
Don't crash when atomic key in :params of %Conn{}

### DIFF
--- a/lib/phoenix/controller/logger.ex
+++ b/lib/phoenix/controller/logger.ex
@@ -43,7 +43,7 @@ defmodule Phoenix.Controller.Logger do
   end
   defp filter_values(%{} = map, filter_params) do
     Enum.into map, %{}, fn {k, v} ->
-      if String.contains?(k, filter_params) do
+      if is_binary(k) && String.contains?(k, filter_params) do
         {k, "[FILTERED]"}
       else
         {k, filter_values(v, filter_params)}

--- a/test/phoenix/controller/logger_test.exs
+++ b/test/phoenix/controller/logger_test.exs
@@ -73,4 +73,14 @@ defmodule Phoenix.Controller.LoggerTest do
     end
     assert output =~ "Parameters: %{\"file\" => %{\"__struct__\" => \"s\"}, \"foo\" => \"bar\"}"
   end
+
+  test "does not fail on atomic keys" do
+    output = capture_log fn ->
+      conn(:get, "/", %{password: "should_not_show"})
+      |> fetch_params
+      |> Map.update!(:params, &Dict.put(&1, :foo, "bar"))
+      |> LoggerController.call(LoggerController.init(:index))
+    end
+    assert output =~ "Parameters: %{:foo => \"bar\", \"password\" => \"[FILTERED]\"}"
+  end
 end


### PR DESCRIPTION
Putting atomic keys in the :params can be done by other Plugs so that they can be pattern matched in each action's function parameter list.
