### PR TITLE
textarea tag?

### DIFF
--- a/lib/phoenix/html/form.ex
+++ b/lib/phoenix/html/form.ex
@@ -221,6 +221,25 @@ defmodule Phoenix.HTML.Form do
   end
 
   @doc """
+  Generates a textarea input.
+
+  ## Examples
+
+      # Assuming form contains a User model
+      textarea(form, :description)
+      #=> <textarea id="user_description" name="user[description]"></textarea>
+  """
+  def textarea(form, field, opts \\ []) do
+    opts =
+      opts
+      |> Keyword.put_new(:id, id_from(form, field))
+      |> Keyword.put_new(:name, name_from(form, field))
+
+    {value, opts} = Keyword.pop(opts, :value, value_from(form, field) || "")
+    content_tag(:textarea, value, opts)
+  end
+
+  @doc """
   Generates a file input.
 
   It requires the given form to be configured with `multipart: true`

--- a/lib/phoenix/html/tag.ex
+++ b/lib/phoenix/html/tag.ex
@@ -198,7 +198,7 @@ defmodule Phoenix.HTML.Tag do
         "Hello"
       end
       <form action="/hello" method="post">...Hello...</form>
-    
+
   """
   def form_tag(action, options, do: block) do
     safe_concat [form_tag(action, options), block, safe("</form>")]

--- a/test/phoenix/html/form_test.exs
+++ b/test/phoenix/html/form_test.exs
@@ -75,6 +75,27 @@ defmodule Phoenix.HTML.FormTest do
            {:safe, ~s(<input id="key" name="search[key][]" type="text" value="foo">)}
   end
 
+  ## textarea/3
+
+  test "textarea/3" do
+    assert textarea(:search, :key) ==
+           {:safe, ~s(<textarea id="search_key" name="search[key]"></textarea>)}
+
+    assert textarea(:search, :key) ==
+           {:safe, ~s(<textarea id="search_key" name="search[key]"></textarea>)}
+
+    assert textarea(:search, :key, id: "key", name: "search[key][]") ==
+           {:safe, ~s(<textarea id="key" name="search[key][]"></textarea>)}
+  end
+
+  test "textarea/3 with form" do
+    assert with_form(&textarea(&1, :key)) ==
+           {:safe, ~s(<textarea id="search_key" name="search[key]">value</textarea>)}
+
+    assert with_form(&textarea(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+           {:safe, ~s(<textarea id="key" name="search[key][]">foo</textarea>)}
+  end
+
   ## number_input/3
 
   test "number_input/3" do

--- a/test/phoenix/html/form_test.exs
+++ b/test/phoenix/html/form_test.exs
@@ -250,7 +250,7 @@ defmodule Phoenix.HTML.FormTest do
     assert content =~ ~s(<option selected="selected" value="foo">foo</option>)
   end
 
-test "select/4 with form" do
+  test "select/4 with form" do
     assert with_form(&select(&1, :key, ~w(value novalue), default: "novalue")) ==
            {:safe, ~s(<select id="search_key" name="search[key]">) <>
                    ~s(<option selected="selected" value="value">value</option>) <>


### PR DESCRIPTION
Hi guys, thanks for the awesome work in phoenix framework.

While updating to phoenix 0.10.0, and updating the html to use the new form helpers, I noticed that there is no `textarea` tag. Is there any reason for not include this one?

Thanks in advance!