### PR TITLE
[WIP] Accept view in controller render

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -424,7 +424,16 @@ defmodule Phoenix.Controller do
   By default, Controllers render templates in a view with a similar name to the
   controller. For example, `MyApp.UserController` will render templates inside
   the `MyApp.UserView`. This information can be changed any time by using the
+  render/3 and render/4 function that accepts a view or by using the
   `put_view/2` function:
+
+      def show(conn) do
+        render(conn, MyApp.SpecialView, :show)
+      end
+
+      def show(conn) do
+        render(conn, MyApp.SpecialView, :show, message: "Hello")
+      end
 
       def show(conn) do
         conn
@@ -469,6 +478,8 @@ defmodule Phoenix.Controller do
   which formats support/require layout rendering (defaults to "html" only).
   """
   @spec render(Plug.Conn.t, binary | atom, Dict.t | binary | atom) :: Plug.Conn.t
+  def render(conn, view_or_template, template_or_assigns)
+
   def render(conn, template, assigns) when is_atom(template) and is_list(assigns) do
     format =
       conn.params["format"] ||
@@ -493,7 +504,14 @@ defmodule Phoenix.Controller do
     |> render(template)
   end
 
+  @doc """
+  Render the template for a given view or the template for the default view.
+
+  See `render/3` for more information.
+  """
   @spec render(Plug.Conn.t, atom | binary, binary | atom, Dict.t) :: Plug.Conn.t
+  def render(conn, view_or_template, template_or_format, assigns)
+
   def render(conn, view, template, assigns) when is_atom(view) do
     conn
     |> put_view(view)

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -468,8 +468,8 @@ defmodule Phoenix.Controller do
   `layout_formats/2` and `put_layout_formats/2` can be used to configure
   which formats support/require layout rendering (defaults to "html" only).
   """
-  @spec render(Plug.Conn.t, binary | atom, Dict.t) :: Plug.Conn.t
-  def render(conn, template, assigns) when is_atom(template) do
+  @spec render(Plug.Conn.t, binary | atom, Dict.t | binary | atom) :: Plug.Conn.t
+  def render(conn, template, assigns) when is_atom(template) and is_list(assigns) do
     format =
       conn.params["format"] ||
       raise "cannot render template #{inspect template} because conn.params[\"format\"] is not set. " <>
@@ -477,7 +477,7 @@ defmodule Phoenix.Controller do
     render(conn, template_name(template, format), format, assigns)
   end
 
-  def render(conn, template, assigns) when is_binary(template) do
+  def render(conn, template, assigns) when is_binary(template) and is_list(assigns) do
     case Path.extname(template) do
       "." <> format ->
         render(conn, template, format, assigns)
@@ -485,6 +485,19 @@ defmodule Phoenix.Controller do
         raise "cannot render template #{inspect template} without format. Use an atom if the " <>
               "template format is meant to be set dynamically based on the request format"
     end
+  end
+
+  def render(conn, view, template) do
+    conn
+    |> put_view(view)
+    |> render(template)
+  end
+
+  @spec render(Plug.Conn.t, atom | binary, binary | atom, Dict.t) :: Plug.Conn.t
+  def render(conn, view, template, assigns) when is_atom(view) do
+    conn
+    |> put_view(view)
+    |> render(template, assigns)
   end
 
   def render(conn, template, format, assigns) do

--- a/test/phoenix/controller/render_test.exs
+++ b/test/phoenix/controller/render_test.exs
@@ -33,6 +33,19 @@ defmodule Phoenix.Controller.RenderTest do
     refute conn.halted
   end
 
+  test "renders template from specified view" do
+    conn = conn(:get, "/") |> fetch_params
+    conn = render(conn, MyApp.UserView, "index.html")
+    assert html_response?(conn)
+  end
+
+  test "renders template from specified view with assigns" do
+    conn = conn(:get, "/") |> fetch_params
+    conn = render(conn, MyApp.UserView, "index.html", title: "Hello")
+    assert conn.resp_body == "Hello\n"
+    assert html_response?(conn)
+  end
+
   test "renders string template with put layout" do
     conn = render(layout_conn, "index.html", title: "Hello")
     assert conn.resp_body =~ ~r"<title>Hello</title>"


### PR DESCRIPTION
refs: https://github.com/phoenixframework/phoenix/issues/720

This still breaks some tests. Will get back to this later and fix it up. At first glance, it was breaking tests that shouldn't break when running it locally. `action_name/1` would fail since it couldn't find `conn.private.phoenix_action` when running "render_errors_test.exs".