### PR TITLE
serve all static files by default

### DIFF
--- a/installer/templates/new/lib/application_name/endpoint.ex
+++ b/installer/templates/new/lib/application_name/endpoint.ex
@@ -8,8 +8,7 @@ defmodule <%= application_module %>.Endpoint do
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
   plug Plug.Static,
-    at: "/", from: :<%= application_name %>, gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+    at: "/", from: :<%= application_name %>, gzip: false
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.


### PR DESCRIPTION
The new app template was limiting static file serving to `only: ~w(css fonts images js favicon.ico robots.txt)`

I think if a file exists in /priv/static that it should be served for the following reasons:

  * it is common to deploy behind a proxy where the proxy will first check the uri in a static location and then forward to the dynamic backend
  * element of least surprise, user happiness:  other frameworks and static file servers I use serve the entire dir by default.  Thus I'm submitting this pull request because this caused me some delay figuring out why my `js` and `css` files were being served but not `img` (note, I use img by convention over images)

I'm not sure if this needs testing, but I did run mix test before and after all tests passed.

Thanks,

Troy

