### PR TITLE
Adds support for processes per Phoenix.Socket

### DIFF
--- a/lib/phoenix/channel/transport.ex
+++ b/lib/phoenix/channel/transport.ex
@@ -97,7 +97,6 @@ defmodule Phoenix.Channel.Transport do
     {:ok, HashDict.put(sockets, topic, socket)}
   end
   defp transport_response({:leave, socket}, topic, sockets) do
-    Socket.Supervisor.terminate_child(socket)
     {:ok, HashDict.delete(sockets, topic)}
   end
   defp transport_response({:heartbeat, _socket}, _topic, sockets) do
@@ -151,7 +150,6 @@ defmodule Phoenix.Channel.Transport do
   end
 
   defp handle_result({:ok, socket}, "leave") do
-    :ok = Socket.Server.do_leave(socket)
     {:leave, socket}
   end
   defp handle_result({:ok, socket}, _event) do

--- a/lib/phoenix/socket/server.ex
+++ b/lib/phoenix/socket/server.ex
@@ -1,0 +1,160 @@
+defmodule Phoenix.Socket.Supervisor do
+  @moduledoc false
+  use Supervisor
+  alias Phoenix.Socket
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok, name: __MODULE__)
+  end
+
+  def start_child(%Socket{} = socket) do
+    Supervisor.start_child(__MODULE__, [socket])
+  end
+
+  def terminate_child(child) do
+    Supervisor.terminate_child(__MODULE__, child)
+  end
+
+  def init(:ok) do
+    children = [
+      worker(Phoenix.Socket.Server, [], restart: :temporary)
+    ]
+    supervise(children, strategy: :simple_one_for_one)
+  end
+end
+
+
+defmodule Phoenix.Socket.Server do
+  @moduledoc """
+  Defines a server for socket operations. Delegates to the actual Transport.
+  """
+  use GenServer
+  require Logger
+  alias Phoenix.Socket
+  alias Phoenix.Socket.Message
+  alias Phoenix.PubSub
+
+  # External API
+
+  def start_link(%Socket{} = socket) do
+    GenServer.start_link(__MODULE__, socket)
+  end
+
+  def dispatch_join(server, topic, message) do
+    GenServer.call(server, {:dispatch_join, topic, message})
+  end
+
+  def dispatch_in(server, topic, event, message) do
+    GenServer.call(server, {:dispatch_in, topic, event, message})
+  end
+
+  def dispatch_out(server, event, message) do
+    GenServer.call(server, {:dispatch_out, event, message})
+  end
+
+  def dispatch_leave(server, message) do
+    GenServer.call(server, {:dispatch_leave, :ignore_topic, message})
+  end
+  def dispatch_leave(server, topic, message) do
+    GenServer.call(server, {:dispatch_leave, topic, message})
+  end
+
+  def do_join(server) do
+    GenServer.call(server, :do_join)
+  end
+
+  def do_leave(server) do
+    GenServer.call(server, :do_leave)
+  end
+
+  def authorized?(server, topic) do
+    GenServer.call(server, {:authorized, topic})
+  end
+
+  def dispatch_reply(server, %Message{} = message) do
+    GenServer.cast(server, {:dispatch_reply, message})
+  end
+
+  # Server internal
+
+  def init(%Socket{} = socket) do
+    {:ok, socket}
+  end
+
+  def handle_call({:dispatch_join, topic, message}, _from, socket) do
+    case socket.router.channel_for_topic(topic, socket.transport) do
+      nil ->
+        Logger.debug fn -> "Ignoring unmatched topic \"#{socket.topic}\" in #{inspect(socket.router)}" end
+        create_reply(:ignore)
+      channel ->
+        topic
+        |> channel.join(message, Socket.put_channel(socket, channel))
+        |> create_reply
+    end
+  end
+
+  def handle_call({:dispatch_in, topic, event, message}, _from, socket) do
+    if Socket.authorized?(socket, topic) do
+      socket.channel.handle_in(event, message, socket)
+      |> create_reply
+    else
+      create_reply({:error, :unauthenticated, socket})
+    end
+  end
+
+  def handle_call({:dispatch_out, event, message}, _from, socket) do
+    socket.channel.handle_out(event, message, socket)
+    |> create_reply
+  end
+
+  def handle_call({:dispatch_leave, :ignore_topic, message}, _from, socket) do
+    socket.channel.leave(message, socket)
+    |> create_reply
+  end
+
+  def handle_call({:dispatch_leave, topic, message}, _from, socket) do
+    if Socket.authorized?(socket, topic) do
+      socket.channel.leave(message, socket)
+      |> create_reply
+    else
+      create_reply({:error, :unauthenticated, socket})
+    end
+  end
+
+  def handle_call(:do_join, _from, socket) do
+    PubSub.subscribe(socket.pubsub_server, socket.pid, socket.topic, link: true)
+    {:reply, :ok, Socket.authorize(socket, socket.topic)}
+  end
+
+  def handle_call(:do_leave, _from, socket) do
+    PubSub.unsubscribe(socket.pubsub_server, socket.pid, socket.topic)
+    {:reply, :ok, Socket.deauthorize(socket)}
+  end
+
+  def handle_call({:authorized, topic}, _from, socket) do
+    {:reply, Socket.authorized?(socket, topic), socket}
+  end
+
+  def handle_cast({:dispatch_reply, message}, socket) do
+    send socket.pid, {:socket_reply, message}
+    {:noreply, socket}
+  end
+
+  def handle_info(message, socket) do
+    {:ok, socket} = socket.channel.handle_info(message, socket)
+    # TODO accept the normal channel results here?
+    {:noreply, socket}
+  end
+
+  # Internal
+
+  defp create_reply({result, socket}) do
+    {:reply, {result, self}, socket}
+  end
+  defp create_reply({:error, reason, socket}) do
+    {:reply, {:error, reason, self}, socket}
+  end
+  defp create_reply(reply) do
+    {:reply, reply, %{}}
+  end
+end

