### PR TITLE
remove obsolete roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
   - [Building phoenix.coffee](#building-phoenixcoffee)
 - [Contributing](#contributing)
 - [Important links](#important-links)
-- [Feature Roadmap](#feature-roadmap)
 
 
 ## Getting started


### PR DESCRIPTION
Roadmap section in README is already removed by @chrismccord's commit:

https://github.com/phoenixframework/phoenix/commit/8ae36a9ff791008ff5448554d73211807fd576f9

