### PR TITLE
Include generated model fields in JSON output

### DIFF
--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -31,7 +31,8 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
     binding = Mix.Phoenix.inflect(singular)
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
-    binding = binding ++ [plural: plural, route: route, params: Mix.Phoenix.params(attrs)]
+    binding = binding ++ [plural: plural, route: route, json_fields: json_fields(binding, attrs),
+                          params: Mix.Phoenix.params(attrs)]
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")
@@ -66,6 +67,12 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
           $ mix ecto.migrate
       """
     end
+  end
+
+  defp json_fields(binding, attrs) do
+    [{:id, nil}] ++ attrs
+    |> Enum.map(fn {k, _} -> "#{k}: #{binding[:singular]}.#{k}" end)
+    |> Enum.join("\n      ")
   end
 
   defp validate_args!([_, plural | _] = args) do

--- a/priv/templates/phoenix.gen.json/view.ex
+++ b/priv/templates/phoenix.gen.json/view.ex
@@ -10,6 +10,6 @@ defmodule <%= module %>View do
   end
 
   def render("<%= singular %>.json", %{<%= singular %>: <%= singular %>}) do
-    %{id: <%= singular %>.id}
+    %{<%= json_fields %>}
   end
 end

--- a/test/mix/tasks/phoenix.gen.json_test.exs
+++ b/test/mix/tasks/phoenix.gen.json_test.exs
@@ -34,6 +34,8 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
       assert_file "web/views/user_view.ex", fn file ->
         assert file =~ "defmodule Phoenix.UserView do"
         assert file =~ "use Phoenix.Web, :view"
+        assert file =~ "id: user.id"
+        assert file =~ "name: user.name"
       end
 
       assert_file "test/controllers/user_controller_test.exs", fn file ->


### PR DESCRIPTION
Addresses #1125.

This will include generated fields in the default JSON output. So if you run `mix phoenix.gen.json User users name:string email:string` you'll get the following in the `web/views/user_view.ex` file:

```elixir
def render("user.json", %{user: user}) do
  %{
    id: user.id,
    name: user.name,
    email: user.email
  }
end
```

I added tests similar to how the HTML generator did it (it didn't explicitly check for all fields, just one of them). 

I opted to build the list of fields in the generator itself instead of iterating inside the template as I found it easier to get clean output without extra whitespace, without an errant comma after the last field, etc. This also gracefully handles the case where the user doesn't provide any fields (e.g. `mix phoenix.gen.json User users`).

Let me know if I should approach this differently; any feedback is welcome. Thanks!
