### PR TITLE
Providing port in URL overrides all other ports when calculating URL

### DIFF
--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -168,7 +168,7 @@ defmodule Phoenix.Endpoint.Adapter do
     port   = port_to_string(url[:port] || port)
 
     case {scheme, port} do
-      {"https", "443"} -> "https://" <> host
+      {"https", _} when port in ~w(443 80) -> "https://" <> host
       {"http", "80"}   -> "http://" <> host
       {_, _}           -> scheme <> "://" <> host <> ":" <> port
     end

--- a/test/phoenix/endpoint/adapter_test.exs
+++ b/test/phoenix/endpoint/adapter_test.exs
@@ -53,6 +53,12 @@ defmodule Phoenix.Endpoint.AdapterTest do
     def config(:static_url), do: [host: "static.example.com"]
   end
 
+  defmodule URLPortEndpoint do
+    def config(:url), do: [host: "example.com", port: 80]
+    def config(:https), do: [port: 4001]
+    def config(:http), do: [port: 4000]
+  end
+
   test "generates the static url based on the static host configuration" do
     static_host = {:cache, "http://static.example.com"}
     assert Adapter.static_url(StaticURLEndpoint) == static_host
@@ -67,6 +73,7 @@ defmodule Phoenix.Endpoint.AdapterTest do
     assert Adapter.url(HTTPEndpoint) == {:cache, "http://example.com"}
     assert Adapter.url(HTTPSEndpoint) == {:cache, "https://example.com"}
     assert Adapter.url(HTTPEnvVarEndpoint) == {:cache, "http://example.com:8080"}
+    assert Adapter.url(URLPortEndpoint) == {:cache, "https://example.com"}
   end
 
   test "static_path/2 returns file's path with lookup cache" do


### PR DESCRIPTION
My Phoenix app generates a url like `https://myapp.com:80` because I set `:url` config to `[host: "myapp.com", port:80]` and https. This PR fixes that invalid URL by displaying the https url without the port when it is either `80` or `443`.

Although technically we wouldn't set https to port 80, this was the quickest and least intrusive fix. Another way is to have `url[:port]` be a flag instead. When it's `false`, it will not include port when generating the url. When it's true, it will include the port that we set in `http` and `https` config.

Which is the better way to go?