### PR TITLE
Add `static_url` configuration.

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -337,6 +337,13 @@ defmodule Phoenix.Endpoint do
       end
 
       @doc """
+      Generates the endpoint base URL without any path informat
+      """
+      def static_url do
+        url
+      end
+
+      @doc """
       Generates the path information when routing to this endpoint.
       """
       script_name = var!(config)[:url][:path]

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -340,7 +340,9 @@ defmodule Phoenix.Endpoint do
       Generates the endpoint base URL without any path informat
       """
       def static_url do
-        url
+        Phoenix.Config.cache(__MODULE__,
+          :__phoenix_static_url__,
+          &Phoenix.Endpoint.Adapter.static_url/1)
       end
 
       @doc """

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -121,6 +121,10 @@ defmodule Phoenix.Endpoint do
       as a workaround for releases where environment specific information
       is loaded only at compile-time.
 
+    * `:static_url` - configuration for generating URLs for static files.
+      It will fallback to `url` if no option is provided. Accepts the same
+      options as `url`.
+
     * `:watchers` - a set of watchers to run alongside your server. It
       expects a list of tuples containing the executable and its arguments.
       Watchers are guaranteed to run in the application directory but only
@@ -337,7 +341,7 @@ defmodule Phoenix.Endpoint do
       end
 
       @doc """
-      Generates the endpoint base URL without any path informat
+      Generates the static URL without any path information.
       """
       def static_url do
         Phoenix.Config.cache(__MODULE__,

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -113,7 +113,7 @@ defmodule Phoenix.Endpoint.Adapter do
      reloadable_paths: ["web"],
      secret_key_base: nil,
      server: Application.get_env(:phoenix, :serve_endpoints, false),
-     static_host: nil,
+     static_url: nil,
      url: [host: "localhost", path: "/"],
 
      # Supervisor config
@@ -155,8 +155,7 @@ defmodule Phoenix.Endpoint.Adapter do
   the Phoenix.Config layer knows how to cache it.
   """
   def static_url(endpoint) do
-    url  = endpoint.config(:static_host)
-    {:cache, calculate_url(endpoint, url) }
+    {:cache, calculate_url(endpoint, endpoint.config(:static_url))}
   end
 
   defp calculate_url(endpoint, url) do

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -113,7 +113,7 @@ defmodule Phoenix.Endpoint.Adapter do
      reloadable_paths: ["web"],
      secret_key_base: nil,
      server: Application.get_env(:phoenix, :serve_endpoints, false),
-     multiple_static_hosts: [],
+     static_host: nil,
      url: [host: "localhost", path: "/"],
 
      # Supervisor config
@@ -155,8 +155,8 @@ defmodule Phoenix.Endpoint.Adapter do
   the Phoenix.Config layer knows how to cache it.
   """
   def static_url(endpoint) do
-    urls  = endpoint.config(:multiple_static_hosts)
-    {:cache, List.to_tuple(Enum.map(urls, &(calculate_url(endpoint, &1))))}
+    url  = endpoint.config(:static_host)
+    {:cache, calculate_url(endpoint, url) }
   end
 
   defp calculate_url(endpoint, url) do

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -155,7 +155,8 @@ defmodule Phoenix.Endpoint.Adapter do
   the Phoenix.Config layer knows how to cache it.
   """
   def static_url(endpoint) do
-    {:cache, calculate_url(endpoint, endpoint.config(:static_url))}
+    url = endpoint.config(:static_url) || endpoint.config(:url)
+    {:cache, calculate_url(endpoint, url)}
   end
 
   defp calculate_url(endpoint, url) do

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -148,8 +148,7 @@ defmodule Phoenix.Endpoint.Adapter do
   end
 
   @doc """
-  Builds the endpoint static url from its configuration based on the multiple
-  static hosts configured
+  Builds the static url from its configuration.
 
   The result is wrapped in a `{:cache, value}` tuple so
   the Phoenix.Config layer knows how to cache it.

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -33,7 +33,7 @@ defmodule Phoenix.Router.Helpers do
       Generates the connection/endpoint base URL without any path information.
       """
       def url(%Conn{private: private}) do
-        private.phoenix_endpoint.url
+        private.phoenix_endpoint.static_url
       end
 
       def url(%Socket{endpoint: endpoint}) do
@@ -41,7 +41,7 @@ defmodule Phoenix.Router.Helpers do
       end
 
       def url(endpoint) when is_atom(endpoint) do
-        endpoint.url
+        endpoint.static_url
       end
 
       @doc """

--- a/test/phoenix/endpoint/adapter_test.exs
+++ b/test/phoenix/endpoint/adapter_test.exs
@@ -44,6 +44,7 @@ defmodule Phoenix.Endpoint.AdapterTest do
     def config(:https), do: false
     def config(:http), do: false
     def config(:url), do: [host: "example.com", port: 678, scheme: "random"]
+    def config(:static_url), do: nil
   end
 
   defmodule StaticURLEndpoint do
@@ -56,6 +57,10 @@ defmodule Phoenix.Endpoint.AdapterTest do
     static_host = {:cache, "http://static.example.com"}
 
     assert Adapter.static_url(StaticURLEndpoint) == static_host
+  end
+
+  test "static url fallbacks to url when there is no configuration for static_url" do
+    assert Adapter.static_url(URLEndpoint) == {:cache, "random://example.com:678"}
   end
 
   test "generates url" do

--- a/test/phoenix/endpoint/adapter_test.exs
+++ b/test/phoenix/endpoint/adapter_test.exs
@@ -49,21 +49,13 @@ defmodule Phoenix.Endpoint.AdapterTest do
   defmodule StaticURLEndpoint do
     def config(:https), do: false
     def config(:http), do: false
-    def config(:multiple_static_hosts) do
-      [[host: "example1.com", port: 678, scheme: "random"],
-       [host: "example2.com"],
-       [host: "example3.com", port: 8888],
-       [host: "example4.com", port: 669]]
-    end
+    def config(:static_host), do: [host: "static.example.com"]
   end
 
-  test "generates all the possible url based on the multiple assets hosts" do
-    available_static_hosts = {:cache, {"random://example1.com:678",
-                                       "http://example2.com",
-                                       "http://example3.com:8888",
-                                       "http://example4.com:669"}}
+  test "generates the static url based on the static host configuration" do
+    static_host = {:cache, "http://static.example.com"}
 
-    assert Adapter.static_url(StaticURLEndpoint) == available_static_hosts
+    assert Adapter.static_url(StaticURLEndpoint) == static_host
   end
 
   test "generates url" do

--- a/test/phoenix/endpoint/adapter_test.exs
+++ b/test/phoenix/endpoint/adapter_test.exs
@@ -46,6 +46,32 @@ defmodule Phoenix.Endpoint.AdapterTest do
     def config(:url), do: [host: "example.com", port: 678, scheme: "random"]
   end
 
+  defmodule StaticURLEndpoint do
+    def config(:https), do: false
+    def config(:http), do: false
+    def config(:multiple_static_hosts) do
+      [[host: "example1.com", port: 678, scheme: "random"],
+       [host: "example2.com"],
+       [host: "example3.com", port: 8888],
+       [host: "example4.com", port: 669]]
+    end
+  end
+
+  test "generates static url based on multiple assets hosts" do
+    available_static_hosts = [
+      {:cache, "http://example1.com:678"},
+      {:cache, "http://example2.com"},
+      {:cache, "http://example3.com:8888"},
+      {:cache, "http://example4.com:669"}
+    ]
+    :random.seed(:erlang.now)
+
+    assert Adapter.static_url(StaticURLEndpoint) in available_static_hosts
+    assert Adapter.static_url(StaticURLEndpoint) in available_static_hosts
+    assert Adapter.static_url(StaticURLEndpoint) in available_static_hosts
+    assert Adapter.static_url(StaticURLEndpoint) in available_static_hosts
+  end
+
   test "generates url" do
     assert Adapter.url(URLEndpoint) == {:cache, "random://example.com:678"}
     assert Adapter.url(HTTPEndpoint) == {:cache, "http://example.com"}

--- a/test/phoenix/endpoint/adapter_test.exs
+++ b/test/phoenix/endpoint/adapter_test.exs
@@ -49,7 +49,7 @@ defmodule Phoenix.Endpoint.AdapterTest do
   defmodule StaticURLEndpoint do
     def config(:https), do: false
     def config(:http), do: false
-    def config(:static_host), do: [host: "static.example.com"]
+    def config(:static_url), do: [host: "static.example.com"]
   end
 
   test "generates the static url based on the static host configuration" do

--- a/test/phoenix/endpoint/adapter_test.exs
+++ b/test/phoenix/endpoint/adapter_test.exs
@@ -57,19 +57,13 @@ defmodule Phoenix.Endpoint.AdapterTest do
     end
   end
 
-  test "generates static url based on multiple assets hosts" do
-    available_static_hosts = [
-      {:cache, "http://example1.com:678"},
-      {:cache, "http://example2.com"},
-      {:cache, "http://example3.com:8888"},
-      {:cache, "http://example4.com:669"}
-    ]
-    :random.seed(:erlang.now)
+  test "generates all the possible url based on the multiple assets hosts" do
+    available_static_hosts = {:cache, {"random://example1.com:678",
+                                       "http://example2.com",
+                                       "http://example3.com:8888",
+                                       "http://example4.com:669"}}
 
-    assert Adapter.static_url(StaticURLEndpoint) in available_static_hosts
-    assert Adapter.static_url(StaticURLEndpoint) in available_static_hosts
-    assert Adapter.static_url(StaticURLEndpoint) in available_static_hosts
-    assert Adapter.static_url(StaticURLEndpoint) in available_static_hosts
+    assert Adapter.static_url(StaticURLEndpoint) == available_static_hosts
   end
 
   test "generates url" do

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -2,7 +2,8 @@ defmodule Phoenix.Endpoint.EndpointTest do
   use ExUnit.Case, async: true
   use RouterHelper
 
-  @config [url: [host: "example.com", path: "/api"], server: false,
+  @config [url: [host: "example.com", path: "/api"],
+           static_url: [host: "static.example.com"], server: false,
            cache_static_lookup: true, cache_static_manifest: "../../../../test/fixtures/manifest.json",
            pubsub: [adapter: Phoenix.PubSub.PG2, name: :endpoint_pub]]
   Application.put_env(:phoenix, __MODULE__.Endpoint, @config)
@@ -23,12 +24,18 @@ defmodule Phoenix.Endpoint.EndpointTest do
 
   test "has reloadable configuration" do
     assert Endpoint.config(:url) == [host: "example.com", path: "/api"]
+    assert Endpoint.config(:static_url) == [host: "static.example.com"]
     assert Endpoint.url == "http://example.com"
+    assert Endpoint.static_url == "http://static.example.com"
 
     config = put_in(@config[:url][:port], 1234)
+    |> put_in([:static_url, :port], 456)
+
     assert Endpoint.config_change([{Endpoint, config}], []) == :ok
     assert Endpoint.config(:url) == [host: "example.com", path: "/api", port: 1234]
+    assert Endpoint.config(:static_url) == [port: 456, host: "static.example.com"]
     assert Endpoint.url == "http://example.com:1234"
+    assert Endpoint.static_url == "http://static.example.com:456"
   end
 
   test "sets script name when using path" do

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -89,6 +89,10 @@ defmodule Phoenix.Router.HelpersTest do
     "https://example.com"
   end
 
+  def static_url do
+    url
+  end
+
   def path(path) do
     path
   end
@@ -308,6 +312,10 @@ defmodule Phoenix.Router.HelpersTest do
   defmodule ScriptName do
     def url do
       "https://example.com"
+    end
+
+    def static_url do
+      url
     end
 
     def path(path) do


### PR DESCRIPTION
This option is the first step to achieve multiple assets hosts (#617).

When accessing the `static_url` function it will return the URL based on this configuration. If no configuration for `static_url` is provided, it will fallback to `url`.