### PR TITLE
Channel generator

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Phoenix.New do
     {:eex,  "new/test/views/error_view_test.exs",            "test/views/error_view_test.exs"},
     {:eex,  "new/test/views/page_view_test.exs",             "test/views/page_view_test.exs"},
     {:eex,  "new/test/support/conn_case.ex",                 "test/support/conn_case.ex"},
+    {:eex,  "new/test/support/channel_case.ex",              "test/support/channel_case.ex"},
     {:eex,  "new/test/test_helper.exs",                      "test/test_helper.exs"},
     {:keep, "new/web/channels",                              "web/channels"},
     {:eex,  "new/web/controllers/page_controller.ex",        "web/controllers/page_controller.ex"},

--- a/installer/templates/new/test/support/channel_case.ex
+++ b/installer/templates/new/test/support/channel_case.ex
@@ -1,0 +1,46 @@
+defmodule <%= application_module %>.ChannelCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  channel tests.
+
+  Such tests rely on `Phoenix.ChannelTest` and also
+  imports other functionality to make it easier
+  to build and query models.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with channels
+      use Phoenix.ChannelTest
+<%= if ecto do %>
+      # Alias the data repository and import query/model functions
+      alias <%= application_module %>.Repo
+      import Ecto.Model
+      import Ecto.Query, only: [from: 2]
+<% end %>
+
+      # The default endpoint for testing
+      @endpoint <%= application_module %>.Endpoint
+    end
+  end
+
+  setup_all do
+    @endpoint.start_link()
+    :ok
+  end
+
+  setup tags do
+<%= if ecto do %>    unless tags[:async] do
+      Ecto.Adapters.SQL.restart_test_transaction(<%= application_module %>.Repo, [])
+    end
+<% end %>
+    :ok
+  end
+end

--- a/lib/mix/tasks/phoenix.gen.channel.ex
+++ b/lib/mix/tasks/phoenix.gen.channel.ex
@@ -1,0 +1,54 @@
+defmodule Mix.Tasks.Phoenix.Gen.Channel do
+  use Mix.Task
+
+  @shortdoc "Generates a Phoenix channel"
+
+  @moduledoc """
+  Generates a Phoenix channel.
+
+      mix phoenix.gen.channel Room rooms new_msg
+
+  The first argument is the module name for the channel.
+  The second argument is the plural used as the topic.
+  The rest of the other arguments will be treated as events.
+
+  """
+  def run([singular, plural|events] = args) do
+    if String.contains?(plural, ":"), do: raise_with_help
+    Mix.Task.run "phoenix.gen.model", args
+
+    binding = Mix.Phoenix.inflect(singular)
+    path    = binding[:path]
+
+    binding = binding ++ [plural: plural, events: events]
+
+    Mix.Phoenix.copy_from source_dir, "", binding, [
+      {:eex, "channel.ex",       "web/channels/#{path}_channel.ex"},
+      {:eex, "channel_test.exs", "test/channels/#{path}_channel_test.exs"},
+    ]
+
+    Mix.shell.info """
+
+    Add the channel to the proper scope in web/router.ex:
+
+        channel "#{plural}:*", #{binding[:scoped]}Channel
+    """
+  end
+
+  def run(_) do
+    raise_with_help
+  end
+
+  defp raise_with_help do
+    Mix.raise """
+    mix phoenix.gen.channel expects both the module name and topic name
+    followed by any number of event names:
+
+        mix phoenix.gen.channel Room rooms new_msg
+    """
+  end
+
+  defp source_dir do
+    Application.app_dir(:phoenix, "priv/templates/channel")
+  end
+end

--- a/lib/mix/tasks/phoenix.gen.channel.ex
+++ b/lib/mix/tasks/phoenix.gen.channel.ex
@@ -6,21 +6,24 @@ defmodule Mix.Tasks.Phoenix.Gen.Channel do
   @moduledoc """
   Generates a Phoenix channel.
 
-      mix phoenix.gen.channel Room rooms new_msg
+      mix phoenix.gen.channel Room rooms
 
   The first argument is the module name for the channel.
   The second argument is the plural used as the topic.
-  The rest of the other arguments will be treated as events.
+
+  The generated model will contain:
+
+    * a channel in web/channels
+    * a channel_test in test/channels
 
   """
