### PR TITLE
Declare missing applications in mix.exs

### DIFF
--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -19,7 +19,8 @@ defmodule <%= application_module %>.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [mod: {<%= application_module %>, []},
-     applications: [:phoenix, :cowboy, :logger<%= if ecto do %>, :ecto<% end %>]]
+     applications: [:phoenix, :cowboy, :logger<%= if ecto do %>,
+                    :phoenix_ecto, :postgrex<% end %>]]
   end
 
   # Specifies which paths to compile per environment


### PR DESCRIPTION
postgrex and phoenix_ecto should be also listed in
the application configuration in order to make these
libs' modules available in within an OTP release.

Reference: https://github.com/bitwalker/exrm#common-issues

I need small help with testing the changed generator. The approach described in docs (with `--dev` param) seems to use my global phoenix installation. (I tried from the git checkout directory and from installer/ directory)