### PR TITLE
babel-brunch option key has changed from ES6to5 to babel.

### DIFF
--- a/brunch-config.js
+++ b/brunch-config.js
@@ -29,7 +29,7 @@ exports.config = {
 
   // Configure your plugins
   plugins: {
-    ES6to5: {
+    babel: {
       // Do not use ES6 compiler in vendor code
       ignore: [/^(web\/static\/vendor)/],
       loose: "all"

--- a/installer/templates/static/brunch/brunch-config.js
+++ b/installer/templates/static/brunch/brunch-config.js
@@ -31,7 +31,7 @@ exports.config = {
 
   // Configure your plugins
   plugins: {
-    ES6to5: {
+    babel: {
       // Do not use ES6 compiler in vendor code
       ignore: [/^(web\/static\/vendor)/]
     }


### PR DESCRIPTION
Backward-compatibility is maintained but we might as well be using the new name. It's also less confusing.

Here is the commit that introduced that change: https://github.com/babel/babel-brunch/commit/fa8dd643431e99d8a4fd05ad6637204264e9f497