### PR TITLE
Add `Phoenix.Channel.Test` for testing channels more easily

### DIFF
--- a/lib/phoenix/channel/test_helpers.ex
+++ b/lib/phoenix/channel/test_helpers.ex
@@ -1,0 +1,166 @@
+defmodule Phoenix.Channel.Test do
+  import ExUnit.Assertions
+  alias Phoenix.Socket
+
+  @moduledoc """
+  Conveniences for testing Phoenix Channels.
+
+  Includes functions for creating sockets, working with channels, and asserting
+  that a socket sent expected payloads. You'll typically want to import
+  `Phoenix.Channel.Test`
+
+  ## Examples
+
+      defmodule MyApp.RoomChannelTest do
+        use ExUnit.Case
+        import Phoenix.Channel.Test
+        alias MyApp.RoomChannel
+
+        test "room:new_chat broadcasts a new chat" do
+          build_socket("room:new_chat")
+          |> handle_in(RoomChannel)
+
+          # Code that creates a chat
+
+          assert_socket_broadcasted("room:new_chat", %{user: "person"})
+        end
+
+        test "room:user_info replies with the user's info" do
+          build_socket(topic: "room:user_info")
+          |> handle_in(RoomChannel)
+
+          assert_socket_replied("room:user_info", %{name: "Gumbi", admin: true})
+        end
+      end
+
+  """
+
+  @doc """
+  Returns a socket ready for testing. You can pass it a map to override socket
+  attributes or just a binary to set the topic and keep the default socket
+  options.
+
+  Note: This also creates a subscription to this topic so that you can test
+  broadcasting using `assert_socket_broadcasted/2`
+
+  ## Examples
+
+      # returns a socket with topic "room:new_chat"
+      build_socket("room:new_chat")
+      # returns a socket with topic "room:new_chat" and router `Router`
+      build_socket(topic: "room:new_chat", router: Router)
+
+  """
+  def build_socket(topic) when is_binary(topic) do
+    build_socket(topic: topic)
+  end
+  def build_socket(attributes) do
+    attributes = attributes |> Enum.into(%{})
+    # TODO: Get the App's configured PubSub server and Router
+    %Socket{
+      pid: self,
+      router: Constable.Router,
+      topic: "foo:bar",
+      pubsub_server: Constable.PubSub,
+      assigns: []
+    }
+    |> Map.merge(attributes)
+    |> subscribe
+  end
+
+  @doc """
+  A convenience method for testing the `join` call to Channels. Makes it easier
+  to compose modify sockets before testing the join code.
+
+  ## Example
+
+      build_socket("room:lobby")
+      |> join(RoomChannel, %{auth_token: "correct_token"})
+
+  """
+  def join(socket, channel, params \\ %{}) do
+    channel.join("", params, socket)
+  end
+
+  @doc """
+  A convenience method for testing the `handle_in` call to Channels.
+
+  Like `join` and `handle_out`, this makes it easier to modify sockets before
+  doing something with them.
+
+  ## Example
+
+      user = %User{id: 1, name: "Leonard"}
+
+      build_socket("room:user_info")
+      |> authenticate_socket(user)
+      |> handle_in(RoomChannel)
+
+      def authenticate_socket(socket, user) do
+        Phoenix.Socket.assign(socket, :current_user_id, user.id)
+      end
+  """
+  def handle_in(socket, channel, params \\ %{}) do
+    channel.handle_in(socket.topic, params, socket)
+  end
+
+  @doc """
+  A convenience method for testing the `handle_out` call to Channels.
+
+  Like `join` and `handle_in`, this makes it easier to modify sockets before
+  doing something with them.
+
+  ## Example
+
+      build_socket("room:user_info")
+      |> handle_out(RoomChannel)
+  """
+  def handle_out(socket, channel, params \\ %{}) do
+    channel.handle_out(socket.topic, params, socket)
+  end
+
+  @doc """
+  Test that a socket broadcasted a message with `topic` to `payload`.
+
+  If you decide not to use `build_socket` to build a socket, remember to
+  subscribe with like `Phoenix.PubSub.subscribe(MyApp.PubSub, self, "foo:bar")`.
+
+  ## Examples
+
+      build_socket("room:new_chat")
+      |> handle_in(RoomChannel)
+
+      assert_socket_broadcasted("room:new_chat", %{name: "John Doe"})
+
+  """
+  def assert_socket_broadcasted(topic, payload) do
+    assert_receive {
+      :socket_broadcast,
+      %Socket.Message{event: ^topic, payload: ^payload, topic: ^topic}
+    }
+  end
+
+  @doc """
+  Test that a socket broadcasted a message with `topic` to `payload`.
+
+  ## Examples
+
+      build_socket("room:user_info")
+      |> handle_in(RoomChannel)
+
+      assert_socket_replied("room:user_info", %{name: "John Doe"})
+
+  """
+  def assert_socket_replied(topic, payload) do
+    assert_receive {
+      :socket_reply,
+      %Socket.Message{event: ^topic, payload: ^payload, topic: ^topic}
+    }
+  end
+
+  defp subscribe(socket) do
+    # TODO: Get the App's configured PubSub server
+    Phoenix.PubSub.subscribe(MyApp.PubSub, self, socket.topic)
+    socket
+  end
+end

