### PR TITLE
Fix the case of Location in redirected_to/2

### DIFF
--- a/lib/phoenix/conn_test.ex
+++ b/lib/phoenix/conn_test.ex
@@ -276,7 +276,7 @@ defmodule Phoenix.ConnTest do
   end
 
   def redirected_to(%Conn{status: status} = conn, status) do
-    location = Conn.get_resp_header(conn, "location") |> List.first
+    location = Conn.get_resp_header(conn, "Location") |> List.first
     location || raise "no location header was set on redirected_to"
   end
 

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -141,7 +141,7 @@ defmodule Phoenix.Test.ConnTest do
   test "redirected_to/1" do
     conn =
       conn(:get, "/")
-      |> put_resp_header("location", "new location")
+      |> put_resp_header("Location", "new location")
       |> send_resp(302, "foo")
 
     assert redirected_to(conn) == "new location"
@@ -151,7 +151,7 @@ defmodule Phoenix.Test.ConnTest do
     Enum.each 300..308, fn(status) ->
       conn =
         conn(:get, "/")
-        |> put_resp_header("location", "new location")
+        |> put_resp_header("Location", "new location")
         |> send_resp(status, "foo")
 
       assert redirected_to(conn, status) == "new location"
@@ -169,7 +169,7 @@ defmodule Phoenix.Test.ConnTest do
   test "redirected_to/2 without redirection" do
     assert_raise RuntimeError, "expected redirection with status 302, got: 200", fn ->
       conn(:get, "/")
-      |> put_resp_header("location", "new location")
+      |> put_resp_header("Location", "new location")
       |> send_resp(200, "ok")
       |> redirected_to()
     end


### PR DESCRIPTION
@josevalim love the changes you made to `redirected_to`! However our shiny new method was not working in the tests I am generating for that other PR. It looks like `Location` needs to be capitalized as that is how it is set in a real response? This change makes `redirected_to` work beautifully for me.