### PR TITLE
Make mix generators supply string keys for controller params

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -106,6 +106,7 @@ defmodule Mix.Phoenix do
         {_, {:references, _}} -> true
         {_, _} -> false
        end)
+    |> Enum.map(fn({k, v}) -> {Atom.to_string(k), v} end)
     |> Enum.into(%{}, fn
         {k, {:array, _}}      -> {k, []}
         {k, :integer}         -> {k, 42}
@@ -120,6 +121,15 @@ defmodule Mix.Phoenix do
         {k, :uuid}            -> {k, "7488a646-e31f-11e4-aace-600308960662"}
         {k, _}                -> {k, "some content"}
     end)
+  end
+
+  @doc """
+  Generates some sample expected attributes based on sample params.
+  """
+  def expected_attrs(attrs) do
+    for {k, v} <- params(attrs), into: %{} do
+      {String.to_atom(k), v}
+    end
   end
 
   @doc """

--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -33,7 +33,8 @@ defmodule Mix.Tasks.Phoenix.Gen.Html do
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
     binding = binding ++ [plural: plural, route: route, attrs: attrs,
-                          inputs: inputs(attrs), params: Mix.Phoenix.params(attrs)]
+                          inputs: inputs(attrs), params: Mix.Phoenix.params(attrs),
+                          expected_attrs: Mix.Phoenix.expected_attrs(attrs)]
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -32,7 +32,8 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
     binding = binding ++ [plural: plural, route: route, json_fields: json_fields(binding, attrs),
-                          params: Mix.Phoenix.params(attrs)]
+                          params: Mix.Phoenix.params(attrs),
+                          expected_attrs: Mix.Phoenix.expected_attrs(attrs)]
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")

--- a/priv/templates/phoenix.gen.html/controller_test.exs
+++ b/priv/templates/phoenix.gen.html/controller_test.exs
@@ -2,8 +2,9 @@ defmodule <%= module %>ControllerTest do
   use <%= base %>.ConnCase
 
   alias <%= module %>
-  @valid_attrs <%= inspect params %>
-  @invalid_attrs %{}
+  @valid_params <%= inspect params %>
+  @expected_attrs <%= inspect expected_attrs %>
+  @invalid_params %{}
 
   setup do
     conn = conn()
@@ -21,13 +22,13 @@ defmodule <%= module %>ControllerTest do
   end
 
   test "creates resource and redirects when data is valid", %{conn: conn} do
-    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @valid_attrs
+    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @valid_params
     assert redirected_to(conn) == <%= singular %>_path(conn, :index)
-    assert Repo.get_by(<%= alias %>, @valid_attrs)
+    assert Repo.get_by(<%= alias %>, @expected_attrs)
   end
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @invalid_attrs
+    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @invalid_params
     assert html_response(conn, 200) =~ "New <%= singular %>"
   end
 
@@ -51,14 +52,14 @@ defmodule <%= module %>ControllerTest do
 
   test "updates chosen resource and redirects when data is valid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @valid_attrs
+    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @valid_params
     assert redirected_to(conn) == <%= singular %>_path(conn, :show, <%= singular %>)
-    assert Repo.get_by(<%= alias %>, @valid_attrs)
+    assert Repo.get_by(<%= alias %>, @expected_attrs)
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_attrs
+    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_params
     assert html_response(conn, 200) =~ "Edit <%= singular %>"
   end
 

--- a/priv/templates/phoenix.gen.json/controller_test.exs
+++ b/priv/templates/phoenix.gen.json/controller_test.exs
@@ -2,8 +2,9 @@ defmodule <%= module %>ControllerTest do
   use <%= base %>.ConnCase
 
   alias <%= module %>
-  @valid_attrs <%= inspect params %>
-  @invalid_attrs %{}
+  @valid_params <%= inspect params %>
+  @expected_attrs <%= inspect expected_attrs %>
+  @invalid_params %{}
 
   setup do
     conn = conn() |> put_req_header("accept", "application/json")
@@ -30,26 +31,26 @@ defmodule <%= module %>ControllerTest do
   end
 
   test "creates and renders resource when data is valid", %{conn: conn} do
-    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @valid_attrs
+    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @valid_params
     assert json_response(conn, 201)["data"]["id"]
-    assert Repo.get_by(<%= alias %>, @valid_attrs)
+    assert Repo.get_by(<%= alias %>, @expected_attrs)
   end
 
   test "does not create resource and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @invalid_attrs
+    conn = post conn, <%= singular %>_path(conn, :create), <%= singular %>: @invalid_params
     assert json_response(conn, 422)["errors"] != %{}
   end
 
   test "updates and renders chosen resource when data is valid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @valid_attrs
+    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @valid_params
     assert json_response(conn, 200)["data"]["id"]
-    assert Repo.get_by(<%= alias %>, @valid_attrs)
+    assert Repo.get_by(<%= alias %>, @expected_attrs)
   end
 
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
-    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_attrs
+    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_params
     assert json_response(conn, 422)["errors"] != %{}
   end
 

--- a/priv/templates/phoenix.gen.model/model_test.exs
+++ b/priv/templates/phoenix.gen.model/model_test.exs
@@ -3,16 +3,16 @@ defmodule <%= module %>Test do
 
   alias <%= module %>
 
-  @valid_attrs <%= inspect params %>
-  @invalid_attrs %{}
+  @valid_params <%= inspect params %>
+  @invalid_params %{}
 
   test "changeset with valid attributes" do
-    changeset = <%= alias %>.changeset(%<%= alias %>{}, @valid_attrs)
+    changeset = <%= alias %>.changeset(%<%= alias %>{}, @valid_params)
     assert changeset.valid?
   end
 
   test "changeset with invalid attributes" do
-    changeset = <%= alias %>.changeset(%<%= alias %>{}, @invalid_attrs)
+    changeset = <%= alias %>.changeset(%<%= alias %>{}, @invalid_params)
     refute changeset.valid?
   end
 end

--- a/test/mix/tasks/phoenix.gen.html_test.exs
+++ b/test/mix/tasks/phoenix.gen.html_test.exs
@@ -79,8 +79,9 @@ defmodule Mix.Tasks.Phoenix.Gen.HtmlTest do
         assert file =~ "defmodule Phoenix.UserControllerTest"
         assert file =~ "use Phoenix.ConnCase"
 
-        assert file =~ ~S|@valid_attrs %{age: 42|
-        assert file =~ ~S|@invalid_attrs %{}|
+        assert file =~ ~S|@valid_params %{"age" => 42|
+        assert file =~ ~S|@expected_attrs %{age: 42|
+        assert file =~ ~S|@invalid_params %{}|
         refute file =~ ~S|address_id: nil|
 
         assert file =~ ~S|test "lists all entries on index"|
@@ -92,12 +93,12 @@ defmodule Mix.Tasks.Phoenix.Gen.HtmlTest do
         assert file =~ ~S|assert html_response(conn, 200) =~ "New user"|
 
         assert file =~ ~S|test "creates resource and redirects when data is valid"|
-        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @valid_attrs|
+        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @valid_params|
         assert file =~ ~S|assert redirected_to(conn) == user_path(conn, :index)|
-        assert file =~ ~r/creates.*when data is valid.*?assert Repo\.get_by\(User, @valid_attrs\).*?end/s
+        assert file =~ ~r/creates.*when data is valid.*?assert Repo\.get_by\(User, @expected_attrs\).*?end/s
 
         assert file =~ ~S|test "does not create resource and renders errors when data is invalid"|
-        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @invalid_attrs|
+        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @invalid_params|
 
         assert file =~ ~S|test "shows chosen resource"|
         assert file =~ ~S|user = Repo.insert! %User{}|
@@ -107,11 +108,11 @@ defmodule Mix.Tasks.Phoenix.Gen.HtmlTest do
         assert file =~ ~S|assert html_response(conn, 200) =~ "Edit user"|
 
         assert file =~ ~S|test "updates chosen resource and redirects when data is valid"|
-        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @valid_attrs|
-        assert file =~ ~r/updates.*when data is valid.*?assert Repo\.get_by\(User, @valid_attrs\).*?end/s
+        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @valid_params|
+        assert file =~ ~r/updates.*when data is valid.*?assert Repo\.get_by\(User, @expected_attrs\).*?end/s
 
         assert file =~ ~S|test "does not update chosen resource and renders errors when data is invalid"|
-        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @invalid_attrs|
+        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @invalid_params|
 
         assert file =~ ~S|test "deletes chosen resource"|
         assert file =~ ~S|conn = delete conn, user_path(conn, :delete, user)|

--- a/test/mix/tasks/phoenix.gen.json_test.exs
+++ b/test/mix/tasks/phoenix.gen.json_test.exs
@@ -41,28 +41,29 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
       assert_file "test/controllers/user_controller_test.exs", fn file ->
         assert file =~ "defmodule Phoenix.UserControllerTest"
         assert file =~ "use Phoenix.ConnCase"
-        assert file =~ ~S|@valid_attrs %{age: 42|
-        assert file =~ ~S|@invalid_attrs %{}|
+        assert file =~ ~S|@valid_params %{"age" => 42|
+        assert file =~ ~S|@expected_attrs %{age: 42|
+        assert file =~ ~S|@invalid_params %{}|
 
         assert file =~ ~S|test "lists all entries on index"|
         assert file =~ ~S|conn = get conn, user_path(conn, :index)|
 
         assert file =~ ~S|test "creates and renders resource when data is valid"|
-        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @valid_attrs|
-        assert file =~ ~r/creates.*when data is valid.*?assert Repo\.get_by\(User, @valid_attrs\).*?end/s
+        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @valid_params|
+        assert file =~ ~r/creates.*when data is valid.*?assert Repo\.get_by\(User, @expected_attrs\).*?end/s
 
         assert file =~ ~S|test "does not create resource and renders errors when data is invalid"|
-        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @invalid_attrs|
+        assert file =~ ~S|conn = post conn, user_path(conn, :create), user: @invalid_params|
 
         assert file =~ ~S|test "shows chosen resource"|
         assert file =~ ~S|user = Repo.insert! %User{}|
 
         assert file =~ ~S|test "updates and renders chosen resource when data is valid"|
-        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @valid_attrs|
-        assert file =~ ~r/updates.*when data is valid.*?assert Repo\.get_by\(User, @valid_attrs\).*?end/s
+        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @valid_params|
+        assert file =~ ~r/updates.*when data is valid.*?assert Repo\.get_by\(User, @expected_attrs\).*?end/s
 
         assert file =~ ~S|test "does not update chosen resource and renders errors when data is invalid"|
-        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @invalid_attrs|
+        assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @invalid_params|
 
         assert file =~ ~S|test "deletes chosen resource"|
         assert file =~ ~S|conn = delete conn, user_path(conn, :delete, user)|

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -56,12 +56,12 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
         assert file =~ "defmodule Phoenix.UserTest"
         assert file =~ "use Phoenix.ModelCase"
 
-        assert file =~ ~S|@valid_attrs %{age: 42|
-        assert file =~ ~S|changeset(%User{}, @valid_attrs)|
+        assert file =~ ~S|@valid_params %{"age" => 42|
+        assert file =~ ~S|changeset(%User{}, @valid_params)|
         assert file =~ ~S|assert changeset.valid?|
 
-        assert file =~ ~S|@invalid_attrs %{}|
-        assert file =~ ~S|changeset(%User{}, @invalid_attrs)|
+        assert file =~ ~S|@invalid_params %{}|
+        assert file =~ ~S|changeset(%User{}, @invalid_params)|
         assert file =~ ~S|refute changeset.valid?|
       end
     end


### PR DESCRIPTION
Ref #1139.

---

Controllers are expected to receive parameters with string keys, but the generators generate tests with atom keys. At best this means the user has to re-write them, at worst it can be misleading about what the standard is.

This commit makes `Mix.Phoenix.params` return a map with string keys, and adds a method `Mix.Phoenix.expected_attr` that returns the same thing with atom keys.

It then amends the generated tests to rename `@valid_attrs` and `@invalid_attrs` to `@*_params`, and adds `@expected_attrs`. The tests themselves are then amended to send `@*_params` to the controller, and test against `@expected_attrs`.

---

I'm guessing a bit with your favoured approach here — I hope you'll set me right if I've gone astray.