### PR TITLE
Make it more clear that the generators dont only generate views

### DIFF
--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Phoenix.Gen.Html do
   use Mix.Task
 
-  @shortdoc "Generates HTML files for a resource"
+  @shortdoc "Generates controller, model, views for an HTML-based resource"
 
   @moduledoc """
   Generates a Phoenix resource.

--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Phoenix.Gen.Html do
   use Mix.Task
 
-  @shortdoc "Generates controller, model, views for an HTML-based resource"
+  @shortdoc "Generates controller, model and views for an HTML-based resource"
 
   @moduledoc """
   Generates a Phoenix resource.

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Phoenix.Gen.Json do
   use Mix.Task
   
-  @shortdoc "Generates controller, model for an JSON-based resource"
+  @shortdoc "Generates a controller and model for an JSON-based resource"
 
   @moduledoc """
   Generates a Phoenix resource.

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Phoenix.Gen.Json do
   use Mix.Task
-
-  @shortdoc "Generates JSON files for a resource"
+  
+  @shortdoc "Generates controller, model for an JSON-based resource"
 
   @moduledoc """
   Generates a Phoenix resource.


### PR DESCRIPTION
I started a new project and I was sure (in my mind) that there was a generator for controllers or resources.

Running `mix -h` showed:

```text
  ...
  mix new                # Create a new Elixir project
  mix phoenix.gen.html   # Generates HTML files for a resource
  mix phoenix.gen.model  # Generates an Ecto model
  ...
```

The description of the `phoenix.gen.html` made me believe that it generated only HTML files, which in my mind sounded like views/templates.

I spent sometime searching for a missing resource generator. I know that this info is in the upgrade guide, but I wasn't upgrading, so I didnt read it. Same thing could happen to a new user.

I think the description could be a little better. This PR is just one suggestion.

(I know the answer lies in checking `mix help phoenix.gen.html` but reading the current description I was sure that `phoenix.gen.html` was *not* for generating controller, model, etc code)

((feel free to ignore me as I feel rantish/stupid after realising the answer was always under my nose))