### PR TITLE
Make websocket timeout configurable

### DIFF
--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -35,7 +35,8 @@ defmodule Phoenix.Endpoint.Adapter do
      # Transports
      transports: [
        longpoller_window_ms: 10_000,
-       websocket_serializer: Phoenix.Transports.JSONSerializer
+       websocket_serializer: Phoenix.Transports.JSONSerializer,
+       websocket_timeout: :infinity
      ],
 
      # Runtime config

--- a/lib/phoenix/endpoint/cowboy_websocket.ex
+++ b/lib/phoenix/endpoint/cowboy_websocket.ex
@@ -32,8 +32,8 @@ defmodule Phoenix.Endpoint.CowboyWebSocket do
   defp format_reason(:error, reason, stack), do: {reason, stack}
 
   def websocket_init(_transport, req, {handler, conn}) do
-    {:ok, state} = handler.ws_init(conn)
-    {:ok, :cowboy_req.compact(req), {handler, state}}
+    {:ok, state, timeout} = handler.ws_init(conn)
+    {:ok, :cowboy_req.compact(req), {handler, state}, timeout}
   end
 
   def websocket_handle({opcode = :text, payload}, req, {handler, state}) do

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -15,6 +15,14 @@ defmodule Phoenix.Transports.WebSocket do
 
   The `websocket_serializer` module needs only to implement the `encode!/1` and
   `decode!/2` functions defined by the `Phoenix.Transports.Serializer` behaviour.
+
+  Websockets, by default, do not timeout if the connection is lost. To set a
+  maximum timeout duration in milliseconds, add this to your Endpoint's transport
+  configuration:
+
+      config :my_app, MyApp.Endpoint, transports: [
+        websocket_timeout: 60000
+      ]
   """
 
   alias Phoenix.Channel.Transport
@@ -35,7 +43,8 @@ defmodule Phoenix.Transports.WebSocket do
   """
   def ws_init(conn) do
     serializer = Dict.fetch!(endpoint_module(conn).config(:transports), :websocket_serializer)
-    {:ok, %{router: router_module(conn), sockets: HashDict.new, serializer: serializer}}
+    timeout = Dict.fetch!(endpoint_module(conn).config(:transports), :websocket_timeout)
+    {:ok, %{router: router_module(conn), sockets: HashDict.new, serializer: serializer}, timeout}
   end
 
   @doc """


### PR DESCRIPTION
Cowboy websockets can be initialized with a maximum timeout time. Until now, this has been left to be the default setting, meaning no timeout at all, since cowboy websockets assume `:infinity` as default.

This PR adds an optional endpoint transport configuration setting `websocket_timeout` that specifies the timeout to be used in milliseconds.

Doesn't break backwards-compatibility.

~cheers, Johanna.