### PR TITLE
Read secret key base value from the environment for production

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -140,7 +140,6 @@ defmodule Mix.Tasks.Phoenix.New do
                phoenix_dep: phoenix_dep(dev),
                pubsub_server: pubsub_server,
                secret_key_base: random_string(64),
-               prod_secret_key_base: random_string(64),
                encryption_salt: random_string(8),
                signing_salt: random_string(8),
                in_umbrella: in_umbrella?(path),

--- a/installer/templates/new/config/prod.secret.exs
+++ b/installer/templates/new/config/prod.secret.exs
@@ -1,7 +1,6 @@
 use Mix.Config
 
-# In this file, we keep production configuration that
-# you likely want to automate and keep it away from
-# your version control system.
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
 config :<%= application_name %>, <%= application_module %>.Endpoint,
-  secret_key_base: "<%= prod_secret_key_base %>"
+  secret_key_base: System.get_env("SECRET_KEY_BASE")


### PR DESCRIPTION
Instead of suggesting to avoid check in the ```prod.secret.exs``` in source control, we rather should suggest to read the secret key base value from the environment. 

See discussion: https://github.com/phoenixframework/phoenix/pull/717