### PR TITLE
token `max_age` is checked in ms, make docs consistent

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -72,7 +72,7 @@ defmodule Phoenix.Token do
 
     message = %{
       data: data,
-      signed: now_ms()
+      signed: now_seconds()
     } |> :erlang.term_to_binary()
     MessageVerifier.sign(message, secret)
   end
@@ -101,7 +101,7 @@ defmodule Phoenix.Token do
       {:ok, message} ->
         %{data: data, signed: signed} = :erlang.binary_to_term(message)
 
-        if (max_age = opts[:max_age]) && (signed + max_age) < now_ms() do
+        if (max_age = opts[:max_age]) && (signed + max_age) < now_seconds() do
           {:error, :expired}
         else
           {:ok, data}
@@ -132,6 +132,6 @@ defmodule Phoenix.Token do
     KeyGenerator.generate(secret_key_base, salt, key_opts)
   end
 
-  defp time_to_ms({mega, sec, _micro}), do: (mega * 1000000 + sec) * 1000
-  defp now_ms, do: :os.timestamp() |> time_to_ms()
+  defp time_to_seconds({mega, sec, _micro}), do: mega * 1000000 + sec
+  defp now_seconds, do: :os.timestamp() |> time_to_seconds()
 end


### PR DESCRIPTION
Prior to this commit, we had a disconnect between the documented units
(seconds) and the actual units (milliseconds) that were used for
validating the maximum age of a token. This meant that the suggestion of
a 2 week maximum age as 1209600 seconds was, in reality, checked as
milliseconds resulting in a default maximum age of a little over 20
minutes. This commit updates the documentation to reflect that `max_age`
is measured in milliseconds, updates the defaults to their millisecond
equivalents, and tests that the `max_age` does, in fact, validate using
milliseconds.