### PR TITLE
Consistent quoting in `brunch-config.js`

### DIFF
--- a/installer/templates/static/brunch/brunch-config.js
+++ b/installer/templates/static/brunch/brunch-config.js
@@ -31,19 +31,22 @@ exports.config = {
   conventions: {
     // This option sets where we should place non-css and non-js assets in.
     // By default, we set this to '/web/static/assets'. Files in this directory
-    // will be copied to `paths.public`, which is "priv/static" by default.
+    // will be copied to `paths.public`, which is 'priv/static' by default.
     assets: /^(web\/static\/assets)/
   },
 
   // Phoenix paths configuration
   paths: {
     // Dependencies and current project directories to watch
-    watched: ["<%= brunch_deps_prefix %><%= phoenix_path %>/web/static",
-              "<%= brunch_deps_prefix %>deps/phoenix_html/web/static",
-              "web/static", "test/static"],
+    watched: [
+      '<%= brunch_deps_prefix %><%= phoenix_path %>/web/static',
+      '<%= brunch_deps_prefix %>deps/phoenix_html/web/static',
+      'web/static',
+      'test/static'
+    ],
 
     // Where to compile files to
-    public: "priv/static"
+    public: 'priv/static'
   },
 
   // Configure your plugins

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -61,7 +61,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
 
       # Brunch
       assert_file "photo_blog/.gitignore", "/node_modules"
-      assert_file "photo_blog/brunch-config.js", ~s["deps/phoenix/web/static"]
+      assert_file "photo_blog/brunch-config.js", ~s['deps/phoenix/web/static']
       assert_file "photo_blog/config/dev.exs", "watchers: [node:"
       assert_file "photo_blog/web/static/assets/favicon.ico"
       assert_file "photo_blog/web/static/assets/images/phoenix.png"
@@ -174,8 +174,8 @@ defmodule Mix.Tasks.Phoenix.NewTest do
         end
 
         assert_file "photo_blog/brunch-config.js", fn(file) ->
-          assert file =~ ~s["../../deps/phoenix/web/static"]
-          assert file =~ ~s["../../deps/phoenix_html/web/static"]
+          assert file =~ ~s['../../deps/phoenix/web/static']
+          assert file =~ ~s['../../deps/phoenix_html/web/static']
         end
 
         assert_file "photo_blog/web/static/js/socket.js",


### PR DESCRIPTION
Update `brunch-config.js` to use single-quotes for all strings.

*Minor nitpick, but my linter complained so I figured I'd "fix" it*