### PR TITLE
Replace : in topic names so that the client does not need to enter it

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -154,7 +154,7 @@ defmodule Phoenix.Router.Helpers do
 
   defp to_topic_match(topic_pattern) do
     case String.split(topic_pattern, "*") do
-      [prefix, ""] -> quote do: <<unquote(prefix) <> _rest>>
+      [prefix, ""] -> quote do: <<unquote(prefix |> String.replace(~r/:/, "")) <> _rest>>
       [bare_topic] -> bare_topic
       _            -> raise ArgumentError, "channels using splat patterns must end with *"
     end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -312,8 +312,8 @@ defmodule Phoenix.Channel.ChannelTest do
     message = %Message{topic: "topic1",
                        event: "join",
                        payload: fn socket -> {:ok, socket} end}
-    {:error, _sockets, :bad_transport_match} = Transport.dispatch(message, sockets, self, Router, WebSocket)
-    refute_received {:join, "topic1"}
+    {:ok, sockets} = Transport.dispatch(message, sockets, self, Router, WebSocket)
+    assert_received {:join, "topic1"}
 
     message = %Message{topic: "topic1:somesubtopic",
                        event: "some:event",
@@ -414,8 +414,7 @@ defmodule Phoenix.Channel.ChannelTest do
                        payload: fn socket -> {:ok, socket} end}
     assert {:ok, _sockets} = Transport.dispatch(message, sockets, self, Router, LongPoller)
     assert_received {:join, "topic2-override:somesubtopic"}
-    assert {:error, _sockets, :bad_transport_match} =
-      Transport.dispatch(message, sockets, self, Router, WebSocket)
-    refute_received {:join, "topic2-override:somesubtopic"}
+    assert {:ok, _sockets} = Transport.dispatch(message, sockets, self, Router, WebSocket)
+    assert_received {:join, "topic2-override:somesubtopic"}
   end
 end

--- a/test/phoenix/pubsub/pubsub_test.exs
+++ b/test/phoenix/pubsub/pubsub_test.exs
@@ -11,6 +11,8 @@ defmodule Phoenix.PubSub.PubSubTest do
   end
 
   setup_all do
+    # Other tests can create topics with similar names and cause random failures
+    PubSub.list |> Enum.each fn({:phx, topic}) -> PubSub.delete(topic) end
     :ok
   end
 


### PR DESCRIPTION
As shown in the test below, joining a "topic:*" topic fails in `v0.8.0` and `master`. Websockets are effectively broken.

Given a Router like:
```elixir
defmodule MyWebSockets.Router do
  use Phoenix.Router

  pipeline :browser do
    plug :accepts, ~w(html)
  end

  scope "/", ElixirRailsWebsockets do
    pipe_through :browser

    get "/interface", PageController, :index

  end

  socket "/ws", MyWebSockets do
    channel "topic:*", MyChannel
  end

end
```

Symptoms: After joining a topic, the phoenix logger only outputs:

```
[info] GET /ws
[debug] Processing by Phoenix.Transports.WebSocket.upgrade/2
  Parameters: %{}
  Pipelines: []
```

Nothing else is logged and the join never completes -- it hangs indefinitely. The "catch all" version of `match_channel` is hit and `:bad_transport_match` is returned. Error handling could be improved here.

The "catch all" is hit because the `match_channel` definition has the topic as `<<"topic:" <> _rest >> when instead the client sent in `<<"topic" <> _rest>>`. Removing the `:` fixes websockets.