### PR TITLE
Fix incorrect error message on channel join pattern mismatch.

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -165,7 +165,7 @@ defmodule Phoenix.Channel.Server do
 
             {:ok, Socket.t} |
             {:ok, reply :: map, Socket.t} |
-            {:error, reply :: map, Socket.t}
+            {:error, reply :: map}
 
         got #{inspect other}
         """


### PR DESCRIPTION
The pattern expected on error seems to only require `{:error, reply :: map}` whereas the outputted error also mentioned a socket was required. Hope this is correct and not something I'm missing.