### PR TITLE
Make sure json view generator joins fields with commas.

### DIFF
--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -72,7 +72,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
   defp json_fields(binding, attrs) do
     [{:id, nil}] ++ attrs
     |> Enum.map(fn {k, _} -> "#{k}: #{binding[:singular]}.#{k}" end)
-    |> Enum.join("\n      ")
+    |> Enum.join(",\n      ")
   end
 
   defp validate_args!([_, plural | _] = args) do

--- a/test/mix/tasks/phoenix.gen.json_test.exs
+++ b/test/mix/tasks/phoenix.gen.json_test.exs
@@ -89,6 +89,8 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
       assert_file "web/views/admin/user_view.ex", fn file ->
         assert file =~ "defmodule Phoenix.Admin.UserView do"
         assert file =~ "use Phoenix.Web, :view"
+        assert file =~ "id: user.id,"
+        assert file =~ "name: user.name"
       end
 
       assert_received {:mix_shell, :info, ["\nAdd the resource" <> _ = message]}
@@ -104,6 +106,30 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
       assert [] = Path.wildcard("priv/repo/migrations/*_create_api_v1_user.exs")
 
       assert_file "web/controllers/api/v1/user_controller.ex"
+
+      assert_file "web/views/api/v1/user_view.ex", fn file ->
+        assert file =~ "defmodule Phoenix.API.V1.UserView do"
+        assert file =~ "use Phoenix.Web, :view"
+        assert file =~ "id: user.id,"
+        assert file =~ "name: user.name"
+      end
+    end
+  end
+
+  test "generates json resource with only id field" do
+    in_tmp "generates json resource with only id field", fn ->
+      Mix.Tasks.Phoenix.Gen.Json.run ["User", "users"]
+
+      assert File.exists? "web/models/user.ex"
+      assert [_] = Path.wildcard("priv/repo/migrations/*_create_user.exs")
+
+      assert_file "web/controllers/user_controller.ex"
+
+      assert_file "web/views/user_view.ex", fn file ->
+        assert file =~ "defmodule Phoenix.UserView do"
+        assert file =~ "use Phoenix.Web, :view"
+        assert file =~ ~S|%{id: user.id}|
+      end
     end
   end
 

--- a/test/mix/tasks/phoenix.gen.json_test.exs
+++ b/test/mix/tasks/phoenix.gen.json_test.exs
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
       assert_file "web/views/user_view.ex", fn file ->
         assert file =~ "defmodule Phoenix.UserView do"
         assert file =~ "use Phoenix.Web, :view"
-        assert file =~ "id: user.id"
+        assert file =~ "id: user.id,"
         assert file =~ "name: user.name"
       end
 


### PR DESCRIPTION
Previous to this change, the `phoenix.gen.json` generator was
creating invalid elixir code when the model included more than
one field. The generator was not placing commas between fields
for the singular method.

I got into this while creating a brand new phoenix project with
version 0.17 and after doing:

```shell
mix phoenix.gen.json Human humans name age:integer
```

I got the following error while trying to run the migrations:

```
== Compilation error on file web/views/human_view.ex ==
** (SyntaxError) web/views/human_view.ex:14: syntax error before: name
    (elixir) lib/kernel/parallel_compiler.ex:97: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/8
```

The problem was in the generated `web/views/human_view.ex`
missing some commas in the following function:

```elixir
  def render("human.json", %{human: human}) do
    %{id: human.id
      name: human.name
      age: human.age}
  end
```

Modified a test to expose this bug.