### PR TITLE
Fix travis after_script invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,6 @@ script:
   - mix test
   - cd installer && mix test
 after_script:
+  - cd $TRAVIS_BUILD_DIR
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report


### PR DESCRIPTION
Hi Chris,

this PR fixes the invocation of the `after_script` on Travis.

Since we switch to the `installer/`dir after `mix test` in order to invoke it again, we have to return to `TRAVIS_BUILD_DIR` for the subsequent invocation of InchEx.