### PR TITLE
Only add content type if not set

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -544,9 +544,11 @@ defmodule Phoenix.Controller do
   defp template_name(name, _format) when is_binary(name), do:
     name
 
-  defp send_resp(conn, default_status, content_type, body) do
-    conn
-    |> put_resp_content_type(content_type)
+  defp send_resp(conn, default_status, default_content_type, body) do
+    case get_resp_header(conn, "content-type") do
+      [] -> put_resp_content_type(conn, default_content_type)
+      _  -> conn
+    end
     |> send_resp(conn.status || default_status, body)
   end
 

--- a/test/phoenix/controller_test.exs
+++ b/test/phoenix/controller_test.exs
@@ -94,6 +94,14 @@ defmodule Phoenix.ControllerTest do
     assert conn.status == 400
   end
 
+  test "json/2 allows content-type injection on connection" do
+    conn = conn(:get, "/") |> put_resp_content_type("application/vnd.api+json")
+    conn = json(conn, %{foo: :bar})
+    assert conn.resp_body == "{\"foo\":\"bar\"}"
+    assert Conn.get_resp_header(conn, "content-type") ==
+             ["application/vnd.api+json; charset=utf-8"]
+  end
+
   test "text/2" do
     conn = text(conn(:get, "/"), "foobar")
     assert conn.resp_body == "foobar"


### PR DESCRIPTION
As discussed in IRC:

`Phoenix.Controller.render/3`, `Phoenix.Controller.json/2`, `Phoenix.Controller.text/2` and `Phoenix.Controller.html/2` overwrite the `content-type` header if set.

We should only add the default headers if it's not set already.