### PR TITLE
Added `Router.resource` for defining a singular resource

### DIFF
--- a/lib/phoenix/router/resource.ex
+++ b/lib/phoenix/router/resource.ex
@@ -30,20 +30,25 @@ defmodule Phoenix.Router.Resource do
   """
   def build(path, controller, options) when
       is_binary(path) and is_atom(controller) and is_list(options) do
-    actions = extract_actions(options)
-    alias   = Keyword.get(options, :alias)
-    param   = Keyword.get(options, :param, @default_param_key)
-    name    = Keyword.get(options, :name, Phoenix.Naming.resource_name(controller, "Controller"))
-    as      = Keyword.get(options, :as, name)
+    alias    = Keyword.get(options, :alias)
+    param    = Keyword.get(options, :param, @default_param_key)
+    name     = Keyword.get(options, :name, Phoenix.Naming.resource_name(controller, "Controller"))
+    as       = Keyword.get(options, :as, name)
+    singular = Keyword.get(options, :singular)
+    actions  = extract_actions(options, singular)
 
-    collection = [path: path, as: as]
-    member     = [path: Path.join(path, ":#{name}_#{param}"), as: as, alias: alias]
+    collection  = [path: path, as: as]
+    member_path = if singular, do: path, else: Path.join(path, ":#{name}_#{param}")
+    member      = [path: member_path, as: as, alias: alias]
 
     %Resource{path: path, actions: actions, param: param, as: as,
               member: member, collection: collection, controller: controller}
   end
 
-  defp extract_actions(opts) do
-    Keyword.get(opts, :only) || (@actions -- Keyword.get(opts, :except, []))
+  defp extract_actions(opts, singular) do
+    Keyword.get(opts, :only) || (default_actions(singular) -- Keyword.get(opts, :except, []))
   end
+
+  defp default_actions(_singular=true),   do: @actions -- [:index]
+  defp default_actions(_singular),        do: @actions
 end

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -68,6 +68,10 @@ defmodule Phoenix.Router.HelpersTest do
 
     resources "/files", FileController
 
+    resource "/account", UserController, as: :account do
+      resource "/page", PagesController, as: :page, only: [:show]
+    end
+
     scope "/admin", alias: Admin do
       resources "/messages", MessageController
     end
@@ -168,6 +172,24 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.file_path(__MODULE__, :show, 123) == "/files/123"
     assert Helpers.file_path(__MODULE__, :new, []) == "/files/new"
     assert Helpers.file_path(__MODULE__, :new) == "/files/new"
+  end
+
+  test "resource generates named routes for :show, :edit, :new, :update, :delete" do
+    assert Helpers.account_path(__MODULE__, :show, []) == "/account"
+    assert Helpers.account_path(__MODULE__, :show) == "/account"
+    assert Helpers.account_path(__MODULE__, :edit, []) == "/account/edit"
+    assert Helpers.account_path(__MODULE__, :edit) == "/account/edit"
+    assert Helpers.account_path(__MODULE__, :new, []) == "/account/new"
+    assert Helpers.account_path(__MODULE__, :new) == "/account/new"
+    assert Helpers.account_path(__MODULE__, :update, []) == "/account"
+    assert Helpers.account_path(__MODULE__, :update) == "/account"
+    assert Helpers.account_path(__MODULE__, :delete, []) == "/account"
+    assert Helpers.account_path(__MODULE__, :delete) == "/account"
+  end
+
+  test "2-Level nested resource generates nested named routes for :show" do
+    assert Helpers.account_page_path(__MODULE__, :show, []) == "/account/page"
+    assert Helpers.account_page_path(__MODULE__, :show) == "/account/page"
   end
 
   test "scoped route helpers generated named routes with :path, and :alias options" do

--- a/test/phoenix/router/resource_test.exs
+++ b/test/phoenix/router/resource_test.exs
@@ -1,0 +1,121 @@
+defmodule Phoenix.Router.ResourceTest do
+  use ExUnit.Case, async: true
+  use RouterHelper
+
+  defmodule AccountController do
+    use Phoenix.Controller
+    plug :action
+    def show(conn, _params), do: text(conn, "show account")
+    def new(conn, _params), do: text(conn, "new account")
+    def edit(conn, _params), do: text(conn, "edit account")
+    def create(conn, _params), do: text(conn, "create account")
+    def update(conn, _params), do: text(conn, "update account")
+    def delete(conn, _params), do: text(conn, "delete account")
+  end
+
+  defmodule Api.SessionController do
+    use Phoenix.Controller
+    plug :action
+    def show(conn, _params), do: text(conn, "show session")
+    def new(conn, _params), do: text(conn, "new session")
+  end
+
+  defmodule Api.CommentController do
+    use Phoenix.Controller
+    plug :action
+    def show(conn, _params), do: text(conn, "show comments")
+  end
+
+  defmodule Router do
+    use Phoenix.Router
+
+    resource "/account", AccountController, alias: Api do
+      resources "/comments", CommentController
+      resource "/session", SessionController, except: [:delete]
+    end
+
+    resource "/session", Api.SessionController, only: [:show]
+  end
+
+  setup do
+    Logger.disable(self())
+    :ok
+  end
+
+  test "toplevel route matches new action" do
+    conn = call(Router, :get, "account/new")
+    assert conn.status == 200
+    assert conn.resp_body == "new account"
+  end
+
+  test "toplevel route matches show action" do
+    conn = call(Router, :get, "account")
+    assert conn.status == 200
+    assert conn.resp_body == "show account"
+  end
+
+  test "toplevel route matches edit action" do
+    conn = call(Router, :get, "account/edit")
+    assert conn.status == 200
+    assert conn.resp_body == "edit account"
+  end
+
+  test "toplevel route matches create action" do
+    conn = call(Router, :post, "account")
+    assert conn.status == 200
+    assert conn.resp_body == "create account"
+  end
+
+  test "toplevel route matches update action with both PUT and PATCH" do
+    for method <- [:put, :patch] do
+      conn = call(Router, method, "account")
+      assert conn.status == 200
+      assert conn.resp_body == "update account"
+
+      conn = call(Router, method, "account")
+      assert conn.status == 200
+      assert conn.resp_body == "update account"
+    end
+  end
+
+  test "toplevel route matches delete action" do
+    conn = call(Router, :delete, "account")
+    assert conn.status == 200
+    assert conn.resp_body == "delete account"
+  end
+
+  test "1-Level nested route matches" do
+    conn = call(Router, :get, "account/comments/2")
+    assert conn.status == 200
+    assert conn.resp_body == "show comments"
+    assert conn.params["id"] == "2"
+  end
+
+  test "nested prefix context reverts back to previous scope after expansion" do
+    conn = call(Router, :get, "account/session")
+    assert conn.status == 200
+    assert conn.resp_body == "show session"
+
+    conn = call(Router, :get, "session")
+    assert conn.status == 200
+    assert conn.resp_body == "show session"
+  end
+
+  test "limit resource by passing :except option" do
+    assert_raise Phoenix.Router.NoRouteError, fn ->
+      call(Router, :delete, "account/session")
+    end
+
+    conn = call(Router, :get, "account/session/new")
+    assert conn.status == 200
+  end
+
+  test "limit resource by passing :only option" do
+    assert_raise Phoenix.Router.NoRouteError, fn ->
+      call(Router, :patch, "session/new")
+    end
+
+    conn = call(Router, :get, "session")
+    assert conn.status == 200
+  end
+end


### PR DESCRIPTION
Adds the ability to define a set of routes that wont require an index action or an ID parameter in the path.

Example:

```elixir
# in web.router.ex
resource "/session", SessionsController
```

Will generate the following routes:

    * `GET /session` => `:show`
    * `GET /session/new` => `:new`
    * `POST /session` => `:create`
    * `GET /session/edit` => `:edit`
    * `PATCH /session` => `:update`
    * `PUT /session` => `:update`
    * `DELETE /session` => `:delete`