### PR TITLE
Fix module definition call

### DIFF
--- a/lib/phoenix/supervisor.ex
+++ b/lib/phoenix/supervisor.ex
@@ -7,7 +7,7 @@ defmodule Phoenix.Supervisor do
 
   def init([]) do
     children = [
-      worker(Phoenix.Transports.LongPoll.Supervisor, [])
+      supervisor(Phoenix.Transports.LongPoll.Supervisor, [])
     ]
     supervise(children, strategy: :one_for_one)
   end


### PR DESCRIPTION
The module specification for `Phoenix.Transports.LongPoll.Supervisor` should be `supervise/2`.