### PR TITLE
Clearer error msg when module passed to route is not a Phoenix Controller

### DIFF
--- a/lib/phoenix/router/route.ex
+++ b/lib/phoenix/router/route.ex
@@ -101,8 +101,17 @@ defmodule Phoenix.Router.Route do
       var!(conn)
       |> Plug.Conn.put_private(:phoenix_pipelines, unquote(route.pipe_through))
       |> Plug.Conn.put_private(:phoenix_route, fn conn ->
-           opts = unquote(route.controller).init(unquote(route.action))
-           unquote(route.controller).call(conn, opts)
+           controller   = unquote(route.controller)
+           defined_funs = controller.__info__(:functions)
+
+           if {:init, 1} in defined_funs && {:call, 2} in defined_funs do
+             opts = controller.init(unquote(route.action))
+             controller.call(conn, opts)
+           else
+             raise ArgumentError, "The module passed to the route must be a Phoenix controller." <>
+               " Double-check the module you passed to the route or make sure that you" <>
+               " `use Phoenix.Controller` in the module"
+           end
          end)
     end
 

--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -14,6 +14,9 @@ defmodule Phoenix.Router.RoutingTest do
     def image(conn, _params), do: text(conn, conn.params["path"] || "show files")
   end
 
+  defmodule User do
+  end
+
   defmodule Router do
     use Phoenix.Router
 
@@ -32,6 +35,7 @@ defmodule Phoenix.Router.RoutingTest do
     connect "/connect", UserController, :connect
 
     get "/users/:user_id/files/:id", UserController, :image
+    get "/test", User, :test
     get "/*path", UserController, :not_found
   end
 
@@ -124,6 +128,15 @@ defmodule Phoenix.Router.RoutingTest do
     conn = call(Router, :get, "backups/silly%20name")
     assert conn.status == 200
     assert conn.params["path"] == ["silly name"]
+  end
+
+  test "get with non-Phoenix controller module" do
+    msg = "** (ArgumentError) The module passed to the route must be a Phoenix controller. " <>
+    "Double-check the module you passed to the route or make sure that you `use Phoenix.Controller` " <>
+    "in the module"
+    assert_raise Plug.Conn.WrapperError, msg, fn ->
+      call(Router, :get, "/test")
+    end
   end
 
   test "catch-all splat route matches" do


### PR DESCRIPTION
I accidentally passed a non-controller module to a route and saw the error raised wasn't helpful to beginners `** (UndefinedFunctionError) undefined function: MyApp.User.init/1`. Replaced it with a clearer error msg if the module passed isn't a Plug. 