### PR TITLE
Update brunch-config.js to use all double-quotes

### DIFF
--- a/installer/templates/static/brunch/brunch-config.js
+++ b/installer/templates/static/brunch/brunch-config.js
@@ -2,35 +2,35 @@ exports.config = {
   // See http://brunch.io/#documentation for docs.
   files: {
     javascripts: {
-      joinTo: 'js/app.js'
+      joinTo: "js/app.js"
 
       // To use a separate vendor.js bundle, specify two files path
       // https://github.com/brunch/brunch/blob/stable/docs/config.md#files
       // joinTo: {
-      //  'js/app.js': /^(web\/static\/js)/,
-      //  'js/vendor.js': /^(web\/static\/vendor)|(deps)/
+      //  "js/app.js": /^(web\/static\/js)/,
+      //  "js/vendor.js": /^(web\/static\/vendor)|(deps)/
       // }
       //
       // To change the order of concatenation of files, explicitly mention here
       // https://github.com/brunch/brunch/tree/master/docs#concatenation
       // order: {
       //   before: [
-      //     'web/static/vendor/js/jquery-2.1.1.js',
-      //     'web/static/vendor/js/bootstrap.min.js'
+      //     "web/static/vendor/js/jquery-2.1.1.js",
+      //     "web/static/vendor/js/bootstrap.min.js"
       //   ]
       // }
     },
     stylesheets: {
-      joinTo: 'css/app.css'
+      joinTo: "css/app.css"
     },
     templates: {
-      joinTo: 'js/app.js'
+      joinTo: "js/app.js"
     }
   },
 
   conventions: {
     // This option sets where we should place non-css and non-js assets in.
-    // By default, we set this to '/web/static/assets'. Files in this directory
+    // By default, we set this to "/web/static/assets". Files in this directory
     // will be copied to `paths.public`, which is "priv/static" by default.
     assets: /^(web\/static\/assets)/
   },
@@ -38,9 +38,12 @@ exports.config = {
   // Phoenix paths configuration
   paths: {
     // Dependencies and current project directories to watch
-    watched: ["<%= brunch_deps_prefix %><%= phoenix_path %>/web/static",
-              "<%= brunch_deps_prefix %>deps/phoenix_html/web/static",
-              "web/static", "test/static"],
+    watched: [
+      "<%= brunch_deps_prefix %><%= phoenix_path %>/web/static",
+      "<%= brunch_deps_prefix %>deps/phoenix_html/web/static",
+      "web/static",
+      "test/static"
+    ],
 
     // Where to compile files to
     public: "priv/static"
@@ -56,7 +59,7 @@ exports.config = {
 
   modules: {
     autoRequire: {
-      'js/app.js': ['web/static/js/app']
+      "js/app.js": ["web/static/js/app"]
     }
   },
 


### PR DESCRIPTION
Changed `brunch-config` to using all double-quotes now to be consistent with the other `.js` templates

Swapped over from https://github.com/phoenixframework/phoenix/pull/1177