### PR TITLE
Use npm script for building brunch

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -293,7 +293,7 @@ defmodule Mix.Tasks.Phoenix.New do
   end
 
   defp install_brunch(install?) do
-    maybe_cmd "npm install && node node_modules/brunch/bin/brunch build",
+    maybe_cmd "npm install && npm run brunch-build",
               File.exists?("brunch-config.js"), install? && System.find_executable("npm")
   end
 

--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -1,6 +1,9 @@
 {
   "repository": {
   },
+  "scripts": {
+    "brunch-build": "brunch build"
+  },
   "dependencies": {
     "brunch": "^1.8.5",
     "babel-brunch": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "repository": {
   },
+  "scripts": {
+    "brunch-build": "brunch build"
+  },
   "dependencies": {
     "brunch": "^1.8.1",
     "babel-brunch": "^5.1.1",


### PR DESCRIPTION
This updates the installer to utilize an [npm run script](https://docs.npmjs.com/cli/run-script) for running `brunch build`.

npm run scripts are run with any locally installed bins in the `PATH`, so that you can call the executables directly without having to call into `node_modules/...` or ask that someone install a dependency globally. This is preferable because the current method of reaching into `node_modules/...` is prone to breaking if the `brunch` package ever changes where it stores the bin, whereas this will always work as long as it defines an executable in its `package.json`.