### PR TITLE
improve coverage for `Naming.underscore` function

### DIFF
--- a/test/phoenix/naming_test.exs
+++ b/test/phoenix/naming_test.exs
@@ -9,6 +9,10 @@ defmodule Phoenix.NamingTest do
     assert Naming.underscore("Foobar") == "foobar"
     assert Naming.underscore("Foo-bar") == "foo_bar"
     assert Naming.underscore("APIWorld") == "api_world"
+    assert Naming.underscore("ErlangVM") == "erlang_vm"
+    assert Naming.underscore("Tmp/../usr") == "tmp/../usr"
+    assert Naming.underscore("Tmp/./usr") == "tmp///usr"
+    assert Naming.underscore("Foo.") == "foo."
   end
 
   test "camelize/1 converts Strings to camel case" do


### PR DESCRIPTION
Improve test coverage related `Naming.underscore` function.
