### PR TITLE
Add --install-dependencies option for phoenix.new

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -119,6 +119,8 @@ defmodule Mix.Tasks.Phoenix.New do
     * `--binary-id` - use `binary_id` as primary key type
       in ecto models
 
+    * `--install-dependencies` - Fetch and install dependencies without a user prompt
+
   ## Examples
 
       mix phoenix.new hello_world
@@ -134,7 +136,7 @@ defmodule Mix.Tasks.Phoenix.New do
   """
   @switches [dev: :boolean, brunch: :boolean, ecto: :boolean,
              app: :string, module: :string, database: :string,
-             binary_id: :boolean, html: :boolean]
+             binary_id: :boolean, html: :boolean, install_dependencies: :boolean]
 
   def run([version]) when version in ~w(-v --version) do
     Mix.shell.info "Phoenix v#{@version}"
@@ -178,6 +180,8 @@ defmodule Mix.Tasks.Phoenix.New do
     binary_id = Keyword.get(opts, :binary_id, false)
     adapter_config = Keyword.put_new(adapter_config, :binary_id, binary_id)
 
+    install_dependencies = Keyword.get(opts, :install_dependencies, false)
+
     binding = [application_name: app,
                application_module: mod,
                phoenix_dep: phoenix_dep(phoenix_path),
@@ -207,7 +211,7 @@ defmodule Mix.Tasks.Phoenix.New do
     copy_html   app, path, binding
 
     # Parallel installs
-    install? = Mix.shell.yes?("\nFetch and install dependencies?")
+    install? = install_dependencies || Mix.shell.yes?("\nFetch and install dependencies?")
 
     File.cd!(path, fn ->
       brunch =


### PR DESCRIPTION
Allows for programmatic running of phoenix.new without a shell prompt.

I did try adding a test, but the mix_shell message still throws an error because of some other input interaction.  I think maybe this tiny flag doesn't need a test?

```elixir
  test "new with --install-dependencies option" do
    in_tmp "new with --install-dependencies option" do
      Mix.Tasks.Phoenix.New.run [@app_name]
      refute_received {:mix_shell, :yes?, ["\nFetch and install dependencies?"]}
    end
  end
```

```
1) test new with --install-dependencies option (Mix.Tasks.Phoenix.NewTest)
     test/phoenix_new_test.exs:369
     ** (RuntimeError) no shell process input given for yes?/1
     stacktrace:
       (mix) lib/mix/shell/process.ex:155: Mix.Shell.Process.yes?/1
       (mix) lib/mix/generator.ex:20: Mix.Generator.create_file/3
       (phoenix_new) lib/phoenix_new.ex:505: anonymous fn/5 in Mix.Tasks.Phoenix.New.copy_from/3
       (elixir) lib/enum.ex:1385: Enum."-reduce/3-lists^foldl/2-0-"/3
       (phoenix_new) lib/phoenix_new.ex:494: Mix.Tasks.Phoenix.New.copy_from/3
       (phoenix_new) lib/phoenix_new.ex:206: Mix.Tasks.Phoenix.New.run/4
       test/phoenix_new_test.exs:371
```