### PR TITLE
Add --no-html flag to Phoenix installer

### DIFF
--- a/installer/templates/new/config/config.exs
+++ b/installer/templates/new/config/config.exs
@@ -14,7 +14,7 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
   url: [host: "localhost"],
   root: Path.dirname(__DIR__),
   secret_key_base: "<%= secret_key_base %>",
-  render_errors: [accepts: ~w(html json)],
+  render_errors: [accepts: ~w(<%= if html do %>html <% end %>json)],
   pubsub: [name: <%= application_module %>.PubSub,
            adapter: Phoenix.PubSub.PG2]
 

--- a/installer/templates/new/config/dev.exs
+++ b/installer/templates/new/config/dev.exs
@@ -14,7 +14,7 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
   check_origin: false,
   watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin"]]<% else %>[]<% end %>
 
-# Watch static and templates for browser reloading.
+<%= if html do %># Watch static and templates for browser reloading.
 config :<%= application_name %>, <%= application_module %>.Endpoint,
   live_reload: [
     patterns: [
@@ -24,7 +24,7 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
     ]
   ]
 
-# Do not include metadata nor timestamps in development logs
+<% end %># Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"
 
 # Set a higher stacktrace during development.

--- a/installer/templates/new/lib/application_name/endpoint.ex
+++ b/installer/templates/new/lib/application_name/endpoint.ex
@@ -13,9 +13,9 @@ defmodule <%= application_module %>.Endpoint do
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
-  if code_reloading? do
+  if code_reloading? do<%= if html do %>
     socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
-    plug Phoenix.LiveReloader
+    plug Phoenix.LiveReloader<% end %>
     plug Phoenix.CodeReloader
   end
 

--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -19,7 +19,7 @@ defmodule <%= application_module %>.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [mod: {<%= application_module %>, []},
-     applications: [:phoenix, :phoenix_html, :cowboy, :logger<%= if ecto do %>,
+     applications: [:phoenix<%= if html do %>, :phoenix_html<% end %>, :cowboy, :logger<%= if ecto do %>,
                     :phoenix_ecto, <%= inspect adapter_app %><% end %>]]
   end
 
@@ -33,9 +33,9 @@ defmodule <%= application_module %>.Mixfile do
   defp deps do
     [<%= phoenix_dep %>,<%= if ecto do %>
      {:phoenix_ecto, "~> 1.1"},
-     {<%= inspect adapter_app %>, ">= 0.0.0"},<% end %>
+     {<%= inspect adapter_app %>, ">= 0.0.0"},<% end %><%= if html do %>
      {:phoenix_html, "~> 2.1"},
-     {:phoenix_live_reload, "~> 1.0", only: :dev},
+     {:phoenix_live_reload, "~> 1.0", only: :dev},<% end %>
      {:cowboy, "~> 1.0"}]
   end
 end

--- a/installer/templates/new/test/views/error_view_test.exs
+++ b/installer/templates/new/test/views/error_view_test.exs
@@ -4,7 +4,7 @@ defmodule <%= application_module %>.ErrorViewTest do
   # Bring render/3 and render_to_string/3 for testing custom views
   import Phoenix.View
 
-  test "renders 404.html" do
+  <%= if html do %>test "renders 404.html" do
     assert render_to_string(<%= application_module %>.ErrorView, "404.html", []) ==
            "Page not found"
   end
@@ -17,5 +17,18 @@ defmodule <%= application_module %>.ErrorViewTest do
   test "render any other" do
     assert render_to_string(<%= application_module %>.ErrorView, "505.html", []) ==
            "Server internal error"
+  end<% else %>test "renders 404.json" do
+    assert render(<%= application_module %>.ErrorView, "404.json", []) ==
+           %{"errors" => %{"detail" => "Page not found"}}
   end
+
+  test "render 500.json" do
+    assert render(<%= application_module %>.ErrorView, "500.json", []) ==
+           %{"errors" => %{"detail" => "Server internal error"}}
+  end
+
+  test "render any other" do
+    assert render(<%= application_module %>.ErrorView, "505.json", []) ==
+           %{"errors" => %{"detail" => "Server internal error"}}
+  end<% end %>
 end

--- a/installer/templates/new/web/router.ex
+++ b/installer/templates/new/web/router.ex
@@ -1,5 +1,5 @@
 defmodule <%= application_module %>.Router do
-  use <%= application_module %>.Web, :router
+  use <%= application_module %>.Web, :router<%= if html do %>
 
   pipeline :browser do
     plug :accepts, ["html"]
@@ -7,11 +7,11 @@ defmodule <%= application_module %>.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
-  end
+  end<% end %>
 
   pipeline :api do
     plug :accepts, ["json"]
-  end
+  end<%= if html do %>
 
   scope "/", <%= application_module %> do
     pipe_through :browser # Use the default browser stack
@@ -22,5 +22,9 @@ defmodule <%= application_module %>.Router do
   # Other scopes may use custom stacks.
   # scope "/api", <%= application_module %> do
   #   pipe_through :api
-  # end
+  # end<% else %>
+
+  scope "/api", <%= application_module %> do
+    pipe_through :api
+  end<% end %>
 end

--- a/installer/templates/new/web/views/error_view.ex
+++ b/installer/templates/new/web/views/error_view.ex
@@ -1,7 +1,7 @@
 defmodule <%= application_module %>.ErrorView do
   use <%= application_module %>.Web, :view
 
-  def render("404.html", _assigns) do
+  <%= if html do %>def render("404.html", _assigns) do
     "Page not found"
   end
 
@@ -13,5 +13,17 @@ defmodule <%= application_module %>.ErrorView do
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do
     render "500.html", assigns
+  end<% else %>def render("404.json", _assigns) do
+    %{"errors" => %{"detail" => "Page not found"}}
   end
+
+  def render("500.json", _assigns) do
+    %{"errors" => %{"detail" => "Server internal error"}}
+  end
+
+  # In case no render clause matches or no
+  # template is found, let's render it as 500
+  def template_not_found(_template, assigns) do
+    render "500.json", assigns
+  end<% end %>
 end

--- a/installer/templates/new/web/web.ex
+++ b/installer/templates/new/web/web.ex
@@ -47,10 +47,10 @@ defmodule <%= application_module %>.Web do
       use Phoenix.View, root: "web/templates"<%= if namespaced? do %>, namespace: <%= application_module %><% end %>
 
       # Import convenience functions from controllers
-      import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, view_module: 1]
+      import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, view_module: 1]<%= if html do %>
 
       # Use all HTML functionality (forms, tags, etc)
