### PR TITLE
implemented jsonp support for controllers and added tests

### DIFF
--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -132,6 +132,45 @@ defmodule Phoenix.Controller.ControllerTest do
              ["application/vnd.api+json; charset=utf-8"]
   end
 
+  test "jsonp/3 returns json when no callback param is present" do
+    conn = jsonp(conn(:get, "/") |> fetch_query_params, %{foo: :bar})
+    assert conn.resp_body == "{\"foo\":\"bar\"}"
+    assert get_resp_content_type(conn) == "application/json"
+    refute conn.halted
+  end
+
+  test "jsonp/3 returns javascript when callback param is present" do
+    conn = conn(:get, "/?callback=cb") |> fetch_query_params()
+    conn = jsonp(conn, %{foo: :bar})
+    assert conn.resp_body == "/**/ typeof cb === 'function' && cb({\"foo\":\"bar\"});"
+    assert get_resp_content_type(conn) == "text/javascript"
+    refute conn.halted
+  end
+    
+  test "jsonp/3 allows to override the callback name" do
+    conn = conn(:get, "/?cb=cb") |> fetch_query_params()
+    conn = jsonp(conn, %{foo: :bar}, callback: "cb")
+    assert conn.resp_body == "/**/ typeof cb === 'function' && cb({\"foo\":\"bar\"});"
+    assert get_resp_content_type(conn) == "text/javascript"
+    refute conn.halted
+  end
+
+  test "jsonp/3 normalizes callback name" do
+    conn = conn(:get, "/?cb=_c*b!()[0]") |> fetch_query_params()
+    conn = jsonp(conn, %{foo: :bar}, callback: "cb")
+    assert conn.resp_body == "/**/ typeof _cb[0] === 'function' && _cb[0]({\"foo\":\"bar\"});"
+    assert get_resp_content_type(conn) == "text/javascript"
+    refute conn.halted
+  end
+
+  test "jsonp/3 escapes invalid javascript characters" do
+    conn = conn(:get, "/?cb=cb") |> fetch_query_params()
+    conn = jsonp(conn, %{foo: <<0x2028::utf8>> <> <<0x2029::utf8>>}, callback: "cb")
+    assert conn.resp_body == "/**/ typeof cb === 'function' && cb({\"foo\":\"\\u2028\\u2029\"});"
+    assert get_resp_content_type(conn) == "text/javascript"
+    refute conn.halted
+  end
+
   test "text/2" do
     conn = text(conn(:get, "/"), "foobar")
     assert conn.resp_body == "foobar"


### PR DESCRIPTION
Adds jsonp support to controllers. While CORS is usually preferable for cross domain requests I think there is also some value in having jsonp support: works well with older browsers (IE < 10), good jQuery integration, etc.

The syntax for the jsonp feature is the same as for json:

```elixir
jsonp conn, %{foo: :bar}
```
This will produce the following output on request (GET /?callback=cb):

```javascript
/**/ typeof cb === 'function' && cb({"foo":"bar"});
```

It's possible to override the callback parameter:

```elixir
jsonp conn, %{foo: :bar}, callback: "cb"
```
that allows you to use the overridden callback name in the query string (GET /?cb=cb)