### PR TITLE
Raise an error when the port number in the config is nil.

### DIFF
--- a/lib/phoenix/endpoint/server.ex
+++ b/lib/phoenix/endpoint/server.ex
@@ -38,6 +38,7 @@ defmodule Phoenix.Endpoint.Server do
       |> Keyword.put_new(:otp_app, otp_app)
       |> Keyword.put_new(:port, port)
 
+    if config[:port] == nil, do: raise ":port in config is nil. Use a valid port number."
     Keyword.put(config, :port, to_integer(config[:port]))
   end
 


### PR DESCRIPTION
This PR attempts to make tracking down port number related bugs a little bit easier when deploying the application by raising a descriptive error. By default the prod environment uses only an environment variable to get the port, but if that variable doesn't exist the config's port is set to nil. This causes a no function clause matching error when starting the app.