### PR TITLE
link to docs instead the github repository

### DIFF
--- a/priv/template/web/templates/layout/application.html.eex
+++ b/priv/template/web/templates/layout/application.html.eex
@@ -15,7 +15,7 @@
     <div class="container">
       <div class="header">
         <ul class="nav nav-pills pull-right">
-          <li><a href="https://github.com/phoenixframework/phoenix">Get Started</a></li>
+          <li><a href="http://www.phoenixframework.org/docs">Get Started</a></li>
         </ul>
         <span class="logo"></span>
       </div>


### PR DESCRIPTION
Hi,

Would it be an idea to link to the docs instead the Github repository?

Cheers

Samuel
