### PR TITLE
Test against Elixir v1.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ otp_release:
   - 17.1
 sudo: false
 before_install:
-  - wget http://s3.hex.pm/builds/elixir/v1.0.3.zip
-  - unzip -d elixir v1.0.3.zip
+  - wget http://s3.hex.pm/builds/elixir/v1.0.4.zip
+  - unzip -d elixir v1.0.4.zip
 before_script:
   - export PATH=`pwd`/elixir/bin:$PATH
   - mix local.hex --force


### PR DESCRIPTION
:information_desk_person: This change updates Phoenix to run tests against version 1.0.4 of Elixir. 

Might also be worth running the test suite against a matrix of Erlang and Elixir versions, but I'll work on that in a follow up changeset.