### PR TITLE
Remove bottlenecks from Phoenix PubSub Local

### DIFF
--- a/lib/phoenix/pubsub.ex
+++ b/lib/phoenix/pubsub.ex
@@ -114,22 +114,22 @@ defmodule Phoenix.PubSub do
 
   """
   @spec subscribe(atom, pid, binary, Keyword.t) :: :ok | {:error, term}
-  def subscribe(server, pid, topic, opts \\ []),
-    do: call(server, {:subscribe, pid, topic, opts})
+  def subscribe(server, pid, topic, opts \\ []) when is_atom(server),
+    do: call(server, :subscribe, [pid, topic, opts])
 
   @doc """
   Unsubscribes the pid from the PubSub adapter's topic.
   """
   @spec unsubscribe(atom, pid, binary) :: :ok | {:error, term}
-  def unsubscribe(server, pid, topic),
-    do: call(server, {:unsubscribe, pid, topic})
+  def unsubscribe(server, pid, topic) when is_atom(server),
+    do: call(server, :unsubscribe, [pid, topic])
 
   @doc """
   Broadcasts message on given topic.
   """
   @spec broadcast(atom, binary, term) :: :ok | {:error, term}
-  def broadcast(server, topic, message),
-    do: call(server, {:broadcast, :none, topic, message})
+  def broadcast(server, topic, message) when is_atom(server),
+    do: call(server, :broadcast, [:none, topic, message])
 
   @doc """
   Broadcasts message on given topic.
@@ -148,8 +148,8 @@ defmodule Phoenix.PubSub do
   Broadcasts message to all but `from_pid` on given topic.
   """
   @spec broadcast_from(atom, pid, binary, term) :: :ok | {:error, term}
-  def broadcast_from(server, from_pid, topic, message) when is_pid(from_pid),
-    do: call(server, {:broadcast, from_pid, topic, message})
+  def broadcast_from(server, from_pid, topic, message) when is_atom(server) and is_pid(from_pid),
+    do: call(server, :broadcast, [from_pid, topic, message])
 
   @doc """
   Broadcasts message to all but `from_pid` on given topic.
