### PR TITLE
Adds head/2 and head/3 to PhoenixController.

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -179,6 +179,34 @@ defmodule Phoenix.Controller do
   end
 
   @doc """
+  Sends an empty response with a status code.
+
+  ## Examples
+
+      iex> head conn, 200
+      iex> head conn, :ok
+
+  """
+  @spec head(Plug.Conn.t, binary | integer) :: Plug.Conn.t
+  def head(conn, status), do: send_resp(conn, status, "")
+
+  @doc """
+  Sends an empty response with a status code and content type.
+
+  ## Examples
+
+      iex> head conn, 200, "application/json"
+      iex> head conn, :ok, "application/json"
+
+  """
+  @spec head(Plug.Conn.t, binary | integer, binary) :: Plug.Conn.t
+  def head(conn, status, content_type) when is_binary(content_type) do
+    conn
+    |> put_resp_content_type(content_type)
+    |> head(status)
+  end
+
+  @doc """
   Sends redirect response to the given url.
 
   For security, `:to` only accepts paths. Use the `:external`

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -159,6 +159,26 @@ defmodule Phoenix.Controller.ControllerTest do
     assert conn.status == 400
   end
 
+  test "head/2" do
+    conn = head(conn(:get, "/"), 200)
+    assert conn.resp_body == ""
+    assert conn.status == 200
+    refute conn.halted
+
+    conn = head(conn(:get, "/"), :ok)
+    assert conn.resp_body == ""
+    assert conn.status == 200
+    refute conn.halted
+  end
+
+  test "head/3" do
+    conn = head(conn(:get, "/"), 200, "application/json")
+    assert get_resp_content_type(conn) == "application/json"
+    assert conn.resp_body == ""
+    assert conn.status == 200
+    refute conn.halted
+  end
+
   test "redirect/2 with :to" do
     conn = redirect(conn(:get, "/"), to: "/foobar")
     assert conn.resp_body =~ "/foobar"


### PR DESCRIPTION
This adds head/2 and head/3 convenience functions for returning empty responses with just a status code and optionally a specific content type.  Per this thread on phoenix-talk: https://groups.google.com/forum/#!topic/phoenix-talk/110izD_r-Zw

Examples:

```elixir
  iex> head conn, 200
  iex> head conn, :ok
  iex> head conn, :ok, "application/json"
```