### PR TITLE
Add some dependencies to build by exrm

### DIFF
--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -17,7 +17,7 @@ defmodule <%= application_module %>.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [mod: {<%= application_module %>, []},
-     applications: [:phoenix, :cowboy, :logger]]
+     applications: [:phoenix, :cowboy, :logger<%= if ecto do %>, :ecto<% end %>]]
   end
 
   # Specifies your project dependencies


### PR DESCRIPTION
I found a problem to build [in this way](http://www.phoenixframework.org/v0.10.0/docs/advanced-deployment).
I think it's up to lack of some dependencies to build by exrm.

So, I added some dependencies. Please check out my code.