--- a/lib/phoenix/channel/test_helpers.ex
+++ b/lib/phoenix/channel/test_helpers.ex
@@ -40,9 +40,6 @@ defmodule Phoenix.Channel.Test do
   attributes or just a binary to set the topic and keep the default socket
   options.
 
-  Note: This also creates a subscription to this topic so that you can test
-  broadcasting using `assert_socket_broadcasted/2`
-
   ## Examples
 
       # returns a socket with topic "room:new_chat"
@@ -60,11 +57,9 @@ defmodule Phoenix.Channel.Test do
     %Socket{
       pid: self,
       topic: "foo:bar",
-      pubsub_server: Constable.PubSub,
       assigns: []
     }
     |> Map.merge(attributes)
-    |> subscribe
   end
 
   @doc """
@@ -121,12 +116,12 @@ defmodule Phoenix.Channel.Test do
   @doc """
   Test that a socket broadcasted a message with `topic` to `payload`.
 
-  If you decide not to use `build_socket` to build a socket, remember to
-  subscribe with like `Phoenix.PubSub.subscribe(MyApp.PubSub, self, "foo:bar")`.
+  Remember to subscribe using `subscribe/2` or there will be no broadcast
 
   ## Examples
 
       build_socket("room:new_chat")
+      |> subscribe(MyApp.PubSub)
       |> handle_in(RoomChannel)
 
       assert_socket_broadcasted("room:new_chat", %{name: "John Doe"})
@@ -157,9 +152,18 @@ defmodule Phoenix.Channel.Test do
     }
   end
 
-  defp subscribe(socket) do
-    # TODO: Get the App's configured PubSub server
-    Phoenix.PubSub.subscribe(MyApp.PubSub, self, socket.topic)
+  @doc """
+  Sets the pubsub_server of the socket and subscribes to it.
+
+  ## Examples
+
+      build_socket("room:user_info")
+      |> subscribe(MyApp.PubSub)
+
+  """
+  def subscribe(socket, pubsub) do
+    socket = socket |> Map.put(:pubsub_server, pubsub)
+    Phoenix.PubSub.subscribe(pubsub, self, socket.topic)
     socket
   end
 end

--- a/lib/phoenix/channel/test_helpers.ex
+++ b/lib/phoenix/channel/test_helpers.ex
@@ -117,7 +117,10 @@ defmodule Phoenix.Channel.Test do
   @doc """
   Test that a socket broadcasted a message with `topic` to `payload`.
 
-  Remember to subscribe using `subscribe/2` or there will be no broadcast
+  Remember to subscribe using `subscribe/2` or there will be no broadcast.
+
+  Note: the payload will not be encoded. The payload will be the exact message
+  you passed to `broadcast` in your Channel.
 
   ## Examples
 
@@ -147,6 +150,9 @@ defmodule Phoenix.Channel.Test do
 
   @doc """
   Test that a socket broadcasted a message with `topic` to `payload`.
+
+  Note: the payload will not be encoded. The payload will be the exact message
+  you passed to `reply` in your Channel.
 
   ## Examples
 

--- a/lib/phoenix/channel/test_helpers.ex
+++ b/lib/phoenix/channel/test_helpers.ex
@@ -56,7 +56,7 @@ defmodule Phoenix.Channel.Test do
     # TODO: Get the App's configured PubSub server and Router
     %Socket{
       pid: self,
-      topic: "foo:bar",
+      topic: "",
       assigns: []
     }
     |> Map.merge(attributes)
@@ -73,7 +73,7 @@ defmodule Phoenix.Channel.Test do
 
   """
   def join(socket, channel, params \\ %{}) do
-    channel.join("", params, socket)
+    channel.join(socket.topic, params, socket)
   end
 
   @doc """

