### PR TITLE
Version channel transport contract

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -35,6 +35,7 @@ defmodule Phoenix.Socket do
                      ref: term,
                      topic: String.t,
                      transport: atom,
+                     vsn: String.t,
                      transport_pid: pid}
 
   defstruct assigns: %{},
@@ -46,6 +47,7 @@ defmodule Phoenix.Socket do
             ref: nil,
             topic: nil,
             transport: nil,
+            vsn: nil,
             transport_pid: nil
 end
 

--- a/lib/phoenix/transports/long_poller.ex
+++ b/lib/phoenix/transports/long_poller.ex
@@ -117,7 +117,11 @@ defmodule Phoenix.Transports.LongPoller do
       |> Kernel.<>(Base.encode64(:crypto.strong_rand_bytes(16)))
       |> Kernel.<>(:os.timestamp() |> Tuple.to_list |> Enum.join(""))
 
-    child = [router, timeout_window_ms(conn), priv_topic, endpoint_module(conn)]
+    child = [router,
+             timeout_window_ms(conn),
+             priv_topic,
+             endpoint_module(conn),
+             conn.params["vsn"]]
     {:ok, server_pid} = Supervisor.start_child(LongPoller.Supervisor, child)
 
     {conn, priv_topic, sign(conn, priv_topic), server_pid}

--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -185,6 +185,7 @@ var _classCallCheck = function (instance, Constructor) { if (!(instance instance
 // `chan.leave()`
 //
 
+var CHAN_VSN = "~> 1.0.0";
 var SOCKET_STATES = { connecting: 0, open: 1, closing: 2, closed: 3 };
 var CHAN_STATES = {
   closed: "closed",
@@ -601,6 +602,11 @@ var Socket = exports.Socket = (function () {
     },
     expandEndpoint: {
       value: function expandEndpoint(endPoint) {
+        if (endPoint.search(/\?/) >= 0) {
+          endPoint = endPoint + ("&vsn=" + CHAN_VSN);
+        } else {
+          endPoint = endPoint + ("?vsn=" + CHAN_VSN);
+        }
         if (endPoint.charAt(0) !== "/") {
           return endPoint;
         }

--- a/test/phoenix/channel/transport_test.exs
+++ b/test/phoenix/channel/transport_test.exs
@@ -44,4 +44,8 @@ defmodule Phoenix.Channel.TransportTest do
     assert call("https://scheme.com").status == 403
     assert call("http://port.com:82").status == 403
   end
+
+  test "provides the protocol version" do
+    assert Version.match?(Phoenix.Channel.Transport.protocol_version(), "~> 1.0")
+  end
 end

--- a/test/phoenix/transports/long_poller_test.exs
+++ b/test/phoenix/transports/long_poller_test.exs
@@ -14,6 +14,7 @@ defmodule Phoenix.Tranports.LongPollerTest do
 
   def conn_with_sess(session \\ %{}) do
     %Conn{private: %{plug_session: session}}
+    |> Conn.fetch_query_params()
     |> put_private(:phoenix_router, Router)
     |> put_private(:phoenix_endpoint, __MODULE__.Endpoint)
     |> with_session

--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -87,6 +87,7 @@
 // `chan.leave()`
 //
 
+const CHAN_VSN = "~> 1.0.0"
 const SOCKET_STATES = {connecting: 0, open: 1, closing: 2, closed: 3}
 const CHAN_STATES = {
   closed: "closed",
@@ -355,6 +356,11 @@ export class Socket {
   protocol(){ return location.protocol.match(/^https/) ? "wss" : "ws" }
 
   expandEndpoint(endPoint){
+    if(endPoint.search(/\?/) >= 0){
+      endPoint = endPoint + `&vsn=${CHAN_VSN}`
+    } else {
+      endPoint = endPoint + `?vsn=${CHAN_VSN}`
+    }
     if(endPoint.charAt(0) !== "/"){ return endPoint }
     if(endPoint.charAt(1) === "/"){ return `${this.protocol()}:${endPoint}` }
 


### PR DESCRIPTION
TODO:
- [ ] Test failure semantics

Some notes:

- Sends vsn param on socket connect
- Default to 1.0.0 for legacy clients
- Raises on incompatible versions (resulting in socket.onError callbacks on client)

Some questions:

Is the naming what we want here? We talk about the "transport adapter contract", but I'm calling this a "protocol version". I feel like I could do better with naming.

Are the failure semantics what we want? The websocket/longpolling adapters raise on init if the client sends an incompatible version. I don't think we can do much else, but the client would only receive a `socket.onError` event, without the reason for the crash. Having the vsn doesn't buy us much now, but down the road it would let us (or a third-party transport) support legacy clients in a forward compatible way if we release v2 of a channels api/contract. All thoughts appreciated. // @josevalim @ericmj @jeregrine @scrogson 