### PR TITLE
Sync channel messaging with new push API

### DIFF
--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -27,6 +27,7 @@ defmodule <%= application_module %>.Mixfile do
     [<%= phoenix_dep %>,<%= if ecto do %>
      {:phoenix_ecto, "~> 0.2"},
      {:postgrex, ">= 0.0.0"},<% end %>
+     # TODO bump to 0.3 for phoenix 0.11 release
      {:phoenix_live_reload, "~> 0.2"},
      {:cowboy, "~> 1.0"}]
   end

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -48,10 +48,9 @@ defmodule Phoenix.Channel.Server do
     }}
   end
 
-  # TODO decide if leave is treated specially
-  # def handle_cast({:handle_in, "phx_leave", payload, ref}, socket) do
-  #   term_and_stop(payload, put_in(socket.ref, ref))
-  # end
+  def handle_cast({:handle_in, "phx_leave", _payload, ref}, socket) do
+    handle_result({:stop, :normal, :ok, put_in(socket.ref, ref)}, :handle_in)
+  end
 
   @doc """
   Forwards incoming client messages through `handle_in/3` callbacks
@@ -140,18 +139,4 @@ defmodule Phoenix.Channel.Server do
     got #{inspect result}
     """
   end
-
-  # defp term_and_stop(reason, socket) do
-  #   case socket.channel.leave(reason, socket) do
-  #     :ok ->
-  #       {:stop, :normal, :left}
-  #     {:error, reason} ->
-  #       {:stop, {:error, reason}, :left}
-  #     other ->
-  #       raise """
-  #       Expected `leave/2` to return one of `:ok | {:error, reason}` got:
-  #       `#{inspect other}`
-  #       """
-  #    end
-  # end
 end

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -103,7 +103,7 @@ defmodule Phoenix.Channel.Server do
   defp handle_result({:reply, _, _socket}, _) do
     raise """
     Channel replies can only be sent from a `handle_in/3` callback.
-    Use `push/3` to send an out-of-bad message down the socket
+    Use `push/3` to send an out-of-band message down the socket
     """
   end
   defp handle_result({:noreply, socket}, _callback_type), do: {:noreply, socket}
@@ -126,7 +126,6 @@ defmodule Phoenix.Channel.Server do
   end
 
   defp leave_and_stop(reason, socket) do
-    PubSub.unsubscribe(socket.pubsub_server, self, socket.topic)
     case socket.channel.leave(reason, socket) do
       :ok ->
         {:stop, :normal, :left}

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -31,9 +31,12 @@ defmodule Phoenix.Channel.Server do
         {:ok, socket}
           PubSub.subscribe(socket.pubsub_server, self, socket.topic, link: true)
 
+          Phoenix.Channel.push(socket, "phx_reply_ok", %{ref: socket.ref, reply: %{}})
           {:ok, socket}
 
-      :ignore -> :ignore
+      :ignore ->
+        Phoenix.Channel.push(socket, "phx_reply_error", %{ref: socket.ref, reply: %{error: "ignore"}})
+        :ignore
 
       result ->
         {:stop, {:badarg, result}}

--- a/lib/phoenix/channel/transport.ex
+++ b/lib/phoenix/channel/transport.ex
@@ -97,10 +97,23 @@ defmodule Phoenix.Channel.Transport do
     GenServer.cast(socket_pid, {:handle_in, msg.event, msg.payload})
     :ok
   end
-
   defp log_ignore(topic, router) do
     Logger.debug fn -> "Ignoring unmatched topic \"#{topic}\" in #{inspect(router)}" end
     :ignore