-      use Phoenix.HTML
+      use Phoenix.HTML<% end %>
 
       import <%= application_module %>.Router.Helpers
     end

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
 
   test "new without defaults" do
     in_tmp "new without defaults", fn ->
-      Mix.Tasks.Phoenix.New.run([@app_name, "--no-brunch", "--no-ecto"])
+      Mix.Tasks.Phoenix.New.run([@app_name, "--no-html", "--no-brunch", "--no-ecto"])
 
       # No Brunch
       refute File.read!("photo_blog/.gitignore") |> String.contains?("/node_modules")
@@ -134,6 +134,33 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "photo_blog/config/test.exs", &refute(&1 =~ config)
       assert_file "photo_blog/config/prod.secret.exs", &refute(&1 =~ config)
       assert_file "photo_blog/web/web.ex", &refute(&1 =~ ~r"alias PhotoBlog.Repo")
+
+      # No HTML
+      assert File.exists?("photo_blog/test/controllers")
+      refute File.exists?("photo_blog/test/controllers/.keep")
+
+      assert File.exists?("photo_blog/web/controllers")
+      refute File.exists?("photo_blog/web/controllers/.keep")
+      assert File.exists?("photo_blog/web/views")
+      refute File.exists?("photo_blog/web/views/.keep")
+
+      refute File.exists? "photo_blog/test/controllers/pager_controller_test.exs"
+      refute File.exists? "photo_blog/test/views/layout_view_test.exs"
+      refute File.exists? "photo_blog/test/views/page_view_test.exs"
+      refute File.exists? "photo_blog/web/controllers/page_controller.ex"
+      refute File.exists? "photo_blog/web/templates/layout/app.html.eex"
+      refute File.exists? "photo_blog/web/templates/page/index.html.eex"
+      refute File.exists? "photo_blog/web/views/layout_view.ex"
+      refute File.exists? "photo_blog/web/views/page_view.ex"
+
+      assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_html")
+      assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_live_reload")
+      assert_file "photo_blog/lib/photo_blog/endpoint.ex",
+                  &refute(&1 =~ ~r"Phoenix.LiveReloader")
+      assert_file "photo_blog/lib/photo_blog/endpoint.ex",
+                  &refute(&1 =~ ~r"Phoenix.LiveReloader.Socket")
+      assert_file "photo_blog/web/views/error_view.ex", ~r".json"
+      assert_file "photo_blog/web/router.ex", &refute(&1 =~ ~r"pipeline :browser")
     end
   end
 


### PR DESCRIPTION
This allows to skip generating HTML views and including related
dependencies (phoenix_html, phoenix_live_reload).

Fixes https://github.com/phoenixframework/phoenix/issues/1192