### PR TITLE
Updated freenode IRC link to use http on the welcome page

### DIFF
--- a/installer/templates/new/web/templates/page/index.html.eex
+++ b/installer/templates/new/web/templates/page/index.html.eex
@@ -29,7 +29,7 @@
         <a href="https://github.com/phoenixframework/phoenix/issues?state=open">Issues</a>
       </li>
       <li>
-        <a href="irc://irc.freenode.net/elixir-lang">#elixir-lang on freenode IRC</a>
+        <a href="http://webchat.freenode.net/?channels=elixir-lang">#elixir-lang on freenode IRC</a>
       </li>
       <li>
         <a href="https://twitter.com/elixirphoenix">@elixirphoenix</a>
@@ -37,4 +37,3 @@
     </ul>
   </div>
 </div>
-


### PR DESCRIPTION
Updated the ```freenode IRC``` link to use ```http://webchat.freenode.net/?channels=elixir-lang``` instead of ```irc://irc.freenode.net/elixir-lang``` on the newly generated app welcome page.

Nothing major but to make it consistent with the on-line docs.