### PR TITLE
Commented example of having a separate vendor.js bundle

### DIFF
--- a/installer/templates/static/brunch/brunch-config.js
+++ b/installer/templates/static/brunch/brunch-config.js
@@ -3,6 +3,13 @@ exports.config = {
   files: {
     javascripts: {
       joinTo: 'js/app.js'
+      // To use a separate vendor.js bundle, specify two files path
+      // https://github.com/brunch/brunch/blob/stable/docs/config.md#files
+      // joinTo: {
+      //  'js/app.js': /^(web\/static\/js)/,
+      //  'js/vendor.js': /^(web\/static\/vendor)/
+      // }
+      //
       // To change the order of concatenation of files, explictly mention here
       // https://github.com/brunch/brunch/tree/stable/docs#concatenation
       // order: {


### PR DESCRIPTION
We decided to leave the default as is but to give an example of separating the two bundles (app and vendor).

