### PR TITLE
Ignore prod.secret.exs

### DIFF
--- a/priv/static/bare/.gitignore
+++ b/priv/static/bare/.gitignore
@@ -5,3 +5,5 @@
 
 # Generate on crash by the VM
 erl_crash.dump
+
+/config/prod.secret.exs

--- a/priv/static/brunch/.gitignore
+++ b/priv/static/brunch/.gitignore
@@ -14,3 +14,5 @@ erl_crash.dump
 # comment this depending on your deployment strategy.
 /priv/static/css
 /priv/static/js
+
+/config/prod.secret.exs


### PR DESCRIPTION
Since it's probably not a good idea for prod.secret.exs to be in version
control, it's best we add it to .gitignore by default.