### PR TITLE
fix(Mix.Phoenix): validate attrs on generators

### DIFF
--- a/installer/test/mix_helper.exs
+++ b/installer/test/mix_helper.exs
@@ -20,6 +20,10 @@ defmodule MixHelper do
     assert File.regular?(file), "Expected #{file} to exist, but does not"
   end
 
+  def refute_file(file) do
+    refute File.regular?(file), "Expected #{file} to not exist, but it does"
+  end
+
   def assert_file(file, match) do
     cond do
       is_list(match) ->

--- a/test/mix/tasks/phoenix.gen.json_test.exs
+++ b/test/mix/tasks/phoenix.gen.json_test.exs
@@ -75,6 +75,20 @@ defmodule Mix.Tasks.Phoenix.Gen.JsonTest do
     end
   end
 
+  test "doesn't generate a resource when there is an error" do
+    in_tmp "doesnt generate resource on error", fn ->
+      assert_raise(Mix.Error, fn ->
+        Mix.Tasks.Phoenix.Gen.Json.run ["user", "users", "name", "age:integer", "info:notvalid"]
+      end)
+
+      refute_file "web/models/user.ex"
+      refute_file "test/models/user_test.exs"
+      refute_file "web/controllers/user_controller.ex"
+      refute_file "test/controllers/user_controller_test.exs"
+      refute_file "web/views/user_view.ex"
+    end
+  end
+
   test "generates nested resource" do
     in_tmp "generates nested resource", fn ->
       Mix.Tasks.Phoenix.Gen.Json.run ["Admin.User", "users", "name:string"]


### PR DESCRIPTION
This prevents code from being generated if one of the types is invalid.

Fixes #1215