### PR TITLE
Add documentation about passing `false` to put_layout/2

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -316,7 +316,8 @@ defmodule Phoenix.Controller do
   accepts the layout name to be given as a string or as an atom. If a
   string, it must contain the format. Passing an atom means the layout
   format will be found at rendering time, similar to the template in
-  `render/3`.
+  `render/3`. It can also be set to `false`. In this case, no layout
+  would be used.
 
   ## Examples
 


### PR DESCRIPTION
Just clarifying that `false` can be passed to `put_layout/2` and no layout would be rendered. I wanted to add a doctest but they are currently disabled for this file. 