### PR TITLE
Make sure controller test from generator uses all model fields

### DIFF
--- a/priv/templates/phoenix.gen.json/controller_test.exs
+++ b/priv/templates/phoenix.gen.json/controller_test.exs
@@ -18,9 +18,7 @@ defmodule <%= module %>ControllerTest do
   test "shows chosen resource", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = get conn, <%= singular %>_path(conn, :show, <%= singular %>)
-    assert json_response(conn, 200)["data"] == %{
-      "id" => <%= singular %>.id
-    }
+    assert json_response(conn, 200)["data"] == %{<%= json_fields %>}
   end
 
   test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do

--- a/test/mix/tasks/phoenix.gen.json_test.exs
+++ b/test/mix/tasks/phoenix.gen.json_test.exs
@@ -56,6 +56,8 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
 
         assert file =~ ~S|test "shows chosen resource"|
         assert file =~ ~S|user = Repo.insert! %User{}|
+        assert file =~ ~S|id: user.id,|
+        assert file =~ ~S|name: user.name|
 
         assert file =~ ~S|test "updates and renders chosen resource when data is valid"|
         assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @valid_attrs|


### PR DESCRIPTION
## What does this PR do?

This PR will fix a failing test after using the json generator.
```
mix phoenix.gen.json User users name:string
```

I got the following failing test after running the migrations and `mix test `
```
test/controllers/user_controller_test.exs:18
Assertion with == failed
code: json_response(conn, 200)["data"] == %{"id" => user.id()}
lhs:  %{"id" => 20, "name" => nil}
rhs:  %{"id" => 20}
stacktrace:
test/controllers/user_controller_test.exs:21
```
The controller test that fails contains the following lines:
```
assert json_response(conn, 200)["data"] == %{
  "id" => <%= singular %>.id
}
```
but it's missing the name.

I'm new to Phoenix and Elixir and was checking out the generators (great stuff btw) when I stumbled upon this. Thought I might submit a PR.