### PR TITLE
Subscribers function returns a list not a hashset

### DIFF
--- a/lib/phoenix/pubsub/local.ex
+++ b/lib/phoenix/pubsub/local.ex
@@ -82,7 +82,7 @@ defmodule Phoenix.PubSub.Local do
   ## Examples
 
       iex> subscribers(:local_server, "foo")
-      #HashSet<[]>
+      [#PID<0.333.0>]
 
   """
   def subscribers(local_server, topic) do


### PR DESCRIPTION
This fixes the documentation of the Phoenix.PubSub.Local.subscribers function, so it is documented what is actually returned (list instead of hashset).

Is there a reason for converting the hashset to a list? I'd prefer to just get the hashset. Also converting the hashset to a list might be very expensive.