--- a/lib/phoenix/socket/server.ex
+++ b/lib/phoenix/socket/server.ex
@@ -128,7 +128,7 @@ defmodule Phoenix.Socket.Server do
     {:stop, :normal, {result, self}, Socket.deauthorize(s)}
   end
   defp handle_stop({:error, reason, %Socket{} = s}) do
-    {:stop, :normal, {:error, {reason, self}}, Socket.deauthorize(s)}
+    {:stop, reason, {:error, {reason, self}}, Socket.deauthorize(s)}
   end
   defp handle_stop(bad_return) do
     {:stop, :bad_return, {:error, {{:invalid_return, bad_return}}, self}, %{}}

--- a/lib/phoenix/supervisor.ex
+++ b/lib/phoenix/supervisor.ex
@@ -11,6 +11,7 @@ defmodule Phoenix.Supervisor do
     []
     |> child(Phoenix.CodeReloader.Server, [], code_reloader)
     |> child(Phoenix.Transports.LongPoller.Supervisor, [], true)
+    |> child(Phoenix.Socket.Supervisor, [], true)
     |> supervise(strategy: :one_for_one)
   end
 

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -240,11 +240,11 @@ defmodule Phoenix.ChannelTest do
     # send broadcast that returns {:leave, socket} now that we've joined
     msg = %Message{event: "everyone:leave", topic: "topic1:subtopic", payload: %{}}
     {:ok, sockets} = Transport.dispatch_broadcast(sockets, msg)
+    assert_received :everyone_leaving
+    assert_received :leave_triggered
     refute HashDict.get(sockets, "topic1:subtopic")
     assert sockets == HashDict.new
     assert subscribers(:phx_pub, "topic1:subtopic") == []
-    assert_received :everyone_leaving
-    assert_received :leave_triggered
   end
 
   test "successful join authorizes and subscribes socket to topic" do
@@ -381,7 +381,7 @@ defmodule Phoenix.ChannelTest do
     message = %Message{topic: "baretopic",
                        event: "some:event",
                        payload: fn socket -> {:ok, socket} end}
