### PR TITLE
add test Phoenix.HTML.html_escape when argument is char lists

### DIFF
--- a/lib/phoenix/html.ex
+++ b/lib/phoenix/html.ex
@@ -70,6 +70,9 @@ defmodule Phoenix.HTML do
       iex> Phoenix.HTML.html_escape("<hello>")
       {:safe, "&lt;hello&gt;"}
 
+      iex> Phoenix.HTML.html_escape('<hello>')
+      {:safe, ["&lt;", 104, 101, 108, 108, 111, "&gt;"]}
+
       iex> Phoenix.HTML.html_escape({:safe, "<hello>"})
       {:safe, "<hello>"}
   """


### PR DESCRIPTION
Adding test when given argument is char lists.
This code increases code coverage.
