### PR TITLE
Set different assets directory

### DIFF
--- a/installer/templates/static/brunch/brunch-config.js
+++ b/installer/templates/static/brunch/brunch-config.js
@@ -27,6 +27,13 @@ exports.config = {
     }
   },
 
+  conventions: {
+    // This option sets where we should place non-css and non-js assets in.
+    // By default, we set this to '/web/static/assets'. Files in this directory
+    // will be copied to `paths.public`, which is "priv/static" by default.
+    assets: /^(web\/static\/assets)/
+  },
+
   // Phoenix paths configuration
   paths: {
     // Which directories to watch


### PR DESCRIPTION
I encountered a problem when installing bootstrap-sass through bower where I noticed its JS files weren't being compiled. Turns out bootstrap-sass has an `/assets` directory and brunch, by default, copies all files in any `/assets` dir, even ones in bower deps, straight to `priv/static`.

This PR fixes this problem and shows where to copy non-css and non-js assets to, which is `web/static/assets` by default.