### PR TITLE
Fix `accept` request header typo in docs

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -29,7 +29,7 @@ defmodule Phoenix.ConnTest do
   follows:
 
       conn()
-      |> put_req_header("accepts", "application/json")
+      |> put_req_header("accept", "application/json")
       |> get("/")
 
   The endpoint being tested is accessed via the `@endpoint` module


### PR DESCRIPTION
The `accept` header should be singular.