### PR TITLE
Ignore the /rel directory in generated projects

### DIFF
--- a/priv/template/.gitignore
+++ b/priv/template/.gitignore
@@ -1,5 +1,6 @@
 /_build
 /deps
-/rel
+rel/*
+!rel/relx.config
 erl_crash.dump
 *.ez

--- a/priv/template/.gitignore
+++ b/priv/template/.gitignore
@@ -1,4 +1,5 @@
 /_build
 /deps
+/rel
 erl_crash.dump
 *.ez


### PR DESCRIPTION
Using exrm/relx is the preferred and suggested method for doing releases. Compiled output is stored in `/rel`, and there isn't any reason to check it in.