### PR TITLE
Fixed the docstring to comply with the latest version of ecto

### DIFF
--- a/priv/templates/model/model.ex
+++ b/priv/templates/model/model.ex
@@ -14,7 +14,7 @@ defmodule <%= module %> do
   @doc """
   Creates a changeset based on the `model` and `params`.
 
-  If `params` are nil, an invalid changeset is returned
+  If the value of `params` is the symbol :empty, an invalid changeset is returned
   with no validation performed.
   """
   def changeset(model, params \\ :empty) do


### PR DESCRIPTION
The docstring says that you have to pass nil as params to return an empty changeset, yet this functionality is (will be) deprecated.