### PR TITLE
Fix static_url helper to use static_url endpoint config

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -33,7 +33,7 @@ defmodule Phoenix.Router.Helpers do
       Generates the connection/endpoint base URL without any path information.
       """
       def url(%Conn{private: private}) do
-        private.phoenix_endpoint.static_url
+        private.phoenix_endpoint.url
       end
 
       def url(%Socket{endpoint: endpoint}) do
@@ -41,7 +41,7 @@ defmodule Phoenix.Router.Helpers do
       end
 
       def url(endpoint) when is_atom(endpoint) do
-        endpoint.static_url
+        endpoint.url
       end
 
       @doc """
@@ -94,7 +94,7 @@ defmodule Phoenix.Router.Helpers do
       end
 
       def static_url(endpoint, path) when is_atom(endpoint) do
-        endpoint.url <> endpoint.static_path(path)
+        endpoint.static_url <> endpoint.static_path(path)
       end
 
       # Functions used by generated helpers

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -90,7 +90,7 @@ defmodule Phoenix.Router.HelpersTest do
   end
 
   def static_url do
-    url
+    "https://static.example.com"
   end
 
   def path(path) do
@@ -279,7 +279,7 @@ defmodule Phoenix.Router.HelpersTest do
   end
 
   test "helpers module generates a static_url helper" do
-    url = "https://example.com/images/foo.png"
+    url = "https://static.example.com/images/foo.png"
     assert Helpers.static_url(__MODULE__, "/images/foo.png") == url
     assert Helpers.static_url(conn_with_endpoint, "/images/foo.png") == url
     assert Helpers.static_url(socket_with_endpoint, "/images/foo.png") == url
@@ -315,7 +315,7 @@ defmodule Phoenix.Router.HelpersTest do
     end
 
     def static_url do
-      url
+      "https://static.example.com"
     end
 
     def path(path) do
@@ -357,6 +357,6 @@ defmodule Phoenix.Router.HelpersTest do
            "/api/images/foo.png"
 
     assert Helpers.static_url(conn_with_script_name(~w(foo)), "/images/foo.png") ==
-           "https://example.com/api/images/foo.png"
+           "https://static.example.com/api/images/foo.png"
   end
 end


### PR DESCRIPTION
Configured `static_url` was not used to generate the url via the `static_url` helper and the `url` helper was also broken.