### PR TITLE
Add layout_view_test.exs to Match page_view_test.exs

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -20,6 +20,7 @@ defmodule Mix.Tasks.Phoenix.New do
     {:eex,  "new/test/controllers/page_controller_test.exs", "test/controllers/page_controller_test.exs"},
     {:eex,  "new/test/views/error_view_test.exs",            "test/views/error_view_test.exs"},
     {:eex,  "new/test/views/page_view_test.exs",             "test/views/page_view_test.exs"},
+    {:eex,  "new/test/views/layout_view_test.exs",           "test/views/layout_view_test.exs"},
     {:eex,  "new/test/support/conn_case.ex",                 "test/support/conn_case.ex"},
     {:eex,  "new/test/support/channel_case.ex",              "test/support/channel_case.ex"},
     {:eex,  "new/test/test_helper.exs",                      "test/test_helper.exs"},

--- a/installer/templates/new/test/views/layout_view_test.exs
+++ b/installer/templates/new/test/views/layout_view_test.exs
@@ -1,0 +1,3 @@
+defmodule <%= application_module %>.LayoutViewTest do
+  use <%= application_module %>.ConnCase, async: true
+end

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -43,6 +43,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "photo_blog/test/controllers/page_controller_test.exs"
       assert_file "photo_blog/test/views/page_view_test.exs"
       assert_file "photo_blog/test/views/error_view_test.exs"
+      assert_file "photo_blog/test/views/layout_view_test.exs"
       assert_file "photo_blog/test/support/conn_case.ex"
       assert_file "photo_blog/test/test_helper.exs"
 


### PR DESCRIPTION
A newly generated Phoenix application has an "empty" test file for the page view, but not for the layout view. This PR generates one for the layout view as well.