### PR TITLE
Add `button/2` to HTML link helpers

### DIFF
--- a/lib/phoenix/html/link.ex
+++ b/lib/phoenix/html/link.ex
@@ -46,4 +46,40 @@ defmodule Phoenix.HTML.Link do
       end
     end
   end
+
+  @doc """
+  Generates a button that uses a regular HTML form to submit to the given URL.
+  Useful to ensure that links that change data are not triggered by
+  search engines and other spidering software.
+
+  ## Examples
+
+      <%= button("hello", to: "/world") %>
+
+  generates
+
+      <form action="/world" class="button" method="post">
+        <input name="_csrf_token" value=""><input type="submit" value="hello">
+      </form>
+
+  ## Options
+
+    * `:to` - the page to link to. This option is required
+
+    * `:method` - the method to use with the link. Defaults to :post.
+
+  """
+  def button(text, opts) do
+    {to, opts} = Keyword.pop(opts, :to)
+    {method, opts} = Keyword.pop(opts, :method, :post)
+    {htmlClass, opts} = Keyword.pop(opts, :class, :button)
+
+    unless to do
+      raise ArgumentError, "option :to is required in button/2"
+    end
+
+    form_tag(to, [method: method, class: htmlClass, enforce_utf8: false] ++ opts) do
+      tag(:input, [type: "submit", value: text])
+    end
+  end
 end

--- a/lib/phoenix/html/link.ex
+++ b/lib/phoenix/html/link.ex
@@ -85,13 +85,13 @@ defmodule Phoenix.HTML.Link do
   """
   def button(text, opts) do
     {to, opts} = Keyword.pop(opts, :to)
-    {htmlClass, opts} = Keyword.pop(opts, :class, :button)
+    {html_class, opts} = Keyword.pop(opts, :class, :button)
 
     unless to do
       raise ArgumentError, "option :to is required in button/2"
     end
 
-    form_tag(to, [class: htmlClass, enforce_utf8: false] ++ opts) do
+    form_tag(to, [class: html_class, enforce_utf8: false] ++ opts) do
       tag(:input, [type: "submit", value: text])
     end
   end

--- a/lib/phoenix/html/link.ex
+++ b/lib/phoenix/html/link.ex
@@ -49,6 +49,7 @@ defmodule Phoenix.HTML.Link do
 
   @doc """
   Generates a button that uses a regular HTML form to submit to the given URL.
+
   Useful to ensure that links that change data are not triggered by
   search engines and other spidering software.
 
@@ -62,23 +63,35 @@ defmodule Phoenix.HTML.Link do
         <input name="_csrf_token" value=""><input type="submit" value="hello">
       </form>
 
+      <%= button("hello", to: "/world", method: "get", class: "btn") %>
+
+  generates
+
+      <form action="/world" class="btn" method="post">
+        <input type="submit" value="hello">
+      </form>
+
   ## Options
 
     * `:to` - the page to link to. This option is required
 
     * `:method` - the method to use with the link. Defaults to :post.
 
+    * `:class` - the CSS class for the form. Defaults to "button".
+
+  All other options are forwarded to the underlying `<form>` tag.
+  See `Phoenix.HTML.Tag.form_tag/2` for more information on the
+  options above.
   """
   def button(text, opts) do
     {to, opts} = Keyword.pop(opts, :to)
-    {method, opts} = Keyword.pop(opts, :method, :post)
     {htmlClass, opts} = Keyword.pop(opts, :class, :button)
 
     unless to do
       raise ArgumentError, "option :to is required in button/2"
     end
 
-    form_tag(to, [method: method, class: htmlClass, enforce_utf8: false] ++ opts) do
+    form_tag(to, [class: htmlClass, enforce_utf8: false] ++ opts) do
       tag(:input, [type: "submit", value: text])
     end
   end

--- a/test/phoenix/html/link_test.exs
+++ b/test/phoenix/html/link_test.exs
@@ -24,4 +24,39 @@ defmodule Phoenix.HTML.LinkTest do
                    ~s[<a href="#" onclick="this.parentNode.submit(); return false;">hello</a>] <>
                    ~s[</form>]}
   end
+
+  test "button with post (default)" do
+
+    csrf_token = Phoenix.Controller.get_csrf_token()
+
+    assert button("hello", to: "/world") ==
+           {:safe, ~s[<form action="/world" class="button" method="post">] <>
+                   ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
+                   ~s[<input type="submit" value="hello">] <>
+                   ~s[</form>]}
+
+  end
+
+  test "button with get does not generate CSRF" do
+
+    csrf_token = Phoenix.Controller.get_csrf_token()
+
+    assert button("hello", to: "/world", method: :get) ==
+           {:safe, ~s[<form action="/world" class="button" method="get">] <>
+                   ~s[<input type="submit" value="hello">] <>
+                   ~s[</form>]}
+
+  end
+
+  test "button with class overrides default" do
+
+    csrf_token = Phoenix.Controller.get_csrf_token()
+
+    assert button("hello", to: "/world", class: "btn rounded") ==
+           {:safe, ~s[<form action="/world" class="btn rounded" method="post">] <>
+                   ~s[<input name="_csrf_token" type="hidden" value="#{csrf_token}">] <>
+                   ~s[<input type="submit" value="hello">] <>
+                   ~s[</form>]}
+
+  end
 end

--- a/test/phoenix/html/link_test.exs
+++ b/test/phoenix/html/link_test.exs
@@ -37,8 +37,6 @@ defmodule Phoenix.HTML.LinkTest do
   end
 
   test "button with get does not generate CSRF" do
-    csrf_token = Phoenix.Controller.get_csrf_token()
-
     assert button("hello", to: "/world", method: :get) ==
            {:safe, ~s[<form action="/world" class="button" method="get">] <>
                    ~s[<input type="submit" value="hello">] <>

--- a/test/phoenix/html/link_test.exs
+++ b/test/phoenix/html/link_test.exs
@@ -26,7 +26,6 @@ defmodule Phoenix.HTML.LinkTest do
   end
 
   test "button with post (default)" do
-
     csrf_token = Phoenix.Controller.get_csrf_token()
 
     assert button("hello", to: "/world") ==
@@ -38,7 +37,6 @@ defmodule Phoenix.HTML.LinkTest do
   end
 
   test "button with get does not generate CSRF" do
-
     csrf_token = Phoenix.Controller.get_csrf_token()
 
     assert button("hello", to: "/world", method: :get) ==
@@ -49,7 +47,6 @@ defmodule Phoenix.HTML.LinkTest do
   end
 
   test "button with class overrides default" do
-
     csrf_token = Phoenix.Controller.get_csrf_token()
 
     assert button("hello", to: "/world", class: "btn rounded") ==


### PR DESCRIPTION
Add support for `button` link helper to create navigation buttons to
destructive actions. This provides an alternative to link/2 which
can have accessibility issues as it requires JavaScript. Also prevents
web spidering software from following links to potentially destructive
actions.