### PR TITLE
Transform controller action function clause errors into 400's. Closes…

### DIFF
--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -82,6 +82,7 @@ defmodule Phoenix.Controller.Pipeline do
   which is responsible for dispatching the appropriate action
   after the plug stack (and is also overridable).
   """
+  require Logger
 
   @doc false
   defmacro __using__(_) do
@@ -125,9 +126,38 @@ defmodule Phoenix.Controller.Pipeline do
         _ = var!(controller)
         _ = var!(action)
 
-        unquote(body)
+        try do
+          unquote(body)
+        catch
+          kind, reason ->
+            Phoenix.Controller.Pipeline.__catch__(
+              var!(conn), kind, reason, System.stacktrace, var!(controller), var!(action)
+            )
+        end
       end
     end
+  end
+
+  @doc false
+  def __catch__(conn, :error = kind, :function_clause = reason, stack, controller, action) do
+    case stack do
+      [{^controller, ^action, [%Plug.Conn{}, %{} | _], location} | _] ->
+        Logger.debug "Bad request to #{inspect controller}.#{action}. No matching action clause to process request\n" <>
+                     "  File: #{location[:file]}:#{location[:line]}\n" <>
+                     "  Parameters: #{inspect conn.params}"
+
+        Phoenix.Endpoint.RenderErrors.maybe_send_resp(conn, fn ->
+          conn
+          |> Plug.Conn.send_resp(400, "Bad Request")
+          |> Plug.Conn.halt()
+        end)
+
+       _ ->
+         :erlang.raise(kind, reason, stack)
+     end
+  end
+  def __catch__(_conn, kind, reason, stack, _controller, _action) do
+    :erlang.raise(kind, reason, stack)
   end
 
   @doc """

--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -145,8 +145,11 @@ defmodule Phoenix.Controller.Pipeline do
 
   @doc false
   def __catch__(:error, :function_clause, controller, action,
-                [{controller, action, [%Plug.Conn{} | _], _loc} | _]) do
-    raise Phoenix.ActionClauseError, controller: controller, action: action
+                [{controller, action, [%Plug.Conn{} | _], _loc} | _] = stack) do
+
+    msg = "bad request to #{inspect controller}.#{action}, " <>
+          "no matching action clause to process request"
+    reraise Phoenix.ActionClauseError, [message: msg], stack
   end
   def __catch__(kind, reason, _controller, _action, stack) do
     :erlang.raise(kind, reason, stack)

--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -126,7 +126,7 @@ defmodule Phoenix.Controller.Pipeline do
         catch
           kind, reason ->
             Phoenix.Controller.Pipeline.__catch__(
-              kind, reason, System.stacktrace, __MODULE__, conn.private.phoenix_action
+              kind, reason, __MODULE__, conn.private.phoenix_action, System.stacktrace
             )
         end
       end
@@ -144,15 +144,11 @@ defmodule Phoenix.Controller.Pipeline do
   end
 
   @doc false
-  def __catch__(:error = kind, :function_clause = reason, stack, controller, action) do
-    case stack do
-      [{^controller, ^action, [%Plug.Conn{} | _], _location} | _] ->
-        raise Phoenix.ActionClauseError, controller: controller, action: action
-       _ ->
-         :erlang.raise(kind, reason, stack)
-     end
+  def __catch__(:error, :function_clause, controller, action,
+                [{controller, action, [%Plug.Conn{} | _], _loc} | _]) do
+    raise Phoenix.ActionClauseError, controller: controller, action: action
   end
-  def __catch__(kind, reason, stack, _controller, _action) do
+  def __catch__(kind, reason, _controller, _action, stack) do
     :erlang.raise(kind, reason, stack)
   end
 

--- a/lib/phoenix/endpoint/render_errors.ex
+++ b/lib/phoenix/endpoint/render_errors.ex
@@ -51,11 +51,11 @@ defmodule Phoenix.Endpoint.RenderErrors do
   end
 
   defp __catch__(_conn, :error, %Phoenix.Router.NoRouteError{} = reason, stack, opts) do
-    maybe_send_resp(reason.conn, fn -> render(reason.conn, :error, reason, stack, opts) end)
+    maybe_render(reason.conn, :error, reason, stack, opts)
   end
 
   defp __catch__(conn, kind, reason, stack, opts) do
-    maybe_send_resp(conn, fn -> render(conn, kind, reason, stack, opts) end)
+    maybe_render(conn, kind, reason, stack, opts)
     :erlang.raise(kind, reason, stack)
   end
 
@@ -83,17 +83,14 @@ defmodule Phoenix.Endpoint.RenderErrors do
     end
   end
 
-  @doc """
-  Sends the response only if it hasn't already been sent
-  """
-  def maybe_send_resp(conn, func) do
+  defp maybe_render(conn, kind, reason, stack, opts) do
     receive do
       @already_sent ->
         send self(), @already_sent
         %{conn | state: :sent}
     after
       0 ->
-        func.()
+        render conn, kind, reason, stack, opts
     end
   end
 

--- a/lib/phoenix/exceptions.ex
+++ b/lib/phoenix/exceptions.ex
@@ -22,12 +22,10 @@ defmodule Phoenix.MissingParamError do
 end
 
 defmodule Phoenix.ActionClauseError do
-  defexception [message: nil, plug_status: 400, controller: nil, action: nil]
+  defexception [message: nil, plug_status: 400]
 
   def exception(opts) do
-    msg = "bad request to #{inspect opts[:controller]}.#{opts[:action]}, " <>
-          "no matching action clause to process request"
-    %Phoenix.ActionClauseError{message: msg}
+    %Phoenix.ActionClauseError{message: opts[:msg]}
   end
 
 end

--- a/lib/phoenix/exceptions.ex
+++ b/lib/phoenix/exceptions.ex
@@ -20,3 +20,14 @@ defmodule Phoenix.MissingParamError do
     %Phoenix.MissingParamError{message: msg}
   end
 end
+
+defmodule Phoenix.ActionClauseError do
+  defexception [message: nil, plug_status: 400, controller: nil, action: nil]
+
+  def exception(opts) do
+    msg = "bad request to #{inspect opts[:controller]}.#{opts[:action]}, " <>
+          "no matching action clause to process request"
+    %Phoenix.ActionClauseError{message: msg}
+  end
+
+end


### PR DESCRIPTION
@josevalim ready for review. How lenient or strict should we be on the action clause match? I made it so we match on actions that have %Plug.Conn{}, %{}, and any further args. 