### PR TITLE
update phoenix.js so it passes jshint linter

### DIFF
--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -1,3 +1,5 @@
+// jshint asi: true, expr: true
+
 // Phoenix Channels JavaScript client
 //
 // ## Socket Connection
@@ -163,7 +165,7 @@ class Push {
 
   // private
 
-  matchReceive({status, response, ref}){
+  matchReceive({status, response}){
     this.recHooks.filter( h => h.status === status )
                  .forEach( h => h.callback(response) )
   }
@@ -282,7 +284,7 @@ export class Channel {
   // Overridable message hook
   //
   // Receives all events for specialized message handling
-  onMessage(event, payload, ref){}
+  onMessage(/* event, payload, ref */){}
 
   // private
 
@@ -441,8 +443,8 @@ export class Socket {
 
   chan(topic, chanParams = {}){
     let mergedParams = {}
-    for(var key in this.params){ mergedParams[key] = this.params[key] }
-    for(var key in chanParams){ mergedParams[key] = chanParams[key] }
+    for(let key in this.params){ mergedParams[key] = this.params[key] }
+    for(let key in chanParams){ mergedParams[key] = chanParams[key] }
 
     let chan = new Channel(topic, mergedParams, this)
     this.channels.push(chan)
@@ -531,13 +533,9 @@ export class LongPoller {
     if(!(this.readyState === SOCKET_STATES.open || this.readyState === SOCKET_STATES.connecting)){ return }
 
     Ajax.request("GET", this.endpointURL(), "application/json", null, this.timeout, this.ontimeout.bind(this), (resp) => {
-      if(resp){
-        var {status, token, sig, messages} = resp
-        this.token = token
-        this.sig = sig
-      } else{
-        var status = 0
-      }
+      const {status, token, sig, messages} = resp || {status: 0}
+      this.token = token
+      this.sig = sig
 
       switch(status){
         case 200:
@@ -571,7 +569,7 @@ export class LongPoller {
     })
   }
 
-  close(code, reason){
+  close(/* code, reason */){
     this.readyState = SOCKET_STATES.closed
     this.onclose()
   }
@@ -586,8 +584,8 @@ export class Ajax {
       this.xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback)
     } else {
       let req = window.XMLHttpRequest ?
-                  new XMLHttpRequest() : // IE7+, Firefox, Chrome, Opera, Safari
-                  new ActiveXObject("Microsoft.XMLHTTP") // IE6, IE5
+                  new window.XMLHttpRequest() : // IE7+, Firefox, Chrome, Opera, Safari
+                  new window.ActiveXObject("Microsoft.XMLHTTP") // IE6, IE5
       this.xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback)
     }
   }


### PR DESCRIPTION
[Jshint](http://jshint.com) is really useful to catch errors, and it is setup by default with several frameworks like Ember (with ember-cli). In order to use Phoenix with Ember we currently need to copy the ES2015 original version to the Ember application folder. Which runs jshint on `phoenix.js` and generate warnings.

I've set two Jshint options to allow for not using semi-colons ([asi](http://jshint.com/docs/options/#asi)) and for using assignments in boolean expressions ([boss](http://jshint.com/docs/options/#boss)).

Here are the remaining warnings I've fixed:

```
utils/phoenix.js: line 446, col 17, 'key' is already defined.
utils/phoenix.js: line 540, col 20, 'status' is already defined.
utils/phoenix.js: line 543, col 14, 'status' used out of scope.
utils/phoenix.js: line 545, col 11, 'messages' used out of scope.
utils/phoenix.js: line 561, col 49, 'status' used out of scope.
utils/phoenix.js: line 591, col 23, 'ActiveXObject' is not defined.
utils/phoenix.js: line 167, col 35, 'ref' is defined but never used.
utils/phoenix.js: line 286, col 29, 'ref' is defined but never used.
utils/phoenix.js: line 286, col 20, 'payload' is defined but never used.
utils/phoenix.js: line 286, col 13, 'event' is defined but never used.
utils/phoenix.js: line 540, col 13, 'status' is defined but never used.
utils/phoenix.js: line 536, col 34, 'messages' is defined but never used.
utils/phoenix.js: line 575, col 15, 'reason' is defined but never used.
utils/phoenix.js: line 575, col 9, 'code' is defined but never used.

14 errors
```

If you find Jshint useful it could easily be add to new Phoenix applications using [jshint-brunch](https://github.com/brunch/jshint-brunch).

Thanks again for Phoenix!