### PR TITLE
[WIP] Allow Router to handle additional HTTP verbs/methods

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -317,7 +317,19 @@ defmodule Phoenix.Router do
     end
   end
 
-  for verb <- @http_methods do
+  # Allow additional http methods being set by using the project's config file:
+  # 
+  # ## Example config.exs:
+  # 
+  #   config :phoenix, :router,
+  #     additional_http_methods: [:mymethod]
+  #       
+  additional_http_methods = Application.get_env(:phoenix, :router) || []
+    |> Keyword.get(:additional_http_methods)
+
+  http_methods = @http_methods ++ (additional_http_methods || [])
+
+  for verb <- http_methods do
     @doc """
     Generates a route to handle a #{verb} request to the given path.
     """


### PR DESCRIPTION
After a brief discussion in [this Stackoverflow thread](http://stackoverflow.com/questions/32802381/custom-http-verbs-with-phoenix-router), I continued trying adding custom HTTP methods to the Phoenix Router.

While this option surely comes as a danger (using custom HTTP methods is generally not a favourable desire), it may be necessary to implement some protocols that extend HTTP with own method names, such as WebDAV/CalDAV.

Allowing the programmer to add custom HTTP methods turned out to be more difficult than I originally thought, because the method macros are being generated at phoenix's compile time, and not the application's. That made it impossible to either use

```ex
use Phoenix.Router, additional_http_methods: [:move, :copy]
```
or
```ex
defmodule Router do
    @additional_http_methods [:move, :copy]
    use Phoenix.Router
end
```

However, the current approach uses the projects config files and by adding this command adds any custom methods as desired by the programmer:

```exs
# Add additional HTTP methods
config :phoenix, :router,
  additional_http_methods: [:move, :copy]
```

A short list of tasks that came up to my mind:

- [ ] Documentation (Possible in the Router's guide)
- [ ] Tests (I don't know how to stub the Application.get_env call to *simulate* such a config as above)
- [ ] The CSRF Plug denies any requests with a custom HTTP Method without a valid CSRF token (this is not a blocker but it would be nice to at least mention this somewhere, right?)

Please tell me what you think about this addition. 