### PR TITLE
Allow host to be configured for live_reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@
             use Phoenix.CodeReloader
           end
 
+  * The `live_reload` configuration has changed to allow a `:url` option to be
+    customized for operation with tools like [pow](http://pow.cx) in
+    development. By default live reload WebSocket url is "/phoenix". This will
+    cause `window.location` to be used. As `pow` only works with HTTP, you need
+    to set the `:url` option accordingly with your localhost config and port.
+
+        config :your_app, Your.Endpoint,
+          code_reloader: true,
+          url: "ws://localhost:4000",
+          paths: [Path.expand("priv/static/javascripts/app.js"),
+                  Path.expand("priv/static/stylesheets/app.css"),
+                  Path.expand("web/templates/**/*.eex")]]
+
 * Enhancements
   * Allow the default format used when rendering errors to be customized in the `render_views` configuration
   * Add `button/2` function to `Phoenix.HTML`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,11 @@
 
         config :your_app, Your.Endpoint,
           code_reloader: true,
-          url: "ws://localhost:4000",
-          paths: [Path.expand("priv/static/javascripts/app.js"),
-                  Path.expand("priv/static/stylesheets/app.css"),
-                  Path.expand("web/templates/**/*.eex")]]
+          live_reload: [
+            url: "ws://localhost:4000",
+            paths: [Path.expand("priv/static/javascripts/app.js"),
+                    Path.expand("priv/static/stylesheets/app.css"),
+                    Path.expand("web/templates/**/*.eex")]]]
 
 * Enhancements
   * Allow the default format used when rendering errors to be customized in the `render_views` configuration

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -125,6 +125,14 @@ defmodule Phoenix.Endpoint do
 
           [{"node", ["node_modules/brunch/bin/brunch", "watch"]}]
 
