### PR TITLE
Allow any code in channel intercept argument

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -254,7 +254,7 @@ defmodule Phoenix.Channel do
       {:stop, reason :: term, Socket.t}
 
   """
-  defmacro intercept(events) when is_list(events) do
+  defmacro intercept(events) do
     quote do
       @phoenix_intercepts unquote(events)
     end


### PR DESCRIPTION
The current guard doesn’t allow the ~w sigil for example.