### PR TITLE
Encourage accessible HTML

### DIFF
--- a/installer/templates/new/web/templates/layout/application.html.eex
+++ b/installer/templates/new/web/templates/layout/application.html.eex
@@ -12,7 +12,7 @@
   </head>
 
   <body>
-    <div class="container">
+    <div class="container" role="main">
       <div class="header">
         <ul class="nav nav-pills pull-right">
           <li><a href="http://www.phoenixframework.org/docs">Get Started</a></li>
@@ -20,8 +20,8 @@
         <span class="logo"></span>
       </div>
 
-      <p class="alert alert-info"><%%= get_flash(@conn, :info) %></p>
-      <p class="alert alert-danger"><%%= get_flash(@conn, :error) %></p>
+      <p class="alert alert-info" role="alert"><%%= get_flash(@conn, :info) %></p>
+      <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
 
       <%%= @inner %>
 


### PR DESCRIPTION
Encourage others to write HTML which is accessible. Roles aid assistive technologies in deciding what the correct way to announce content to a user is. For this reason, I think it is important to encourage developers to write accessible HTML using roles, as recommended by Bootstrap which is used here, rather than bare HTML.