### PR TITLE
Allow custom refs in child_specs

### DIFF
--- a/lib/phoenix/endpoint/cowboy_handler.ex
+++ b/lib/phoenix/endpoint/cowboy_handler.ex
@@ -24,14 +24,16 @@ defmodule Phoenix.Endpoint.CowboyHandler do
   end
 
   def child_spec(scheme, endpoint, config) do
-    # Use put_new to allow custom dispatches
-    config = Keyword.put_new(config, :dispatch, [{:_, [{:_, __MODULE__, {endpoint, []}}]}])
+    # Use put_new to allow custom dispatches and refs
+    config = config
+    |> Keyword.put_new(:dispatch, [{:_, [{:_, __MODULE__, {endpoint, []}}]}])
+    |> Keyword.put_new(:ref, scheme)
 
-    {_ref, mfa, type, timeout, kind, modules} =
+    {ref, mfa, type, timeout, kind, modules} =
       Plug.Adapters.Cowboy.child_spec(scheme, endpoint, [], config)
 
     mfa = {__MODULE__, :start_link, [scheme, endpoint, config, mfa]}
-    {scheme, mfa, type, timeout, kind, modules}
+    {ref, mfa, type, timeout, kind, modules}
   end
 
   ## Cowboy Handler


### PR DESCRIPTION
This lets me run multiple listeners for the same endpoint under a single supervisor, for instance an IPv4 and an IPv6 listener. (There are a few other places where Phoenix assumes that there will only ever be one HTTP and one HTTPS listener, for instance in configuration and, by extension, the URL building functions.)