### PR TITLE
Friendly plugs - raise AlreadySentError when calling layout functions on sent conn

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -272,21 +272,25 @@ defmodule Phoenix.Controller do
   Raises `Plug.Conn.AlreadySentError` if the conn was already sent.
   """
   @spec put_layout(Plug.Conn.t, {atom, binary} | binary | false) :: Plug.Conn.t
-  def put_layout(conn, layout)
-
-  def put_layout(%Plug.Conn{state: state}, _layout) when not state in @unsent do
-    raise Plug.Conn.AlreadySentError
+  def put_layout(%Plug.Conn{state: state} = conn, layout) do
+    if state in @unsent do
+      _put_layout(conn, layout)
+    else
+      raise Plug.Conn.AlreadySentError
+    end
   end
 
-  def put_layout(conn, false) do
+  def _put_layout(conn, layout)
+
+  def _put_layout(conn, false) do
     put_private(conn, :phoenix_layout, false)
   end
 
-  def put_layout(conn, {mod, layout}) when is_atom(mod) do
+  def _put_layout(conn, {mod, layout}) when is_atom(mod) do
     put_private(conn, :phoenix_layout, {mod, layout})
   end
 
-  def put_layout(conn, layout) when is_binary(layout) or is_atom(layout) do
+  def _put_layout(conn, layout) when is_binary(layout) or is_atom(layout) do
     update_in conn.private, fn private ->
       case Map.get(private, :phoenix_layout, false) do
         {mod, _} -> Map.put(private, :phoenix_layout, {mod, layout})
@@ -294,6 +298,8 @@ defmodule Phoenix.Controller do
       end
     end
   end
+
+
 
   @doc """
   Stores the layout for rendering if one was not stored yet.

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -97,15 +97,6 @@ defmodule Phoenix.Controller do
     end
   end
 
-  defmodule AlreadySentError do
-    defexception message: "the response was already sent. Ensure your plug " <>
-                          "is above `plug: action`"
-
-    @moduledoc """
-    Error raised when trying to modify already sent response
-    """
-  end
-
   @doc """
   Returns the action name as an atom, raises if unavailable.
   """
@@ -218,11 +209,11 @@ defmodule Phoenix.Controller do
   @doc """
   Stores the view for rendering.
 
-  Raises `Phoenix.ControllerAlreadySentError` if the conn was already sent.
+  Raises `Plug.Conn.AlreadySentError` if the conn was already sent.
   """
   @spec put_view(Plug.Conn.t, atom) :: Plug.Conn.t
   def put_view(%Plug.Conn{state: state}, _module) when not state in @unsent do
-    raise AlreadySentError
+    raise Plug.Conn.AlreadySentError
   end
 
   def put_view(conn, module) do
@@ -232,12 +223,12 @@ defmodule Phoenix.Controller do
   @doc """
   Stores the view for rendering if one was not stored yet.
 
-  Raises `Phoenix.ControllerAlreadySentError` if the conn was already sent.
+  Raises `Plug.Conn.AlreadySentError` if the conn was already sent.
   """
   @spec put_new_view(Plug.Conn.t, atom) :: Plug.Conn.t
   def put_new_view(%Plug.Conn{state: state}, _module)
       when not state in @unsent do
-    raise AlreadySentError
+    raise Plug.Conn.AlreadySentError
   end
 
   def put_new_view(conn, module) do
@@ -279,13 +270,13 @@ defmodule Phoenix.Controller do
       iex> layout(conn)
       {AppView, :print}
 
-  Raises `Phoenix.ControllerAlreadySentError` if the conn was already sent.
+  Raises `Plug.Conn.AlreadySentError` if the conn was already sent.
   """
   @spec put_layout(Plug.Conn.t, {atom, binary} | binary | false) :: Plug.Conn.t
   def put_layout(conn, layout)
 
   def put_layout(%Plug.Conn{state: state}, _layout) when not state in @unsent do
-    raise AlreadySentError
+    raise Plug.Conn.AlreadySentError
   end
 
   def put_layout(conn, false) do
@@ -308,11 +299,11 @@ defmodule Phoenix.Controller do
   @doc """
   Stores the layout for rendering if one was not stored yet.
 
-  Raises `Phoenix.ControllerAlreadySentError` if the conn was already sent.
+  Raises `Plug.Conn.AlreadySentError` if the conn was already sent.
   """
   @spec put_new_layout(Plug.Conn.t, {atom, binary} | false) :: Plug.Conn.t
   def put_new_layout(%Plug.Conn{state: state}, _layout) when not state in @unsent do
-    raise AlreadySentError
+    raise Plug.Conn.AlreadySentError
   end
 
   def put_new_layout(conn, layout)
@@ -333,12 +324,12 @@ defmodule Phoenix.Controller do
       iex> layout_formats conn
       ["html", "mobile"]
 
-  Raises `Phoenix.ControllerAlreadySentError` if the conn was already sent.
+  Raises `Plug.Conn.AlreadySentError` if the conn was already sent.
   """
   @spec put_layout_formats(Plug.Conn.t, [String.t]) :: Plug.Conn.t
   def put_layout_formats(%Plug.Conn{state: state}, _formats)
       when not state in @unsent do
