### PR TITLE
Fix latin abbreviations in Phoenix.js comments

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -27,7 +27,7 @@ defmodule Phoenix.Channel do
         {:ok, socket}
       end
 
-      # handles any other subtopic as the room ID, ie `"rooms:12"`, `"rooms:34"`
+      # handles any other subtopic as the room ID, for example `"rooms:12"`, `"rooms:34"`
       def join("rooms:" <> room_id, auth_message, socket) do
         {:ok, socket}
       end

--- a/lib/phoenix/channel/transport.ex
+++ b/lib/phoenix/channel/transport.ex
@@ -119,7 +119,7 @@ defmodule Phoenix.Channel.Transport do
 
     * `topic` - The String value "phoenix"
     * `event` - The String value "heartbeat"
-    * `payload` - An empty JSON message payload, ie {}
+    * `payload` - An empty JSON message payload, that is {}
 
   The server will respond to heartbeats with the same message
   """

--- a/lib/phoenix/channel/transport.ex
+++ b/lib/phoenix/channel/transport.ex
@@ -119,7 +119,7 @@ defmodule Phoenix.Channel.Transport do
 
     * `topic` - The String value "phoenix"
     * `event` - The String value "heartbeat"
-    * `payload` - An empty JSON message payload, that is {}
+    * `payload` - An empty JSON message payload (`{}`)
 
   The server will respond to heartbeats with the same message
   """

--- a/lib/phoenix/pubsub/local.ex
+++ b/lib/phoenix/pubsub/local.ex
@@ -26,7 +26,7 @@ defmodule Phoenix.PubSub.Local do
 
     * `local_server` - The registered server name or pid
     * `pid` - The subscriber pid
-    * `topic` - The string topic, ie "users:123"
+    * `topic` - The string topic, for example "users:123"
     * `opts` - The optional list of options. Supported options
       only include `:link` to link the subscriber to local
 
@@ -45,7 +45,7 @@ defmodule Phoenix.PubSub.Local do
 
     * `local_server` - The registered server name or pid
     * `pid` - The subscriber pid
-    * `topic` - The string topic, ie "users:123"
+    * `topic` - The string topic, for example "users:123"
 
   ## Examples
 
@@ -61,7 +61,7 @@ defmodule Phoenix.PubSub.Local do
   Sends a message to all subscribers of a topic.
 
     * `local_server` - The registered server name or pid
-    * `topic` - The string topic, ie "users:123"
+    * `topic` - The string topic, for example "users:123"
 
   ## Examples
 
@@ -115,7 +115,7 @@ defmodule Phoenix.PubSub.Local do
   Returns a set of subscribers pids for the given topic.
 
     * `local_server` - The registered server name or pid
-    * `topic` - The string topic, ie "users:123"
+    * `topic` - The string topic, for example "users:123"
 
   ## Examples
 

--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -208,8 +208,8 @@ var Push = (function () {
   // Initializes the Push
   //
   // chan - The Channel
-  // event - The event, ie `"phx_join"`
-  // payload - The payload, ie `{user_id: 123}`
+  // event - The event, e.g. `"phx_join"`
+  // payload - The payload, e.g. `{user_id: 123}`
   //
 
   function Push(chan, event, payload) {
@@ -550,9 +550,9 @@ var Socket = exports.Socket = (function () {
   //                                               "wss://example.com"
   //                                               "/ws" (inherited host & protocol)
   // opts - Optional configuration
-  //   transport - The Websocket Transport, ie WebSocket, Phoenix.LongPoll.
+  //   transport - The Websocket Transport, e.g. WebSocket, Phoenix.LongPoll.
   //               Defaults to WebSocket with automatic LongPoll fallback.
-  //   params - The defaults for all channel params, ie `{user_id: userToken}`
+  //   params - The defaults for all channel params, e.g. `{user_id: userToken}`
   //   heartbeatIntervalMs - The millisec interval to send a heartbeat message
   //   reconnectAfterMs - The optional function that returns the millsec
   //                      reconnect interval. Defaults to stepped backoff of:

--- a/test/phoenix/integration/http_client.exs
+++ b/test/phoenix/integration/http_client.exs
@@ -2,8 +2,8 @@ defmodule Phoenix.Integration.HTTPClient do
   @doc """
   Performs HTTP Request and returns Response
 
-    * method - The http methid, ie :get, :post, :put, etc
-    * url - The string url, ie "http://example.com"
+    * method - The http methid, for example :get, :post, :put, etc
+    * url - The string url, for example "http://example.com"
     * headers - The map of headers
     * body - The optional string body. If the body is a map, it is convered
              to a URI encoded string of parameters

--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -111,8 +111,8 @@ class Push {
   // Initializes the Push
   //
   // chan - The Channel
-  // event - The event, ie `"phx_join"`
-  // payload - The payload, ie `{user_id: 123}`
+  // event - The event, for example `"phx_join"`
+  // payload - The payload, for example `{user_id: 123}`
   //
   constructor(chan, event, payload){
     this.chan         = chan
@@ -320,9 +320,9 @@ export class Socket {
   //                                               "wss://example.com"
   //                                               "/ws" (inherited host & protocol)
   // opts - Optional configuration
-  //   transport - The Websocket Transport, ie WebSocket, Phoenix.LongPoll.
+  //   transport - The Websocket Transport, for example WebSocket or Phoenix.LongPoll.
   //               Defaults to WebSocket with automatic LongPoll fallback.
-  //   params - The defaults for all channel params, ie `{user_id: userToken}`
+  //   params - The defaults for all channel params, for example `{user_id: userToken}`
   //   heartbeatIntervalMs - The millisec interval to send a heartbeat message
   //   reconnectAfterMs - The optional function that returns the millsec
   //                      reconnect interval. Defaults to stepped backoff of:


### PR DESCRIPTION
Previously, the comments read "ie", which is short for "id est", meaning, "that is". This implies that what follows is what you're really trying to say. For example, on line 211, ie meant that the event was always going to be `"phx_join"`.
Now, the comments read "e.g.", which is short for "exempli gratia", meaning "for example". That same example now means that event is going to be a string from the list of events, like `"phx_join"`