### PR TITLE
Add usage example about resources singleton option

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -480,6 +480,10 @@ defmodule Phoenix.Router do
     * `PUT /user` => `:update`
     * `DELETE /user` => `:delete`
 
+    Usage example:
+
+      `resources "/account", AccountController, only: [:show], singleton: true`
+
   """
   defmacro resources(path, controller, opts, do: nested_context) do
     add_resources path, controller, opts, do: nested_context


### PR DESCRIPTION
Just clarifying singleton option usage on resources, because I'm getting this question too often :sweat_smile:  (specially since `resource` deprecation warnings on 0.14)