+  end
+
+  @doc """
+  Returns the `%Phoenix.Message{}` for a channel close event
+  """
+  def chan_close_message(topic) do
+    %Message{topic: topic, event: "phx_chan_close", payload: %{}}
+  end
+
+  @doc """
+  Returns the `%Phoenix.Message{}` for a channel error event
+  """
+  def chan_error_message(topic) do
+    %Message{topic: topic, event: "phx_chan_error", payload: %{}}
   end
 
   @doc """

--- a/lib/phoenix/channel/transport.ex
+++ b/lib/phoenix/channel/transport.ex
@@ -73,7 +73,7 @@ defmodule Phoenix.Channel.Transport do
   def dispatch(_, %{topic: "phoenix", event: "heartbeat"}, transport_pid, _router, _pubsub_server, _transport) do
     send transport_pid, {:socket_push, %Message{topic: "phoenix", event: "heartbeat", payload: %{}}}
   end
-  def dispatch(nil, %{event: "join"} = msg, transport_pid, router, endpoint, transport) do
+  def dispatch(nil, %{event: "phx_join"} = msg, transport_pid, router, endpoint, transport) do
     case router.channel_for_topic(msg.topic, transport) do
       nil     -> log_ignore(msg.topic, router)
       channel ->
@@ -94,7 +94,7 @@ defmodule Phoenix.Channel.Transport do
     :ignore
   end
   def dispatch(socket_pid, msg, _transport_pid, _router, _pubsub_server, _transport) do
-    GenServer.cast(socket_pid, {:handle_in, msg.event, msg.payload})
+    GenServer.cast(socket_pid, {:handle_in, msg.event, msg.payload, msg.ref})
     :ok
   end
   defp log_ignore(topic, router) do

--- a/lib/phoenix/channel/transport.ex
+++ b/lib/phoenix/channel/transport.ex
@@ -28,12 +28,12 @@ defmodule Phoenix.Channel.Transport do
       Elixir process messages, then encoding and fowarding to remote client.
     * Trap exits and handle receiving `{:EXIT, socket_pid, reason}` messages
       and delete the entries from the kept HashDict of socket processes.
-      When exists are received, the adapter transport must reply to their client
+      When exits are received, the adapter transport must reply to their client
       with one of two messages:
 
-        - for `:normal` exists, send a reply to the remote client of a message
+        - for `:normal` exits, send a reply to the remote client of a message
           from `Transport.chan_close_message/1`
-        - for abnormal exists, send a reply to the remote client of a message
+        - for abnormal exits, send a reply to the remote client of a message
           from `Transport.chan_error_message/1`
 
 
@@ -44,9 +44,9 @@ defmodule Phoenix.Channel.Transport do
 
   Synchronouse Replies and `ref`'s:
 
-  Channels can reply, synchronously, to any handle_in/3 event. To match pushes
+  Channels can reply, synchronously, to any `handle_in/3` event. To match pushes
   with replies, clients must include a unique `ref` with every message and the
-  channel server will reply with a match ref where the client and pick up the
+  channel server will reply with a matching ref where the client and pick up the
   callback for the matching reply.
 
   Phoenix includes a JavaScript client for WebSocket and Longpolling support using JSON
@@ -121,14 +121,14 @@ defmodule Phoenix.Channel.Transport do
   Returns the `%Phoenix.Message{}` for a channel close event
   """
   def chan_close_message(topic) do
-    %Message{topic: topic, event: "phx_chan_close", payload: %{}}
+    %Message{topic: topic, event: "phx_close", payload: %{}}
   end
 
   @doc """
   Returns the `%Phoenix.Message{}` for a channel error event
   """
   def chan_error_message(topic) do
-    %Message{topic: topic, event: "phx_chan_error", payload: %{}}
+    %Message{topic: topic, event: "phx_error", payload: %{}}
   end
 
   @doc """

--- a/lib/phoenix/channel/transport.ex
+++ b/lib/phoenix/channel/transport.ex
@@ -28,11 +28,26 @@ defmodule Phoenix.Channel.Transport do
       Elixir process messages, then encoding and fowarding to remote client.
     * Trap exits and handle receiving `{:EXIT, socket_pid, reason}` messages
       and delete the entries from the kept HashDict of socket processes.
+      When exists are received, the adapter transport must reply to their client
+      with one of two messages:
+
+        - for `:normal` exists, send a reply to the remote client of a message
+          from `Transport.chan_close_message/1`
+        - for abnormal exists, send a reply to the remote client of a message
+          from `Transport.chan_error_message/1`
+
 
   See `Phoenix.Transports.WebSocket` for an example transport server implementation.
 
 
   ### Remote Client
+
+  Synchronouse Replies and `ref`'s:
+
+  Channels can reply, synchronously, to any handle_in/3 event. To match pushes
+  with replies, clients must include a unique `ref` with every message and the
+  channel server will reply with a match ref where the client and pick up the
+  callback for the matching reply.
 
   Phoenix includes a JavaScript client for WebSocket and Longpolling support using JSON
   encodings.

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -31,6 +31,7 @@ defmodule Phoenix.Socket do
             transport: nil,
             pubsub_server: nil,
             ref: nil,
+            joined: false,
             assigns: %{}
 
 

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -14,6 +14,7 @@ defmodule Phoenix.Socket do
   * `assigns` - The map of socket assigns, default: `%{}`
   * `transport` - The socket's Transport, ie: `Phoenix.Transports.WebSocket`
   * `pubsub_server` - The registered name of the socket's PubSub server
+  * `ref` - The latest ref sent by the client
 
 
   """
