### PR TITLE
Support for Mongodb in installer

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -374,7 +374,8 @@ defmodule Mix.Tasks.Phoenix.New do
     {:sqlite_ecto, Sqlite.Ecto,
       dev:  [database: "db/#{app}_dev.sqlite"],
       test: [database: "db/#{app}_test.sqlite", pool: Ecto.Adapters.SQL.Sandbox],
-      prod: [database: "db/#{app}_prod.sqlite"]}
+      prod: [database: "db/#{app}_prod.sqlite"],
+      test_reset: "Ecto.Adapters.SQL.restart_test_transaction"}
   end
   defp get_ecto_adapter(db, _app) do
     Mix.raise "Unknown database #{inspect db}"
@@ -384,7 +385,8 @@ defmodule Mix.Tasks.Phoenix.New do
     [dev:  [username: user, password: pass, database: "#{app}_dev", hostname: "localhost"],
      test: [username: user, password: pass, database: "#{app}_test", hostname: "localhost",
             pool: Ecto.Adapters.SQL.Sandbox],
-     prod: [username: user, password: pass, database: "#{app}_prod"]]
+     prod: [username: user, password: pass, database: "#{app}_prod"],
+     test_reset: "Ecto.Adapters.SQL.restart_test_transaction"]
   end
 
   defp kw_to_config(kw) do

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -377,6 +377,14 @@ defmodule Mix.Tasks.Phoenix.New do
       prod: [database: "db/#{app}_prod.sqlite"],
       test_reset: "Ecto.Adapters.SQL.restart_test_transaction"}
   end
+  defp get_ecto_adapter("mongodb", app) do
+    {:mongodb_ecto, Mongo.Ecto,
+     dev:  [database: "#{app}_dev"],
+     test: [database: "#{app}_test", pool_size: 1],
+     prod: [database: "#{app}_prod"],
+     binary_id: true,
+     test_reset: "Mongo.Ecto.truncate"}
+  end
   defp get_ecto_adapter(db, _app) do
     Mix.raise "Unknown database #{inspect db}"
   end

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -251,6 +251,14 @@ defmodule Mix.Tasks.Phoenix.New do
         adapter: #{inspect binding[:adapter_module]}#{kw_to_config adapter_config[:prod]},
         pool_size: 20
       """
+
+      append_to path, "config/config.exs", """
+
+      # Configure phoenix generators
+      config :phoenix, :generators,
+        migration: #{adapter_config[:migration]},
+        binary_id: #{adapter_config[:binary_id]}
+      """
     end
   end
 
@@ -375,7 +383,8 @@ defmodule Mix.Tasks.Phoenix.New do
       dev:  [database: "db/#{app}_dev.sqlite"],
       test: [database: "db/#{app}_test.sqlite", pool: Ecto.Adapters.SQL.Sandbox],
       prod: [database: "db/#{app}_prod.sqlite"],
-      test_reset: "Ecto.Adapters.SQL.restart_test_transaction"}
+      test_reset: "Ecto.Adapters.SQL.restart_test_transaction",
+      migration: true}
   end
   defp get_ecto_adapter("mongodb", app) do
     {:mongodb_ecto, Mongo.Ecto,
@@ -383,7 +392,8 @@ defmodule Mix.Tasks.Phoenix.New do
      test: [database: "#{app}_test", pool_size: 1],
      prod: [database: "#{app}_prod"],
      binary_id: true,
-     test_reset: "Mongo.Ecto.truncate"}
+     test_reset: "Mongo.Ecto.truncate",
+     migration: false}
   end
   defp get_ecto_adapter(db, _app) do
     Mix.raise "Unknown database #{inspect db}"
@@ -394,7 +404,8 @@ defmodule Mix.Tasks.Phoenix.New do
      test: [username: user, password: pass, database: "#{app}_test", hostname: "localhost",
             pool: Ecto.Adapters.SQL.Sandbox],
      prod: [username: user, password: pass, database: "#{app}_prod"],
-     test_reset: "Ecto.Adapters.SQL.restart_test_transaction"]
+     test_reset: "Ecto.Adapters.SQL.restart_test_transaction",
+     migration: true]
   end
 
   defp kw_to_config(kw) do

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -108,6 +108,9 @@ defmodule Mix.Tasks.Phoenix.New do
     * `--no-ecto` - do not generate ecto files for
       the model layer
 
+    * `--binary-id` - use `binary_id` as primary key type
+      in ecto models
+
   ## Examples
 
       mix phoenix.new hello_world
@@ -122,7 +125,8 @@ defmodule Mix.Tasks.Phoenix.New do
 
   """
   @switches [dev: :boolean, brunch: :boolean, ecto: :boolean,
-             app: :string, module: :string, database: :string]
+             app: :string, module: :string, database: :string,
+             binary_id: :boolean]
 
   def run([version]) when version in ~w(-v --version) do
     Mix.shell.info "Phoenix v#{@version}"
