### PR TITLE
Add UUID's to socket

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -257,7 +257,8 @@ defmodule Phoenix.Channel do
     send socket.pid, {:socket_reply, %Message{
       topic: socket.topic,
       event: event,
-      payload: message
+      payload: message,
+      uuid: socket.uuid
     }}
     {:ok, socket}
   end

--- a/lib/phoenix/channel/transport.ex
+++ b/lib/phoenix/channel/transport.ex
@@ -70,8 +70,10 @@ defmodule Phoenix.Channel.Transport do
                      topic: msg.topic,
                      transport: transport}
 
+
     sockets
     |> HashDict.get(msg.topic, socket)
+    |> Map.put(:uuid, msg.uuid)
     |> dispatch(msg.topic, msg.event, msg.payload)
     |> transport_response(sockets)
   end
@@ -98,7 +100,6 @@ defmodule Phoenix.Channel.Transport do
     end
     {:error, reason, HashDict.delete(sockets, socket.topic)}
   end
-
 
   @doc """
   Dispatches `%Phoenix.Socket.Message{}` in response to a heartbeat message sent from the client.

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -28,7 +28,8 @@ defmodule Phoenix.Socket do
             authorized: false,
             transport: nil,
             pubsub_server: nil,
-            assigns: %{}
+            assigns: %{},
+            uuid: nil
 
 
   @doc """

--- a/lib/phoenix/socket/message.ex
+++ b/lib/phoenix/socket/message.ex
@@ -13,7 +13,7 @@ defmodule Phoenix.Socket.Message do
 
   alias Phoenix.Socket.Message
 
-  defstruct topic: nil, event: nil, payload: nil
+  defstruct topic: nil, event: nil, payload: nil, uuid: nil
 
   defmodule InvalidMessage do
     defexception [:message]
@@ -31,7 +31,8 @@ defmodule Phoenix.Socket.Message do
       %Message{
         topic: Map.fetch!(map, "topic"),
         event:   Map.fetch!(map, "event"),
-        payload: Map.fetch!(map, "payload")
+        payload: Map.fetch!(map, "payload"),
+        uuid: Map.get(map, "uuid", nil)
       }
     rescue
       err in [KeyError] -> raise InvalidMessage, message: "Missing key: '#{err.key}'"

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -448,4 +448,17 @@ defmodule Phoenix.ChannelTest do
     assert sockets == HashDict.new
     refute_received {:join, "topic2-override:somesubtopic"}
   end
+
+  test "#reply responds with uuid" do
+    socket = Socket.put_topic(new_socket, "top:subtop") |> Map.put(:uuid, "123")
+    assert Channel.reply(socket, "event", %{payload: "hello"})
+
+    assert Enum.any?(Process.info(self)[:messages], &match?({:socket_reply, %Message{}}, &1))
+    assert_received {:socket_reply, %Message{
+      uuid: "123",
+      topic: "top:subtop",
+      event: "event",
+      payload: %{payload: "hello"}
+    }}
+  end
 end

--- a/test/phoenix/transports/json_serializer_test.exs
+++ b/test/phoenix/transports/json_serializer_test.exs
@@ -4,7 +4,7 @@ defmodule Phoenix.Tranports.JSONSerializerTest do
   alias Phoenix.Transports.JSONSerializer
   alias Phoenix.Socket.Message
 
-  @msg_json "{\"topic\":\"t\",\"payload\":\"m\",\"event\":\"e\"}"
+  @msg_json "{\"uuid\":null,\"topic\":\"t\",\"payload\":\"m\",\"event\":\"e\"}"
 
   test "encode!/1 encodes `Phoenix.Socket.Message` as JSON" do
     msg = %Message{topic: "t", event: "e", payload: "m"}


### PR DESCRIPTION
When a socket receives a message, we set its UUID property to the UUID
that the client message passed in, even if it's nil. When `broadcast` or
`reply` is called the UUID will be passed back to the client, allowing
it to associate the response with the request that has a matching UUID.

I'm still working on phoenix.js while implementing an Ember adapter for it, but this is the first step in getting that completely working. I currently have `findAll` and `find` working and will follow up in another PR (or this one) with the updated JavaScript once I get it to a good point.

I also think the test added isn't that great, I'd love pointers on how I to make a test that would test the actual response for `reply`/`broadcast`.