### PR TITLE
Set controller logger mode to info

### DIFF
--- a/lib/phoenix/controller/logger.ex
+++ b/lib/phoenix/controller/logger.ex
@@ -25,7 +25,7 @@ defmodule Phoenix.Controller.Logger do
   def init(opts), do: opts
 
   def call(conn, _level) do
-    Logger.debug fn ->
+    Logger.info fn ->
       module = conn |> controller_module |> inspect
       action = conn |> action_name |> Atom.to_string
 

--- a/test/phoenix/controller/logger_test.exs
+++ b/test/phoenix/controller/logger_test.exs
@@ -17,7 +17,7 @@ defmodule Phoenix.Controller.LoggerTest do
       |> put_private(:phoenix_pipelines, [:browser])
       |> action
     end
-    assert output =~ "[debug] Processing by Phoenix.Controller.LoggerTest.LoggerController.index/2"
+    assert output =~ "[info]  Processing by Phoenix.Controller.LoggerTest.LoggerController.index/2"
     assert output =~ "Parameters: %{\"foo\" => \"bar\", \"format\" => \"html\"}"
     assert output =~ "Pipelines: [:browser]"
   end


### PR DESCRIPTION
Changing the log level to info exposes helpful information like request params in production. Talk about a simple change! As discussed in phoenixframework/phoenix/issues/651