### PR TITLE
Kill channels on WS transport terminate

### DIFF
--- a/lib/phoenix/endpoint/cowboy_websocket.ex
+++ b/lib/phoenix/endpoint/cowboy_websocket.ex
@@ -60,7 +60,8 @@ defmodule Phoenix.Endpoint.CowboyWebSocket do
   end
 
   def websocket_terminate(reason, req, {handler, state}) do
-    handle_reply req, handler, handler.ws_terminate(reason, state)
+    handler.ws_terminate(reason, state)
+    :ok
   end
 
 

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -92,7 +92,10 @@ defmodule Phoenix.Transports.WebSocket do
     {:reply, serializer.encode!(message), state}
   end
 
-  def ws_terminate(_reason, state) do
+  def ws_terminate(reason, state) do
+    for channel <- state.sockets |> HashDict.values do
+      :erlang.exit(channel, :die)
+    end
     {:shutdown, state}
   end
 


### PR DESCRIPTION
This is just proof of concept to demo a fix for #795.  Sadly, it doesn't matter what we return in the `ws_terminate` method as cowboy's just going to kill us no matter what and call it a day. So, we need to send some sort of notification to the transport's open channels to notify them they should exit. I've hacked that by just having the VM do it for me ;)