### PR TITLE
Allow render in controllers to accept the view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
   * [Endpoint] Allow the default format used when rendering errors to be customized in the `render_views` configuration
   * [HTML] Add `button/2` function to `Phoenix.HTML`
   * [HTML] Add `textarea/3` function to `Phoenix.HTML.Form`
+  * [Controller] `render/3` and `render/4` allows a view to be specified
+    directly.
 
 * Bug fixes
   * [HTML] Fix out of order hours, minutes and days in date/time select

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -505,8 +505,7 @@ defmodule Phoenix.Controller do
     |> render(template, assigns)
   end
 
-  defp do_render(conn, template, format, assigns)
-    when is_binary(template) and is_binary(format) do
+  defp do_render(conn, template, format, assigns) do
     assigns = to_map(assigns)
     content_type = Plug.MIME.type(format)
     conn = prepare_assigns(conn, assigns, format)

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -423,10 +423,14 @@ defmodule Phoenix.Controller do
 
   By default, Controllers render templates in a view with a similar name to the
   controller. For example, `MyApp.UserController` will render templates inside
-  the `MyApp.UserView`. This information can be changed any time by using the
-  `put_view/2` function:
+  the `MyApp.UserView`. This information can be changed any time by using
+  `render/3`, `render/4` or the `put_view/2` function:
 
-      def show(conn) do
+      def show(conn, _params) do
+        render(conn, MyApp.SpecialView, :show, message: "Hello")
+      end
+
+      def show(conn, _params) do
         conn
         |> put_view(MyApp.SpecialView)
         |> render(:show, message: "Hello")

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -479,13 +479,13 @@ defmodule Phoenix.Controller do
       conn.params["format"] ||
       raise "cannot render template #{inspect template} because conn.params[\"format\"] is not set. " <>
             "Please set `plug :accepts, %w(html json ...)` in your pipeline."
-    render(conn, template_name(template, format), format, assigns)
+    do_render(conn, template_name(template, format), format, assigns)
   end
 
   def render(conn, template, assigns) when is_binary(template) do
     case Path.extname(template) do
       "." <> format ->
-        render(conn, template, format, assigns)
+        do_render(conn, template, format, assigns)
       "" ->
         raise "cannot render template #{inspect template} without format. Use an atom if the " <>
               "template format is meant to be set dynamically based on the request format"
@@ -504,7 +504,7 @@ defmodule Phoenix.Controller do
     |> render(template, assigns)
   end
 
-  def render(conn, template, format, assigns)
+  defp do_render(conn, template, format, assigns)
     when is_binary(template) and is_binary(format) do
     assigns = to_map(assigns)
     content_type = Plug.MIME.type(format)

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -474,7 +474,7 @@ defmodule Phoenix.Controller do
   """
   @spec render(Plug.Conn.t, binary | atom, atom | binary | Dict.t) :: Plug.Conn.t
   def render(conn, template, assigns)
-    when is_atom(template) and not is_binary(assigns) do
+    when is_atom(template) and is_list(assigns) do
     format =
       conn.params["format"] ||
       raise "cannot render template #{inspect template} because conn.params[\"format\"] is not set. " <>
@@ -492,13 +492,14 @@ defmodule Phoenix.Controller do
     end
   end
 
-  def render(conn, view, template) when is_atom(view) and is_binary(template) do
     conn |> render(view, template, [])
+  def render(conn, view, template)
+    when is_atom(view) and is_binary(template) or is_atom(template) do
   end
 
   @spec render(Plug.Conn.t, atom | binary, atom | binary, Dict.t) :: Plug.Conn.t
   def render(conn, view, template, assigns)
-    when is_atom(view) and is_binary(template) do
+    when is_atom(view) and is_binary(template) or is_atom(template) do
     conn
     |> put_view(view)
     |> render(template, assigns)

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -472,7 +472,8 @@ defmodule Phoenix.Controller do
   `layout_formats/2` and `put_layout_formats/2` can be used to configure
   which formats support/require layout rendering (defaults to "html" only).
   """