+    * `:live_reload` - configuration for the live reload option.
+      Configuration expects a `:paths` option which should be a list of
+      file paths. If you are using a tool like [pow](http://pow.cx) in
+      development, you may need to set the `:url` option appropriately.
+
+          [url: "ws://localhost:4000",
+           paths: [Path.expand("priv/static/js/phoenix.js")]]
+
     * `:pubsub` - configuration for this endpoint's pubsub adapter.
       Configuration either requires a `:name` of the registered pubsub server
       or a `:name`, `:adapter`, and options which starts the adapter in

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -126,9 +126,10 @@ defmodule Phoenix.Endpoint do
           [{"node", ["node_modules/brunch/bin/brunch", "watch"]}]
 
     * `:live_reload` - configuration for the live reload option.
-      Configuration expects a `:paths` option which should be a list of
-      file paths. If you are using a tool like [pow](http://pow.cx) in
-      development, you may need to set the `:url` option appropriately.
+      Configuration requires a `:paths` option which should be a list of
+      files to watch. When these files change, it will trigger a reload.
+      If you are using a tool like [pow](http://pow.cx) in development,
+      you may need to set the `:url` option appropriately.
 
           [url: "ws://localhost:4000",
            paths: [Path.expand("priv/static/js/phoenix.js")]]

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -61,9 +61,9 @@ defmodule Phoenix.Endpoint.Adapter do
   end
 
   defp live_reload_children(mod, conf) do
-    case conf[:live_reload] do
-      []     -> []
-      config -> [worker(ChangeDetector, [config[:paths], {__MODULE__, :assets_change, [mod]}])]
+    case Keyword.get(conf[:live_reload], :paths, []) do
+      []    -> []
+      paths -> [worker(ChangeDetector, [paths, {__MODULE__, :assets_change, [mod]}])]
     end
   end
 

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -62,8 +62,8 @@ defmodule Phoenix.Endpoint.Adapter do
 
   defp live_reload_children(mod, conf) do
     case conf[:live_reload] do
-      []    -> []
-      paths -> [worker(ChangeDetector, [paths, {__MODULE__, :assets_change, [mod]}])]
+      []     -> []
+      config -> [worker(ChangeDetector, [config[:paths], {__MODULE__, :assets_change, [mod]}])]
     end
   end
 

--- a/lib/phoenix/router/live_reloader.ex
+++ b/lib/phoenix/router/live_reloader.ex
@@ -25,7 +25,7 @@ defmodule Phoenix.Router.LiveReload do
     register_before_send conn, fn conn ->
       if conn |> get_resp_header("content-type") |> html_content_type? do
         [page | rest] = String.split(to_string(conn.resp_body), "</body>")
-        body = page <> reload_assets_tag() <> Enum.join(["</body>" | rest], "")
+        body = page <> reload_assets_tag(conn) <> Enum.join(["</body>" | rest], "")
 
         put_in conn.resp_body, body
       else
@@ -36,12 +36,13 @@ defmodule Phoenix.Router.LiveReload do
   defp html_content_type?([]), do: false
   defp html_content_type?([type | _]), do: String.starts_with?(type, "text/html")
 
-  defp reload_assets_tag() do
+  defp reload_assets_tag(conn) do
+    host = conn.private.phoenix_endpoint.config(:live_reload_host) || ""
     """
     <script>
       #{@phoenix_js}
       var phx = require("phoenix")
-      var socket = new phx.Socket("/phoenix")
+      var socket = new phx.Socket("#{host}/phoenix")
       socket.connect()
       socket.join("phoenix", {}, function(chan){
         chan.on("assets:change", function(msg){ window.location.reload(); })

--- a/lib/phoenix/router/live_reloader.ex
+++ b/lib/phoenix/router/live_reloader.ex
@@ -38,12 +38,12 @@ defmodule Phoenix.Router.LiveReload do
 
   defp reload_assets_tag(conn) do
     config = conn.private.phoenix_endpoint.config(:live_reload)
-    url = config[:url] || ""
+    url = Path.join((config[:url] || "/"), "phoenix")
     """
     <script>
       #{@phoenix_js}
       var phx = require("phoenix")
-      var socket = new phx.Socket("#{url}/phoenix")
+      var socket = new phx.Socket("#{url}")
       socket.connect()
       socket.join("phoenix", {}, function(chan){
         chan.on("assets:change", function(msg){ window.location.reload(); })

--- a/lib/phoenix/router/live_reloader.ex
+++ b/lib/phoenix/router/live_reloader.ex
@@ -37,12 +37,13 @@ defmodule Phoenix.Router.LiveReload do
   defp html_content_type?([type | _]), do: String.starts_with?(type, "text/html")
 
   defp reload_assets_tag(conn) do
-    host = conn.private.phoenix_endpoint.config(:live_reload_host) || ""
+    config = conn.private.phoenix_endpoint.config(:live_reload)
+    url = config[:url] || ""
     """
     <script>
       #{@phoenix_js}
       var phx = require("phoenix")
-      var socket = new phx.Socket("#{host}/phoenix")
+      var socket = new phx.Socket("#{url}/phoenix")
       socket.connect()
       socket.join("phoenix", {}, function(chan){
         chan.on("assets:change", function(msg){ window.location.reload(); })

--- a/priv/templates/new/config/dev.exs
+++ b/priv/templates/new/config/dev.exs
@@ -18,9 +18,11 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
 # will use higher CPU in dev as the number of files
 # grow. Adjust as necessary.
 config :<%= application_name %>, <%= application_module %>.Endpoint,
-  live_reload: [Path.expand("priv/static/js/app.js"),
-                Path.expand("priv/static/css/app.css"),
-                Path.expand("web/templates/**/*.eex")]
+  live_reload: [
+    paths: [
+      Path.expand("priv/static/js/app.js"),
+      Path.expand("priv/static/css/app.css"),
+      Path.expand("web/templates/**/*.eex")]]
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"

--- a/test/phoenix/code_reloader_test.exs
+++ b/test/phoenix/code_reloader_test.exs
@@ -6,7 +6,7 @@ defmodule Phoenix.CodeReloaderTest do
     root: File.cwd!,
     code_reloader: true,
     reloadable_paths: ["web"],
-    live_reload: ["some/path"])
+    live_reload: [url: "ws://localhost:4000", paths: ["some/path"]])
 
   defmodule Endpoint do
     use Phoenix.Endpoint, otp_app: :phoenix
@@ -58,6 +58,7 @@ defmodule Phoenix.CodeReloaderTest do
            |> put_resp_content_type("text/html")
            |> Phoenix.CodeReloader.call(opts)
            |> send_resp(200, "")
+    assert to_string(conn.resp_body) =~ ~r/"ws:\/\/localhost:4000\/phoenix"/
     assert to_string(conn.resp_body) =~ ~r/require\("phoenix"\)/
   end
 


### PR DESCRIPTION
Live reload doesn't work when using [pow](http://pow.cx) in development. Pow
doesn't work with websockets, so it just throws errors in the console.

I propose adding a `live_reload_host` option that can be set to
`ws://localhost:4000` in order to work around this issue.

This is just a quick hack, so I'm open to suggestions.

If we are cool with this, I'll add documentation.