### PR TITLE
Fix typos in phoenix.gen.html/json

### DIFF
--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Phoenix.Gen.Html do
   use Mix.Task
 
-  @shortdoc "Generates controller, model and views for an HTML-based resource"
+  @shortdoc "Generates controller, model and views for an HTML based resource"
 
   @moduledoc """
   Generates a Phoenix resource.

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Phoenix.Gen.Json do
   use Mix.Task
 
-  @shortdoc "Generates a controller and model for an JSON-based resource"
+  @shortdoc "Generates a controller and model for a JSON based resource"
 
   @moduledoc """
   Generates a Phoenix resource.


### PR DESCRIPTION
* Changes `an` -> `a`
* Removes unnecessary `-`
