### PR TITLE
Improve content-type negotiation

### DIFF
--- a/test/phoenix/controller_test.exs
+++ b/test/phoenix/controller_test.exs
@@ -207,6 +207,9 @@ defmodule Phoenix.ControllerTest do
     conn = accepts with_accept("application/json, text/html; q=0.7"), ~w(html json)
     assert conn.params["format"] == "json"
 
+    conn = accepts with_accept("application/json, */*; q=0.7"), ~w(html json)
+    assert conn.params["format"] == "json"
+
     conn = accepts with_accept("application/json; q=1.0, text/html; q=0.7"), ~w(html json)
     assert conn.params["format"] == "json"
 


### PR DESCRIPTION
Do not fall back to html due to `*/*` if it has a `q` value other than 1

This bug was pointed out in the IRC channel by @tmjoen.  jQuery includes `*/*; q=0.01` on its headers, which was causing Phoenix to fall back to html in spite of the q value.  This PR adds a failing test and a fix.

For reference, see:

http://bugs.jquery.com/ticket/12250 
and
https://github.com/jquery/jquery/blob/master/src/ajax.js#L594-L601

