### PR TITLE
include svg in files that cause a reload

### DIFF
--- a/installer/templates/new/config/dev.exs
+++ b/installer/templates/new/config/dev.exs
@@ -17,7 +17,7 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
 config :<%= application_name %>, <%= application_module %>.Endpoint,
   live_reload: [
     patterns: [
-      ~r{priv/static/.*(js|css|png|jpeg|jpg|gif)$},
+      ~r{priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$},
       ~r{web/views/.*(ex)$},
       ~r{web/templates/.*(eex)$}
     ]


### PR DESCRIPTION
svg files are common for image assets and changes to them should cause a page reload.