@@ -161,6 +165,9 @@ defmodule Mix.Tasks.Phoenix.New do
 
     {brunch_deps_prefix, static_deps_prefix} =
       if in_umbrella?, do: {"../../", "../../../"}, else: {"", ""}
+
+    binary_id = Keyword.get(opts, :binary_id, false)
+    adapter_config = Keyword.put_new(adapter_config, :binary_id, binary_id)
 
     binding = [application_name: app,
                application_module: mod,

--- a/installer/templates/ecto/model_case.ex
+++ b/installer/templates/ecto/model_case.ex
@@ -25,7 +25,7 @@ defmodule <%= application_module %>.ModelCase do
 
   setup tags do
     unless tags[:async] do
-      Ecto.Adapters.SQL.restart_test_transaction(<%= application_module %>.Repo, [])
+      <%= adapter_config[:test_reset] %>(<%= application_module %>.Repo, [])
     end
 
     :ok

--- a/installer/templates/new/test/support/channel_case.ex
+++ b/installer/templates/new/test/support/channel_case.ex
@@ -32,7 +32,7 @@ defmodule <%= application_module %>.ChannelCase do
 
   setup tags do
 <%= if ecto do %>    unless tags[:async] do
-      Ecto.Adapters.SQL.restart_test_transaction(<%= application_module %>.Repo, [])
+      <%= adapter_config[:test_reset] %>(<%= application_module %>.Repo, [])
     end
 <% end %>
     :ok

--- a/installer/templates/new/test/support/conn_case.ex
+++ b/installer/templates/new/test/support/conn_case.ex
@@ -33,7 +33,7 @@ defmodule <%= application_module %>.ConnCase do
 
   setup tags do
 <%= if ecto do %>    unless tags[:async] do
-      Ecto.Adapters.SQL.restart_test_transaction(<%= application_module %>.Repo, [])
+      <%= adapter_config[:test_reset] %>(<%= application_module %>.Repo, [])
     end
 <% end %>
     :ok

--- a/installer/templates/new/web/web.ex
+++ b/installer/templates/new/web/web.ex
@@ -19,6 +19,8 @@ defmodule <%= application_module %>.Web do
   def model do
     quote do
       use Ecto.Model
+      <%= if adapter_config[:binary_id] do %>@primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id<% end %>
     end
   end
 <% else %>

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -131,6 +131,17 @@ defmodule Mix.Tasks.Phoenix.NewTest do
     end
   end
 
+  test "new with binary_id" do
+    in_tmp "new with binary_id", fn ->
+      Mix.Tasks.Phoenix.New.run([@app_name, "--binary-id"])
+
+      assert_file "photo_blog/web/web.ex", fn file ->
+        assert file =~ ~r/@primary_key {:id, :binary_id, autogenerate: true}/
+        assert file =~ ~r/@foreign_key_type :binary_id/
+      end
+    end
+  end
+
   test "new with uppercase" do
     in_tmp "new with uppercase", fn ->
       Mix.Tasks.Phoenix.New.run(["photoBlog"])

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -267,6 +267,28 @@ defmodule Mix.Tasks.Phoenix.NewTest do
     end
   end
 
+  test "new with mongodb adapter" do
+    in_tmp "new with mongodb adapter", fn ->
+      project_path = Path.join(File.cwd!, "custom_path")
+      Mix.Tasks.Phoenix.New.run([project_path, "--database", "mongodb"])
+
+      assert_file "custom_path/mix.exs", ~r/:mongodb_ecto/
+
+      assert_file "custom_path/config/dev.exs", ~r/Mongo.Ecto/
+      assert_file "custom_path/config/test.exs", [~r/Mongo.Ecto/, ~r/pool_size: 1/]
+      assert_file "custom_path/config/prod.secret.exs", ~r/Mongo.Ecto/
+
+      assert_file "custom_path/web/web.ex", fn file ->
+        assert file =~ ~r/@primary_key {:id, :binary_id, autogenerate: true}/
+        assert file =~ ~r/@foreign_key_type :binary_id/
+      end
+
+      assert_file "custom_path/test/support/conn_case.ex", ~r/Mongo.Ecto.truncate/
+      assert_file "custom_path/test/support/model_case.ex", ~r/Mongo.Ecto.truncate/
+      assert_file "custom_path/test/support/channel_case.ex", ~r/Mongo.Ecto.truncate/
+    end
+  end
+
   test "new defaults to pg adapter" do
     in_tmp "new defaults to pg adapter", fn ->
       project_path = Path.join(File.cwd!, "custom_path")

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -31,6 +31,11 @@ defmodule Mix.Tasks.Phoenix.NewTest do
 
       assert_file "photo_blog/config/config.exs", fn file ->
         refute file =~ "app_namespace"
+        assert file =~ """
+        config :phoenix, :generators,
+          migration: true,
+          binary_id: false
+        """
       end
 
       assert_file "photo_blog/config/prod.exs", fn file ->
@@ -124,6 +129,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       refute File.exists?("photo_blog/lib/photo_blog/repo.ex")
 
       assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_ecto")
+      assert_file "photo_blog/config/config.exs", &refute(&1 =~ "config :phoenix, :generators")
       assert_file "photo_blog/config/dev.exs", &refute(&1 =~ config)
       assert_file "photo_blog/config/test.exs", &refute(&1 =~ config)
       assert_file "photo_blog/config/prod.secret.exs", &refute(&1 =~ config)
@@ -139,6 +145,8 @@ defmodule Mix.Tasks.Phoenix.NewTest do
         assert file =~ ~r/@primary_key {:id, :binary_id, autogenerate: true}/
         assert file =~ ~r/@foreign_key_type :binary_id/
       end
+
+      assert_file "photo_blog/config/config.exs", ~r/binary_id: true/
     end
   end
 
@@ -286,6 +294,11 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "custom_path/test/support/conn_case.ex", ~r/Mongo.Ecto.truncate/
       assert_file "custom_path/test/support/model_case.ex", ~r/Mongo.Ecto.truncate/
       assert_file "custom_path/test/support/channel_case.ex", ~r/Mongo.Ecto.truncate/
+
+      assert_file "custom_path/config/config.exs", fn file ->
+        assert file =~ ~r/binary_id: true/
+        assert file =~ ~r/migration: false/
+      end
     end
   end
 

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -207,6 +207,13 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "custom_path/config/dev.exs", [~r/Ecto.Adapters.MySQL/, ~r/username: "root"/, ~r/password: ""/]
       assert_file "custom_path/config/test.exs", [~r/Ecto.Adapters.MySQL/, ~r/username: "root"/, ~r/password: ""/]
       assert_file "custom_path/config/prod.secret.exs", [~r/Ecto.Adapters.MySQL/, ~r/username: "root"/, ~r/password: ""/]
+
+      assert_file "custom_path/test/support/conn_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+      assert_file "custom_path/test/support/channel_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+      assert_file "custom_path/test/support/model_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
     end
   end
 
@@ -219,6 +226,13 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "custom_path/config/dev.exs", ~r/Tds.Ecto/
       assert_file "custom_path/config/test.exs", ~r/Tds.Ecto/
       assert_file "custom_path/config/prod.secret.exs", ~r/Tds.Ecto/
+
+      assert_file "custom_path/test/support/conn_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+      assert_file "custom_path/test/support/channel_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+      assert_file "custom_path/test/support/model_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
     end
   end
 
@@ -243,6 +257,13 @@ defmodule Mix.Tasks.Phoenix.NewTest do
         assert file =~ ~r/Sqlite.Ecto/
         assert file =~ ~r/database: "db\/custom_path_prod.sqlite"/
       end
+
+      assert_file "custom_path/test/support/conn_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+      assert_file "custom_path/test/support/channel_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+      assert_file "custom_path/test/support/model_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
     end
   end
 
@@ -255,6 +276,13 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "custom_path/config/dev.exs", [~r/Ecto.Adapters.Postgres/, ~r/username: "postgres"/, ~r/password: "postgres"/, ~r/hostname: "localhost"/]
       assert_file "custom_path/config/test.exs", [~r/Ecto.Adapters.Postgres/, ~r/username: "postgres"/, ~r/password: "postgres"/, ~r/hostname: "localhost"/]
       assert_file "custom_path/config/prod.secret.exs", [~r/Ecto.Adapters.Postgres/, ~r/username: "postgres"/, ~r/password: "postgres"/]
+
+      assert_file "custom_path/test/support/conn_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+      assert_file "custom_path/test/support/channel_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+      assert_file "custom_path/test/support/model_case.ex",
+        ~r/Ecto.Adapters.SQL.restart_test_transaction/
     end
   end
 

--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -38,10 +38,6 @@ defmodule Mix.Tasks.Phoenix.Gen.Html do
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")
 
-    if opts[:model] != false do
-      Mix.Task.run "phoenix.gen.model", args
-    end
-
     Mix.Phoenix.copy_from paths(), "priv/templates/phoenix.gen.html", "", binding, [
       {:eex, "controller.ex",       "web/controllers/#{path}_controller.ex"},
       {:eex, "edit.html.eex",       "web/templates/#{path}/edit.html.eex"},
@@ -61,11 +57,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Html do
     """
 
     if opts[:model] != false do
-      Mix.shell.info """
-      and then update your repository by running migrations:
-
-          $ mix ecto.migrate
-      """
+      Mix.Task.run "phoenix.gen.model", args
     end
   end
 

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -37,10 +37,6 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")
 
-    if opts[:model] != false do
-      Mix.Task.run "phoenix.gen.model", args
-    end
-
     files = [
       {:eex, "controller.ex",       "web/controllers/#{path}_controller.ex"},
       {:eex, "view.ex",             "web/views/#{path}_view.ex"},
@@ -61,11 +57,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
     """
 
     if opts[:model] != false do
-      Mix.shell.info """
-      and then update your repository by running migrations:
-
-          $ mix ecto.migrate
-      """
+      Mix.Task.run "phoenix.gen.model", args
     end
   end
 

--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -106,6 +106,15 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
     end
 
     Mix.Phoenix.copy_from paths(), "priv/templates/phoenix.gen.model", "", binding, files
+
+    if opts[:migration] != false do
+      Mix.shell.info """
+
+      Remeber to update your repository by running migrations:
+
+          $ mix ecto.migrate
+      """
+    end
   end
 
   defp validate_args!([_, plural | _] = args) do

--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
 
   ## binary_id
 
-  Migration can use `binary_id` for model's primary key and it's
+  Generated migration can use `binary_id` for model's primary key and it's
   references with option `--binary-id`.
 
   This option assumes the project was generated with the `--binary-id` option,
@@ -62,12 +62,22 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
       @primary_key {:id, :binary_id, autogenerate: true}
       @foreign_key_type :binary_id
 
+  ## Default options
+
+  This generator uses default options provided in the `:generators` configuration
+  of the `:phoenix` application. You can override those options providing
+  corresponding switches, e.g. `--no-binary-id` to use normal ids despite
+  the default configuration or `--migration` to force generation of the migration.
+
   """
   def run(args) do
     switches = [migration: :boolean, binary_id: :boolean]
 
     {opts, parsed, _} = OptionParser.parse(args, switches: switches)
     [singular, plural | attrs] = validate_args!(parsed)
+
+    default_opts = Application.get_env(:phoenix, :generators, [])
+    opts = Keyword.merge(default_opts, opts)
 
     attrs     = Mix.Phoenix.attrs(attrs)
     binding   = Mix.Phoenix.inflect(singular)

--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
     * a model in web/models
     * a migration file for the repository
 
-  The generated model can be skipped with `--no-migration`.
+  The generated migration can be skipped with `--no-migration`.
 
   ## Attributes
 
@@ -48,9 +48,25 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
 
       mix phoenix.gen.model Admin.User users name:string age:integer
 
+  ## binary_id
+
+  Migration can use `binary_id` for model's primary key and it's
+  references with option `--binary-id`.
+
+  This option assumes the project was generated with the `--binary-id` option,
+  that sets up models to use `binary_id` by default. If that's not the case
+  you can still set all your models to use `binary_id` by default, by adding
+  following to your `model` function in `web/web.ex`option or by adding
+  following to the generated model before the `schema` declaration:
+
+      @primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id
+
   """
   def run(args) do
-    {opts, parsed, _} = OptionParser.parse(args, switches: [migration: :boolean])
+    switches = [migration: :boolean, binary_id: :boolean]
+
+    {opts, parsed, _} = OptionParser.parse(args, switches: switches)
     [singular, plural | attrs] = validate_args!(parsed)
 
     attrs     = Mix.Phoenix.attrs(attrs)
@@ -66,7 +82,8 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
     binding = binding ++
               [attrs: attrs, plural: plural, types: types(attrs),
                assocs: assocs(assocs), indexes: indexes(plural, assocs),
-               defaults: defaults(attrs), params: params]
+               defaults: defaults(attrs), params: params,
+               binary_id: opts[:binary_id]]
 
     files = [
       {:eex, "model.ex",       "web/models/#{path}.ex"},

--- a/priv/templates/phoenix.gen.model/migration.exs
+++ b/priv/templates/phoenix.gen.model/migration.exs
@@ -2,9 +2,10 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
   use Ecto.Migration
 
   def change do
-    create table(:<%= plural %>) do
-<%= for {k, v} <- attrs do %>      add <%= inspect k %>, <%= inspect v %><%= defaults[k] %>
-<% end %><%= for {_, i, _, s} <- assocs do %>      add <%= inspect i %>, references(<%= inspect(s) %>)
+    create table(:<%= plural %><%= if binary_id do %>, primary_key: false<% end %>) do
+<%= if binary_id do %>      add :id, :binary_id, primary_key: true
+<% end %><%= for {k, v} <- attrs do %>      add <%= inspect k %>, <%= inspect v %><%= defaults[k] %>
+<% end %><%= for {_, i, _, s} <- assocs do %>      add <%= inspect i %>, references(<%= inspect(s) %><%= if binary_id do %>, type: :binary_id<% end %>)
 <% end %>
       timestamps
     end

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -109,6 +109,20 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
     end
   end
 
+  test "generates migration with binary_id" do
+    in_tmp "generates migration with binary_id", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts", "title", "user_id:references:users", "--binary-id"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
+
+      assert_file migration, fn file ->
+        assert file =~ "create table(:posts, primary_key: false) do"
+        assert file =~ "add :id, :binary_id, primary_key: true"
+        assert file =~ "add :user_id, references(:users, type: :binary_id)"
+      end
+    end
+  end
+
   test "plural can't contain a colon" do
     assert_raise Mix.Error, fn ->
       Mix.Tasks.Phoenix.Gen.Model.run ["Admin.User", "name:string", "foo:string"]

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -123,6 +123,37 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
     end
   end
 
+  test "skips migration with --no-migration option" do
+    in_tmp "skips migration with -no-migration option", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts", "--no-migration"]
+
+      assert [] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
+    end
+  end
+
+  test "uses defaults from :generators configuration" do
+    in_tmp "uses defaults from :generators configuration (migration)", fn ->
+      with_generators_config [migration: false], fn ->
+        Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts"]
+
+        assert [] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
+      end
+    end
+
+    in_tmp "uses defaults from :generators configuration (binary_id)", fn ->
+      with_generators_config [binary_id: true], fn ->
+        Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts"]
+
+        assert [migration] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
+
+        assert_file migration, fn file ->
+          assert file =~ "create table(:posts, primary_key: false) do"
+          assert file =~ "add :id, :binary_id, primary_key: true"
+        end
+      end
+    end
+  end
+
   test "plural can't contain a colon" do
     assert_raise Mix.Error, fn ->
       Mix.Tasks.Phoenix.Gen.Model.run ["Admin.User", "name:string", "foo:string"]
@@ -132,6 +163,16 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
   test "name is already defined" do
     assert_raise Mix.Error, fn ->
       Mix.Tasks.Phoenix.Gen.Model.run ["Dup", "dups"]
+    end
+  end
+
+  defp with_generators_config(config, fun) do
+    old_value = Application.get_env(:phoenix, :generators, [])
+    try do
+      Application.put_env(:phoenix, :generators, config)
+      fun.()
+    after
+      Application.put_env(:phoenix, :generators, old_value)
     end
   end
 end


### PR DESCRIPTION
Adds support for:
* `binary_id` as default in ecto models in installer
* `binary_id` in the model generator
* default generator options
* MongoDB adapter in installer