### PR TITLE
Full Module Name in Example

### DIFF
--- a/lib/mix/tasks/phoenix.gen.channel.ex
+++ b/lib/mix/tasks/phoenix.gen.channel.ex
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Channel do
 
     Add the channel to your `web/channels/user_socket.ex` handler, for example:
 
-        channel "#{plural}:lobby", #{binding[:scoped]}Channel
+        channel "#{plural}:lobby", #{binding[:module]}Channel
     """
   end
 


### PR DESCRIPTION
I believe the full module name should be in the example so it works out of the box without aliasing your channel in user_socket.ex