### PR TITLE
String keys gen.json controller test show resource

### DIFF
--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -32,6 +32,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
     binding = binding ++ [plural: plural, route: route, json_fields: json_fields(binding, attrs),
+                          json_fields_string_keys: json_fields_string_keys(binding, attrs),
                           params: Mix.Phoenix.params(attrs)]
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
@@ -69,10 +70,19 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
     end
   end
 
-  defp json_fields(binding, attrs) do
+  defp json_fields(binding, attrs, key_value_to_template_representation) do
     [{:id, nil}] ++ attrs
-    |> Enum.map(fn {k, _} -> "#{k}: #{binding[:singular]}.#{k}" end)
+    |> Enum.map(fn {k, _} -> {k, "#{binding[:singular]}.#{k}"} end)
+    |> Enum.map(key_value_to_template_representation)
     |> Enum.join(",\n      ")
+  end
+
+  defp json_fields(binding, attrs) do
+    json_fields(binding, attrs, fn {k, v} -> "#{k}: #{v}" end)
+  end
+
+  defp json_fields_string_keys(binding, attrs) do
+    json_fields(binding, attrs, fn {k, v} -> "\"#{k}\" => #{v}" end)
   end
 
   defp validate_args!([_, plural | _] = args) do

--- a/priv/templates/phoenix.gen.json/controller_test.exs
+++ b/priv/templates/phoenix.gen.json/controller_test.exs
@@ -18,7 +18,7 @@ defmodule <%= module %>ControllerTest do
   test "shows chosen resource", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = get conn, <%= singular %>_path(conn, :show, <%= singular %>)
-    assert json_response(conn, 200)["data"] == %{<%= json_fields %>}
+    assert json_response(conn, 200)["data"] == %{<%= json_fields_string_keys %>}
   end
 
   test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do

--- a/test/mix/tasks/phoenix.gen.json_test.exs
+++ b/test/mix/tasks/phoenix.gen.json_test.exs
@@ -56,8 +56,8 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
 
         assert file =~ ~S|test "shows chosen resource"|
         assert file =~ ~S|user = Repo.insert! %User{}|
-        assert file =~ ~S|id: user.id,|
-        assert file =~ ~S|name: user.name|
+        assert file =~ ~S|"id" => user.id,|
+        assert file =~ ~S|"name" => user.name|
 
         assert file =~ ~S|test "updates and renders chosen resource when data is valid"|
         assert file =~ ~S|conn = put conn, user_path(conn, :update, user), user: @valid_attrs|


### PR DESCRIPTION
The generated controller test for `mix phoenix.gen.json` used atom keys
in the "shows chosen resource" test, when comparing against the
controller response data. The actual response has string keys, so the
test failed.

eg
```
  1) test shows chosen resource (ConmanData.BobControllerTest)
     test/controllers/bob_controller_test.exs:18
     Assertion with == failed
     code: json_response(conn, 200)["data"] == %{id: bob.id(), name: bob.name(), eyes: bob.eyes()}
     lhs:  %{"eyes" => nil, "id" => 13, "name" => nil}
     rhs:  %{eyes: nil, id: 13, name: nil}
```

This now expects string keys, so the generated test should succeed.