### PR TITLE
Fix typo in Phoenix.Socket.Transport.parse_origin

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -376,7 +376,7 @@ defmodule Phoenix.Socket.Transport do
     case URI.parse(origin) do
       %{host: nil} ->
         raise ArgumentError,
-          "invalid check_origin: #{inspect origin} (expected a origin with a host)"
+          "invalid check_origin: #{inspect origin} (expected an origin with a host)"
       %{scheme: scheme, port: port, host: host} ->
         {scheme, host, port}
     end


### PR DESCRIPTION
Corrected a tiny spelling mistake.