### PR TITLE
Remove redundancies

### DIFF
--- a/lib/phoenix/endpoint/server.ex
+++ b/lib/phoenix/endpoint/server.ex
@@ -11,8 +11,6 @@ defmodule Phoenix.Endpoint.Server do
   end
 
   def init({otp_app, endpoint}) do
-    import Supervisor.Spec
-
     children = []
 
     if config = endpoint.config(:http) do

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -49,7 +49,6 @@ defmodule Phoenix.Transports.LongPoll do
   ## Plug callbacks
 
   @behaviour Plug
-  @behaviour Phoenix.Socket.Transport
   @plug_parsers Plug.Parsers.init(parsers: [:json], json_decoder: Poison)
 
   import Plug.Conn


### PR DESCRIPTION
This just removes some redundancies:

- Endpoint.Server doesn't have to `import Supervisor.Spec`, as it calls `use Supervisor` at the top of the module
- `@behaviour Phoenix.Socket.Transport` was stated twice in Transports.LongPoll