### PR TITLE
Add --adapter option to phoenix.new

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -89,8 +89,8 @@ defmodule Mix.Tasks.Phoenix.New do
     * `--module` - the name of the base module in
       the generated skeleton
 
-    * `--db-adapter` - specify the database adapter for ecto.
-      Values can be `mysql`, `tds`, or `pg`. Defaults to `pg`
+    * `--database` - specify the database adapter for ecto.
+      Values can be `mysql` or `mssql`. Defaults to `postgres`
 
     * `--no-brunch` - do not generate brunch files
       for static asset building
@@ -139,7 +139,7 @@ defmodule Mix.Tasks.Phoenix.New do
     ecto = Keyword.get(opts, :ecto, true)
     brunch = Keyword.get(opts, :brunch, true)
 
-    {adapter_app, adapter_module} = set_ecto_adapter(opts[:db_adapter])
+    {adapter_app, adapter_module} = set_ecto_adapter(opts[:database])
     pubsub_server = set_pubsub_server(mod)
 
     binding = [application_name: app,
@@ -329,7 +329,7 @@ defmodule Mix.Tasks.Phoenix.New do
     end
   end
 
-  defp set_ecto_adapter("tds"),   do: {:tds_ecto, Tds.Ecto}
+  defp set_ecto_adapter("mssql"), do: {:tds_ecto, Tds.Ecto}
   defp set_ecto_adapter("mysql"), do: {:mariaex, Ecto.Adapters.MySQL}
   defp set_ecto_adapter(_),       do: {:postgrex, Ecto.Adapters.Postgres}
 

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -187,7 +187,7 @@ defmodule Mix.Tasks.Phoenix.New do
 
       # Configure your database
       config :#{binding[:application_name]}, #{binding[:application_module]}.Repo,
-        adapter: #{binding[:adapter_module]},
+        adapter: #{inspect binding[:adapter_module]},
         username: "postgres",
         password: "postgres",
         database: "#{binding[:application_name]}_dev"
@@ -197,7 +197,7 @@ defmodule Mix.Tasks.Phoenix.New do
 
       # Configure your database
       config :#{binding[:application_name]}, #{binding[:application_module]}.Repo,
-        adapter: #{binding[:adapter_module]},
+        adapter: #{inspect binding[:adapter_module]},
         username: "postgres",
         password: "postgres",
         database: "#{binding[:application_name]}_test",
@@ -209,7 +209,7 @@ defmodule Mix.Tasks.Phoenix.New do
 
       # Configure your database
       config :#{binding[:application_name]}, #{binding[:application_module]}.Repo,
-        adapter: #{binding[:adapter_module]},
+        adapter: #{inspect binding[:adapter_module]},
         username: "postgres",
         password: "postgres",
         database: "#{binding[:application_name]}_prod"

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -136,11 +136,12 @@ defmodule Mix.Tasks.Phoenix.New do
   end
 
   def run(app, mod, path, opts) do
+    db = Keyword.get(opts, :database, "postgres")
     dev = Keyword.get(opts, :dev, false)
     ecto = Keyword.get(opts, :ecto, true)
     brunch = Keyword.get(opts, :brunch, true)
 
-    {adapter_app, adapter_module} = set_ecto_adapter(opts[:database])
+    {adapter_app, adapter_module} = set_ecto_adapter(db)
     pubsub_server = set_pubsub_server(mod)
 
     binding = [application_name: app,
@@ -332,7 +333,8 @@ defmodule Mix.Tasks.Phoenix.New do
 
   defp set_ecto_adapter("mssql"), do: {:tds_ecto, Tds.Ecto}
   defp set_ecto_adapter("mysql"), do: {:mariaex, Ecto.Adapters.MySQL}
-  defp set_ecto_adapter(_),       do: {:postgrex, Ecto.Adapters.Postgres}
+  defp set_ecto_adapter("postgres"), do: {:postgrex, Ecto.Adapters.Postgres}
+  defp set_ecto_adapter(db), do: Mix.raise "Unknown database #{inspect db}"
 
   defp set_pubsub_server(module) do
     module

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Phoenix.New do
     * `--module` - the name of the base module in
       the generated skeleton
 
-    * `--adapter` - specify the database adapter for ecto.
+    * `--db-adapter` - specify the database adapter for ecto.
       Values can be `mysql`, `tds`, or `pg`. Defaults to `pg`
 
     * `--no-brunch` - do not generate brunch files
@@ -139,7 +139,7 @@ defmodule Mix.Tasks.Phoenix.New do
     ecto = Keyword.get(opts, :ecto, true)
     brunch = Keyword.get(opts, :brunch, true)
 
-    {adapter_app, adapter_module} = set_ecto_adapter(opts[:adapter])
+    {adapter_app, adapter_module} = set_ecto_adapter(opts[:db_adapter])
     pubsub_server = set_pubsub_server(mod)
 
     binding = [application_name: app,

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -89,9 +89,8 @@ defmodule Mix.Tasks.Phoenix.New do
     * `--module` - the name of the base module in
       the generated skeleton
 
-    * `--adapter` - specify the database adapter
-      for ecto. values can be `mysql` or `pg`.
-      Defaults to `pg`
+    * `--adapter` - specify the database adapter for ecto.
+      Values can be `mysql`, `tds`, or `pg`. Defaults to `pg`
 
     * `--no-brunch` - do not generate brunch files
       for static asset building
@@ -330,6 +329,7 @@ defmodule Mix.Tasks.Phoenix.New do
     end
   end
 
+  defp set_ecto_adapter("tds"),   do: {:tds_ecto, Tds.Ecto}
   defp set_ecto_adapter("mysql"), do: {:mariaex, Ecto.Adapters.MySQL}
   defp set_ecto_adapter(_),       do: {:postgrex, Ecto.Adapters.Postgres}
 

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -111,7 +111,8 @@ defmodule Mix.Tasks.Phoenix.New do
       mix phoenix.new ~/Workspace/hello_world --no-brunch
 
   """
-  @switches [dev: :boolean, brunch: :boolean, ecto: :boolean]
+  @switches [dev: :boolean, brunch: :boolean, ecto: :boolean,
+             app: :string, module: :string, database: :string]
 
   def run([version]) when version in ~w(-v --version) do
     Mix.shell.info "Phoenix v#{@version}"

--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -20,7 +20,7 @@ defmodule <%= application_module %>.Mixfile do
   def application do
     [mod: {<%= application_module %>, []},
      applications: [:phoenix, :cowboy, :logger<%= if ecto do %>,
-                    :phoenix_ecto, :postgrex<% end %>]]
+                    :phoenix_ecto, <%= inspect adapter_app %><% end %>]]
   end
 
   # Specifies which paths to compile per environment
@@ -33,7 +33,7 @@ defmodule <%= application_module %>.Mixfile do
   defp deps do
     [<%= phoenix_dep %>,<%= if ecto do %>
      {:phoenix_ecto, "~> 0.3"},
-     {:postgrex, ">= 0.0.0"},<% end %>
+     {<%= inspect adapter_app %>, ">= 0.0.0"},<% end %>
      {:phoenix_live_reload, "~> 0.3"},
      {:cowboy, "~> 1.0"}]
   end

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -177,6 +177,15 @@ defmodule Mix.Tasks.Phoenix.NewTest do
     end
   end
 
+  test "new with invalid database adapter" do
+    in_tmp "new with invalid database adapter", fn ->
+      project_path = Path.join(File.cwd!, "custom_path")
+      assert_raise Mix.Error, ~s(Unknown database "invalid"), fn ->
+        Mix.Tasks.Phoenix.New.run([project_path, "--database", "invalid"])
+      end
+    end
+  end
+
   test "new with invalid args" do
     assert_raise Mix.Error, ~r"Application name must start with a letter and ", fn ->
       Mix.Tasks.Phoenix.New.run ["007invalid"]

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -144,7 +144,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
   test "new with mysql adapter" do
     in_tmp "new with mysql adapter", fn ->
       project_path = Path.join(File.cwd!, "custom_path")
-      Mix.Tasks.Phoenix.New.run([project_path, "--adapter", "mysql"])
+      Mix.Tasks.Phoenix.New.run([project_path, "--db-adapter", "mysql"])
 
       assert_file "custom_path/mix.exs", ~r/:mariaex/
       assert_file "custom_path/config/dev.exs", ~r/Ecto.Adapters.MySQL/
@@ -156,7 +156,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
   test "new with tds adapter" do
     in_tmp "new with tds adapter", fn ->
       project_path = Path.join(File.cwd!, "custom_path")
-      Mix.Tasks.Phoenix.New.run([project_path, "--adapter", "tds"])
+      Mix.Tasks.Phoenix.New.run([project_path, "--db-adapter", "tds"])
 
       assert_file "custom_path/mix.exs", ~r/:tds_ecto/
       assert_file "custom_path/config/dev.exs", ~r/Tds.Ecto/

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -144,7 +144,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
   test "new with mysql adapter" do
     in_tmp "new with mysql adapter", fn ->
       project_path = Path.join(File.cwd!, "custom_path")
-      Mix.Tasks.Phoenix.New.run([project_path, "--db-adapter", "mysql"])
+      Mix.Tasks.Phoenix.New.run([project_path, "--database", "mysql"])
 
       assert_file "custom_path/mix.exs", ~r/:mariaex/
       assert_file "custom_path/config/dev.exs", ~r/Ecto.Adapters.MySQL/
@@ -156,7 +156,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
   test "new with tds adapter" do
     in_tmp "new with tds adapter", fn ->
       project_path = Path.join(File.cwd!, "custom_path")
-      Mix.Tasks.Phoenix.New.run([project_path, "--db-adapter", "tds"])
+      Mix.Tasks.Phoenix.New.run([project_path, "--database", "mssql"])
 
       assert_file "custom_path/mix.exs", ~r/:tds_ecto/
       assert_file "custom_path/config/dev.exs", ~r/Tds.Ecto/

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
     :ok
   end
 
-  test "returns the versin" do
+  test "returns the version" do
     Mix.Tasks.Phoenix.New.run(["-v"])
     assert_received {:mix_shell, :info, ["Phoenix v" <> _]}
   end
@@ -138,6 +138,42 @@ defmodule Mix.Tasks.Phoenix.NewTest do
           assert file =~ "lockfile: \"../../mix.lock\""
         end
       end
+    end
+  end
+
+  test "new with mysql adapter" do
+    in_tmp "new with mysql adapter", fn ->
+      project_path = Path.join(File.cwd!, "custom_path")
+      Mix.Tasks.Phoenix.New.run([project_path, "--adapter", "mysql"])
+
+      assert_file "custom_path/mix.exs", ~r/:mariaex/
+      assert_file "custom_path/config/dev.exs", ~r/Ecto.Adapters.MySQL/
+      assert_file "custom_path/config/test.exs", ~r/Ecto.Adapters.MySQL/
+      assert_file "custom_path/config/prod.secret.exs", ~r/Ecto.Adapters.MySQL/
+    end
+  end
+
+  test "new with tds adapter" do
+    in_tmp "new with tds adapter", fn ->
+      project_path = Path.join(File.cwd!, "custom_path")
+      Mix.Tasks.Phoenix.New.run([project_path, "--adapter", "tds"])
+
+      assert_file "custom_path/mix.exs", ~r/:tds_ecto/
+      assert_file "custom_path/config/dev.exs", ~r/Tds.Ecto/
+      assert_file "custom_path/config/test.exs", ~r/Tds.Ecto/
+      assert_file "custom_path/config/prod.secret.exs", ~r/Tds.Ecto/
+    end
+  end
+
+  test "new defaults to pg adapter" do
+    in_tmp "new defaults to pg adapter", fn ->
+      project_path = Path.join(File.cwd!, "custom_path")
+      Mix.Tasks.Phoenix.New.run([project_path])
+
+      assert_file "custom_path/mix.exs", ~r/:postgrex/
+      assert_file "custom_path/config/dev.exs", ~r/Ecto.Adapters.Postgres/
+      assert_file "custom_path/config/test.exs", ~r/Ecto.Adapters.Postgres/
+      assert_file "custom_path/config/prod.secret.exs", ~r/Ecto.Adapters.Postgres/
     end
   end
 

--- a/test/mix/tasks/phoenix.new_test.exs
+++ b/test/mix/tasks/phoenix.new_test.exs
@@ -75,6 +75,22 @@ defmodule Mix.Tasks.Phoenix.NewTest do
     end
   end
 
+  test "bootstraps generated project with adapter option" do
+    Logger.disable(self())
+
+    Application.put_env(:mysql_test, MySQLTest.Endpoint,
+      secret_key_base: String.duplicate("abcdefgh", 8),
+      root: File.cwd!)
+
+    in_tmp "bootstrap", fn ->
+      Mix.Tasks.Phoenix.New.run(["mysql_test", "--no-brunch", "--adapter", "mysql"])
+    end
+
+    in_project :mysql_test, Path.join(tmp_path, "bootstrap/mysql_test"), fn _ ->
+      assert_file "mix.exs", ~r/mariaex/
+    end
+  end
+
   defp in_project(app, path, fun) do
     %{name: name, file: file} = Mix.Project.pop
 

--- a/test/mix/tasks/phoenix.new_test.exs
+++ b/test/mix/tasks/phoenix.new_test.exs
@@ -75,22 +75,6 @@ defmodule Mix.Tasks.Phoenix.NewTest do
     end
   end
 
-  test "bootstraps generated project with adapter option" do
-    Logger.disable(self())
-
-    Application.put_env(:mysql_test, MySQLTest.Endpoint,
-      secret_key_base: String.duplicate("abcdefgh", 8),
-      root: File.cwd!)
-
-    in_tmp "bootstrap", fn ->
-      Mix.Tasks.Phoenix.New.run(["mysql_test", "--no-brunch", "--adapter", "mysql"])
-    end
-
-    in_project :mysql_test, Path.join(tmp_path, "bootstrap/mysql_test"), fn _ ->
-      assert_file "mix.exs", ~r/mariaex/
-    end
-  end
-
   defp in_project(app, path, fun) do
     %{name: name, file: file} = Mix.Project.pop
 


### PR DESCRIPTION
We should have an option to specify which adapter should be used with `phoenix_ecto`. Right now we assume everyone is using Postgres.

```
mix phoenix.new my_app --adapter mysql
```

Should it default to `pg` ?