### PR TITLE
Changed phoenix.server to phoenix.start in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 3. Change directory to `/path/to/scaffold/my_app`. Install dependencies and start web server
 
         mix do deps.get, compile
-        mix phoenix.server
+        mix phoenix.start
 
 
 When running in production, use protocol consolidation for increased performance:


### PR DESCRIPTION
Just getting started with Phoenix, noticed an apparent error in the getting started docs on the README
