### PR TITLE
Fix protocol detection when no protocol was used.

### DIFF
--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -909,7 +909,7 @@ var LongPoller = exports.LongPoller = (function () {
   _prototypeProperties(LongPoller, null, {
     normalizeEndpoint: {
       value: function normalizeEndpoint(endPoint) {
-        return endPoint.replace("ws://", "http://").replace("wss://", "https://");
+        return endPoint.replace("http://", "ws://").replace("https://", "wss://");
       },
       writable: true,
       configurable: true


### PR DESCRIPTION
JavaScript's String.replace() accepts arguments in different order than the original author anticipated. This causes applications not connecting properly over HTTPs interfaces, when relative endPoint was specified, such as "/ws".

To see this 'in action', simply visit the demo page for @chrismccord 's chat app:
https://phoenixchat.herokuapp.com/

the demo breaks because HTTPS is used by Heroku, but the app still tries to connect via ws:// protocol.

The demo app with this patch is located and can be previewed here:
https://phoenix-chat-fixed.herokuapp.com/
