### PR TITLE
Show full local URL when starting server

### DIFF
--- a/lib/phoenix/endpoint/cowboy_handler.ex
+++ b/lib/phoenix/endpoint/cowboy_handler.ex
@@ -32,14 +32,14 @@ defmodule Phoenix.Endpoint.CowboyHandler do
   It is also important to specify your handlers first, otherwise Phoenix will
   intercept the requests before they get to your handler
   """
-  def start_link(scheme, endpoint, config, {m, f, a}) do
+  def start_link(_scheme, endpoint, _config, {m, f, a}) do
     case apply(m, f, a) do
       {:ok, pid} ->
-        Logger.info info(scheme, endpoint, config)
+        Logger.info info(endpoint)
         {:ok, pid}
 
       {:error, {:shutdown, {_, _, {{_, {:error, :eaddrinuse}}, _}}}} = error ->
-        Logger.error [info(scheme, endpoint, config), " failed, port already in use"]
+        Logger.error [info(endpoint), " failed, port already in use"]
         error
 
       {:error, _} = error ->
@@ -47,8 +47,8 @@ defmodule Phoenix.Endpoint.CowboyHandler do
     end
   end
 
-  defp info(scheme, endpoint, config) do
-    "Running #{inspect endpoint} with Cowboy on port #{inspect config[:port]} (#{scheme})"
+  defp info(endpoint) do
+    "Running #{inspect endpoint} with Cowboy on #{endpoint.url}"
   end
 
   def child_spec(scheme, endpoint, config) do


### PR DESCRIPTION
Starting a Phoenix server in dev:

```
[debug] Running StockholmElixir.Endpoint with Cowboy on port 4000 (http)
```

Starting a Ruby on Rails server in dev:

```
=> Rails 4.1.4 application starting in development on http://0.0.0.0:3000
```

I like about the Rails message how you can click the link (in certain terminals) or copy-paste it.

Starting a Phoenix server in dev, after this pull request:

```
[debug] Running StockholmElixir.Endpoint with Cowboy on http://localhost:4000
```

Note how this pull request just hardcodes "localhost". I suspect that perhaps this isn't suitable in every situation, but I thought I'd make a first attempt. I'm happy to make it smarter as needed. Let me know of any issues.