### PR TITLE
Dynamic port : obtain the port number at runtime 

### DIFF
--- a/lib/phoenix/endpoint/server.ex
+++ b/lib/phoenix/endpoint/server.ex
@@ -38,13 +38,13 @@ defmodule Phoenix.Endpoint.Server do
       |> Keyword.put_new(:otp_app, otp_app)
       |> Keyword.put_new(:port, port)
 
-    Keyword.put(config, :port, to_integer(config[:port]))
+    Keyword.put(config, :port, get_port_value(config[:port]))
   end
 
-  defp to_integer({ :dynamic, var_name }) do
-    var_name |> System.get_env |> to_integer
+  defp get_port_value({ :dynamic, var_name }) do
+    var_name |> System.get_env |> get_port_value
   end
-  defp to_integer(function) when is_function(function), do: function.() |> to_integer
-  defp to_integer(binary)   when is_binary(binary),     do: String.to_integer(binary)
-  defp to_integer(integer)  when is_integer(integer),   do: integer
+  defp get_port_value(function) when is_function(function), do: function.() |> get_port_value
+  defp get_port_value(binary)   when is_binary(binary),     do: String.to_integer(binary)
+  defp get_port_value(integer)  when is_integer(integer),   do: integer
 end

--- a/lib/phoenix/endpoint/server.ex
+++ b/lib/phoenix/endpoint/server.ex
@@ -41,6 +41,9 @@ defmodule Phoenix.Endpoint.Server do
     Keyword.put(config, :port, to_integer(config[:port]))
   end
 
+  defp to_integer({ :dynamic, var_name }) do
+    var_name |> System.get_env |> to_integer
+  end
   defp to_integer(function) when is_function(function), do: function.() |> to_integer
   defp to_integer(binary)   when is_binary(binary),     do: String.to_integer(binary)
   defp to_integer(integer)  when is_integer(integer),   do: integer

--- a/lib/phoenix/endpoint/server.ex
+++ b/lib/phoenix/endpoint/server.ex
@@ -41,6 +41,7 @@ defmodule Phoenix.Endpoint.Server do
     Keyword.put(config, :port, to_integer(config[:port]))
   end
 
-  defp to_integer(binary)  when is_binary(binary),   do: String.to_integer(binary)
-  defp to_integer(integer) when is_integer(integer), do: integer
+  defp to_integer(function) when is_function(function), do: function.() |> to_integer
+  defp to_integer(binary)   when is_binary(binary),     do: String.to_integer(binary)
+  defp to_integer(integer)  when is_integer(integer),   do: integer
 end


### PR DESCRIPTION
The intent of this pull request is to allow obtaining the port number at runtime. Two options are proposed :

1. In the config file, set the value of the port to an anonymous function responsible for providing the port value. Note that this won't work when releasing with exrm.

2. In the config file, set the value of the port to {:dynamic, var_name} where var_name is the name of the system environment variable which contains the port number. This option is fully compatible with exrm releases. 