@@ -157,20 +157,15 @@ defmodule Phoenix.PubSub do
   Raises `Phoenix.PubSub.BroadcastError` if broadcast fails.
   """
   @spec broadcast_from(atom, pid, binary, term) :: :ok | no_return
-  def broadcast_from!(server, from_pid, topic, message) when is_pid(from_pid) do
+  def broadcast_from!(server, from_pid, topic, message) when is_atom(server) and is_pid(from_pid) do
     case broadcast_from(server, from_pid, topic, message) do
       :ok -> :ok
       {:error, reason} -> raise BroadcastError, message: reason
     end
   end
 
-  defp call(server, msg) do
-    GenServer.call(server, msg) |> perform
+  defp call(server, kind, args) do
+    [{^kind, module, head}] = :ets.lookup(server, kind)
+    apply(module, kind, head ++ args)
   end
-
-  defp perform({:perform, {mod, func, args}}) do
-    apply(mod, func, args) |> perform
-  end
-
-  defp perform(result), do: result
 end

--- a/lib/phoenix/pubsub/pg2_server.ex
+++ b/lib/phoenix/pubsub/pg2_server.ex
@@ -4,49 +4,38 @@ defmodule Phoenix.PubSub.PG2Server do
   use GenServer
   alias Phoenix.PubSub.Local
 
-  def start_link(opts) do
-    GenServer.start_link __MODULE__, opts, name: Dict.fetch!(opts, :name)
+  def start_link(name, local_name) do
+    GenServer.start_link __MODULE__, {name, local_name}, name: name
   end
 
-  def init(opts) do
-    server_name   = Keyword.fetch!(opts, :name)
-    local_name    = Keyword.fetch!(opts, :local_name)
-    pg2_namespace = pg2_namespace(server_name)
-
-    :ok = :pg2.create(pg2_namespace)
-    :ok = :pg2.join(pg2_namespace, self)
-
-    {:ok, %{local_name: local_name, namespace: pg2_namespace}}
-  end
-
-  def handle_call({:subscribe, pid, topic, opts}, _from, state) do
-    response = {:perform, {Local, :subscribe, [state.local_name, pid, topic, opts]}}
-    {:reply, response, state}
-  end
-
-  def handle_call({:unsubscribe, pid, topic}, _from, state) do
-    response = {:perform, {Local, :unsubscribe, [state.local_name, pid, topic]}}
-    {:reply, response, state}
-  end
-
-  def handle_call({:broadcast, from_pid, topic, msg}, _from, state) do
-    case :pg2.get_members(state.namespace) do
+  def broadcast(name, local_name, from_pid, topic, msg) do
+    case :pg2.get_members(pg2_namespace(name)) do
       {:error, {:no_such_group, _}} ->
-        {:stop, :no_such_group, {:error, :no_such_group}, state}
+        {:error, :no_such_group}
 
       pids when is_list(pids) ->
-        Enum.each(pids, &send(&1, {:forward_to_local, from_pid, topic, msg}))
-        {:reply, :ok, state}
+        Enum.each(pids, fn
+          pid when node(pid) == node() ->
+            Local.broadcast(local_name, from_pid, topic, msg)
+          pid ->
+            send(pid, {:forward_to_local, from_pid, topic, msg})
+        end)
+        :ok
     end
   end
 
-  def handle_call(:stop, _from, state) do
-    {:stop, :normal, :ok, state}
+  def init({name, local_name}) do
+    pg2_namespace = pg2_namespace(name)
+    :ok = :pg2.create(pg2_namespace)
+    :ok = :pg2.join(pg2_namespace, self)
+    {:ok, local_name}
   end
 
-  def handle_info({:forward_to_local, from_pid, topic, msg}, state) do
-    Local.broadcast(state.local_name, from_pid, topic, msg)
-    {:noreply, state}
+  def handle_info({:forward_to_local, from_pid, topic, msg}, local_name) do
+    # The whole broadcast will happen inside the current process
+    # but only for messages coming from the distributed system.
+    Local.broadcast(local_name, from_pid, topic, msg)
+    {:noreply, local_name}
   end
 
   defp pg2_namespace(server_name), do: {:phx, server_name}

--- a/lib/phoenix/transports/long_poll/server.ex
+++ b/lib/phoenix/transports/long_poll/server.ex
@@ -52,7 +52,7 @@ defmodule Phoenix.Transports.LongPoll.Server do
               sockets_inverse: HashDict.new,
               window_ms: trunc(window_ms * 1.5),
               endpoint: endpoint,
-              pubsub_server: Process.whereis(endpoint.__pubsub_server__()),
+              pubsub_server: endpoint.__pubsub_server__(),
               priv_topic: priv_topic,
               last_client_poll: now_ms(),
               client_ref: nil}

--- a/test/phoenix/pubsub/local_test.exs
+++ b/test/phoenix/pubsub/local_test.exs
@@ -10,7 +10,7 @@ defmodule Phoenix.LocalTest do
   test "subscribe/2 joins a pid to a topic and broadcast/2 sends messages", config do
     # subscribe
     pid = spawn fn -> :timer.sleep(:infinity) end
-    assert Local.subscribers(config.test, "foo") |> Enum.to_list == []
+    assert Local.subscribers(config.test, "foo") == []
     assert :ok = Local.subscribe(config.test, self, "foo")
     assert :ok = Local.subscribe(config.test, pid, "foo")
     assert :ok = Local.subscribe(config.test, self, "bar")
@@ -24,7 +24,7 @@ defmodule Phoenix.LocalTest do
     assert_received :hellobar
     assert Process.info(pid)[:messages] == [:hellofoo]
 
-    assert {:error, :no_topic} = Local.broadcast(config.test, :none, "ksfjlfsf", :hellobar)
+    assert :ok = Local.broadcast(config.test, :none, "unknown", :hellobar)
     assert Process.info(self)[:messages] == []
   end
 
@@ -33,11 +33,11 @@ defmodule Phoenix.LocalTest do
     assert :ok = Local.subscribe(config.test, self, "topic1")
     assert :ok = Local.subscribe(config.test, pid, "topic1")
 
-    assert Enum.sort(Local.subscribers(config.test, "topic1")) ==
-           Enum.sort([self, pid])
+    assert Local.subscribers(config.test, "topic1") ==
+           [self, pid]
 
     assert :ok = Local.unsubscribe(config.test, self, "topic1")
-    assert Enum.sort(Local.subscribers(config.test, "topic1")) ==
+    assert Local.subscribers(config.test, "topic1") ==
            [pid]
   end
 
@@ -65,8 +65,9 @@ defmodule Phoenix.LocalTest do
     Process.exit(pid,  :kill)
     assert_receive {:DOWN, ^ref, _, _, _}
 
-    assert Enum.sort(Local.subscribers(config.test, "topic5")) == Enum.sort([self])
-    assert Enum.sort(Local.subscribers(config.test, "topic6")) == Enum.sort([])
+    assert Local.subscription(config.test, pid) == :error
+    assert Local.subscribers(config.test, "topic5") == [self]
+    assert Local.subscribers(config.test, "topic6") == []
 
     # Assert topic was also garbage collected
     assert Local.list(config.test) == ["topic5"]

--- a/test/phoenix/pubsub/pubsub_test.exs
+++ b/test/phoenix/pubsub/pubsub_test.exs
@@ -3,16 +3,15 @@ defmodule Phoenix.PubSub.PubSubTest do
 
   alias Phoenix.PubSub
 
-  defmodule FailedBroadcaster do
-    use GenServer
-
-    def handle_call(_msg, _from, state) do
-      {:reply, {:error, :boom}, state}
-    end
+  def broadcast(error, _, _, _) do
+    {:error, error}
   end
 
   test "broadcast!/3 and broadcast_from!/4 raises if broadcast fails" do
-    GenServer.start_link(FailedBroadcaster, :ok, name: FailedBroadcaster)
+    :ets.new(FailedBroadcaster, [:named_table])
+    :ets.insert(FailedBroadcaster, {:broadcast, __MODULE__, [:boom]})
+
+    {:error, :boom} = PubSub.broadcast(FailedBroadcaster, "hello", %{})
 
     assert_raise PubSub.BroadcastError, fn ->
       PubSub.broadcast!(FailedBroadcaster, "topic", :ping)

--- a/test/shared/pubsub_test.exs
+++ b/test/shared/pubsub_test.exs
@@ -52,6 +52,7 @@ defmodule Phoenix.PubSubTest do
 
     kill_and_wait(pid)
     assert Process.alive?(local)
+    assert Local.subscription(config.local, pid) == :error
     assert Local.subscribers(config.local, "topic4") |> Dict.size == 0
   end
 


### PR DESCRIPTION
The clients are the ones sending the messages now, except for distributed messages, which are spread by the PG2 Server.