### PR TITLE
Allow "normal" exit of websocket with `exit(:shutdown)`

### DIFF
--- a/lib/phoenix/endpoint/cowboy_websocket.ex
+++ b/lib/phoenix/endpoint/cowboy_websocket.ex
@@ -12,29 +12,8 @@ defmodule Phoenix.Endpoint.CowboyWebSocket do
     try do
       apply(mod, fun, args)
     catch
-      class, [reason: reason, mfa: {__MODULE__, :websocket_init, 3},
-          stacktrace: stack, req: _req, opts: {handler, conn}] ->
-        mfa = {handler, :ws_init, [conn]}
-        exit(class, reason, stack, mfa, conn, env)
-      class, [reason: reason, mfa: {__MODULE__, :websocket_handle, 3},
-          stacktrace: stack, msg: {:text, text}, req: _req,
-          state: {handler, state}] ->
-        mfa = {handler, :ws_handle, [text, state]}
-        exit(class, reason, stack, mfa, conn, env)
-      class, [reason: reason, mfa: {__MODULE__, :websocket_info, 3},
-          stacktrace: stack, msg: :hibernate, req: _req,
-          state: {handler, state}] ->
-        mfa = {handler, :ws_hibernate, [state]}
-        exit(class, reason, stack, mfa, conn, env)
-      class, [reason: reason, mfa: {__MODULE__, :websocket_info, 3},
-          stacktrace: stack, msg: msg, req: _req, state: {handler, state}] ->
-        mfa = {handler, :ws_info, [msg, state]}
-        exit(class, reason, stack, mfa, conn, env)
-      class, [reason: reason, mfa: {__MODULE__, :websocket_terminate, 3},
-          stacktrace: stack, req: _req, state: {handler, state},
-          terminate_reason: terminate_reason] ->
-        mfa = {handler, :ws_terminate, [terminate_reason, state]}
-        exit(class, reason, stack, mfa, conn, env)
+      class, [{:reason, reason}, {:mfa, _mfa}, {:stacktrace, stack} | _rest] ->
+        exit(class, reason, stack, conn, env)
     else
       {:ok, _req, _env} = ok ->
         ok
@@ -45,8 +24,8 @@ defmodule Phoenix.Endpoint.CowboyWebSocket do
     end
   end
 
-  defp exit(class, reason, stack, mfa, conn, env) do
-    reason2 = {format_reason(class, reason, stack), mfa}
+  defp exit(class, reason, stack, conn, env) do
+    reason2 = format_reason(class, reason, stack)
     exit({reason2, {__MODULE__, :call, [conn, env]}})
   end
 


### PR DESCRIPTION
This is a rather subtle OTP exit reason change. If you try calling `exit(:shutdown)` in a channel with this patch you will observe that logs nolonger appear. This means we are generating a "normal" exit reason, and so can also shutdown linked processes cleanly. A longer explanation is available below/in the commit message:

Previously it was not possible to exit a websocket channel and shutdown linked processes without an abnormal reason exit reason. If `exit(:shutdown)` was called the process would exit with `{{:shutdown, mfa2}, mfa1}`, which is abnormal. The inner `mfa2`, has been removed so that `exit(:shutdown)` causes an exit with `{:shutdown, mfa1}`. This means that linked processes (that don't trap exits) will nolonger exit abnormally on receiving the exit signal, allowing transient shutdown.

This change also means that no log message is produced for the websocket process and any linked supervised process that is temporary or transient if `exit(:shutdown)` is called.

This patch is also nice as it simplifies the code and the `mfa2` mentioned above is actually a phoenix internal that is never exposed in public API.
