### PR TITLE
Add documentation about route globbing

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -31,6 +31,11 @@ defmodule Phoenix.Router do
   The `get/3` macro above accepts a request of format "/pages/VALUE" and
   dispatches it to the show action in the `PageController`.
 
+  Routes can also match glob-like patterns, routing any path with a common
+  base to the same controller. For example:
+
+      get "/dynamic*anything", DynamicController, :show
+
   Phoenix's router is extremely efficient, as it relies on Elixir
   pattern matching for matching routes and serving requests.
 


### PR DESCRIPTION
There is an example of route globbing within the channel section, but the pattern is different for controllers. Routes with a glob need to be followed by a word value, like `*other`. This took a few tries for me to figure out and I didn't see it documented anywhere.