### PR TITLE
Adding link to official site in the main Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 
 ## Getting started
 
+- Also see the offical site at http://www.phoenixframework.org/
+
 ### Requirements
 
 - Elixir v1.0.2+


### PR DESCRIPTION
After setting up a local environment and running the server I found that you have a lovely documentation site at http://www.phoenixframework.org/

I've added a link to main readme to help others find it faster as currently there's no link contained in the main readme.
