### PR TITLE
Improve websocket error to give accurate MFA

### DIFF
--- a/lib/phoenix/endpoint/cowboy_websocket.ex
+++ b/lib/phoenix/endpoint/cowboy_websocket.ex
@@ -4,49 +4,57 @@ defmodule Phoenix.Endpoint.CowboyWebSocket do
   @behaviour :cowboy_websocket_handler
   @connection Plug.Adapters.Cowboy.Conn
 
-  def upgrade(req, env, handler, conn) do
-    resume(:cowboy_websocket, :upgrade, [req, env, __MODULE__, {handler, conn}])
+  def call(%Plug.Conn{private: %{phoenix_upgrade: upgrade}} = conn, env) do
+    {@connection, req}    = conn.adapter
+    {:websocket, handler} = upgrade
+    upgrade(req, env, handler, conn)
   end
 
-  def resume(mod, fun, args) do
+  def upgrade(req, env, handler, conn) do
+    args = [req, env, __MODULE__, {handler, conn}]
+    resume(conn, env, :cowboy_websocket, :upgrade, args)
+  end
+
+  def resume(conn, env, mod, fun, args) do
     try do
       apply(mod, fun, args)
     catch
       class, [reason: reason, mfa: {__MODULE__, :websocket_init, 3},
           stacktrace: stack, req: _req, opts: {handler, conn}] ->
         mfa = {handler, :ws_init, [conn]}
-        exit(class, reason, stack, mfa)
+        exit(class, reason, stack, mfa, conn, env)
       class, [reason: reason, mfa: {__MODULE__, :websocket_handle, 3},
           stacktrace: stack, msg: {:text, text}, req: _req,
           state: {handler, state}] ->
         mfa = {handler, :ws_handle, [text, state]}
-        exit(class, reason, stack, mfa)
+        exit(class, reason, stack, mfa, conn, env)
       class, [reason: reason, mfa: {__MODULE__, :websocket_info, 3},
           stacktrace: stack, msg: :hibernate, req: _req,
           state: {handler, state}] ->
         mfa = {handler, :ws_hibernate, [state]}
-        exit(class, reason, stack, mfa)
+        exit(class, reason, stack, mfa, conn, env)
       class, [reason: reason, mfa: {__MODULE__, :websocket_info, 3},
           stacktrace: stack, msg: msg, req: _req, state: {handler, state}] ->
         mfa = {handler, :ws_info, [msg, state]}
-        exit(class, reason, stack, mfa)
+        exit(class, reason, stack, mfa, conn, env)
       class, [reason: reason, mfa: {__MODULE__, :websocket_terminate, 3},
           stacktrace: stack, req: _req, state: {handler, state},
           terminate_reason: terminate_reason] ->
         mfa = {handler, :ws_terminate, [terminate_reason, state]}
-        exit(class, reason, stack, mfa)
+        exit(class, reason, stack, mfa, conn, env)
     else
       {:ok, _req, _env} = ok ->
         ok
       {:suspend, module, fun, args} ->
-        {:suspend, __MODULE__, :resume, [module, fun, args]}
+        {:suspend, __MODULE__, :resume, [conn, env, module, fun, args]}
       {:stop, _req} = stop ->
         stop
     end
   end
 
-  defp exit(class, reason, stack, mfa) do
-    exit({format_reason(class, reason, stack), mfa})
+  defp exit(class, reason, stack, mfa, conn, env) do
+    reason2 = {format_reason(class, reason, stack), mfa}
+    exit({reason2, {__MODULE__, :call, [conn, env]}})
   end
 
   defp format_reason(:exit, reason, _), do: reason


### PR DESCRIPTION
In #530 the top MFA in the reason would point to the `Endpoint`. However the `Endpoint` has returned and so the MFA is inaccurate. Therefore the websocket upgrade is made to look like a plug (even though it isn't!) and this allows us to get a nice + accurate MFA that can parsed by the Plug translator. I admit this is abit of hack but we want to keep the `Plug.Conn` information in the log message.

Note that a fix is required to support hibernation of websockets, as the stack is lost on hibernation and so any errors won't be caught by `Phoenix.Endpoint.CowboyHandler`.

Before:

```
[error] #PID<0.262.0> running ChannelExample.Endpoint terminated
Server: localhost:4000 (http)
Request: GET /ws
** (exit) exited in: Phoenix.Transports.WebSocket.ws_handle("{\"channel\":\"gamechannel\",\"topic\":\"topic\",\"event\":\"join\",\"message\":{\"id\":123}}", %{router: ChannelExample.Router, serializer: Phoenix.Transports.JSONSerializer, sockets: #HashDict<[]>})
** (EXIT) an exception was raised:
** (RuntimeError) goo
(channel_example) web/channels/game_channel.ex:5: ChannelExample.GameChannel.join/3
(phoenix) lib/phoenix/channel/transport.ex:96: Phoenix.Channel.Transport.dispatch/4
(phoenix) lib/phoenix/channel/transport.ex:67: Phoenix.Channel.Transport.dispatch/4
(phoenix) lib/phoenix/transports/websocket.ex:45: Phoenix.Transports.WebSocket.ws_handle/2
(phoenix) lib/phoenix/router/cowboy_websocket.ex:63: Phoenix.Router.CowboyWebSocket.websocket_handle/3
(cowboy) src/cowboy_websocket.erl:588: :cowboy_websocket.handler_call/7
(phoenix) lib/phoenix/router/cowboy_websocket.ex:14: Phoenix.Router.CowboyWebSocket.resume/3
(phoenix) lib/phoenix/endpoint/cowboy_handler.ex:18: Phoenix.Endpoint.CowboyHandler.upgrade/4
```

After:

```
[error] #PID<0.262.0> running Phoenix.Endpoint.CowboyWebsocket terminated
Server: localhost:4000 (http)
Request: GET /ws
** (exit) exited in: Phoenix.Transports.WebSocket.ws_handle("{\"channel\":\"gamechannel\",\"topic\":\"topic\",\"event\":\"join\",\"message\":{\"id\":123}}", %{router: ChannelExample.Router, serializer: Phoenix.Transports.JSONSerializer, sockets: #HashDict<[]>})
** (EXIT) an exception was raised:
** (RuntimeError) goo
(channel_example) web/channels/game_channel.ex:5: ChannelExample.GameChannel.join/3
(phoenix) lib/phoenix/channel/transport.ex:96: Phoenix.Channel.Transport.dispatch/4
(phoenix) lib/phoenix/channel/transport.ex:67: Phoenix.Channel.Transport.dispatch/4
(phoenix) lib/phoenix/transports/websocket.ex:45: Phoenix.Transports.WebSocket.ws_handle/2
(phoenix) lib/phoenix/router/cowboy_websocket.ex:63: Phoenix.Router.CowboyWebSocket.websocket_handle/3
(cowboy) src/cowboy_websocket.erl:588: :cowboy_websocket.handler_call/7
(phoenix) lib/phoenix/router/cowboy_websocket.ex:14: Phoenix.Router.CowboyWebSocket.resume/3
(phoenix) lib/phoenix/endpoint/cowboy_handler.ex:18: Phoenix.Endpoint.CowboyHandler.upgrade/4
```
