### PR TITLE
Prevent Push leaking receive hooks

### DIFF
--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -146,6 +146,7 @@ class Push {
   receive(status, callback){
     if(this.receivedResp && this.receivedResp.status === status){
       callback(this.receivedResp.response)
+      return this
     }
 
     this.recHooks.push({status, callback})
@@ -166,6 +167,7 @@ class Push {
   matchReceive({status, response, ref}){
     this.recHooks.filter( h => h.status === status )
                  .forEach( h => h.callback(response) )
+    this.recHooks = null
   }
 
   cancelRefEvent(){ this.chan.off(this.refEvent) }


### PR DESCRIPTION
This makes `receive` return early if it already has been received in order to allow `matchReceive` to safely clear the receive hooks array.

I use `null` instead of `delete`<sup>[1][] [2][]</sup> to not [change the shape][3] of the Push object, since that is a known [optimization killer][4]. The last link doesn't talk about `delete` specifically, but contains useful general optimization advice.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete#section_5
[2]: http://perfectionkills.com/understanding-delete/
[3]: http://www.html5rocks.com/en/tutorials/speed/v8/
[4]: https://github.com/petkaantonov/bluebird/wiki/Optimization-killers