### PR TITLE
Switch to use Repo.get! to properly 404

### DIFF
--- a/priv/templates/html/controller.ex
+++ b/priv/templates/html/controller.ex
@@ -30,18 +30,18 @@ defmodule <%= module %>Controller do
   end
 
   def show(conn, %{"id" => id}) do
-    <%= singular %> = Repo.get(<%= alias %>, id)
+    <%= singular %> = Repo.get!(<%= alias %>, id)
     render(conn, "show.html", <%= singular %>: <%= singular %>)
   end
 
   def edit(conn, %{"id" => id}) do
-    <%= singular %> = Repo.get(<%= alias %>, id)
+    <%= singular %> = Repo.get!(<%= alias %>, id)
     changeset = <%= alias %>.changeset(<%= singular %>)
     render(conn, "edit.html", <%= singular %>: <%= singular %>, changeset: changeset)
   end
 
   def update(conn, %{"id" => id, <%= inspect singular %> => <%= singular %>_params}) do
-    <%= singular %> = Repo.get(<%= alias %>, id)
+    <%= singular %> = Repo.get!(<%= alias %>, id)
     changeset = <%= alias %>.changeset(<%= singular %>, <%= singular %>_params)
 
     if changeset.valid? do
@@ -56,7 +56,7 @@ defmodule <%= module %>Controller do
   end
 
   def delete(conn, %{"id" => id}) do
-    <%= singular %> = Repo.get(<%= alias %>, id)
+    <%= singular %> = Repo.get!(<%= alias %>, id)
     Repo.delete(<%= singular %>)
 
     conn

--- a/priv/templates/html/controller_test.exs
+++ b/priv/templates/html/controller_test.exs
@@ -38,8 +38,9 @@ defmodule <%= module %>ControllerTest do
   end
 
   test "renders page not found when id is nonexistent", %{conn: conn} do
-    conn = get conn, <%= singular %>_path(conn, :show, -1)
-    assert html_response(conn, 404) =~ "not found"
+    assert_raise Ecto.NoResultsError, fn ->
+      get conn, <%= singular %>_path(conn, :show, -1)
+    end
   end
 
   test "renders form for editing chosen resource", %{conn: conn} do

--- a/priv/templates/html/controller_test.exs
+++ b/priv/templates/html/controller_test.exs
@@ -37,6 +37,11 @@ defmodule <%= module %>ControllerTest do
     assert html_response(conn, 200) =~ "Show <%= singular %>"
   end
 
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    conn = get conn, <%= singular %>_path(conn, :show, -1)
+    assert html_response(conn, 404) =~ "not found"
+  end
+
   test "renders form for editing chosen resource", %{conn: conn} do
     <%= singular %> = Repo.insert %<%= alias %>{}
     conn = get conn, <%= singular %>_path(conn, :edit, <%= singular %>)

--- a/priv/templates/json/controller.ex
+++ b/priv/templates/json/controller.ex
@@ -24,12 +24,12 @@ defmodule <%= module %>Controller do
   end
 
   def show(conn, %{"id" => id}) do
-    <%= singular %> = Repo.get(<%= alias %>, id)
+    <%= singular %> = Repo.get!(<%= alias %>, id)
     render conn, "show.json", <%= singular %>: <%= singular %>
   end
 
   def update(conn, %{"id" => id, <%= inspect singular %> => <%= singular %>_params}) do
-    <%= singular %> = Repo.get(<%= alias %>, id)
+    <%= singular %> = Repo.get!(<%= alias %>, id)
     changeset = <%= alias %>.changeset(<%= singular %>, <%= singular %>_params)
 
     if changeset.valid? do
@@ -43,7 +43,7 @@ defmodule <%= module %>Controller do
   end
 
   def delete(conn, %{"id" => id}) do
-    <%= singular %> = Repo.get(<%= alias %>, id)
+    <%= singular %> = Repo.get!(<%= alias %>, id)
 
     <%= singular %> = Repo.delete(<%= singular %>)
     render(conn, "show.json", <%= singular %>: <%= singular %>)

--- a/priv/templates/json/controller_test.exs
+++ b/priv/templates/json/controller_test.exs
@@ -23,6 +23,11 @@ defmodule <%= module %>ControllerTest do
     }
   end
 