@@ -29,6 +30,7 @@ defmodule Phoenix.Socket do
             authorized: false,
             transport: nil,
             pubsub_server: nil,
+            ref: nil,
             assigns: %{}
 
 

--- a/lib/phoenix/socket/message.ex
+++ b/lib/phoenix/socket/message.ex
@@ -6,7 +6,7 @@ defmodule Phoenix.Socket.Message do
   The Message format requires the following keys:
 
     * `topic` - The string topic or topic:subtopic pair namespace, ie "messages", "messages:123"
-    * `event`- The string event name, ie "join"
+    * `event`- The string event name, ie "phx_join"
     * `payload` - The string JSON message payload
     * `ref` - The unique string ref
 

--- a/lib/phoenix/socket/message.ex
+++ b/lib/phoenix/socket/message.ex
@@ -33,7 +33,7 @@ defmodule Phoenix.Socket.Message do
         topic: Map.fetch!(map, "topic"),
         event: Map.fetch!(map, "event"),
         payload: Map.fetch!(map, "payload"),
-        ref: Map.get(map, "ref")
+        ref: Map.fetch!(map, "ref")
       }
     rescue
       err in [KeyError] -> raise InvalidMessage, message: "Missing key: '#{err.key}'"

--- a/lib/phoenix/socket/message.ex
+++ b/lib/phoenix/socket/message.ex
@@ -5,15 +5,16 @@ defmodule Phoenix.Socket.Message do
 
   The Message format requires the following keys:
 
-    * topic - The String topic or topic:subtopic pair namespace, ie "messages", "messages:123"
-    * event - The String event name, ie "join"
-    * payload - The String JSON message payload
+    * `topic` - The string topic or topic:subtopic pair namespace, ie "messages", "messages:123"
+    * `event`- The string event name, ie "join"
+    * `payload` - The string JSON message payload
+    * `ref` - The unique string ref
 
   """
 
   alias Phoenix.Socket.Message
 
-  defstruct topic: nil, event: nil, payload: nil
+  defstruct topic: nil, event: nil, payload: nil, ref: nil
 
   defmodule InvalidMessage do
     defexception [:message]
@@ -30,8 +31,9 @@ defmodule Phoenix.Socket.Message do
     try do
       %Message{
         topic: Map.fetch!(map, "topic"),
-        event:   Map.fetch!(map, "event"),
-        payload: Map.fetch!(map, "payload")
+        event: Map.fetch!(map, "event"),
+        payload: Map.fetch!(map, "payload"),
+        ref: Map.get(map, "ref")
       }
     rescue
       err in [KeyError] -> raise InvalidMessage, message: "Missing key: '#{err.key}'"

--- a/lib/phoenix/transports/long_poller/server.ex
+++ b/lib/phoenix/transports/long_poller/server.ex
@@ -116,9 +116,9 @@ defmodule Phoenix.Transports.LongPoller.Server do
                               sockets_inverse: HashDict.delete(state.sockets_inverse, socket_pid)}
         case reason do
           :normal ->
-            publish_reply(%Message{topic: topic, event: "phx_chan_close", payload: %{}}, new_state)
+            publish_reply(Transport.chan_close_message(topic), new_state)
           _other ->
-            publish_reply(%Message{topic: topic, event: "phx_chan_error", payload: %{}}, new_state)
+            publish_reply(Transport.chan_error_message(topic), new_state)
         end
     end
   end

--- a/lib/phoenix/transports/long_poller/server.ex
+++ b/lib/phoenix/transports/long_poller/server.ex
@@ -116,9 +116,9 @@ defmodule Phoenix.Transports.LongPoller.Server do
                               sockets_inverse: HashDict.delete(state.sockets_inverse, socket_pid)}
         case reason do
           :normal ->
-            publish_reply(%Message{topic: topic, event: "chan:close", payload: %{}}, new_state)
+            publish_reply(%Message{topic: topic, event: "phx_chan_close", payload: %{}}, new_state)
           _other ->
-            publish_reply(%Message{topic: topic, event: "chan:error", payload: %{}}, new_state)
+            publish_reply(%Message{topic: topic, event: "phx_chan_error", payload: %{}}, new_state)
         end
     end
   end

--- a/lib/phoenix/transports/long_poller/server.ex
+++ b/lib/phoenix/transports/long_poller/server.ex
@@ -19,7 +19,6 @@ defmodule Phoenix.Transports.LongPoller.Server do
 
   @moduledoc false
 
-  alias Phoenix.Socket.Message
   alias Phoenix.Channel.Transport
   alias Phoenix.Transports.LongPoller
   alias Phoenix.PubSub

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -78,14 +78,14 @@ defmodule Phoenix.Transports.WebSocket do
           :normal ->
             {:reply, state.serializer.encode!(%Message{
               topic: topic,
-              event: "chan:close",
+              event: "phx_chan_close",
               payload: %{}
             }), new_state}
 
           _other ->
             {:reply, state.serializer.encode!(%Message{
               topic: topic,
-              event: "chan:error",
+              event: "phx_chan_error",
               payload: %{}
             }), new_state}
         end

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -1,5 +1,6 @@
 defmodule Phoenix.Transports.WebSocket do
   use Plug.Builder
+  require Logger
 
   import Phoenix.Controller, only: [endpoint_module: 1, router_module: 1]
 
@@ -62,7 +63,10 @@ defmodule Phoenix.Transports.WebSocket do
     case Transport.dispatch(msg, state.sockets, self, state.router, state.endpoint, __MODULE__) do
       {:ok, socket_pid} ->
         {:ok, put(state, msg.topic, socket_pid)}
-      _ ->
+      {:error, reason} ->
+        Logger.error fn -> Exception.format_exit(reason) end
+        {:ok, state}
+      _ignore ->
         {:ok, state}
     end
   end

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -28,7 +28,6 @@ defmodule Phoenix.Transports.WebSocket do
   """
 
   alias Phoenix.Channel.Transport
