### PR TITLE
Read prod secret_key_base from env instead of using generated value

### DIFF
--- a/priv/template/config/prod.exs
+++ b/priv/template/config/prod.exs
@@ -3,7 +3,7 @@ use Mix.Config
 config :<%= application_name %>, <%= application_module %>.Endpoint,
   url: [host: "example.com"],
   http: [port: System.get_env("PORT")],
-  secret_key_base: "<%= secret_key_base %>"
+  secret_key_base: System.get_env("SECRET_KEY_BASE")
   
 # ## SSL Support
 #


### PR DESCRIPTION
Checking in the production value for `secret_key_base` (and its previous incarnations) has been a gotcha for rails apps that would be best to avoid. Not attached to the implementation, but I think something like this would be nice.

(Apologies if this has been discussed before, but I couldn't find anything in issues or on the mailing list.)