### PR TITLE
Update to latest phoenix_ecto

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -201,7 +201,8 @@ defmodule Mix.Tasks.Phoenix.New do
         adapter: #{inspect binding[:adapter_module]},
         username: #{inspect binding[:db_user]},
         password: #{inspect binding[:db_password]},
-        database: "#{binding[:application_name]}_dev"
+        database: "#{binding[:application_name]}_dev",
+        size: 10 # The amount of database connections in the pool
       """
 
       append_to path, "config/test.exs", """
@@ -212,8 +213,7 @@ defmodule Mix.Tasks.Phoenix.New do
         username: #{inspect binding[:db_user]},
         password: #{inspect binding[:db_password]},
         database: "#{binding[:application_name]}_test",
-        size: 1,
-        max_overflow: 0
+        size: 1 # Use a single connection for transactional tests
       """
 
       append_to path, "config/prod.secret.exs", """

--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -32,7 +32,7 @@ defmodule <%= application_module %>.Mixfile do
   # Type `mix help deps` for examples and options
   defp deps do
     [<%= phoenix_dep %>,<%= if ecto do %>
-     {:phoenix_ecto, "~> 0.3"},
+     {:phoenix_ecto, "~> 0.4"},
      {<%= inspect adapter_app %>, ">= 0.0.0"},<% end %>
      {:phoenix_html, "~> 1.0"},
      {:phoenix_live_reload, "~> 0.3", only: :dev},

--- a/priv/templates/model/model.ex
+++ b/priv/templates/model/model.ex
@@ -17,7 +17,7 @@ defmodule <%= module %> do
   If `params` are nil, an invalid changeset is returned
   with no validation performed.
   """
-  def changeset(model, params \\ nil) do
+  def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)
   end


### PR DESCRIPTION
This pull request uses latest phoenix_ecto that depends on phoenix_html + poison instead of phoenix. Unfortunately, we cannot merge this yet, because we haven't released the latest phoenix_ecto as doing so would break existing applications (due to its dependency on phoenix_html).

We will need to release phoenix_ecto and merge this right before the next phoenix release.