### PR TITLE
Ignore priv static

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -16,7 +16,6 @@ defmodule Mix.Tasks.Phoenix.New do
     {:eex,  "new/config/test.exs",                           "config/test.exs"},
     {:eex,  "new/lib/application_name.ex",                   "lib/application_name.ex"},
     {:eex,  "new/lib/application_name/endpoint.ex",          "lib/application_name/endpoint.ex"},
-    {:text, "new/priv/static/robots.txt",                    "priv/static/robots.txt"},
     {:keep, "new/test/channels",                             "test/channels"},
     {:eex,  "new/test/controllers/page_controller_test.exs", "test/controllers/page_controller_test.exs"},
     {:eex,  "new/test/views/error_view_test.exs",            "test/views/error_view_test.exs"},
@@ -51,12 +50,14 @@ defmodule Mix.Tasks.Phoenix.New do
     {:text, "static/brunch/package.json",     "package.json"},
     {:text, "static/app.css",                 "web/static/css/app.scss"},
     {:text, "static/brunch/app.js",           "web/static/js/app.js"},
+    {:text, "static/robots.txt",              "web/static/assets/robots.txt"},
   ]
 
   @bare [
     {:text, "static/bare/.gitignore", ".gitignore"},
     {:text, "static/app.css",         "priv/static/css/app.css"},
     {:text, "static/bare/app.js",     "priv/static/js/app.js"},
+    {:text, "static/robots.txt",      "priv/static/robots.txt"},
   ]
 
   # Embed all defined templates
@@ -240,7 +241,7 @@ defmodule Mix.Tasks.Phoenix.New do
     else
       copy_from path, binding, @brunch
       create_file Path.join(path, "web/static/vendor/phoenix.js"), phoenix_js_text()
-      create_file Path.join(path, "priv/static/images/phoenix.png"), phoenix_png_text()
+      create_file Path.join(path, "web/static/assets/images/phoenix.png"), phoenix_png_text()
     end
   end
 

--- a/installer/templates/static/brunch/.gitignore
+++ b/installer/templates/static/brunch/.gitignore
@@ -12,8 +12,7 @@ erl_crash.dump
 # Since we are building js and css from web/static,
 # we ignore priv/static/{css,js}. You may want to
 # comment this depending on your deployment strategy.
-/priv/static/css
-/priv/static/js
+/priv/static/
 
 # The config/prod.secret.exs file by default contains sensitive
 # data and you should not commit it into version control.

--- a/installer/templates/static/brunch/.gitignore
+++ b/installer/templates/static/brunch/.gitignore
@@ -9,9 +9,9 @@ erl_crash.dump
 # Static artifacts
 /node_modules
 
-# Since we are building js and css from web/static,
-# we ignore priv/static/{css,js}. You may want to
-# comment this depending on your deployment strategy.
+# Since we are building assets from web/static,
+# we ignore priv/static. You may want to comment
+# this depending on your deployment strategy.
 /priv/static/
 
 # The config/prod.secret.exs file by default contains sensitive

--- a/installer/templates/static/robots.txt
+++ b/installer/templates/static/robots.txt
@@ -1,0 +1,5 @@
+# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+#
+# To ban all spiders from the entire site uncomment the next two lines:
+# User-agent: *
+# Disallow: /

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
 
       # Brunch
       assert_file "photo_blog/.gitignore", ~r"/node_modules"
-      assert_file "photo_blog/priv/static/images/phoenix.png"
+      assert_file "photo_blog/web/static/assets/images/phoenix.png"
       assert_file "photo_blog/web/static/vendor/phoenix.js"
       assert_file "photo_blog/web/static/js/app.js"
       assert_file "photo_blog/web/static/css/app.scss"


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix/issues/875

When generating a new Phoenix app with brunch, it generates all static files in `web/static` and gitignores all files in `priv/static`.