-    raise AlreadySentError
+    raise Plug.Conn.AlreadySentError
   end
 
   def put_layout_formats(conn, formats) when is_list(formats) do

--- a/test/phoenix/controller_test.exs
+++ b/test/phoenix/controller_test.exs
@@ -41,6 +41,10 @@ defmodule Phoenix.ControllerTest do
 
     conn = put_layout_formats conn, ~w(json xml)
     assert layout_formats(conn) == ~w(json xml)
+
+    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+      put_layout_formats sent_conn, ~w(json)
+    end
   end
 
   test "put_layout/2 and layout/1" do
@@ -62,6 +66,10 @@ defmodule Phoenix.ControllerTest do
     assert_raise RuntimeError, fn ->
       put_layout conn, "print"
     end
+
+    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+      put_layout sent_conn, {AppView, :print}
+    end
   end
 
   test "put_new_layout/2" do
@@ -74,6 +82,10 @@ defmodule Phoenix.ControllerTest do
     assert layout(conn) == {AppView, "application.html"}
     conn = put_new_layout(conn, false)
     assert layout(conn) == {AppView, "application.html"}
+
+    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+      put_new_layout sent_conn, false
+    end
   end
 
   test "put_view/2 and put_new_view/2" do
@@ -83,6 +95,13 @@ defmodule Phoenix.ControllerTest do
     assert view_module(conn) == Hello
     conn = put_view(conn, World)
     assert view_module(conn) == World
+
+    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+      put_new_view sent_conn, Hello
+    end
+    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+      put_view sent_conn, Hello
+    end
   end
 
   test "json/2" do
@@ -307,5 +326,9 @@ defmodule Phoenix.ControllerTest do
   test "__layout__ returns the layout modoule based on controller module" do
     assert Phoenix.Controller.__layout__(MyApp.UserController) == MyApp.LayoutView
     assert Phoenix.Controller.__layout__(MyApp.Admin.UserController) == MyApp.LayoutView
+  end
+
+  defp sent_conn do
+    conn(:get, "/") |> send_resp(:ok, "")
   end
 end

--- a/test/phoenix/controller_test.exs
+++ b/test/phoenix/controller_test.exs
@@ -42,7 +42,7 @@ defmodule Phoenix.ControllerTest do
     conn = put_layout_formats conn, ~w(json xml)
     assert layout_formats(conn) == ~w(json xml)
 
-    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+    assert_raise Plug.Conn.AlreadySentError, fn ->
       put_layout_formats sent_conn, ~w(json)
     end
   end
@@ -67,7 +67,7 @@ defmodule Phoenix.ControllerTest do
       put_layout conn, "print"
     end
 
-    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+    assert_raise Plug.Conn.AlreadySentError, fn ->
       put_layout sent_conn, {AppView, :print}
     end
   end
@@ -83,7 +83,7 @@ defmodule Phoenix.ControllerTest do
     conn = put_new_layout(conn, false)
     assert layout(conn) == {AppView, "application.html"}
 
-    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+    assert_raise Plug.Conn.AlreadySentError, fn ->
       put_new_layout sent_conn, false
     end
   end
@@ -96,10 +96,10 @@ defmodule Phoenix.ControllerTest do
     conn = put_view(conn, World)
     assert view_module(conn) == World
 
-    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+    assert_raise Plug.Conn.AlreadySentError, fn ->
       put_new_view sent_conn, Hello
     end
-    assert_raise Phoenix.Controller.AlreadySentError, fn ->
+    assert_raise Plug.Conn.AlreadySentError, fn ->
       put_view sent_conn, Hello
     end
   end

--- a/test/phoenix/controller_test.exs
+++ b/test/phoenix/controller_test.exs
@@ -84,7 +84,7 @@ defmodule Phoenix.ControllerTest do
     assert layout(conn) == {AppView, "application.html"}
 
     assert_raise Plug.Conn.AlreadySentError, fn ->
-      put_new_layout sent_conn, false
+      put_new_layout sent_conn, {AppView, "application.html"}
     end
   end
 


### PR DESCRIPTION
It's easy to think that the layout and view is set when calling `plug :action` in a controller so people (myself included) put their plugs below `plug :action` and then wonder why `put_layout` and friends don't work as expected. In reality the view and layout are set when you call `use Phoenix.Controller` so user's plugs should go above `plug :action` if you're working with the view or layout (and in most other cases too).

This PR makes it so that when you call `put_layout`, `put_new_layout`, `put_view`, `put_new_view` and `put_layout_formats` on a conn that was already sent, you get a friendly error instead of wondering why the wrong view/layout was rendered.