### PR TITLE
Clean up websocket transport termination code

### DIFF
--- a/lib/phoenix/endpoint/cowboy_websocket.ex
+++ b/lib/phoenix/endpoint/cowboy_websocket.ex
@@ -60,7 +60,7 @@ defmodule Phoenix.Endpoint.CowboyWebSocket do
   end
 
   def websocket_terminate(reason, req, {handler, state}) do
-    handle_reply req, handler, handler.ws_terminate(reason, state)
+    handler.ws_terminate(reason, state)
   end
 
 

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -92,9 +92,20 @@ defmodule Phoenix.Transports.WebSocket do
     {:reply, serializer.encode!(message), state}
   end
 
-  def ws_terminate(_reason, state) do
+  @doc """
+  Exits with a reason other than `:normal` to ensure that linked channels
+  also exit.
+  If the original exit reason was normal or due to the remote end, an error-less
+  shutdown happens. Other reasons will log errors.
+  """
+  def ws_terminate({:normal, _}, _state) do
     exit(:shutdown)
-    {:shutdown, state}
+  end
+  def ws_terminate({:remote, _, _}, _state) do
+    exit(:shutdown)
+  end
+  def ws_terminate(reason, _state) do
+    exit(reason)
   end
 
   defp check_origin(conn, _opts) do


### PR DESCRIPTION
- Removes dead code around ws_terminate
- Changes websocket transport to exit with reasons specified by cowboy, rather than just :shutdown all the time

Ref this comment: https://github.com/phoenixframework/phoenix/commit/3a60e42f7598d7e1e7a8dd87d85f349559aaa72c#commitcomment-10868355