### PR TITLE
Pass arguments from task phoenix.server to app.start

### DIFF
--- a/lib/mix/tasks/phoenix.server.ex
+++ b/lib/mix/tasks/phoenix.server.ex
@@ -5,6 +5,16 @@ defmodule Mix.Tasks.Phoenix.Server do
 
   @moduledoc """
   Starts the application by configuring all endpoints servers to run.
+
+  ## Command line options
+
+  This task accepts the same command-line arguments as `app.start`. For additional
+  information, refer to the documentation for `Mix.Tasks.App.Start`.
+
+  For example, to run `phoenix.server` without checking dependencies:
+
+    mix phoenix.server --no-deps-check
+
   """
   def run(args) do
     Application.put_env(:phoenix, :serve_endpoints, true, persistent: true)

--- a/lib/mix/tasks/phoenix.server.ex
+++ b/lib/mix/tasks/phoenix.server.ex
@@ -6,9 +6,9 @@ defmodule Mix.Tasks.Phoenix.Server do
   @moduledoc """
   Starts the application by configuring all endpoints servers to run.
   """
-  def run(_args) do
+  def run(args) do
     Application.put_env(:phoenix, :serve_endpoints, true, persistent: true)
-    Mix.Task.run "app.start", []
+    Mix.Task.run "app.start", args
     no_halt
   end
 


### PR DESCRIPTION
It may be desired to pass arguments from `mix phoenix.server` to "app.start".  An example of this would be `--no-deps-check` which comes up when .git directories are wiped on a PaaS (in my case, `flynn` re: [elixir issue #1430](https://github.com/elixir-lang/elixir/issues/1430)).  This pull request passes through those arguments for the Mix task.

I'd be happy to discuss the merits of this patch.