### PR TITLE
no need to generate docs for this module

### DIFF
--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -1,4 +1,6 @@
 defmodule Phoenix do
+  @moduledoc false
+
   use Application
 
   @doc false


### PR DESCRIPTION
Hi,

Prevents `ex_doc` from generating an empty `Phoenix.html` page.

Cheers

Samuel