### PR TITLE
Reloadable paths config for Code Reloader

### DIFF
--- a/priv/template/config/dev.exs
+++ b/priv/template/config/dev.exs
@@ -3,7 +3,8 @@ use Mix.Config
 config :<%= application_name %>, <%= application_module %>.Endpoint,
   http: [port: System.get_env("PORT") || 4000],
   debug_errors: true,
-  cache_static_lookup: false
+  cache_static_lookup: false,
+  reloadable_paths: ["--elixirc-paths", "web"]
 
 # Enables code reloading for development
 config :phoenix, :code_reloader, true


### PR DESCRIPTION
This PR addresses https://github.com/phoenixframework/phoenix/issues/581

Adds `:reloadable_paths` Endpoint config that is set to `["--elixirc-paths", "web"]` by default in dev.exs.