### PR TITLE
Url decode route params

### DIFF
--- a/lib/phoenix/router/route.ex
+++ b/lib/phoenix/router/route.ex
@@ -89,8 +89,16 @@ defmodule Phoenix.Router.Route do
   defp maybe_binding([]), do: nil
   defp maybe_binding(binding) do
     quote do
+      decoded_params = unquote({:%{}, [], binding})
+         |> Enum.map(fn({k,v}) -> 
+           case v do
+             <<_::binary>> -> {k, URI.decode(v)} 
+             _ -> {k, v}
+           end
+         end)
+         |> Enum.into(%{})
       var!(conn) =
-        update_in var!(conn).params, &Map.merge(&1, unquote({:%{}, [], binding}))
+        update_in var!(conn).params, &Map.merge(&1, decoded_params)
     end
   end
 

--- a/lib/phoenix/router/route.ex
+++ b/lib/phoenix/router/route.ex
@@ -50,6 +50,20 @@ defmodule Phoenix.Router.Route do
       dispatch: build_dispatch(route, binding)}
   end
 
+  @doc """
+  Used by the binding macros built in maybe_binding, to URI decode params
+  embedded in paths.
+
+  Strings are decoded directly. Lists of strings decodes each string.
+  """
+  def uri_decode_param_value(value) do
+    case value do
+      <<str::binary>> -> URI.decode(str)
+      list when is_list(list) -> list |> Enum.map &uri_decode_param_value/1
+      other -> other
+    end
+  end
+
   defp build_path_and_binding(path) do
     {params, segments} = Plug.Router.Utils.build_path_match(path)
 
@@ -90,12 +104,7 @@ defmodule Phoenix.Router.Route do
   defp maybe_binding(binding) do
     quote do
       decoded_params = unquote({:%{}, [], binding})
-         |> Enum.map(fn({k,v}) -> 
-           case v do
-             <<_::binary>> -> {k, URI.decode(v)} 
-             _ -> {k, v}
-           end
-         end)
+         |> Enum.map(fn({k,v}) -> {k, Phoenix.Router.Route.uri_decode_param_value(v)} end)
          |> Enum.into(%{})
       var!(conn) =
         update_in var!(conn).params, &Map.merge(&1, decoded_params)

--- a/test/phoenix/router/pipeline_test.exs
+++ b/test/phoenix/router/pipeline_test.exs
@@ -104,6 +104,11 @@ defmodule Phoenix.Router.PipelineTest do
     assert conn.assigns[:params] == %{"id" => "hello"}
   end
 
+  test "parameters are url decoded" do
+    conn = call(Router, :get, "/browser/hello%20matey")
+    assert conn.assigns[:params] == %{"id" => "hello matey"}
+  end
+
   test "invalid pipelines" do
     assert_raise ArgumentError, ~r"unknown pipeline :unknown", fn ->
       defmodule ErrorRouter do

--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -109,6 +109,12 @@ defmodule Phoenix.Router.RoutingTest do
     assert conn.params["image"] == ["elixir", "logos", "main.png"]
   end
 
+  test "splat args are %encodings in path" do
+    conn = call(Router, :get, "backups/silly%20name")
+    assert conn.status == 200
+    assert conn.params["path"] == ["silly name"]
+  end
+
   test "catch-all splat route matches" do
     conn = call(Router, :get, "foo/bar/baz")
     assert conn.status == 404


### PR DESCRIPTION
This is an issue noticed by someone (not me) at the Elixir Conf EU Phoenix Tutorial (22 April 2015).

Query params are URI decoded in Plug, but params that are embedded in a route such as

```
    get "/hello/:name", HelloController, :hello
```

```http://myserver.com/hello/Bob%20Smith``` will result in params being ```%{name: "Bob%20Smith}``` rather than ```%{name: "Bob Smith}```.