### PR TITLE
Fix path to generated favicon file.

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -245,11 +245,11 @@ defmodule Mix.Tasks.Phoenix.New do
       copy_from path, binding, @bare
       create_file Path.join(path, "priv/static/js/phoenix.js"), phoenix_js_text()
       create_file Path.join(path, "priv/static/images/phoenix.png"), phoenix_png_text()
-      create_file Path.join(path, "priv/static/images/favicon.ico"), phoenix_favicon_text()
+      create_file Path.join(path, "priv/static/favicon.ico"), phoenix_favicon_text()
     else
       copy_from path, binding, @brunch
       create_file Path.join(path, "web/static/assets/images/phoenix.png"), phoenix_png_text()
-      create_file Path.join(path, "web/static/assets/images/favicon.ico"), phoenix_favicon_text()
+      create_file Path.join(path, "web/static/assets/favicon.ico"), phoenix_favicon_text()
     end
   end
 

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -63,8 +63,8 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "photo_blog/.gitignore", "/node_modules"
       assert_file "photo_blog/brunch-config.js", ~s["deps/phoenix/web/static"]
       assert_file "photo_blog/config/dev.exs", "watchers: [node:"
+      assert_file "photo_blog/web/static/assets/favicon.ico"
       assert_file "photo_blog/web/static/assets/images/phoenix.png"
-      assert_file "photo_blog/web/static/assets/images/favicon.ico"
       assert_file "photo_blog/web/static/css/app.css"
       assert_file "photo_blog/web/static/js/app.js",
                   ~s[import socket from "./socket"]
@@ -111,8 +111,8 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       refute File.read!("photo_blog/.gitignore") |> String.contains?("/node_modules")
       assert_file "photo_blog/config/dev.exs", ~r/watchers: \[\]/
       assert_file "photo_blog/priv/static/css/app.css"
+      assert_file "photo_blog/priv/static/favicon.ico"
       assert_file "photo_blog/priv/static/images/phoenix.png"
-      assert_file "photo_blog/priv/static/images/favicon.ico"
       assert_file "photo_blog/priv/static/js/phoenix.js"
       assert_file "photo_blog/priv/static/js/app.js"
 


### PR DESCRIPTION
This commit fixes a bug in the installer `phoenix.new` task
that was causing the `favicon.ico` file to not be found
when requested by browsers at `/favicon.ico`.

The `favicon.ico` file was generated in `web/static/assets/images`
so a `phoenix.digest` will create `priv/static/images/favicon.ico`.
The mount set up by `Plug.Static` can never find this file, since
the mount is relative to `priv/static`.

This commit changes the path of the generated `favicon.ico` to be
`web/static/assets/favicon.ico` so that it will be correctly
digested at `priv/static/favicon.ico`, where it can be found by
the mount.