### PR TITLE
Improve channel testing helpers

### DIFF
--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -157,6 +157,21 @@ defmodule Phoenix.ChannelTest do
   end
 
   @doc """
+  Same as subscribe_and_join/3 but returns either the socket or throws an error
+
+  This is helpful when you are not testing authentication and just need the
+  socket.
+  """
+  defmacro subscribe_and_join!(channel, topic, payload \\ Macro.escape(%{})) do
+    quote do
+      case subscribe_and_join(@endpoint, unquote(channel), unquote(topic), unquote(payload)) do
+        {:ok, _, socket} -> socket
+        {:error, error} -> raise "Could not join channel. Got error: #{inspect(error)}"
+      end
+    end
+  end
+
+  @doc """
   Subscribes to the given topic and joins the channel
   under the given topic and payload.
 

--- a/test/phoenix/test/channel_test.exs
+++ b/test/phoenix/test/channel_test.exs
@@ -180,7 +180,7 @@ defmodule Phoenix.Test.ChannelTest do
   end
 
   test "pushes and broadcast messages" do
-    {:ok, _, socket} = subscribe_and_join(Channel, "foo:ok")
+    socket = subscribe_and_join!(Channel, "foo:ok")
     push socket, "broadcast", %{"foo" => "bar"}
     assert_broadcast "broadcast", %{"foo" => "bar"}
   end
@@ -188,7 +188,7 @@ defmodule Phoenix.Test.ChannelTest do
   ## handle_out
 
   test "push broadcasts by default" do
-    {:ok, _, socket} = subscribe_and_join(Channel, "foo:ok")
+    socket = subscribe_and_join!(Channel, "foo:ok")
     broadcast_from! socket, "default", %{"foo" => "bar"}
     assert_push "default", %{"foo" => "bar"}
   end
@@ -206,7 +206,7 @@ defmodule Phoenix.Test.ChannelTest do
 
   test "handles messages and stops" do
     Process.flag(:trap_exit, true)
-    {:ok, _, socket} = subscribe_and_join(Channel, "foo:ok")
+    socket = subscribe_and_join!(Channel, "foo:ok")
     pid = socket.channel_pid
     send pid, :stop
     assert_receive {:terminate, :shutdown}
@@ -214,13 +214,13 @@ defmodule Phoenix.Test.ChannelTest do
   end
 
   test "handles messages and pushes" do
-    {:ok, _, socket} = subscribe_and_join(Channel, "foo:ok")
+    socket = subscribe_and_join!(Channel, "foo:ok")
     send socket.channel_pid, :push
     assert_push "info", %{"reason" => "push"}
   end
 
   test "handles messages and broadcasts" do
-    {:ok, _, socket} = subscribe_and_join(Channel, "foo:ok")
+    socket = subscribe_and_join!(Channel, "foo:ok")
     send socket.channel_pid, :broadcast
     assert_broadcast "info", %{"reason" => "broadcast"}
   end


### PR DESCRIPTION
I chatted with José in IRC awhile back about adding a subscribe_and_join! function. Here's the PR! I also added some other functions that I have needed when testing channels lately.

* Add subscribe_and_join!/3 for easier for more concise tests
* Add ability to assert that pushes/broadcasts were for a specific
  topic. This makes it possible to test that a push/broadcast was sent for other topics. I