### PR TITLE
Makes routing helpers use request data to determine URLs when invoked with a Plug.Conn

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -72,8 +72,17 @@ defmodule Phoenix.Router.Helpers do
       @doc """
       Generates the connection/endpoint base URL without any path information.
       """
-      def url(%Conn{private: private}) do
-        private.phoenix_endpoint.url
+
+      def url(%Conn{host: host, port: 80, scheme: :http}) do
+        "http://" <> host
+      end
+
+      def url(%Conn{host: host, port: 443, scheme: :https}) do
+        "https://" <> host
+      end
+
+      def url(%Conn{host: host, port: port, scheme: scheme}) do
+        "#{scheme}://" <> host <> ":#{port}"
       end
 
       def url(%Socket{endpoint: endpoint}) do


### PR DESCRIPTION
This is a PR to discuss Phoenix routing helpers using request data to determine URLs instead of the `Endpoint`. A use case for this is multi-tenant apps.

One test is broken, the ScriptName one, because I'm not sure which should take precedence, i.e. the script or the connection?

This is my first PR to an OSS Elixir project so please feel free to comment on anything from the general idea to the implementation. I would find it most helpful.