-    Transport.dispatch(message, sockets, self, Router, :phx_pub, WebSocket)
+    {:ok, sockets} = Transport.dispatch(message, sockets, self, Router, :phx_pub, WebSocket)
     assert_received {:handle_in, "baretopic"}
 
     message = %Message{topic: "baretopic:sub",

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -25,13 +25,18 @@ defmodule Phoenix.ChannelTest do
       send socket.pid, {:join, topic}
       msg.(socket)
     end
+
+    def leave(%{return: msg}, socket) do
+      send socket.pid, :leave_triggered
+      msg
+    end
+    def leave(%{reason: %{return: msg}}, socket) do
+      send socket.pid, :leave_triggered
+      msg
+    end
     def leave(_msg, socket) do
       send socket.pid, :leave_triggered
-      if on_leave = Process.get(:leave) do
-        on_leave.(socket)
-      else
-        {:ok, socket}
-      end
+      {:ok, socket}
     end
 
     def handle_in("some:event", _msg, socket) do
@@ -60,6 +65,11 @@ defmodule Phoenix.ChannelTest do
     end
     def handle_out(event, message, socket) do
       reply(socket, event, message)
+    end
+
+    def handle_info("should:arrive", socket) do
+      send socket.pid, :handle_info_triggered
+      {:ok, socket}
     end
   end
 
@@ -189,8 +199,16 @@ defmodule Phoenix.ChannelTest do
   end
 
   test "#leave can be overridden" do
-    Process.put(:leave, fn _ -> :overridden end)
-    assert MyChannel.leave(%{}, new_socket) == :overridden
+    assert MyChannel.leave(%{return: :overridden}, new_socket) == :overridden
+  end
+
+  test "handle_info handles anything that is sent to the socket directly" do
+    message = join_message(fn socket -> {:ok, socket} end)
+    {:ok, sockets} = Transport.dispatch(message, HashDict.new, self, Router, :phx_pub, WebSocket)
+    sock = HashDict.get(sockets, "topic1:subtopic")
+    assert Socket.Server.authorized?(sock, "topic1:subtopic")
+    send sock, "should:arrive"
+    assert_receive :handle_info_triggered
   end
 
   test "handle_in and handle_out callbacks can return {:leave, socket} to leave channel" do
@@ -236,9 +254,9 @@ defmodule Phoenix.ChannelTest do
     {:ok, sockets} = Transport.dispatch(message, HashDict.new, self, Router, :phx_pub, WebSocket)
     socket = HashDict.get(sockets, "topic1:subtopic")
     assert socket
-    assert Socket.authorized?(socket, "topic1:subtopic")
-    assert socket.pid == self
-    assert subscribers(:phx_pub, "topic1:subtopic") == [socket.pid]
+    assert Socket.Server.authorized?(socket, "topic1:subtopic")
+    #assert socket.pid == self
+    #assert subscribers(:phx_pub, "topic1:subtopic") == [socket.pid]
   end
 
   test "unsuccessful join denies socket access to topic" do
@@ -255,7 +273,6 @@ defmodule Phoenix.ChannelTest do
 
     {:ok, sockets} = Transport.dispatch(message, HashDict.new, self, Router, :phx_pub, WebSocket)
     assert subscribers(:phx_pub, "topic1:subtopic") == [self]
-    Process.put(:leave, fn socket -> {:ok, socket} end)
     Transport.dispatch_leave(sockets, :reason)
     assert subscribers(:phx_pub, "topic1:subtopic") == []
   end
@@ -273,10 +290,10 @@ defmodule Phoenix.ChannelTest do
 
     {:ok, sockets} = Transport.dispatch(message, HashDict.new, self, Router, :phx_pub, WebSocket)
     sock = HashDict.get(sockets, "topic1:subtopic")
-    assert Socket.authorized?(sock, "topic1:subtopic")
-    Process.put(:leave, fn _ -> :badreturn end)
+    assert Socket.Server.authorized?(sock, "topic1:subtopic")
     assert_raise InvalidReturn, fn ->
-      Transport.dispatch_leave(sockets, :reason)
+      Transport.dispatch_leave(sockets, %{return: :badreturn})
+      assert_received :on_leave_triggered
     end
   end
 
@@ -285,7 +302,7 @@ defmodule Phoenix.ChannelTest do
 
     {:ok, sockets} = Transport.dispatch(message, HashDict.new, self, Router, :phx_pub, WebSocket)
     sock = HashDict.get(sockets, "topic1:subtopic")
-    assert Socket.authorized?(sock, "topic1:subtopic")
+    assert Socket.Server.authorized?(sock, "topic1:subtopic")
     message = %Message{topic: "topic1:subtopic",
                        event: "boom",
                        payload: fn _socket -> :badreturn end}
@@ -299,7 +316,7 @@ defmodule Phoenix.ChannelTest do
     msg = %Message{topic: "phoenix", event: "heartbeat", payload: fn _socket -> :badreturn end}
 
     assert {:ok, sockets} = Transport.dispatch(msg, HashDict.new, self, Router, :phx_pub, WebSocket)
-    assert_received {:socket_reply, %Message{topic: "phoenix", event: "heartbeat"}}
+    assert_receive {:socket_reply, %Message{topic: "phoenix", event: "heartbeat"}}
     assert sockets == HashDict.new
   end
 


### PR DESCRIPTION
RFC

Main goal of these changes was to implement `handle_info` for channels, so that the user can send arbitrary messages to its own socket-process (e.g. from within the channel) and handle them there.

Might break backwards compatibility with code that relies on the inner workings of Transport. 