### PR TITLE
"new"route listed but not supported

### DIFF
--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -57,7 +57,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
 
     Add the resource to your api scope in web/router.ex:
 
-        resources "/#{route}", #{binding[:scoped]}Controller
+        resources "/#{route}", #{binding[:scoped]}Controller, except: [:new, :edit]
     """
 
     if opts[:model] != false do

--- a/test/mix/tasks/phoenix.gen.json_test.exs
+++ b/test/mix/tasks/phoenix.gen.json_test.exs
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
       end
 
       assert_received {:mix_shell, :info, ["\nAdd the resource" <> _ = message]}
-      assert message =~ ~s(resources "/users", UserController)
+      assert message =~ ~s(resources "/users", UserController, except: [:new, :edit])
     end
   end
 


### PR DESCRIPTION
Possibly it is only a problem with json resources.   I added  "new" method to my drive_state_controller.ex for this route to work: 
URL:   http://localhost:4000/drive_states/new?state=2&name="drive2"

Code I added to drive_state_controller.ex for the above URL to work

 def new(conn, %{"name" => name, "state" => state} = drive_state_params) do
    create conn, %{"drive_state" => drive_state_params}
 end


This is how I created my model:

>mix phoenix.gen.json DriveState  drive_states name:string state:integer

"new" shows up in the routes below but doesn't work out of the box
>mix phoenix.routes
Generated drive_state app
       page_path  GET     /                       DriveState.PageController :index
drive_state_path  GET     /drive_states           DriveState.DriveStateController :index
drive_state_path  GET     /drive_states/:id/edit  DriveState.DriveStateController :edit
drive_state_path  GET     /drive_states/new       DriveState.DriveStateController :new <=== not supported
drive_state_path  GET     /drive_states/:id       DriveState.DriveStateController :show
drive_state_path  POST    /drive_states           DriveState.DriveStateController :create
drive_state_path  PATCH   /drive_states/:id       DriveState.DriveStateController :update
                  PUT     /drive_states/:id       DriveState.DriveStateController :update
drive_state_path  DELETE  /drive_states/:id       DriveState.DriveStateController :delete
