### PR TITLE
Headers in sockets

### DIFF
--- a/lib/phoenix/channel/transport.ex
+++ b/lib/phoenix/channel/transport.ex
@@ -63,12 +63,13 @@ defmodule Phoenix.Channel.Transport do
 
   The returned `HashDict` of `%Phoenix.Socket{}`s must be held by the adapter
   """
-  def dispatch(msg = %Message{}, sockets, adapter_pid, router, pubsub_server, transport) do
+  def dispatch(msg = %Message{}, conn, sockets, adapter_pid, router, pubsub_server, transport) do
     socket = %Socket{pid: adapter_pid,
                      router: router,
                      pubsub_server: pubsub_server,
                      topic: msg.topic,
-                     transport: transport}
+                     transport: transport,
+                     conn: conn}
 
     sockets
     |> HashDict.get(msg.topic, socket)

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -28,6 +28,7 @@ defmodule Phoenix.Socket do
             authorized: false,
             transport: nil,
             pubsub_server: nil,
+            conn: nil,
             assigns: %{}
 
 

--- a/lib/phoenix/transports/long_poller.ex
+++ b/lib/phoenix/transports/long_poller.ex
@@ -77,7 +77,7 @@ defmodule Phoenix.Transports.LongPoller do
       |> Kernel.<>(Base.encode64(:crypto.strong_rand_bytes(16)))
       |> Kernel.<>(:os.timestamp() |> Tuple.to_list |> Enum.join(""))
 
-    child = [router, timeout_window_ms(conn), priv_topic, pubsub_server(conn)]
+    child = [router, timeout_window_ms(conn), priv_topic, pubsub_server(conn), conn]
     {:ok, server_pid} = Supervisor.start_child(LongPoller.Supervisor, child)
 
     {conn, priv_topic, sign(conn, priv_topic), server_pid}

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -42,7 +42,7 @@ defmodule Phoenix.Transports.WebSocket do
     timeout = Dict.fetch!(endpoint_module(conn).config(:transports), :websocket_timeout)
     {:ok, %{router: router_module(conn),
             pubsub_server: endpoint_module(conn).__pubsub_server__(),
-            sockets: HashDict.new, serializer: serializer}, timeout}
+            sockets: HashDict.new, serializer: serializer, conn: conn}, timeout}
   end
 
   @doc """
@@ -52,7 +52,7 @@ defmodule Phoenix.Transports.WebSocket do
   def ws_handle(opcode, payload, state) do
     payload
     |> state.serializer.decode!(opcode)
-    |> Transport.dispatch(state.sockets, self, state.router, state.pubsub_server, __MODULE__)
+    |> Transport.dispatch(state.conn, state.sockets, self, state.router, state.pubsub_server, __MODULE__)
     |> case do
       {:ok, sockets}             -> %{state | sockets: sockets}
       {:error, _reason, sockets} -> %{state | sockets: sockets}


### PR DESCRIPTION
### I'd like to start out by saying how great I think Phoenix is coming along! Great job! :+1: :tada: 

I know this is a painful topic, but I think it needs to be fleshed out if Phoenix is to succeed in the long run. The client-side HMAC token system cannot be the only method of authentication. I think it is an excellent feature though! There are currently, and will be more to come, use cases in which this system fails. First of all, not running the application over SSL immediately makes one time use token a vulnerability. Anyone who sniffs the token and makes the connection to the application first would gain credential access. Secondly, putting a security token on the client side accessible by javascript is a big time security violation by itself. If somehow you do get some kind injection issue (XSS or otherwise), now user tokens are available. This is the reason why session cookies are marked HTTP only and cannot be accessed by javascript. The web is already built this way for a reason.

In order to use the token system without a security hole, Phoenix must guarantee SSL and prevention of XSS or other injection issues (and even then I'm still uneasy about the architecture). Those are two tall orders to make, so heres what I propose. **Allow access to the session and headers in websocket connections!**

#### You may not like what I've done, thats ok if you prefer to reimplement it. But PLEASE consider adding this feature. Phoenix and its awesome web socket system are pretty much useless to me (and likely many others) without it.

> In case you are wondering what my use case is... 
> I have a Phoenix app here: https://github.com/mgwidmann/elixir-rails-websockets which will proxy to a locally configured (still TODO in the phoenix app) rails app so that I may lighten the web socket load on my rails server behind a reverse proxy like nginx. The Phoenix proxy needs to send over the session cookie to the rails app so that it appears transparently that the request came from the client (the rails session cookie most importantly needs to be sent, but other headers could be useful as well). The whole purpose of this is that I have a built rails application (which currently is better suited being built in rails than Phoenix IMO) which needs web socket support on a very limited set of hardware (which I feel MRI cannot handle since I won't be able to have more than a handful of workers). I didn't want to use JRuby or Rubinius as I have already built the app in MRI and it is too risky at this point to change. I will be deploying to production soon, either with my forked version of Phoenix or master, whichever supports this feature.