### PR TITLE
Using originally wrapped connection, not error.conn

### DIFF
--- a/lib/phoenix/endpoint/error_handler.ex
+++ b/lib/phoenix/endpoint/error_handler.ex
@@ -43,7 +43,7 @@ defmodule Phoenix.Endpoint.ErrorHandler do
       fun.()
     rescue
       e in [Phoenix.Router.NoRouteError] ->
-        maybe_render(e.conn, :error, e, System.stacktrace, opts)
+        maybe_render(conn, :error, e, System.stacktrace, opts)
 
     catch
       kind, reason ->


### PR DESCRIPTION
I was throwing a 404 error and it was ignoring my json format. Talking to Chris I moved plug accepts to endpoint and changed this to get it to work.

@josevalim your input on this would be greatly appreciated.