-  def run([singular, plural|events] = args) do
-    if String.contains?(plural, ":"), do: raise_with_help
-    Mix.Task.run "phoenix.gen.model", args
+  def run(args) do
+    [singular, plural] = validate_args!(args)
 
     binding = Mix.Phoenix.inflect(singular)
     path    = binding[:path]
 
-    binding = binding ++ [plural: plural, events: events]
+    binding = binding ++ [plural: plural]
 
     Mix.Phoenix.copy_from source_dir, "", binding, [
       {:eex, "channel.ex",       "web/channels/#{path}_channel.ex"},
@@ -35,17 +38,20 @@ defmodule Mix.Tasks.Phoenix.Gen.Channel do
     """
   end
 
-  def run(_) do
-    raise_with_help
-  end
-
   defp raise_with_help do
     Mix.raise """
-    mix phoenix.gen.channel expects both the module name and topic name
-    followed by any number of event names:
+    mix phoenix.gen.channel expects just the module name and topic name:
 
         mix phoenix.gen.channel Room rooms new_msg
     """
+  end
+
+  defp validate_args!(args) do
+    if length(args) > 2 do
+      raise_with_help
+    else
+      args
+    end
   end
 
   defp source_dir do

--- a/lib/mix/tasks/phoenix.gen.channel.ex
+++ b/lib/mix/tasks/phoenix.gen.channel.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Channel do
 
     Add the channel to the proper scope in web/router.ex:
 
-        channel "#{plural}:*", #{binding[:scoped]}Channel
+        channel "#{plural}:lobby", #{binding[:scoped]}Channel
     """
   end
 

--- a/priv/templates/channel/channel.ex
+++ b/priv/templates/channel/channel.ex
@@ -1,18 +1,36 @@
 defmodule <%= module %>Channel do
   use <%= base %>.Web, :channel
 
-  def join("<%= plural %>:lobby", _auth_message, socket) do
-    {:ok, socket}
-  end
-
-  def join("<%= plural %>:" <> _<%= singular %>_id, _auth_message, socket) do
-    {:ok, socket}
-  end
-
-  <%= for event <- events do %>
-    def handle_in("<%= event %>", attrs, socket) do
-      broadcast! socket, event, attrs
-      {:noreply, socket}
+  def join("<%= plural %>:lobby", payload, socket) do
+    if authorized?(payload) do
+      {:ok, socket}
+    else
+      {:error, %{reason: "unauthorized"}}
     end
-  <% end %>
+  end
+
+  # Channels can be used in a request/response fashion
+  # by sending replies to requests from the client
+  def handle_in("ping", payload, socket) do
+    {:reply, {"pong", payload}, socket}
+  end
+
+  # It is also common to receive messages from the client and
+  # broadcast to everyone in the current topic (<%= plural %>:lobby).
+  def handle_in("shout", payload, socket) do
+    broadcast socket, "shout", payload
+    {:noreply, socket}
+  end
+
+  # This is invoked every time a notification is being broadcast
+  # to the client. The default implementation is just to push it
+  # downstream but one could filter or change the event.
+  def handle_out(event, payload, socket) do
+    push socket, event, payload
+    {:noreply, socket}
+  end
+
+  defp authorized?(_payload) do
+    true
+  end
 end

--- a/priv/templates/channel/channel.ex
+++ b/priv/templates/channel/channel.ex
@@ -12,7 +12,7 @@ defmodule <%= module %>Channel do
   # Channels can be used in a request/response fashion
   # by sending replies to requests from the client
   def handle_in("ping", payload, socket) do
-    {:reply, {"pong", payload}, socket}
+    {:reply, {:pong, payload}, socket}
   end
 
   # It is also common to receive messages from the client and

--- a/priv/templates/channel/channel.ex
+++ b/priv/templates/channel/channel.ex
@@ -1,0 +1,18 @@
+defmodule <%= module %>Channel do
+  use <%= base %>.Web, :channel
+
+  def join("<%= plural %>:lobby", _auth_message, socket) do
+    {:ok, socket}
+  end
+
+  def join("<%= plural %>:" <> _<%= singular %>_id, _auth_message, socket) do
+    {:ok, socket}
+  end
+
+  <%= for event <- events do %>
+    def handle_in("<%= event %>", attrs, socket) do
+      broadcast! socket, event, attrs
+      {:noreply, socket}
+    end
+  <% end %>
+end

--- a/priv/templates/channel/channel_test.exs
+++ b/priv/templates/channel/channel_test.exs
@@ -11,7 +11,7 @@ defmodule <%= module %>ChannelTest do
   end
 
   test "successful join of <%= plural %>:lobby" do
-    assert {:ok, socket, _} = join(<%= scoped %>Channel, "<%= plural %>:lobby")
+    assert {:ok, _, socket} = join(<%= scoped %>Channel, "<%= plural %>:lobby")
     assert socket.topic == "<%= plural %>:lobby"
   end
 

--- a/priv/templates/channel/channel_test.exs
+++ b/priv/templates/channel/channel_test.exs
@@ -18,16 +18,4 @@ defmodule <%= module %>ChannelTest do
 
     assert status == :ok
   end
-
-  <%= for event <- events do %>
-    test "<%= event %> broadcasts message" do
-      message = %{message: "Test this"}
-
-      build_socket("<%= event %>")
-      |> subscribe(<%= base %>.PubSub)
-      |> handle_out(<%= scoped %>Channel, message)
-
-      assert_socket_broadcasted("<%= event %>", chat_message)
-    end
-  <% end %>
 end

--- a/priv/templates/channel/channel_test.exs
+++ b/priv/templates/channel/channel_test.exs
@@ -1,0 +1,33 @@
+defmodule <%= module %>ChannelTest do
+  use ExUnit.Case
+  import Phoenix.Channel.ChannelTest
+  alias <%= module %>
+
+  test "<%= plural %>:lobby does not require authorization" do
+    {status, _socket} =
+      build_socket("<%= plural %>:lobby")
+      |> join(<%= scoped %>Channel)
+
+    assert status == :ok
+  end
+
+  test "<%= plural %>:<%= singular %>_id does not require authorization" do
+    {status, _socket} =
+      build_socket("<%= plural %>:1")
+      |> join(<%= scoped %>Channel)
+
+    assert status == :ok
+  end
+
+  <%= for event <- events do %>
+    test "<%= event %> broadcasts message" do
+      message = %{message: "Test this"}
+
+      build_socket("<%= event %>")
+      |> subscribe(<%= base %>.PubSub)
+      |> handle_out(<%= scoped %>Channel, message)
+
+      assert_socket_broadcasted("<%= event %>", chat_message)
+    end
+  <% end %>
+end

--- a/priv/templates/channel/channel_test.exs
+++ b/priv/templates/channel/channel_test.exs
@@ -1,14 +1,7 @@
 defmodule <%= module %>ChannelTest do
-  use ExUnit.Case
+  use <%= base %>.ChannelCase
+
   alias <%= module %>
-
-  @endpoint <%= base %>.Endpoint
-  use Phoenix.ChannelTest
-
-  setup_all do
-    @endpoint.start_link()
-    :ok
-  end
 
   test "successful join of <%= plural %>:lobby" do
     assert {:ok, _, socket} = join(<%= scoped %>Channel, "<%= plural %>:lobby")

--- a/priv/templates/channel/channel_test.exs
+++ b/priv/templates/channel/channel_test.exs
@@ -1,21 +1,31 @@
 defmodule <%= module %>ChannelTest do
   use ExUnit.Case
-  import Phoenix.Channel.ChannelTest
   alias <%= module %>
 
-  test "<%= plural %>:lobby does not require authorization" do
-    {status, _socket} =
-      build_socket("<%= plural %>:lobby")
-      |> join(<%= scoped %>Channel)
+  @endpoint <%= base %>.Endpoint
+  use Phoenix.ChannelTest
 
-    assert status == :ok
+  setup_all do
+    @endpoint.start_link()
+    :ok
   end
 
-  test "<%= plural %>:<%= singular %>_id does not require authorization" do
-    {status, _socket} =
-      build_socket("<%= plural %>:1")
-      |> join(<%= scoped %>Channel)
+  test "successful join of <%= plural %>:lobby" do
+    assert {:ok, socket, _} = join(<%= scoped %>Channel, "<%= plural %>:lobby")
+    assert socket.topic == "<%= plural %>:lobby"
+  end
 
-    assert status == :ok
+  test "ping replies with pong" do
+    {:ok, _, socket} = join(<%= scoped %>Channel, "<%= plural %>:lobby")
+
+    ref = push socket, "ping", %{"hello" => "there"}
+    assert_reply ref, :pong, %{"hello" => "there"}
+  end
+
+  test "shout broadcasts to <%= plural %>:lobby" do
+    {:ok, _, socket} = subscribe_and_join(<%= scoped %>Channel, "<%= plural %>:lobby")
+
+    push socket, "broadcast", %{"foo" => "bar"}
+    assert_broadcast "broadcast", %{"foo" => "bar"}
   end
 end

--- a/test/mix/tasks/phoenix.gen.channel_test.exs
+++ b/test/mix/tasks/phoenix.gen.channel_test.exs
@@ -1,0 +1,50 @@
+Code.require_file "../../../installer/test/mix_helper.exs", __DIR__
+
+defmodule Mix.Tasks.Phoenix.Gen.ChannelTest do
+  use ExUnit.Case
+  import MixHelper
+
+  setup do
+    Mix.Task.clear
+    :ok
+  end
+
+  test "generates channel" do
+    in_tmp "generates channel", fn ->
+      Mix.Tasks.Phoenix.Gen.Channel.run ["Room", "rooms", "new_message"]
+
+      assert_file "web/channels/room_channel.ex", fn file ->
+        assert file =~ "defmodule Phoenix.RoomChannel do"
+        assert file =~ "use Phoenix.Web, :channel"
+        assert file =~ "def join(\"rooms:lobby\", _auth_message, socket) do"
+        assert file =~ "def join(\"rooms:\" <> _room_id, _auth_message, socket) do"
+        assert file =~ "def handle_in(\"new_message\", attrs, socket) do"
+        assert file =~ "broadcast! socket, event, attrs"
+      end
+
+      assert_file "test/channels/room_channel_test.exs", fn file ->
+        assert file =~ "defmodule Phoenix.RoomChannelTest"
+        assert file =~ "import Phoenix.Channel.ChannelTest"
+
+        assert file =~ "build_socket(\"rooms:lobby\")"
+        assert file =~ "|> join(RoomChannel)"
+        assert file =~ "assert status == :ok"
+
+        assert file =~ "build_socket(\"rooms:1\")"
+        assert file =~ "|> join(RoomChannel)"
+        assert file =~ "assert status == :ok"
+      end
+    end
+  end
+
+  test "generates nested channel" do
+    in_tmp "generates nested channel", fn ->
+      Mix.Tasks.Phoenix.Gen.Channel.run ["Admin.Room", "rooms", "new_message"]
+
+      assert_file "web/channels/admin/room_channel.ex", fn file ->
+        assert file =~ "defmodule Phoenix.Admin.RoomChannel do"
+        assert file =~ "use Phoenix.Web, :channel"
+      end
+    end
+  end
+end

--- a/test/mix/tasks/phoenix.gen.channel_test.exs
+++ b/test/mix/tasks/phoenix.gen.channel_test.exs
@@ -11,15 +11,19 @@ defmodule Mix.Tasks.Phoenix.Gen.ChannelTest do
 
   test "generates channel" do
     in_tmp "generates channel", fn ->
-      Mix.Tasks.Phoenix.Gen.Channel.run ["Room", "rooms", "new_message"]
+      Mix.Tasks.Phoenix.Gen.Channel.run ["Room", "rooms"]
 
       assert_file "web/channels/room_channel.ex", fn file ->
         assert file =~ "defmodule Phoenix.RoomChannel do"
         assert file =~ "use Phoenix.Web, :channel"
-        assert file =~ "def join(\"rooms:lobby\", _auth_message, socket) do"
-        assert file =~ "def join(\"rooms:\" <> _room_id, _auth_message, socket) do"
-        assert file =~ "def handle_in(\"new_message\", attrs, socket) do"
-        assert file =~ "broadcast! socket, event, attrs"
+        assert file =~ "def join(\"rooms:lobby\", payload, socket) do"
+        assert file =~ "def handle_in(\"ping\", payload, socket) do"
+        assert file =~ "{:reply, {\"pong\", payload}, socket}"
+        assert file =~ "def handle_in(\"shout\", payload, socket) do"
+        assert file =~ "broadcast socket, \"shout\", payload"
+        assert file =~ "{:noreply, socket}"
+        assert file =~ "def handle_out(event, payload, socket) do"
+        assert file =~ "push socket, event, payload"
       end
 
       assert_file "test/channels/room_channel_test.exs", fn file ->
@@ -29,22 +33,24 @@ defmodule Mix.Tasks.Phoenix.Gen.ChannelTest do
         assert file =~ "build_socket(\"rooms:lobby\")"
         assert file =~ "|> join(RoomChannel)"
         assert file =~ "assert status == :ok"
-
-        assert file =~ "build_socket(\"rooms:1\")"
-        assert file =~ "|> join(RoomChannel)"
-        assert file =~ "assert status == :ok"
       end
     end
   end
 
   test "generates nested channel" do
     in_tmp "generates nested channel", fn ->
-      Mix.Tasks.Phoenix.Gen.Channel.run ["Admin.Room", "rooms", "new_message"]
+      Mix.Tasks.Phoenix.Gen.Channel.run ["Admin.Room", "rooms"]
 
       assert_file "web/channels/admin/room_channel.ex", fn file ->
         assert file =~ "defmodule Phoenix.Admin.RoomChannel do"
         assert file =~ "use Phoenix.Web, :channel"
       end
+    end
+  end
+
+  test "passing extra args raises error" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Gen.Channel.run ["Admin.Room", "rooms", "new_message"]
     end
   end
 end

--- a/test/mix/tasks/phoenix.gen.channel_test.exs
+++ b/test/mix/tasks/phoenix.gen.channel_test.exs
@@ -14,25 +14,36 @@ defmodule Mix.Tasks.Phoenix.Gen.ChannelTest do
       Mix.Tasks.Phoenix.Gen.Channel.run ["Room", "rooms"]
 
       assert_file "web/channels/room_channel.ex", fn file ->
-        assert file =~ "defmodule Phoenix.RoomChannel do"
-        assert file =~ "use Phoenix.Web, :channel"
-        assert file =~ "def join(\"rooms:lobby\", payload, socket) do"
-        assert file =~ "def handle_in(\"ping\", payload, socket) do"
-        assert file =~ "{:reply, {\"pong\", payload}, socket}"
-        assert file =~ "def handle_in(\"shout\", payload, socket) do"
-        assert file =~ "broadcast socket, \"shout\", payload"
-        assert file =~ "{:noreply, socket}"
-        assert file =~ "def handle_out(event, payload, socket) do"
-        assert file =~ "push socket, event, payload"
+        assert file =~ ~S|defmodule Phoenix.RoomChannel do|
+        assert file =~ ~S|use Phoenix.Web, :channel|
+        assert file =~ ~S|def join("rooms:lobby", payload, socket) do|
+        assert file =~ ~S|def handle_in("ping", payload, socket) do|
+        assert file =~ ~S|{:reply, {:pong, payload}, socket}|
+        assert file =~ ~S|def handle_in("shout", payload, socket) do|
+        assert file =~ ~S|broadcast socket, "shout", payload|
+        assert file =~ ~S|{:noreply, socket}|
+        assert file =~ ~S|def handle_out(event, payload, socket) do|
+        assert file =~ ~S|push socket, event, payload|
       end
 
       assert_file "test/channels/room_channel_test.exs", fn file ->
-        assert file =~ "defmodule Phoenix.RoomChannelTest"
-        assert file =~ "import Phoenix.Channel.ChannelTest"
+        assert file =~ ~S|defmodule Phoenix.RoomChannelTest|
+        assert file =~ ~S|@endpoint Phoenix.Endpoint|
+        assert file =~ ~S|use Phoenix.ChannelTest|
 
-        assert file =~ "build_socket(\"rooms:lobby\")"
-        assert file =~ "|> join(RoomChannel)"
-        assert file =~ "assert status == :ok"
+        assert file =~ ~S|test "successful join of rooms:lobby" do|
+        assert file =~ ~S|assert {:ok, _, socket} = join(RoomChannel, "rooms:lobby")|
+        assert file =~ ~S|assert socket.topic == "rooms:lobby"|
+
+        assert file =~ ~S|test "ping replies with pong" do|
+        assert file =~ ~S|{:ok, _, socket} = join(RoomChannel, "rooms:lobby")|
+        assert file =~ ~S|ref = push socket, "ping", %{"hello" => "there"}|
+        assert file =~ ~S|assert_reply ref, :pong, %{"hello" => "there"}|
+
+        assert file =~ ~S|test "shout broadcasts to rooms:lobby" do|
+        assert file =~ ~S|{:ok, _, socket} = subscribe_and_join(RoomChannel, "rooms:lobby")|
+        assert file =~ ~S|push socket, "broadcast", %{"foo" => "bar"}|
+        assert file =~ ~S|assert_broadcast "broadcast", %{"foo" => "bar"}|
       end
     end
   end
@@ -42,8 +53,8 @@ defmodule Mix.Tasks.Phoenix.Gen.ChannelTest do
       Mix.Tasks.Phoenix.Gen.Channel.run ["Admin.Room", "rooms"]
 
       assert_file "web/channels/admin/room_channel.ex", fn file ->
-        assert file =~ "defmodule Phoenix.Admin.RoomChannel do"
-        assert file =~ "use Phoenix.Web, :channel"
+        assert file =~ ~S|defmodule Phoenix.Admin.RoomChannel do|
+        assert file =~ ~S|use Phoenix.Web, :channel|
       end
     end
   end

--- a/test/mix/tasks/phoenix.gen.channel_test.exs
+++ b/test/mix/tasks/phoenix.gen.channel_test.exs
@@ -28,8 +28,7 @@ defmodule Mix.Tasks.Phoenix.Gen.ChannelTest do
 
       assert_file "test/channels/room_channel_test.exs", fn file ->
         assert file =~ ~S|defmodule Phoenix.RoomChannelTest|
-        assert file =~ ~S|@endpoint Phoenix.Endpoint|
-        assert file =~ ~S|use Phoenix.ChannelTest|
+        assert file =~ ~S|use Phoenix.ChannelCase|
 
         assert file =~ ~S|test "successful join of rooms:lobby" do|
         assert file =~ ~S|assert {:ok, _, socket} = join(RoomChannel, "rooms:lobby")|


### PR DESCRIPTION
refs: https://github.com/phoenixframework/phoenix/issues/741

This channel generator generates the a channel and channel_test file. The channel generated is very basic. It defines two `join/3` functions that pattern-match on either "topic:lobby" or "topic:" <> subtopic_id and a `handle_in/3` for every event arg. The `handle_in/3` just broadcasts the event with the attrs.

The channel_test here makes use of the helper in the PR here https://github.com/phoenixframework/phoenix/pull/652. Will make changes to it when necessary.

Let me know if there are any changes that need done. Thanks in advance! :)