### PR TITLE
fix(installer): do not attempt to use require without brunch

### DIFF
--- a/installer/templates/new/web/templates/layout/app.html.eex
+++ b/installer/templates/new/web/templates/layout/app.html.eex
@@ -27,6 +27,8 @@
 
     </div> <!-- /container -->
     <script src="<%%= static_path(@conn, "/js/app.js") %>"></script>
+    <%= if brunch do %>
     <script>require("web/static/js/app")</script>
+    <% end %>
   </body>
 </html>

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -64,6 +64,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "photo_blog/web/static/js/app.js"
       assert_file "photo_blog/web/static/css/app.scss"
       assert_file "photo_blog/config/dev.exs", ~r/watchers: \[node:/
+      assert File.read!("photo_blog/web/templates/layout/app.html.eex") |> String.contains?(~s{require("web/static/js/app")})
 
       refute File.exists? "photo_blog/priv/static/css/app.css"
       refute File.exists? "photo_blog/priv/static/js/phoenix.js"
@@ -91,6 +92,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       # No Brunch
       refute File.read!("photo_blog/.gitignore") |> String.contains?("/node_modules")
       assert_file "photo_blog/config/dev.exs", ~r/watchers: \[\]/
+      refute File.read!("photo_blog/web/templates/layout/app.html.eex") |> String.contains?(~s{require("web/static/js/app")})
 
       assert_file "photo_blog/priv/static/css/app.css"
       assert_file "photo_blog/priv/static/images/phoenix.png"


### PR DESCRIPTION
If the `--no-brunch` flag is set when creating a new project using
installer, e.g.

    mix phoenix.new /tmp/testapp --no-brunch

The line that is responsible for running the JavaScript for assets using
brunch is not included.

This prevents the JavaScript error:

 > ReferenceError: require is not defined

This closes issue #942