### PR TITLE
Add support for json prerendered json responses

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -120,6 +120,21 @@ defmodule Phoenix.Controller do
   @doc """
   Sends JSON response.
 
+  It uses a already encoded json string.
+
+  ## Examples
+
+      iex> json conn, "{\"id\": 123}"
+
+  """
+  @spec json(Plug.Conn.t, String.Chars.t) :: Plug.Conn.t
+  def json(conn, data) when is_binary(data) do
+    send_resp(conn, conn.status || 200, "application/json", to_string(data))
+  end
+
+  @doc """
+  Sends JSON response.
+
   It uses the configured `:format_encoders` under the `:phoenix`
   application for `:json` to pick up the encoder module.
 

--- a/test/phoenix/controller_test.exs
+++ b/test/phoenix/controller_test.exs
@@ -80,6 +80,20 @@ defmodule Phoenix.ControllerTest do
     assert view_module(conn) == World
   end
 
+  test "json/2 with json string" do
+    conn = json(conn(:get, "/"), "{\"foo\":\"bar\"}")
+    assert conn.resp_body == "{\"foo\":\"bar\"}"
+    assert get_resp_content_type(conn) == "application/json"
+    refute conn.halted
+  end
+
+  test "json/2 with json string, allows status injection on connection" do
+    conn = conn(:get, "/") |> put_status(400)
+    conn = json(conn, "{\"foo\":\"bar\"}")
+    assert conn.resp_body == "{\"foo\":\"bar\"}"
+    assert conn.status == 400
+  end
+
   test "json/2" do
     conn = json(conn(:get, "/"), %{foo: :bar})
     assert conn.resp_body == "{\"foo\":\"bar\"}"


### PR DESCRIPTION
Hey alchemists,

I am currently working on a JSON api, using Phoenix; With this i use postgrex which returns my result in JSON, i will then use the json/2 method to send my response, but this gave a odd result.

I have a variable containing the following json 

````json
{
    "widget": {
        "title": "fest",
        "size_x": 2,
        "size_y": 2,
        "values": {
            "api_key" : "sklfjklasfj"
        }
    } 
}
````

which i run through with 

````elixir
json conn, widget_json
````

This is my result.

````json
"{\"widgets\":[{\"id\":30,\"title\":\"fest\",\"size_x\":2,\"size_y\":2,\"pos_x\":null,\"pos_y\":null,\"values\":{\"api_key\":\"sklfjklasfj\"},\"board_id\":1,\"inserted_at\":\"2015-02-27 15:36:09\",\"updated_at\":\"2015-02-27 15:36:09\"}]}"
````

I can only assume that Poison is double parsing this somehow. If i use text/2, everthing is fine, but then i lack json header.

````json
{"widgets":[{"id":32,"title":"fest","size_x":2,"size_y":2,"pos_x":null,"pos_y":null,"values":{"api_key":"sklfjklasfj"},"board_id":1,"inserted_at":"2015-02-27 15:42:51","updated_at":"2015-02-27 15:42:51"}]}
````

I created a this pull request, which adds support json strings, i've only been working with Elixir for 1 week, my apologies if this is not best practice.

Best regards 
Elvar