### PR TITLE
Fix typo in phoenix.js

### DIFF
--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -267,7 +267,7 @@ export class Channel {
   //
   leave(){
     return this.push(CHAN_EVENTS.leave).receive("ok", () => {
-      this.trigger(CHANNEl_EVENTS.close, "leave")
+      this.trigger(CHAN_EVENTS.close, "leave")
     })
   }
 


### PR DESCRIPTION
Hi there, found this while reading the ES6 source out of interest, so I am not 100% certain it is an error :sake: 

Caught it because of the downcased "L" in `CHANNEl_EVENTS` ...