### PR TITLE
Track explicit render/2 clauses

### DIFF
--- a/installer/templates/new/web/web.ex
+++ b/installer/templates/new/web/web.ex
@@ -47,7 +47,7 @@ defmodule <%= application_module %>.Web do
       use Phoenix.View, root: "web/templates"
 
       # Import convenience functions from controllers
-      import Phoenix.Controller, only: [get_flash: 2]
+      import Phoenix.Controller, only: [get_flash: 2, view_module: 1]
 
       # Import URL helpers from the router
       import <%= application_module %>.Router.Helpers

--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -213,11 +213,8 @@ defmodule Phoenix.View do
 
   Same as `render/3`, but returns `nil` instead of raising
   """
-  def render_existing(module, template, assigns) do
-    {_path, names} = module.__templates__()
-    if template in names do
-      render(module, template, assigns)
-    end
+  def render_existing(module, template, assigns \\ []) do
+    render(module, template, Dict.put(assigns, :render_existing, {module, template}))
   end
 
   @doc """

--- a/test/fixtures/templates/user/banner.html.eex
+++ b/test/fixtures/templates/user/banner.html.eex
@@ -1,1 +1,0 @@
-a banner

--- a/test/fixtures/templates/user/with_render_existing.html.eex
+++ b/test/fixtures/templates/user/with_render_existing.html.eex
@@ -1,2 +1,0 @@
-<%= render_existing MyApp.UserView, "banner.html", assigns %>
-<%= render_existing MyApp.UserView, "not_exists.html", assigns %>

--- a/test/fixtures/views.exs
+++ b/test/fixtures/views.exs
@@ -42,6 +42,8 @@ defmodule MyApp.UserView do
   def render("edit.html", %{} = assigns) do
     "EDIT#{assigns[:layout]} - #{assigns[:title]}"
   end
+
+  def render("existing.html", _), do: "rendered existing"
 end
 
 defmodule MyApp.Templates.UserView do
@@ -50,6 +52,7 @@ defmodule MyApp.Templates.UserView do
   def escaped_title(title) do
     html_escape title
   end
+
 end
 
 defmodule MyApp.Nested.User do

--- a/test/phoenix/view_test.exs
+++ b/test/phoenix/view_test.exs
@@ -187,12 +187,14 @@ defmodule Phoenix.ViewTest do
   test "renders_existing/3 renders template if it exists" do
     assert render_existing(MyApp.UserView, "index.html", title: "Test") ==
       {:safe, [["" | "Test"] | "\n"]}
-
-    assert render_to_string(MyApp.UserView, "with_render_existing.html", []) |> String.strip() ==
-      "a banner"
   end
 
   test "renders_existing/3 returns nil if template does not exist" do
     assert render_existing(MyApp.UserView, "not-exists", title: "Test") == nil
+  end
+
+  test "render_existing/3 renders explicitly defined functions" do
+    assert render_existing(MyApp.UserView, "existing.html", []) ==
+      "rendered existing"
   end
 end


### PR DESCRIPTION
@josevalim this fixes the issue we had with not tracking explicit render/2 definitions for the `render_existing`. This also has the nice side-effect of including all defined render/2's from both compiled templates and regular functions. This is the first legitimate use I've had for `@on_definition`, so I'm PR'ing to make sure it's sane. Very fun though!