### PR TITLE
Use npm script for brunch watch tasks

### DIFF
--- a/installer/templates/new/config/dev.exs
+++ b/installer/templates/new/config/dev.exs
@@ -12,7 +12,7 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
   code_reloader: true,
   cache_static_lookup: false,
   check_origin: false,
-  watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin"]]<% else %>[]<% end %>
+  watchers: <%= if brunch do %>[npm: ["run", "brunch-watch"]]<% else %>[]<% end %>
 
 <%= if html do %># Watch static and templates for browser reloading.
 config :<%= application_name %>, <%= application_module %>.Endpoint,

--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -2,7 +2,8 @@
   "repository": {
   },
   "scripts": {
-    "brunch-build": "brunch build"
+    "brunch-build": "brunch build",
+    "brunch-watch": "brunch watch --stdin"
   },
   "dependencies": {
     "brunch": "^1.8.5",

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -140,7 +140,7 @@ defmodule Phoenix.Endpoint do
       the "watch" mode of the brunch build tool when the server starts.
       You can configure it to whatever build tool or command you want:
 
-          [node: ["node_modules/brunch/bin/brunch", "watch"]]
+          [npm: ["run", "brunch-watch"]]
 
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:paths` option which should be a list of

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "repository": {
   },
   "scripts": {
-    "brunch-build": "brunch build"
+    "brunch-build": "brunch build",
+    "brunch-watch": "brunch watch --stdin"
   },
   "dependencies": {
     "brunch": "^1.8.1",


### PR DESCRIPTION
This is a follow-up to conversation that happened in #1270 . Moves the `brunch watch --stdin` call into an npm script.