### PR TITLE
License updates

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+# MIT License
+
 Copyright (c) 2014 Chris McCord
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ $ MIX_ENV=docs mix docs
   [2]: https://github.com/phoenixframework/phoenix/issues
   [3]: http://groups.google.com/group/phoenix-talk
   [4]: http://groups.google.com/group/phoenix-core
+
+## Copyright and License
+
+Copyright (c) 2014, Chris McCord.
+
+Phoenix source code is licensed under the [MIT License](LICENSE.md).

--- a/mix.exs
+++ b/mix.exs
@@ -51,6 +51,6 @@ defmodule Phoenix.Mixfile do
      licenses: ["MIT"],
      links: %{github: "https://github.com/phoenixframework/phoenix"},
      files: ~w(lib priv test/shared web) ++
-            ~w(brunch-config.js CHANGELOG.md LICENSE mix.exs package.json README.md)]
+            ~w(brunch-config.js CHANGELOG.md LICENSE.md mix.exs package.json README.md)]
   end
 end


### PR DESCRIPTION
Explicitly mention MIT License in the README.md and convert License to markdown.