### PR TITLE
Fix local subscribers return value

### DIFF
--- a/lib/phoenix/pubsub/local.ex
+++ b/lib/phoenix/pubsub/local.ex
@@ -116,7 +116,7 @@ defmodule Phoenix.PubSub.Local do
   end
 
   def handle_call({:subscribers, topic}, _from, state) do
-    {:reply, HashDict.get(state.topics, topic, HashSet.new) |> Enum.to_list, state}
+    {:reply, HashDict.get(state.topics, topic, HashSet.new), state}
   end
 
   def handle_call({:subscribe, pid, topic, opts}, _from, state) do

--- a/lib/phoenix/pubsub/local.ex
+++ b/lib/phoenix/pubsub/local.ex
@@ -82,7 +82,7 @@ defmodule Phoenix.PubSub.Local do
   ## Examples
 
       iex> subscribers(:local_server, "foo")
-      #HashSet<[]>
+      Enumerable.t
 
   """
   def subscribers(local_server, topic) do

--- a/test/shared/pubsub_test.exs
+++ b/test/shared/pubsub_test.exs
@@ -38,11 +38,11 @@ defmodule Phoenix.PubSubTest do
 
   test "subscribe and unsubscribe", config do
     pid = spawn_pid
-    assert Local.subscribers(config.local, "topic4") == []
+    assert Local.subscribers(config.local, "topic4") |> Dict.size == 0
     assert PubSub.subscribe(config.test, pid, "topic4")
-    assert Local.subscribers(config.local, "topic4") == [pid]
+    assert Local.subscribers(config.local, "topic4") |> Enum.to_list == [pid]
     assert PubSub.unsubscribe(config.test, pid, "topic4")
-    assert Local.subscribers(config.local, "topic4") == []
+    assert Local.subscribers(config.local, "topic4") |> Dict.size == 0
   end
 
   test "subscribe/3 with link does not down adapter", config do
@@ -52,7 +52,7 @@ defmodule Phoenix.PubSubTest do
 
     kill_and_wait(pid)
     assert Process.alive?(local)
-    assert Local.subscribers(config.local, "topic4") == []
+    assert Local.subscribers(config.local, "topic4") |> Dict.size == 0
   end
 
   test "subscribe/3 with link downs subscriber", config do


### PR DESCRIPTION
Return the HashSet directly instead of converting it to a list. The
conversion is not really needed and will be expensive if the number of
subscribers is large.

Updated the function doc so we say we return a `Enumerable.t` instead of the concrete HashSet type.

This replaces PR #937 