-  @spec render(Plug.Conn.t, binary | atom, atom | binary | Dict.t) :: Plug.Conn.t
+  @spec render(Plug.Conn.t, binary | atom, Dict.t) :: Plug.Conn.t
+  @spec render(Plug.Conn.t, module, binary | atom) :: Plug.Conn.t
   def render(conn, template, assigns)
     when is_atom(template) and is_list(assigns) do
     format =

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -497,7 +497,7 @@ defmodule Phoenix.Controller do
     render(conn, view, template, [])
   end
 
-  @spec render(Plug.Conn.t, atom | binary, atom | binary, Dict.t) :: Plug.Conn.t
+  @spec render(Plug.Conn.t, atom, atom | binary, Dict.t) :: Plug.Conn.t
   def render(conn, view, template, assigns)
     when is_atom(view) and is_binary(template) or is_atom(template) do
     conn

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -397,7 +397,7 @@ defmodule Phoenix.Controller do
 
         plug :action
 
-        def show(conn) do
+        def show(conn, _params) do
           render conn, "show.html", message: "Hello"
         end
       end
@@ -409,7 +409,7 @@ defmodule Phoenix.Controller do
   on the request. To do so, you can pass the template name as an atom (without
   the extension):
 
-      def show(conn) do
+      def show(conn, _params) do
         render conn, :show, message: "Hello"
       end
 
@@ -435,7 +435,7 @@ defmodule Phoenix.Controller do
         |> put_view(MyApp.SpecialView)
         |> render(:show, message: "Hello")
       end
-.
+
   `put_view/2` can also be used as a plug:
 
       defmodule MyApp.UserController do
@@ -444,7 +444,7 @@ defmodule Phoenix.Controller do
         plug :put_view, MyApp.SpecialView
         plug :action
 
-        def show(conn) do
+        def show(conn, _params) do
           render conn, :show, message: "Hello"
         end
       end
@@ -459,7 +459,7 @@ defmodule Phoenix.Controller do
 
         plug :action
 
-        def show(conn) do
+        def show(conn, _params) do
           render conn, "show.html", message: "Hello"
         end
       end

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -492,9 +492,9 @@ defmodule Phoenix.Controller do
     end
   end
 
-    conn |> render(view, template, [])
   def render(conn, view, template)
     when is_atom(view) and is_binary(template) or is_atom(template) do
+    render(conn, view, template, [])
   end
 
   @spec render(Plug.Conn.t, atom | binary, atom | binary, Dict.t) :: Plug.Conn.t

--- a/test/phoenix/controller/render_test.exs
+++ b/test/phoenix/controller/render_test.exs
@@ -117,6 +117,14 @@ defmodule Phoenix.Controller.RenderTest do
     assert conn.resp_body == "Hello\n"
   end
 
+  test "render/3 renders with View and Template with atom for template" do
+    conn = put_in conn.params["format"], "json"
+    conn = put_in conn.private[:phoenix_action], :show
+    conn = put_view(conn, nil)
+    conn = render(conn, MyApp.UserView, :show)
+    assert conn.resp_body == ~s({"foo":"bar"})
+  end
+
   test "render/3 renders with View and Template" do
     conn = put_in conn.params["format"], "json"
     conn = put_in conn.private[:phoenix_action], :show

--- a/test/phoenix/controller/render_test.exs
+++ b/test/phoenix/controller/render_test.exs
@@ -117,6 +117,22 @@ defmodule Phoenix.Controller.RenderTest do
     assert conn.resp_body == "Hello\n"
   end
 
+  test "render/3 renders with View and Template" do
+    conn = put_in conn.params["format"], "json"
+    conn = put_in conn.private[:phoenix_action], :show
+    conn = put_view(conn, nil)
+    conn = render(conn, MyApp.UserView, "show.json")
+    assert conn.resp_body == ~s({"foo":"bar"})
+  end
+
+  test "render/4 renders with View and Template" do
+    conn = put_in conn.params["format"], "html"
+    conn = put_in conn.private[:phoenix_action], :index
+    conn = put_view(conn, nil)
+    conn = render(conn, MyApp.UserView, "index.html", title: "Hello")
+    assert conn.resp_body == "Hello\n"
+  end
+
   test "errors when rendering without format" do
     assert_raise RuntimeError, ~r/cannot render template :index because conn.params/, fn ->
       render(conn(), :index)


### PR DESCRIPTION
We should support `render(conn, View, "template")` and `render(conn, View, "template", assigns)`.
