### PR TITLE
Added method Phoenix.version to allow getting Phoenix version in runtime without hassle.

### DIFF
--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -40,4 +40,12 @@ defmodule Phoenix do
     # Start the supervision tree
     Phoenix.Supervisor.start_link
   end
+
+  @doc """
+  Returns the version of Phoenix
+  """
+  def version do
+    {:ok, vsn} = :application.get_key(:phoenix, :vsn)
+    vsn
+  end
 end


### PR DESCRIPTION
At the moment we have no easy way to get Phoenix version in runtime, especially after release.
It's possible:
`:application.loaded_applications |> Enum.find(&( elem(&1, 0) == :phoenix )) |> elem(2)`
But it isn't obvious. 
After some investigations I figured out, that `:application.get_key(:phoenix, :vsn)` could be used here. But I think, that it should be much easier, so I propose to add `Phoenix.version` function to achieve this goal.
