### PR TITLE
Add _input suffix to textarea/3 form input type

### DIFF
--- a/lib/phoenix/html/form.ex
+++ b/lib/phoenix/html/form.ex
@@ -253,7 +253,7 @@ defmodule Phoenix.HTML.Form do
   ## Examples
 
       # Assuming form contains a User model
-      textarea(form, :description)
+      textarea_input(form, :description)
       #=> <textarea id="user_description" name="user[description]"></textarea>
 
   ## New lines
@@ -268,7 +268,7 @@ defmodule Phoenix.HTML.Form do
   automatically add a new line before the text area
   value.
   """
-  def textarea(form, field, opts \\ []) do
+  def textarea_input(form, field, opts \\ []) do
     opts =
       opts
       |> Keyword.put_new(:id, id_from(form, field))

--- a/test/phoenix/html/form_test.exs
+++ b/test/phoenix/html/form_test.exs
@@ -76,24 +76,24 @@ defmodule Phoenix.HTML.FormTest do
            {:safe, ~s(<input id="key" name="search[key][]" type="text" value="foo">)}
   end
 
-  ## textarea/3
+  ## textarea_input/3
 
-  test "textarea/3" do
-    assert textarea(:search, :key) ==
+  test "textarea_input/3" do
+    assert textarea_input(:search, :key) ==
            {:safe, ~s(<textarea id="search_key" name="search[key]">\n</textarea>)}
 
-    assert textarea(:search, :key) ==
+    assert textarea_input(:search, :key) ==
            {:safe, ~s(<textarea id="search_key" name="search[key]">\n</textarea>)}
 
-    assert textarea(:search, :key, id: "key", name: "search[key][]") ==
+    assert textarea_input(:search, :key, id: "key", name: "search[key][]") ==
            {:safe, ~s(<textarea id="key" name="search[key][]">\n</textarea>)}
   end
 
-  test "textarea/3 with form" do
-    assert with_form(&textarea(&1, :key)) ==
+  test "textarea_input/3 with form" do
+    assert with_form(&textarea_input(&1, :key)) ==
            {:safe, ~s(<textarea id="search_key" name="search[key]">\nvalue</textarea>)}
 
-    assert with_form(&textarea(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
+    assert with_form(&textarea_input(&1, :key, value: "foo", id: "key", name: "search[key][]")) ==
            {:safe, ~s(<textarea id="key" name="search[key][]">\nfoo</textarea>)}
   end
 


### PR DESCRIPTION
Update `textarea/3` to `textarea_input/3` for improved naming consistency with other form input types.