### PR TITLE
Print better error when status is formatted incorrectly

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -95,6 +95,16 @@ defmodule Phoenix.Channel.Server do
                                 response: %{}}
     {:noreply, socket}
   end
+  defp handle_result({:reply, status, _socket}, :handle_in) do
+    raise """
+    Channel replies from `handle_in/3` are expected to return one of:
+
+        {:reply, {status :: atom, response :: map}, Socket.t} |
+        {:reply, status :: atom, Socket.t}
+
+    got #{inspect status}
+    """
+  end
   defp handle_result({:reply, _, _socket}, _) do
     raise """
     Channel replies can only be sent from a `handle_in/3` callback.


### PR DESCRIPTION
When the status isn't a two element tuple or an atom show an error that
displays the two proper formats of `reply`.

The wording could probably be better, I'd love feedback on that. I'm also not sure where/how exactly to add a test for this and would also love some pointers for doing that.