### PR TITLE
Fix word usage in `ConnCase` docs.

### DIFF
--- a/installer/templates/new/test/support/conn_case.ex
+++ b/installer/templates/new/test/support/conn_case.ex
@@ -4,7 +4,7 @@ defmodule <%= application_module %>.ConnCase do
   tests that require setting up a connection.
 
   Such tests rely on `Phoenix.ConnTest` and also
-  imports other functionalities to make it easier
+  imports other functionality to make it easier
   to build and query models.
 
   Finally, if the test case interacts with the database,


### PR DESCRIPTION
Functionality is already plural.