### PR TITLE
add origin control headers to simple requests

### DIFF
--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -69,6 +69,7 @@ defmodule Phoenix.Transports.LongPoll do
 
     conn
     |> fetch_query_params
+    |> put_resp_header("access-control-allow-origin", "*")
     |> Plug.Conn.fetch_query_params
     |> Transport.transport_log(opts[:transport_log])
     |> Transport.force_ssl(handler, endpoint, opts)
@@ -86,7 +87,6 @@ defmodule Phoenix.Transports.LongPoll do
     headers = get_req_header(conn, "access-control-request-headers") |> Enum.join(", ")
 
     conn
-    |> put_resp_header("access-control-allow-origin", "*")
     |> put_resp_header("access-control-allow-headers", headers)
     |> put_resp_header("access-control-allow-methods", "get, post, options")
     |> put_resp_header("access-control-max-age", "3600")


### PR DESCRIPTION
Picked up on this here: https://github.com/jerel/phoenix_js/issues/1

I think we need to include the access origin control headers on each simple request (https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests) for the server to allow a cross site request to happen.

Allowing all requests through should be okay because we can use the check_origin method to verify access. (this really only effects long polling). I could even have a crack at using the check_origin list to add the correct hosts to the header if preferred.
