### PR TITLE
Hide reloadable_paths option and add more to doc

### DIFF
--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -42,6 +42,7 @@ defmodule Phoenix.Endpoint.Adapter do
      cache_static_lookup: false,
      http: false,
      https: false,
+     reloadable_paths: ["web"],
      secret_key_base: nil,
      server: Application.get_env(:phoenix, :serve_endpoints, false),
      url: [host: "localhost"]]

--- a/priv/template/config/dev.exs
+++ b/priv/template/config/dev.exs
@@ -3,8 +3,7 @@ use Mix.Config
 config :<%= application_name %>, <%= application_module %>.Endpoint,
   http: [port: System.get_env("PORT") || 4000],
   debug_errors: true,
-  cache_static_lookup: false,
-  reloadable_paths: ["--elixirc-paths", "web"]
+  cache_static_lookup: false
 
 # Enables code reloading for development
 config :phoenix, :code_reloader, true

--- a/test/phoenix/code_reloader_test.exs
+++ b/test/phoenix/code_reloader_test.exs
@@ -2,25 +2,27 @@ defmodule Phoenix.CodeReloaderTest do
   use ExUnit.Case, async: true
   use RouterHelper
 
+  alias Phoenix.CodeReloader
+
   defmodule Endpoint do
     def config(:reloadable_paths) do
-      ["--elixirc-paths", "web"]
+      ["web"]
     end
   end
 
   test "touch/0 touches and returns touched files" do
-    assert Phoenix.CodeReloader.touch == []
+    assert CodeReloader.touch == []
   end
 
   test "reload!/1 sends recompilation through GenServer" do
-    assert Phoenix.CodeReloader.reload!([]) == :noop
+    assert CodeReloader.reload!([]) == :noop
   end
 
   test "reloads on every request" do
-    opts = Phoenix.CodeReloader.init([])
+    opts = CodeReloader.init([])
     conn = conn(:get, "/")
            |> Plug.Conn.put_private(:phoenix_endpoint, Endpoint)
-           |> Phoenix.CodeReloader.call(opts)
+           |> CodeReloader.call(opts)
     assert conn.state == :unset
   end
 
@@ -29,13 +31,18 @@ defmodule Phoenix.CodeReloaderTest do
   end
 
   test "render compilation error on failure" do
-    opts = Phoenix.CodeReloader.init(reloader: &__MODULE__.reload!/1)
+    opts = CodeReloader.init(reloader: &__MODULE__.reload!/1)
     conn = conn(:get, "/")
            |> Plug.Conn.put_private(:phoenix_endpoint, Endpoint)
-           |> Phoenix.CodeReloader.call(opts)
+           |> CodeReloader.call(opts)
     assert conn.state  == :sent
     assert conn.status == 500
     assert conn.resp_body =~ "oops"
     assert conn.resp_body =~ "CompilationError at GET /"
+  end
+
+  test "reloadable_paths/1 prepends '--elixirc-paths' to reloadable_paths" do
+    conn = conn(:get, "/") |> Plug.Conn.put_private(:phoenix_endpoint, Endpoint)
+    assert CodeReloader.reloadable_paths(conn) == ["--elixirc-paths", "web"]
   end
 end


### PR DESCRIPTION
I applied the changes based on your inputs here https://github.com/phoenixframework/phoenix/pull/582.

Need clarification on one thing though, when `reloadable_paths: ["web"]` should `Phoenix.CodeReloader.reload!/1` return `["--elixirc-paths", "web"]`? I also don't get why use flat_map to get  `["--elixirc-paths", "web"]`? Can't I use `["--elixirc-paths"|["web"]]` instead?