### PR TITLE
Making more obvious the https setting

### DIFF
--- a/priv/template/config/prod.exs
+++ b/priv/template/config/prod.exs
@@ -1,20 +1,24 @@
 use Mix.Config
 
-# ## SSL Support
-#
-# To get SSL working, you will need to set:
-#
-#     https: [port: 443,
-#             keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
-#             certfile: System.get_env("SOME_APP_SSL_CERT_PATH")]
-#
-# Where those two env variables point to a file on
-# disk for the key and cert.
-
 config :<%= application_name %>, <%= application_module %>.Endpoint,
   url: [host: "example.com"],
   http: [port: System.get_env("PORT")],
   secret_key_base: "<%= secret_key_base %>"
+  
+# ## SSL Support
+#
+# To get SSL working, you will need to add the `https` key
+# to the previous section:
+#
+#  config:<%= application_name %>, <%= application_module %>.Endpoint,
+#    ...
+#    https: [port: 443,
+#            keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
+#            certfile: System.get_env("SOME_APP_SSL_CERT_PATH")]
+#
+# Where those two env variables point to a file on
+# disk for the key and cert.
+  
 
 # Do not pring debug messages in production
 config :logger, level: :info


### PR DESCRIPTION
It might be a rookie mistake, but I honestly spent 10 minutes trying to find where the `https` setting was going. In retrospect, it was caused by the order of the example code.