### PR TITLE
Any plans to add support for foreign keys to phoenix.gen.model?

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -78,6 +78,7 @@ defmodule Mix.Phoenix do
   def params(attrs) do
     Enum.into attrs, %{}, fn
       {k, {:array, _}} -> {k, []}
+      {k, :belongs_to} -> {k, nil}
       {k, :integer}    -> {k, 42}
       {k, :float}      -> {k, "120.5"}
       {k, :decimal}    -> {k, "120.5"}

--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -90,6 +90,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Html do
   defp inputs(attrs) do
     Enum.map attrs, fn
       {k, {:array, _}} -> {k, nil}
+      {k, :belongs_to} -> {k, "number_input f, #{inspect(k)}_id"}
       {k, :integer}    -> {k, "number_input f, #{inspect(k)}"}
       {k, :float}      -> {k, "number_input f, #{inspect(k)}, step: \"any\""}
       {k, :decimal}    -> {k, "number_input f, #{inspect(k)}, step: \"any\""}

--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -24,6 +24,14 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
 
       mix phoenix.gen.model User users name age:integer
 
+  The generator also supports `belongs_to` associations:
+
+      mix phoenix.gen.model Post posts title user:belongs_to
+
+  This will result in a migration with an `:integer` column
+  of `:user_id` and create an index. It will also generate
+  the appropriate `belongs_to` entry in the model's schema.
+
   Furthermore an array type can also be given if it is
   supported by your database, although it requires the
   type of the underlying array element to be given too:

--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -99,7 +99,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
 
   defp assocs(assocs) do
     Enum.reduce assocs, [], fn {key, _}, acc ->
-      assoc = Mix.Phoenix.inflect(key)
+      assoc = Mix.Phoenix.inflect Atom.to_string(key)
       [{key, :"#{key}_id", assoc[:module]} | acc]
     end
   end

--- a/priv/templates/model/migration.exs
+++ b/priv/templates/model/migration.exs
@@ -5,7 +5,12 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
     create table(:<%= plural %>) do
 <%= for {k, v} <- attrs do %>      add <%= inspect k %>, <%= inspect v %><%= defaults[k] %>
 <% end %>
+<%= for {_, i, _} <- assocs do %>      add <%= inspect i %>, :integer
+<% end %>
       timestamps
     end
+
+<%= for index <- indexes do %>      <%= index %>
+<% end %>
   end
 end

--- a/priv/templates/model/migration.exs
+++ b/priv/templates/model/migration.exs
@@ -4,13 +4,11 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
   def change do
     create table(:<%= plural %>) do
 <%= for {k, v} <- attrs do %>      add <%= inspect k %>, <%= inspect v %><%= defaults[k] %>
-<% end %>
-<%= for {_, i, _} <- assocs do %>      add <%= inspect i %>, :integer
+<% end %><%= for {_, i, _} <- assocs do %>      add <%= inspect i %>, :integer
 <% end %>
       timestamps
     end
-
-<%= for index <- indexes do %>      <%= index %>
+<%= for index <- indexes do %>    <%= index %>
 <% end %>
   end
 end

--- a/priv/templates/model/model.ex
+++ b/priv/templates/model/model.ex
@@ -4,6 +4,8 @@ defmodule <%= module %> do
   schema <%= inspect plural %> do
 <%= for {k, _} <- attrs do %>    field <%= inspect k %>, <%= inspect types[k] %><%= defaults[k] %>
 <% end %>
+<%= for {k, _, m} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>
+<% end %>
     timestamps
   end
 

--- a/priv/templates/model/model.ex
+++ b/priv/templates/model/model.ex
@@ -3,8 +3,7 @@ defmodule <%= module %> do
 
   schema <%= inspect plural %> do
 <%= for {k, _} <- attrs do %>    field <%= inspect k %>, <%= inspect types[k] %><%= defaults[k] %>
-<% end %>
-<%= for {k, _, m} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>
+<% end %><%= for {k, _, m} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>
 <% end %>
     timestamps
   end

--- a/test/mix/tasks/phoenix.gen.html_test.exs
+++ b/test/mix/tasks/phoenix.gen.html_test.exs
@@ -13,7 +13,8 @@ defmodule Mix.Tasks.Phoenix.Gen.HtmlTest do
     in_tmp "generates html resource", fn ->
       Mix.Tasks.Phoenix.Gen.Html.run ["user", "users", "name", "age:integer", "height:decimal",
                                       "nicks:array:text", "famous:boolean", "born_at:datetime",
-                                      "secret:uuid", "first_login:date", "alarm:time"]
+                                      "secret:uuid", "first_login:date", "alarm:time",
+                                      "address:belongs_to"]
 
       assert_file "web/models/user.ex"
       assert_file "test/models/user_test.exs"
@@ -37,6 +38,7 @@ defmodule Mix.Tasks.Phoenix.Gen.HtmlTest do
         assert file =~ ~s(<%= text_input f, :name, class: "form-control" %>)
         assert file =~ ~s(<%= number_input f, :age, class: "form-control" %>)
         assert file =~ ~s(<%= number_input f, :height, step: "any", class: "form-control" %>)
+        assert file =~ ~s(<%= number_input f, :address_id, class: "form-control" %>)
         assert file =~ ~s(<%= checkbox f, :famous, class: "form-control" %>)
         assert file =~ ~s(<%= datetime_select f, :born_at, class: "form-control" %>)
         assert file =~ ~s(<%= text_input f, :secret, class: "form-control" %>)
@@ -61,7 +63,7 @@ defmodule Mix.Tasks.Phoenix.Gen.HtmlTest do
         assert file =~ "defmodule Phoenix.UserControllerTest"
         assert file =~ "use Phoenix.ConnCase"
 
-        assert file =~ ~S|@valid_params user: %{age: 42|
+        assert file =~ ~S|@valid_params user: %{address: nil|
         assert file =~ ~S|@invalid_params user: %{}|
 
         assert file =~ ~S|test "GET /users"|

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -77,6 +77,30 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
     end
   end
 
+  test "generates belongs_to associations" do
+    in_tmp "generates belongs_to associations", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts", "title", "user:belongs_to"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
+
+      assert_file migration, fn file ->
+        assert file =~ "defmodule Phoenix.Repo.Migrations.CreatePost do"
+        assert file =~ "create table(:posts) do"
+        assert file =~ "add :title, :string"
+        assert file =~ "add :user_id, :integer"
+        assert file =~ "create index(:posts, [:user_id])"
+      end
+
+      assert_file "web/models/post.ex", fn file ->
+        assert file =~ "defmodule Phoenix.Post do"
+        assert file =~ "use Phoenix.Web, :model"
+        assert file =~ "schema \"posts\" do"
+        assert file =~ "field :title, :string"
+        assert file =~ "belongs_to :user, Phoenix.User"
+      end
+    end
+  end
+
   test "plural can't contain a colon" do
     assert_raise Mix.Error, fn ->
       Mix.Tasks.Phoenix.Gen.Model.run ["Admin.User", "name:string", "foo:string"]


### PR DESCRIPTION
I'm not sure what the syntax would look like, but It'd be cool to be able to do something like

```
mix phoenix.gen.model Foo foos ...
mix phoenix.gen.model Bar bars foo_id:references(:foos)
```