### PR TITLE
Fix error_view_test to use atoms

### DIFF
--- a/installer/templates/new/test/views/error_view_test.exs
+++ b/installer/templates/new/test/views/error_view_test.exs
@@ -19,16 +19,16 @@ defmodule <%= application_module %>.ErrorViewTest do
            "Server internal error"
   end<% else %>test "renders 404.json" do
     assert render(<%= application_module %>.ErrorView, "404.json", []) ==
-           %{"errors" => %{"detail" => "Page not found"}}
+           %{errors: %{detail: "Page not found"}}
   end
 
   test "render 500.json" do
     assert render(<%= application_module %>.ErrorView, "500.json", []) ==
-           %{"errors" => %{"detail" => "Server internal error"}}
+           %{errors: %{detail: "Server internal error"}}
   end
 
   test "render any other" do
     assert render(<%= application_module %>.ErrorView, "505.json", []) ==
-           %{"errors" => %{"detail" => "Server internal error"}}
+           %{errors: %{detail: "Server internal error"}}
   end<% end %>
 end


### PR DESCRIPTION
Tests were not updated to reflect change to error_view
https://github.com/phoenixframework/phoenix/commit/46f83f1280851d08223bcd42c8fc72ba9081a5f6