### PR TITLE
Adds Phoenix.Template.HTML as a default js encoder

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -79,7 +79,7 @@ defmodule Phoenix.Template do
 
   alias Phoenix.Template
 
-  @encoders [html: Phoenix.Template.HTML, json: Poison]
+  @encoders [html: Phoenix.Template.HTML, json: Poison, js: Phoenix.Template.HTML]
   @engines  [eex: Phoenix.Template.EExEngine, exs: Phoenix.Template.ExsEngine]
 
   defmodule UndefinedError do

--- a/test/phoenix/template_test.exs
+++ b/test/phoenix/template_test.exs
@@ -46,6 +46,7 @@ defmodule Phoenix.TemplateTest do
 
   test "format_encoder/1 returns the formatter for a given template" do
     assert Template.format_encoder("hello.html") == Phoenix.Template.HTML
+    assert Template.format_encoder("hello.js") == Phoenix.Template.HTML
     assert Template.format_encoder("hello.unknown") == nil
   end
 


### PR DESCRIPTION
I was not sure if it was worth creating another module specifically for javascript (like `Phoenix.Template.Javascript`) since it would do exactly the same so I added `Phoenix.Template.HTML` as the default encoder for js.