--- a/lib/phoenix/channel/test_helpers.ex
+++ b/lib/phoenix/channel/test_helpers.ex
@@ -59,7 +59,6 @@ defmodule Phoenix.Channel.Test do
     # TODO: Get the App's configured PubSub server and Router
     %Socket{
       pid: self,
-      router: Constable.Router,
       topic: "foo:bar",
       pubsub_server: Constable.PubSub,
       assigns: []

--- a/lib/phoenix/channel/test_helpers.ex
+++ b/lib/phoenix/channel/test_helpers.ex
@@ -36,9 +36,10 @@ defmodule Phoenix.Channel.Test do
   """
 
   @doc """
-  Returns a socket ready for testing. You can pass it a map to override socket
-  attributes or just a binary to set the topic and keep the default socket
-  options.
+  Returns a socket ready for testing.
+
+  You can pass it a map to override socket attributes or just a binary to set
+  the topic and keep the default socket options.
 
   ## Examples
 
@@ -135,6 +136,16 @@ defmodule Phoenix.Channel.Test do
   end
 
   @doc """
+  The refutation of `assert_socket_broadcasted/2`
+  """
+  def refute_socket_broadcasted(topic, payload) do
+   refute_receive {
+      :socket_broadcast,
+      %Socket.Message{event: ^topic, payload: ^payload, topic: ^topic}
+    }
+  end
+
+  @doc """
   Test that a socket broadcasted a message with `topic` to `payload`.
 
   ## Examples
@@ -147,6 +158,16 @@ defmodule Phoenix.Channel.Test do
   """
   def assert_socket_replied(topic, payload) do
     assert_receive {
+      :socket_reply,
+      %Socket.Message{event: ^topic, payload: ^payload, topic: ^topic}
+    }
+  end
+
+  @doc """
+  The refutation of `assert_socket_replied/2`
+  """
+  def refute_socket_replied(topic, payload) do
+   refute_receive {
       :socket_reply,
       %Socket.Message{event: ^topic, payload: ^payload, topic: ^topic}
     }

--- a/test/phoenix/channel/test_helpers_test.exs
+++ b/test/phoenix/channel/test_helpers_test.exs
@@ -1,0 +1,119 @@
+defmodule Phoenix.Channel.TestHelper do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Channel.Test
+  alias Phoenix.PubSub
+
+  defmodule FakeChannel do
+    def join(topic, params, socket) do
+      send self, {:join_topic, topic}
+      send self, {:join_params, params}
+      send self, {:join_socket, socket}
+    end
+
+    def handle_in(topic, params, socket) do
+      send self, {:handle_in_topic, topic}
+      send self, {:handle_in_params, params}
+      send self, {:handle_in_socket, socket}
+    end
+
+    def handle_out(topic, params, socket) do
+      send self, {:handle_out_topic, topic}
+      send self, {:handle_out_params, params}
+      send self, {:handle_out_socket, socket}
+    end
+  end
+
+  test "build_socket/1 creates a socket with topic" do
+    %{topic: topic} = build_socket("foo:bar")
+
+    assert topic == "foo:bar"
+  end
+
+  test "build_socket/1 creates a socket with attributes" do
+    socket = build_socket(topic: "foo:bar", router: Phoenix.Router)
+    %{topic: topic, router: router} = socket
+
+    assert topic == "foo:bar"
+    assert router == Phoenix.Router
+  end
+
+  test "join/3 calls the channel with socket and params" do
+    socket = build_socket("foo:bar")
+
+    join(socket, FakeChannel, %{foo: "bar"})
+
+    assert_received {:join_topic, "foo:bar"}
+    assert_received {:join_params, %{foo: "bar"}}
+    assert_received {:join_socket, ^socket}
+  end
+
+  test "handle_in/3 calls the channel with socket and params" do
+    socket = build_socket("foo:bar")
+
+    handle_in(socket, FakeChannel, %{foo: "bar"})
+
+    assert_received {:handle_in_topic, "foo:bar"}
+    assert_received {:handle_in_params, %{foo: "bar"}}
+    assert_received {:handle_in_socket, ^socket}
+  end
+
+  test "handle_out/3 calls the channel with socket and params" do
+    socket = build_socket("foo:bar")
+
+    handle_out(socket, FakeChannel, %{foo: "bar"})
+
+    assert_received {:handle_out_topic, "foo:bar"}
+    assert_received {:handle_out_params, %{foo: "bar"}}
+    assert_received {:handle_out_socket, ^socket}
+  end
+
+  test "assert_socket_broadcasted/2" do
+    defmodule BroadcastChannel do
+      use Phoenix.Channel
+
+      def join(_, _, socket), do: {:ok, socket}
+
+      def handle_in(topic, _params, socket) do
+        broadcast socket, topic, %{title: "Phoenix rocks"}
+      end
+    end
+
+    build_socket("foo:bar")
+    |> subscribe(:phx_pub)
+    |> handle_in(BroadcastChannel)
+
+    assert_socket_broadcasted("foo:bar", %{title: "Phoenix rocks"})
+  end
+
+  test "assert_socket_replied/2" do
+    defmodule ReplyChannel do
+      use Phoenix.Channel
+
+      def join(_, _, socket), do: {:ok, socket}
+
+      def handle_in(topic, _params, socket) do
+        reply socket, topic, %{title: "Phoenix rocks"}
+      end
+    end
+
+    build_socket("foo:bar")
+    |> handle_in(ReplyChannel)
+
+    assert_socket_replied("foo:bar", %{title: "Phoenix rocks"})
+  end
+
+  test "subscribe/2 sets the sockests pubsub_server and subscribes" do
+    socket =
+      build_socket("foo:bar")
+      |> subscribe(:phx_pub)
+
+    %{pubsub_server: pubsub_server} = socket
+    assert pubsub_server == :phx_pub
+    assert subscribers(:phx_pub, "foo:bar") == [self]
+  end
+
+  def subscribers(server, topic) do
+    PubSub.Local.subscribers(Module.concat(server, Local), topic)
+  end
+end

--- a/test/phoenix/channel/test_helpers_test.exs
+++ b/test/phoenix/channel/test_helpers_test.exs
@@ -41,31 +41,43 @@ defmodule Phoenix.Channel.TestHelper do
   test "join/3 calls the channel with socket and params" do
     socket = build_socket("foo:bar")
 
-    join(socket, FakeChannel, %{foo: "bar"})
+    join(socket, FakeChannel)
 
     assert_received {:join_topic, "foo:bar"}
-    assert_received {:join_params, %{foo: "bar"}}
+    assert_received {:join_params, %{}}
     assert_received {:join_socket, ^socket}
+
+    join(socket, FakeChannel, %{foo: "bar"})
+
+    assert_received {:join_params, %{foo: "bar"}}
   end
 
   test "handle_in/3 calls the channel with socket and params" do
     socket = build_socket("foo:bar")
 
-    handle_in(socket, FakeChannel, %{foo: "bar"})
+    handle_in(socket, FakeChannel)
 
     assert_received {:handle_in_topic, "foo:bar"}
-    assert_received {:handle_in_params, %{foo: "bar"}}
+    assert_received {:handle_in_params, %{}}
     assert_received {:handle_in_socket, ^socket}
+
+    handle_in(socket, FakeChannel, %{foo: "bar"})
+
+    assert_received {:handle_in_params, %{foo: "bar"}}
   end
 
   test "handle_out/3 calls the channel with socket and params" do
     socket = build_socket("foo:bar")
 
-    handle_out(socket, FakeChannel, %{foo: "bar"})
+    handle_out(socket, FakeChannel)
 
     assert_received {:handle_out_topic, "foo:bar"}
-    assert_received {:handle_out_params, %{foo: "bar"}}
+    assert_received {:handle_out_params, %{}}
     assert_received {:handle_out_socket, ^socket}
+
+    handle_out(socket, FakeChannel, %{foo: "bar"})
+
+    assert_received {:handle_out_params, %{foo: "bar"}}
   end
 
   test "assert_socket_broadcasted/2" do


### PR DESCRIPTION
I was going to write a guide on testing Channels, and I realized it might be nice to add these helpers to core before writing it. I've been using a similar version of these in a project and they've been working well. Feedback on what I have now would be greatly appreciated.

This is a *WIP*. I still have a few things to do:

- [x] Add `refute` versions of `assert_socket_broadcasted` and `assert_socket_replied`
- [x] Get the Router from the App's config - no longer needed
- [x] Get the PubSub server from the App's config - no longer need. Use `subscribe/2` instead
- [x] Add tests for the helpers. 
- [ ] Figure out whether we need to be able to assert that specific sockets replied/broadcasted
- [ ] Figure out whether to go through the whole stack through `Phoenix.Channel.Transport.dispatch`. What would we gain by this? Is it worth it?
- [ ] Improve tests for `assert_socket_replied`, etc. See comment on diff.