+  test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
+    conn = get conn, <%= singular %>_path(conn, :show, -1)
+    assert json_response(conn, 404)["data"] != %{}
+  end
+
   test "creates and renders resource when data is valid", %{conn: conn} do
     conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @valid_attrs
     assert json_response(conn, 200)["data"]["id"]

--- a/priv/templates/json/controller_test.exs
+++ b/priv/templates/json/controller_test.exs
@@ -24,8 +24,9 @@ defmodule <%= module %>ControllerTest do
   end
 
   test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
-    conn = get conn, <%= singular %>_path(conn, :show, -1)
-    assert json_response(conn, 404)["data"] != %{}
+    assert_raise Ecto.NoResultsError, fn ->
+      get conn, <%= singular %>_path(conn, :show, -1)
+    end
   end
 
   test "creates and renders resource when data is valid", %{conn: conn} do

--- a/test/mix/tasks/phoenix.gen.html_test.exs
+++ b/test/mix/tasks/phoenix.gen.html_test.exs
@@ -29,6 +29,7 @@ defmodule Mix.Tasks.Phoenix.Gen.HtmlTest do
       assert_file "web/controllers/user_controller.ex", fn file ->
         assert file =~ "defmodule Phoenix.UserController"
         assert file =~ "use Phoenix.Web, :controller"
+        assert file =~ "Repo.get!"
       end
 
       assert_file "web/views/user_view.ex", fn file ->
@@ -129,6 +130,7 @@ defmodule Mix.Tasks.Phoenix.Gen.HtmlTest do
       assert_file "web/controllers/admin/user_controller.ex", fn file ->
         assert file =~ "defmodule Phoenix.Admin.UserController"
         assert file =~ "use Phoenix.Web, :controller"
+        assert file =~ "Repo.get!"
       end
 
       assert_file "web/views/admin/user_view.ex", fn file ->

--- a/test/mix/tasks/phoenix.gen.json_test.exs
+++ b/test/mix/tasks/phoenix.gen.json_test.exs
@@ -28,6 +28,7 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
       assert_file "web/controllers/user_controller.ex", fn file ->
         assert file =~ "defmodule Phoenix.UserController"
         assert file =~ "use Phoenix.Web, :controller"
+        assert file =~ "Repo.get!"
       end
 
       assert_file "web/views/user_view.ex", fn file ->
@@ -80,6 +81,7 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
       assert_file "web/controllers/admin/user_controller.ex", fn file ->
         assert file =~ "defmodule Phoenix.Admin.UserController"
         assert file =~ "use Phoenix.Web, :controller"
+        assert file =~ "Repo.get!"
       end
 
       assert_file "web/views/admin/user_view.ex", fn file ->


### PR DESCRIPTION
In reference to this issue: https://github.com/phoenixframework/phoenix/issues/957

I switched from using `get` to `get!` then I added some tests in the mix task section and everything worked, which was great. 

Next, I got a little ambitious and tried to use the modified mix tasks to generate controllers so I could make sure they would work. This step wasn't so great because I couldn't get it to work without resorting to using a weird `ln -S` trick in my `~/.mix/phoenix-0.14.0-dev` dir (lol it's very likely I just didn't install the .ez archive correctly, but please forgive, I'm new to elixir).

Next, I used the 0.14-dev phoenix to start a new `hello_phoenix` project to test. I ran `mix phoenix.gen.json User users name:string email:string` and then ran `mix test`

I was greeted by:

```console
** (CompileError) test/controllers/user_controller_test.exs:14: function user_path/2 undefined
    (stdlib) lists.erl:1336: :lists.foreach/2
    (stdlib) erl_eval.erl:657: :erl_eval.do_apply/6
```
Alarmed that such a small change in what I thought were unrelated parts could cause this error, I uninstalled phoenix-0.14.0-dev and went back to 0.13 to try again...

~~And got the same thing with user_path being undefined... so unless I'm going crazy, scaffolded tests aren't working (I will confirm this sometime tomorrow and file an issue if I'm not crazy).~~

edit: yeah, it was me, I forgot to follow instructions and edit my router.ex file