### PR TITLE
Fixing reset call in Channel.leave

### DIFF
--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -313,7 +313,7 @@ var Channel = exports.Channel = (function () {
 
     return this.push(CHANNEL_EVENTS.leave).receive("ok", function () {
       _this.socket.leave(_this);
-      chan.reset();
+      _this.reset();
     });
   };
 

--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -172,7 +172,7 @@ export class Channel {
   leave(){
     return this.push(CHANNEL_EVENTS.leave).receive("ok", () => {
       this.socket.leave(this)
-      chan.reset()
+      this.reset()
     })
   }
 }


### PR DESCRIPTION
As always, thanks for providing such an awesome tool. I just upgraded to Phoenix 0.11, and when leaving a channel I get the following error:

```
/Users/seejee/code/elixir-talk/node-client/vendor/phoenix.js:317
      chan.reset();
      ^
ReferenceError: chan is not defined
    at /Users/seejee/code/elixir-talk/node-client/vendor/phoenix.js:317:7
    at Push.matchReceive (/Users/seejee/code/elixir-talk/node-client/vendor/phoenix.js:195:7)
    at Object.callback (/Users/seejee/code/elixir-talk/node-client/vendor/phoenix.js:148:13)
    at /Users/seejee/code/elixir-talk/node-client/vendor/phoenix.js:297:19
    at Array.map (native)
    at Channel.trigger (/Users/seejee/code/elixir-talk/node-client/vendor/phoenix.js:296:8)
    at Object.callback (/Users/seejee/code/elixir-talk/node-client/vendor/phoenix.js:275:13)
    at /Users/seejee/code/elixir-talk/node-client/vendor/phoenix.js:297:19
    at Array.map (native)
    at Channel.trigger (/Users/seejee/code/elixir-talk/node-client/vendor/phoenix.js:296:8)
```

I think this is just caused by a simple typo in the Channel js client. I changed `chan.reset()` to `this.reset()` and now all appears to be well.

