### PR TITLE
Allow generating --dev projects outside Phoenix source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ $ mix phoenix.new path/to/your/app --dev
 
 The command above will create a new application, using your current Phoenix checkout thanks to the `--dev` flag.
 
-Note that `path/to/your/app` must be within the directory containing the Phoenix source code. This is so that a relative path can be used for the `:phoenix` dependency.
-
 ### Building phoenix.js
 
 ```bash

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -182,7 +182,6 @@ defmodule Mix.Tasks.Phoenix.New do
                application_module: mod,
                phoenix_dep: phoenix_dep(phoenix_path),
                phoenix_path: phoenix_path,
-               phoenix_static_path: phoenix_static_path(phoenix_path),
                pubsub_server: pubsub_server,
                secret_key_base: random_string(64),
                prod_secret_key_base: random_string(64),
@@ -462,8 +461,6 @@ defmodule Mix.Tasks.Phoenix.New do
   defp phoenix_dep("deps/phoenix"), do: ~s[{:phoenix, "~> 1.0.2"}]
   defp phoenix_dep(path), do: ~s[{:phoenix, path: #{inspect path}, override: true}]
 
-  defp phoenix_static_path("deps/phoenix"), do: "deps/phoenix"
-  defp phoenix_static_path(path), do: Path.join("..", path)
 
   defp phoenix_path(true), do: @phoenix
   defp phoenix_path(false), do: "deps/phoenix"

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -162,7 +162,7 @@ defmodule Mix.Tasks.Phoenix.New do
     ecto = Keyword.get(opts, :ecto, true)
     html = Keyword.get(opts, :html, true)
     brunch = Keyword.get(opts, :brunch, true)
-    phoenix_path = phoenix_path(path, Keyword.get(opts, :dev, false))
+    phoenix_path = phoenix_path(Keyword.get(opts, :dev, false))
 
     # We lowercase the database name because according to the
     # SQL spec, they are case insensitive unless quoted, which
@@ -465,23 +465,8 @@ defmodule Mix.Tasks.Phoenix.New do
   defp phoenix_static_path("deps/phoenix"), do: "deps/phoenix"
   defp phoenix_static_path(path), do: Path.join("..", path)
 
-  defp phoenix_path(path, true) do
-    absolute = Path.expand(path)
-    relative = Path.relative_to(absolute, @phoenix)
-
-    if absolute == relative do
-      Mix.raise "--dev project must be inside Phoenix directory"
-    end
-
-    relative
-    |> Path.split
-    |> Enum.map(fn _ -> ".." end)
-    |> Path.join
-  end
-
-  defp phoenix_path(_path, false) do
-    "deps/phoenix"
-  end
+  defp phoenix_path(true), do: @phoenix
+  defp phoenix_path(false), do: "deps/phoenix"
 
   ## Template helpers
 

--- a/installer/templates/static/brunch/socket.js
+++ b/installer/templates/static/brunch/socket.js
@@ -3,7 +3,7 @@
 
 // To use Phoenix channels, the first step is to import Socket
 // and connect at the socket path in "lib/my_app/endpoint.ex":
-import {Socket} from "<%= static_deps_prefix %><%= phoenix_static_path %>/web/static/js/phoenix"
+import {Socket} from "<%= static_deps_prefix %><%= phoenix_path %>/web/static/js/phoenix"
 
 let socket = new Socket("/socket")
 

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -24,6 +24,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
 
       assert_file "photo_blog/README.md"
       assert_file "photo_blog/mix.exs", fn file ->
+        assert file =~ "[{:phoenix, \"~> "
         assert file =~ "app: :photo_blog"
         refute file =~ "deps_path: \"../../deps\""
         refute file =~ "lockfile: \"../../mix.lock\""
@@ -337,6 +338,18 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       end
     end
   end
+
+  test "new with --dev" do
+    in_tmp "new with --dev", fn ->
+      Mix.Tasks.Phoenix.New.run([@app_name, "--dev"])
+
+      assert_file "photo_blog/mix.exs", fn file ->
+        path = Path.expand("../..", __DIR__)
+        assert file =~ "{:phoenix, path: \"#{path}\", override: true},"
+      end
+    end
+  end
+
 
   test "new defaults to pg adapter" do
     in_tmp "new defaults to pg adapter", fn ->

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "repository": {
   },
   "dependencies": {
-    "brunch": "^1.8.1",
+    "brunch": "^1.8.5",
     "babel-brunch": "^5.1.1",
     "clean-css-brunch": ">= 1.0 < 1.8",
     "css-brunch": ">= 1.0 < 1.8",


### PR DESCRIPTION
Right now, generating a Phoenix project with the `--dev` flag throws an error if the generated project is not inside the `installer` directory in the Phoenix source;

```
  $ mix phoenix.new /Users/jeff/opensource/phoenix_edge --dev
  Compiled lib/phoenix_new.ex
  Generated phoenix_new app
  ** (Mix) --dev project must be inside Phoenix directory
```

After poking around for a bit, I wasn’t able to find a reason for this, and I found that projects generated with the `--dev` flag would work properly anywhere if I just changed the path to Phoenix to an absolute one in the project’s `mix.exs` file.

So, I removed the code that checks if the project path is inside `phoenix/installer` and simply returned the absolute path to the Phoenix source when the `--dev` flag is used, which results in this line in the generated mix.exs file;

```
  [{:phoenix, path: "/Users/jeff/opensource/phoenix", override: true},
```

That eliminates the "--dev project must be inside Phoenix directory”-error and cleans up `installer/lib/phoenix_new.ex` quite a bit. What do you think? Did I miss anything?