### PR TITLE
Add #controller_name method to Phoenix.Controller

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -114,12 +114,8 @@ defmodule Phoenix.Controller do
   """
   @spec controller_name(Plug.Conn.t) :: String.t
   def controller_name(conn) do
-    conn.private.phoenix_controller
-    |> Atom.to_string
-    |> String.split(".")
-    |> List.last
-    |> String.replace("Controller", "")
-    |> String.downcase
+    Phoenix.Naming.resource_name(conn.private.phoenix_controller, "Controller")
+    |> String.replace("_", "-")
   end
 
   @doc """

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -115,7 +115,6 @@ defmodule Phoenix.Controller do
   @spec controller_name(Plug.Conn.t) :: String.t
   def controller_name(conn) do
     Phoenix.Naming.resource_name(conn.private.phoenix_controller, "Controller")
-    |> String.replace("_", "-")
   end
 
   @doc """

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -110,6 +110,19 @@ defmodule Phoenix.Controller do
   def action_name(conn), do: conn.private.phoenix_action
 
   @doc """
+  Returns the controller name as a string, raises if unavailable.
+  """
+  @spec controller_name(Plug.Conn.t) :: String.t
+  def controller_name(conn) do
+    conn.private.phoenix_controller
+    |> Atom.to_string
+    |> String.split(".")
+    |> List.last
+    |> String.replace("Controller", "")
+    |> String.downcase
+  end
+
+  @doc """
   Returns the controller module as an atom, raises if unavailable.
   """
   @spec controller_module(Plug.Conn.t) :: atom

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -23,6 +23,9 @@ defmodule Phoenix.Controller.ControllerTest do
   test "controller_name/1" do
     conn = put_private(%Conn{}, :phoenix_controller, Hello)
     assert controller_name(conn) == "hello"
+
+    conn_multi = put_private(%Conn{}, :phoenix_controller, HelloWorld)
+    assert controller_name(conn_multi) == "hello-world"
   end
 
   test "controller_module/1" do

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -20,6 +20,11 @@ defmodule Phoenix.Controller.ControllerTest do
     assert action_name(conn) == :show
   end
 
+  test "controller_name/1" do
+    conn = put_private(%Conn{}, :phoenix_controller, Hello)
+    assert controller_name(conn) == "hello"
+  end
+
   test "controller_module/1" do
     conn = put_private(%Conn{}, :phoenix_controller, Hello)
     assert controller_module(conn) == Hello

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -25,7 +25,7 @@ defmodule Phoenix.Controller.ControllerTest do
     assert controller_name(conn) == "hello"
 
     conn_multi = put_private(%Conn{}, :phoenix_controller, HelloWorld)
-    assert controller_name(conn_multi) == "hello-world"
+    assert controller_name(conn_multi) == "hello_world"
   end
 
   test "controller_module/1" do


### PR DESCRIPTION
Added a `#controller_name` function into `Phoenix.Controller`.

Input: `Plug.Conn.t` connection

Output: lowercase name of the controller.

Example:

```elixir
$ Phoenix.Controller.controller_name @conn
=> "page"
```
where `@conn` was generated by the `PageController`.

**Why?**

When dealing with CSS styling, it's useful to be able to separate out styles by page. The best way to get a page is the combination of it's controller and action. So for example, I can specifically style the homepage if I have `.page.index` as the classes to the `<body>` tag of a page. It also helps for modular loading of JS as well as CSS styles. Coming from Rails, it was great to have access to `controller_name` and `action_name`, and I found it strange that Phoenix only had `action_name` but not `controller_name`, and I felt like this would be a good addition to the core functionality of `Phoenix.Controller`.
