### PR TITLE
Provide info to run migration for phoenix.gen.model

### DIFF
--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -68,6 +68,11 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
       {:eex, "model.ex",       "web/models/#{path}.ex"},
       {:eex, "model_test.exs", "test/models/#{path}_test.exs"},
     ]
+    
+    Mix.shell.info """
+      Update your repository by running migrations:
+        $ mix ecto.migrate
+    """
   end
 
   defp validate_args!([_, plural | _] = args) do


### PR DESCRIPTION
When Phoenix.gen.html generates model and migration files, it gives info about running migrations. However, when Phoenix.gen.model generates the model and migration files, this info is missing. This commit makes it even.