### PR TITLE
Fixes wrong reply tuple in Phoenix.Channel moduledocs

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -91,7 +91,7 @@ defmodule Phoenix.Channel do
 
         if changeset.valid? do
           Repo.insert!(changeset)
-          {:ok, socket}
+          {:reply, :ok, socket}
         else
           {:reply, :error, socket}
         end


### PR DESCRIPTION
`{:ok, socket}` is not a correct result according to Phoenix.Channel