### PR TITLE
feat(brunch-config.js): enable npm by default

### DIFF
--- a/installer/templates/static/brunch/brunch-config.js
+++ b/installer/templates/static/brunch/brunch-config.js
@@ -49,5 +49,8 @@ exports.config = {
       // Do not use ES6 compiler in vendor code
       ignore: [/^(web\/static\/vendor)/]
     }
+  },
+  npm: {
+    enabled: true
   }
 };

--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -2,7 +2,7 @@
   "repository": {
   },
   "dependencies": {
-    "brunch": "^1.8.1",
+    "brunch": "^1.8.3",
     "babel-brunch": "^5.1.1",
     "clean-css-brunch": ">= 1.0 < 1.8",
     "css-brunch": ">= 1.0 < 1.8",


### PR DESCRIPTION
With this flag, dependencies in npm can be loaded in brunch for example:

    npm install --save react

Then in app.js

    import React from "react"

This will use the React dependency from npm instead of requiring it to
be included locally in the "vendor" directory.

The issue can be found at https://github.com/brunch/brunch/issues/991