### PR TITLE
Fix typo in documentation of `render_one`

### DIFF
--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -304,7 +304,7 @@ defmodule Phoenix.View do
 
   The following:
 
-      render_many user, "show.html"
+      render_one user, "show.html"
 
   is roughly equivalent to:
 
@@ -318,7 +318,7 @@ defmodule Phoenix.View do
   the view name. The name of the key in assigns can be
   customized with the `:as` option:
 
-      render_one users, "show.html", as: :data
+      render_one user, "show.html", as: :data
 
   is roughly equivalent to:
 


### PR DESCRIPTION
Just a couple of small typos in the documentation of `render_one` in `Phoenix.View`.