### PR TITLE
Wrap asterisks in backticks to avoid emphasis

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -667,7 +667,7 @@ defmodule Phoenix.Controller do
     * the accepted list of arguments contains the "html" format
 
     * the accept header specified more than one media type preceeded
-      or followed by the wildcard media type "*/*"
+      or followed by the wildcard media type "`*/*`"
 
   This function raises `Phoenix.NotAcceptableError`, which is rendered
   with status 406, whenever the server cannot serve a response in any


### PR DESCRIPTION
Without the backticks, this markdown gets rendered as `"<em>/</em>"` in HTML (see: [Phoenix.Controller.accepts/2](http://hexdocs.pm/phoenix/Phoenix.Controller.html#accepts/2)).

This change keeps the asterisks visible when rendered into HTML.
    
An alternate fix would be to escape the asterisks themselves (`\\*/\\*`) but using backticks looks a little bit nicer when viewing the markdown directly.