-  alias Phoenix.Socket.Message
 
   plug :check_origin
   plug :upgrade
@@ -76,18 +75,10 @@ defmodule Phoenix.Transports.WebSocket do
 
         case reason do
           :normal ->
-            {:reply, state.serializer.encode!(%Message{
-              topic: topic,
-              event: "phx_chan_close",
-              payload: %{}
-            }), new_state}
+            {:reply, state.serializer.encode!(Transport.chan_close_message(topic)), new_state}
 
           _other ->
-            {:reply, state.serializer.encode!(%Message{
-              topic: topic,
-              event: "phx_chan_error",
-              payload: %{}
-            }), new_state}
+            {:reply, state.serializer.encode!(Transport.chan_error_message(topic)), new_state}
         end
     end
   end

--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -119,7 +119,7 @@ var Push = (function () {
 
     this.chan = chan;
     this.event = event;
-    this.payload = payload;
+    this.payload = payload || {};
     this.receivedResp = null;
     this.afterHooks = [];
     this.recHooks = {};

--- a/test/phoenix/integration/channel_test.exs
+++ b/test/phoenix/integration/channel_test.exs
@@ -99,7 +99,8 @@ defmodule Phoenix.Integration.ChannelTest do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws")
 
     WebsocketClient.join(sock, "rooms:lobby", %{})
-    assert_receive %Message{event: "phx_reply", payload: %{"ref" => nil, "response" => %{}, "status" => "ok"}, ref: nil, topic: "rooms:lobby"}
+    assert_receive %Message{event: "phx_reply", payload: %{"ref" => "1", "response" => %{}, "status" => "ok"}, ref: nil, topic: "rooms:lobby"}
+
     assert_receive %Message{event: "joined", payload: %{"status" => "connected"}}
     assert_receive %Message{event: "user:entered", payload: %{"user" => nil}, ref: nil, topic: "rooms:lobby"}
 
@@ -119,7 +120,7 @@ defmodule Phoenix.Integration.ChannelTest do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws")
 
     WebsocketClient.join(sock, "rooms:lobby", %{})
-    assert_receive %Message{event: "phx_reply", payload: %{"ref" => nil, "response" => %{}, "status" => "ok"}}
+    assert_receive %Message{event: "phx_reply", payload: %{"ref" => "1", "response" => %{}, "status" => "ok"}}
     assert_receive %Message{event: "joined"}
     assert_receive %Message{event: "user:entered"}
 
@@ -175,6 +176,7 @@ defmodule Phoenix.Integration.ChannelTest do
     resp = poll :post, "/ws/poll", session, %{
       "topic" => "rooms:lobby",
       "event" => "phx_join",
+      "ref" => "123",
       "payload" => %{}
     }
     assert resp.body["status"] == 200
@@ -184,7 +186,7 @@ defmodule Phoenix.Integration.ChannelTest do
     session = Map.take(resp.body, ["token", "sig"])
     assert resp.body["status"] == 200
     [phx_reply, status_msg, user_entered] = resp.body["messages"]
-    assert phx_reply == %{"event" => "phx_reply", "payload" => %{"ref" => nil, "response" => %{}, "status" => "ok"}, "ref" => nil, "topic" => "rooms:lobby"}
+    assert phx_reply == %{"event" => "phx_reply", "payload" => %{"ref" => "123", "response" => %{}, "status" => "ok"}, "ref" => nil, "topic" => "rooms:lobby"}
     assert status_msg == %{"event" => "joined", "payload" => %{"status" => "connected"}, "ref" => nil, "topic" => "rooms:lobby"}
     assert user_entered == %{"event" => "user:entered", "payload" => %{"user" => nil}, "ref" => nil, "topic" => "rooms:lobby"}
 
@@ -217,6 +219,7 @@ defmodule Phoenix.Integration.ChannelTest do
     resp = poll :post, "/ws/poll", Map.take(resp.body, ["token", "sig"]), %{
       "topic" => "rooms:lobby",
       "event" => "new:msg",
+      "ref" => "123",
       "payload" => %{"body" => "hi!"}
     }
     assert resp.body["status"] == 200
@@ -231,6 +234,7 @@ defmodule Phoenix.Integration.ChannelTest do
       resp = poll :post, "/ws/poll", session, %{
         "topic" => "rooms:private-room",
         "event" => "new:msg",
+        "ref" => "123",
         "payload" => %{"body" => "this method shouldn't send!'"}
       }
       assert resp.body["status"] == 401
@@ -243,6 +247,7 @@ defmodule Phoenix.Integration.ChannelTest do
       resp = poll :post, "/ws/poll", session, %{
         "topic" => "rooms:room123",
         "event" => "phx_join",
+        "ref" => "123",
         "payload" => %{}
       }
       assert resp.body["status"] == 200
@@ -270,6 +275,7 @@ defmodule Phoenix.Integration.ChannelTest do
       resp = poll :post, "/ws/poll", session, %{
         "topic" => "rooms:lobby",
         "event" => "phx_join",
+        "ref" => "123",
         "payload" => %{}
       }
       assert resp.body["status"] == 200
@@ -278,6 +284,7 @@ defmodule Phoenix.Integration.ChannelTest do
       resp = poll :post, "/ws/poll", session, %{
         "topic" => "rooms:lobby",
         "event" => "new:msg",
+        "ref" => "123",
         "payload" => %{"body" => "hi!"}
       }
       assert resp.body["status"] == 410
@@ -308,6 +315,7 @@ defmodule Phoenix.Integration.ChannelTest do
     resp = poll :post, "/ws/poll", session, %{
       "topic" => "rooms:lobby",
       "event" => "phx_join",
+      "ref" => "123",
       "payload" => %{}
     }
     assert resp.body["status"] == 200
@@ -316,6 +324,7 @@ defmodule Phoenix.Integration.ChannelTest do
     resp = poll :post, "/ws/poll", session, %{
       "topic" => "rooms:lobby",
       "event" => "boom",
+      "ref" => "123",
       "payload" => %{}
     }
     assert resp.body["status"] == 200

--- a/test/phoenix/integration/channel_test.exs
+++ b/test/phoenix/integration/channel_test.exs
@@ -107,13 +107,13 @@ defmodule Phoenix.Integration.ChannelTest do
 
     WebsocketClient.leave(sock, "rooms:lobby", %{})
     assert_receive %Message{event: "you:left", payload: %{"message" => "bye!"}}
-    assert_receive %Message{event: "phx_chan_close", payload: %{}}
+    assert_receive %Message{event: "phx_close", payload: %{}}
 
     WebsocketClient.send_event(sock, "rooms:lobby", "new:msg", %{body: "Should ignore"})
     refute_receive %Message{}
   end
 
-  test "websocket adapter sends phx_chan_error if a channel server abnormally exits" do
+  test "websocket adapter sends phx_error if a channel server abnormally exits" do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws")
 
     WebsocketClient.join(sock, "rooms:lobby", %{})
@@ -122,7 +122,7 @@ defmodule Phoenix.Integration.ChannelTest do
     assert_receive %Message{event: "user:entered"}
 
     WebsocketClient.send_event(sock, "rooms:lobby", "boom", %{})
-    assert_receive %Message{event: "phx_chan_error", payload: %{}, topic: "rooms:lobby"}
+    assert_receive %Message{event: "phx_error", payload: %{}, topic: "rooms:lobby"}
   end
 
   test "adapter handles refuses websocket events that haven't joined" do
@@ -296,7 +296,7 @@ defmodule Phoenix.Integration.ChannelTest do
     assert Poison.decode!(conn.resp_body)["status"] == 403
   end
 
-  test "longpoller adapter sends phx_chan_error if a channel server abnormally exits" do
+  test "longpoller adapter sends phx_error if a channel server abnormally exits" do
     # create session
     resp = poll :get, "/ws/poll", %{}, %{}
     session = Map.take(resp.body, ["token", "sig"])
@@ -324,10 +324,10 @@ defmodule Phoenix.Integration.ChannelTest do
     [_phx_reply, _joined, _user_entered, _you_left_msg, chan_error] = resp.body["messages"]
 
     assert chan_error ==
-      %{"event" => "phx_chan_error", "payload" => %{}, "topic" => "rooms:lobby", "ref" => nil}
+      %{"event" => "phx_error", "payload" => %{}, "topic" => "rooms:lobby", "ref" => nil}
   end
 
-  test "longpoller adapter sends phx_chan_close if a channel server normally exits" do
+  test "longpoller adapter sends phx_close if a channel server normally exits" do
     # create session
     resp = poll :get, "/ws/poll", %{}, %{}
     session = Map.take(resp.body, ["token", "sig"])
@@ -355,6 +355,6 @@ defmodule Phoenix.Integration.ChannelTest do
     [_phx_reply, _joined, _user_entered, _you_left_msg, chan_close] = resp.body["messages"]
 
     assert chan_close ==
-      %{"event" => "phx_chan_close", "payload" => %{}, "topic" => "rooms:lobby", "ref" => nil}
+      %{"event" => "phx_close", "payload" => %{}, "topic" => "rooms:lobby", "ref" => nil}
   end
 end

--- a/test/phoenix/integration/channel_test.exs
+++ b/test/phoenix/integration/channel_test.exs
@@ -92,6 +92,7 @@ defmodule Phoenix.Integration.ChannelTest do
 
     WebsocketClient.join(sock, "rooms:lobby", %{})
     assert_receive %Message{event: "join", payload: %{"status" => "connected"}}
+    assert_receive %Message{event: "phx_reply_ok", payload: %{"ref" => nil, "reply" => %{}}, ref: nil, topic: "rooms:lobby"}
 
     WebsocketClient.send_event(sock, "rooms:lobby", "new:msg", %{body: "hi!"})
     assert_receive %Message{event: "new:msg", payload: %{"body" => "hi!"}}
@@ -100,7 +101,7 @@ defmodule Phoenix.Integration.ChannelTest do
     assert_receive %Message{event: "you:left", payload: %{"message" => "bye!"}}
     assert_receive %Message{event: "phx_chan_close", payload: %{}}
 
-    WebsocketClient.send_event(sock, "rooms:lobby", "new:msg", %{body: "hi!"})
+    WebsocketClient.send_event(sock, "rooms:lobby", "new:msg", %{body: "Should ignore"})
     refute_receive %Message{}
   end
 

--- a/test/phoenix/integration/channel_test.exs
+++ b/test/phoenix/integration/channel_test.exs
@@ -44,7 +44,7 @@ defmodule Phoenix.Integration.ChannelTest do
 
     def leave(_message, socket) do
       push socket, "you:left", %{message: "bye!"}
-      {:ok, socket}
+      :ok
     end
 
     def handle_in("new:msg", message, socket) do

--- a/test/phoenix/integration/websocket_client.exs
+++ b/test/phoenix/integration/websocket_client.exs
@@ -48,14 +48,14 @@ defmodule Phoenix.Integration.WebsocketClient do
   Sends join event to the WebSocket server per the Message protocol
   """
   def join(server_pid, topic, msg) do
-    send_event(server_pid, topic, "join", msg)
+    send_event(server_pid, topic, "phx_join", msg)
   end
 
   @doc """
   Sends leave event to the WebSocket server per the Message protocol
   """
   def leave(server_pid, topic, msg) do
-    send_event(server_pid, topic, "leave", msg)
+    send_event(server_pid, topic, "phx_leave", msg)
   end
 
   defp json!(map), do: JSON.encode!(map)

--- a/test/phoenix/integration/websocket_client.exs
+++ b/test/phoenix/integration/websocket_client.exs
@@ -13,23 +13,24 @@ defmodule Phoenix.Integration.WebsocketClient do
   end
 
   def init([sender], _conn_state) do
-    {:ok, sender}
+    {:ok, %{sender: sender, ref: 0}}
   end
 
   @doc """
   Receives JSON encoded Socket.Message from remote WS endpoint and
   forwards message to client sender process
   """
-  def websocket_handle({:text, msg}, _conn_state, sender) do
-    send sender, Phoenix.Transports.JSONSerializer.decode!(msg, :text)
-    {:ok, sender}
+  def websocket_handle({:text, msg}, _conn_state, state) do
+    send state.sender, Phoenix.Transports.JSONSerializer.decode!(msg, :text)
+    {:ok, state}
   end
 
   @doc """
   Sends JSON encoded Socket.Message to remote WS endpoint
   """
-  def websocket_info({:send, msg}, _conn_state, sender) do
-    {:reply, {:text, msg}, sender}
+  def websocket_info({:send, msg}, _conn_state, state) do
+    msg = Map.put(msg, :ref, to_string(state.ref + 1))
+    {:reply, {:text, json!(msg)}, put_in(state, [:ref], state.ref + 1)}
   end
 
   def websocket_terminate(_reason, _conn_state, _state) do
@@ -40,8 +41,7 @@ defmodule Phoenix.Integration.WebsocketClient do
   Sends an event to the WebSocket server per the Message protocol
   """
   def send_event(server_pid, topic, event, msg) do
-    msg = json!(%{topic: topic, event: event, payload: msg})
-    send server_pid, {:send, msg}
+    send server_pid, {:send, %{topic: topic, event: event, payload: msg}}
   end
 
   @doc """

--- a/test/phoenix/socket/message_test.exs
+++ b/test/phoenix/socket/message_test.exs
@@ -5,16 +5,19 @@ defmodule Phoenix.Socket.MessageTest do
   alias Phoenix.Socket.Message.InvalidMessage
 
   test "from_map! converts a map with string keys into a %Message{}" do
-    msg = Message.from_map!(%{"topic" => "c", "event" => "e", "payload" => ""})
-    assert msg == %Message{topic: "c", event: "e", payload: ""}
+    msg = Message.from_map!(%{"topic" => "c", "event" => "e", "payload" => "", "ref" => "r"})
+    assert msg == %Message{topic: "c", event: "e", payload: "", ref: "r"}
   end
 
   test "from_map! raises InvalidMessage when any required key" do
     assert_raise InvalidMessage, fn ->
-      Message.from_map!(%{"event" => "e", "payload" => ""})
+      Message.from_map!(%{"event" => "e", "payload" => "", "ref" => "r"})
     end
     assert_raise InvalidMessage, fn ->
-      Message.from_map!(%{"topic" => "c", "payload" => ""})
+      Message.from_map!(%{"topic" => "c", "payload" => "", "ref" => "r"})
+    end
+    assert_raise InvalidMessage, fn ->
+      Message.from_map!(%{"topic" => "c", "event" => "e", "ref" => "r"})
     end
     assert_raise InvalidMessage, fn ->
       Message.from_map!(%{"topic" => "c", "event" => "e"})

--- a/test/phoenix/transports/json_serializer_test.exs
+++ b/test/phoenix/transports/json_serializer_test.exs
@@ -4,7 +4,7 @@ defmodule Phoenix.Tranports.JSONSerializerTest do
   alias Phoenix.Transports.JSONSerializer
   alias Phoenix.Socket.Message
 
-  @msg_json "{\"topic\":\"t\",\"payload\":\"m\",\"event\":\"e\"}"
+  @msg_json "{\"topic\":\"t\",\"ref\":null,\"payload\":\"m\",\"event\":\"e\"}"
 
   test "encode!/1 encodes `Phoenix.Socket.Message` as JSON" do
     msg = %Message{topic: "t", event: "e", payload: "m"}

--- a/test/phoenix/transports/long_poller_test.exs
+++ b/test/phoenix/transports/long_poller_test.exs
@@ -53,8 +53,8 @@ defmodule Phoenix.Tranports.LongPollerTest do
     assert {:ok, ^priv_topic} = LongPoller.verify_longpoll_topic(conn)
     assert Process.alive?(server_pid)
     :ok = GenServer.call(server_pid, :stop)
-    refute Process.alive?(server_pid)
     assert {:error, :terminated} = LongPoller.verify_longpoll_topic(conn)
+    refute Process.alive?(server_pid)
   end
 
   test "resume_session returns {:ok, conn, pid} if valid session" do

--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -18,7 +18,7 @@ class Push {
   constructor(chan, event, payload, mergePush){
     this.chan         = chan
     this.event        = event
-    this.payload      = payload
+    this.payload      = payload || {}
     this.receivedResp = null
     this.afterHooks   = []
     this.recHooks     = {}


### PR DESCRIPTION
We've overhauled the channel API to allow "synchronous" messaging, and I really love the results. By synchronous, I mean being able to reply to an incoming event directly, while ensuring messaging ordering for the same incoming events. This not only lets you do proper request/response messaging where necessary, but it also fixes issues we have in our <= 0.10 apis where joins were not synchronous and messages could be dropped if you fired them before you were fully joined. With these changes, we have a few high-level concepts which make up channels:

1. The client and server push messages down the socket to communicate
2. The server can reply directly to a pushed message
3. The server can broadcast events to be pushed to all subscribers

The flows looks like this:
- client `push("ev1")` -> server `handle_in("ev1")` -> `server push("ev2")` -> client `on("ev2")`
- client `push("ev1")` -> server `handle_in("ev1")` -> `server broadcast("ev2")` -> N subscribers `handle_out("ev2")` -> N subscribers `push("ev2") -> N clients `on("ev2")`
- client `push("ev1")` -> server `handle_in("ev")` -> server `{:reply, :ok, ...}` -> client `receive("ok", ...)`

Now let's see some cli/server code:
```javascript
    socket.join("rooms:lobby", {})
      .after(5000, () => console.log("We're having trouble connecting...") )
      .receive("ignore", () => console.log("auth error") )
      .receive("ok", chan => {

        // can now bind to channel crash/close events since channels are own processes
        chan.onClose( () => console.log("The channel disconnected") )
        chan.onError( () => console.log("The channel crashed!") )

        $input.onEnter( e => {
          // push without response
          chan.push("new_msg", {body: e.text, user: currentUser}) 
        })
        
        chan.on("status_change", ({status}) => $status.html(status) )
        
        chan.on("new_msg", msg => $messages.append(msg) )
        
        // push with `receive`'d response, and optional `after` hooks
        $createNotice.onClick( e => {
          chan.push("create_notice", e.data)
              .receive("ok", notice =>  console.log("notice created", notice) )
              .receive("error", reasons =>  console.log("creation failed", reasons) )
              .after(5000, () => console.log("network interruption") )
        })
    })
```

```elixir
defmodule Chat.RoomChannel do
  use Phoenix.Channel

  def join("rooms:lobby", message, socket) do
    send(self, {:after_join, message})

    {:ok, socket}
  end
  def join("rooms:" <> _private_subtopic, _message, _socket) do
    :ignore
  end

  def handle_info({:after_join, msg}, socket) do
    broadcast! socket, "user_entered", %{user: msg["user"]}
    push socket, "status_change", %{status: "waiting for users"}
    {:noreply, socket}
  end

  def handle_in("create_notice", attrs, socket) do
    changeset = Notice.changeset(%Notice{}, attrs)

    if changeset.valid? do
      Repo.insert(changeset)
      {:reply, {:ok, changeset}, socket}
    else
      {:reply, {:error, changeset.errors}, socket}
    end
  end
  
  def handle_in("new_msg", msg, socket) do
    broadcast! socket, "new_msg", %{user: msg["user"], body: msg["body"]}
    {:noreply, socket}
  end
  
  # this is forward by the default `handle_out`, but show here for clarity
  def handle_out("new_msg", msg, socket) do
    push socket, "new_msg, msg
    {:noreply, socket}
  end
end
```

Note that `{:reply, {:ok, resp}, socket}` on the server, triggers `.receive("ok", resp => {})` on the client. The "status" of the reply can be anything, ie `{:reply, {:queued, resp}, socket}` on the server, triggers `.receive("queued", resp => { })` on the client.
Also note that client joining, push, and receiving replies all have the same semantics and API now, which is quite nice.

All feedback appreciated before I merged this upstream. Thanks!

