### PR TITLE
mix.exs template: apps and deps on individual lines

### DIFF
--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -2,25 +2,35 @@ defmodule <%= application_module %>.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :<%= application_name %>,
-     version: "0.0.1",<%= if in_umbrella do %>
-     deps_path: "../../deps",
-     lockfile: "../../mix.lock",<% end %>
-     elixir: "~> 1.0",
-     elixirc_paths: elixirc_paths(Mix.env),
-     compilers: [:phoenix] ++ Mix.compilers,
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     deps: deps]
+    [
+       app: :<%= application_name %>,
+       version: "0.0.1",<%= if in_umbrella do %>
+       deps_path: "../../deps",
+       lockfile: "../../mix.lock",<% end %>
+       elixir: "~> 1.0",
+       elixirc_paths: elixirc_paths(Mix.env),
+       compilers: [:phoenix] ++ Mix.compilers,
+       build_embedded: Mix.env == :prod,
+       start_permanent: Mix.env == :prod,
+       deps: deps,
+     ]
   end
 
   # Configuration for the OTP application
   #
   # Type `mix help compile.app` for more information
   def application do
-    [mod: {<%= application_module %>, []},
-     applications: [:phoenix, :phoenix_html, :cowboy, :logger<%= if ecto do %>,
-                    :phoenix_ecto, <%= inspect adapter_app %><% end %>]]
+    [
+      mod: {<%= application_module %>, []},
+      applications: [
+        :phoenix,
+        :phoenix_html,
+        :cowboy,
+        :logger,<%= if ecto do %>
+        :phoenix_ecto,
+        <%= inspect adapter_app %>,<% end %>
+      ]
+    ]
   end
 
   # Specifies which paths to compile per environment
@@ -31,11 +41,13 @@ defmodule <%= application_module %>.Mixfile do
   #
   # Type `mix help deps` for examples and options
   defp deps do
-    [<%= phoenix_dep %>,<%= if ecto do %>
-     {:phoenix_ecto, "~> 0.5"},
-     {<%= inspect adapter_app %>, ">= 0.0.0"},<% end %>
-     {:phoenix_html, "~> 1.1"},
-     {:phoenix_live_reload, "~> 0.4", only: :dev},
-     {:cowboy, "~> 1.0"}]
+    [
+      <%= phoenix_dep %>,<%= if ecto do %>
+      {:phoenix_ecto, "~> 0.5"},
+      {<%= inspect adapter_app %>, ">= 0.0.0"},<% end %>
+      {:phoenix_html, "~> 1.1"},
+      {:phoenix_live_reload, "~> 0.4", only: :dev},
+      {:cowboy, "~> 1.0"},
+    ]
   end
 end


### PR DESCRIPTION
How do you feel about this style change?

It arguably reads cleaner since the first and last line is no longer special.

It has some additional minor benefits: cleaner diffs, lets you more easily move lines around (without accidentally introducing syntax errors thanks to the trailing comma on the last line), won't unnecessarily shift the git blame of the previous line.

It does make this file a few lines longer due to the additional line breaks – I don't mind but maybe someone else does?