### PR TITLE
Show ecto config message on mix phoenix.server

### DIFF
--- a/lib/mix/tasks/phoenix.server.ex
+++ b/lib/mix/tasks/phoenix.server.ex
@@ -20,6 +20,7 @@ defmodule Mix.Tasks.Phoenix.Server do
   """
   def run(args) do
     Application.put_env(:phoenix, :serve_endpoints, true, persistent: true)
+    print_ecto_info
     Mix.Task.run "run", run_args() ++ args
   end
 
@@ -29,5 +30,15 @@ defmodule Mix.Tasks.Phoenix.Server do
 
   defp iex_running? do
     Code.ensure_loaded?(IEx) && IEx.started?
+  end
+
+  defp print_ecto_info do
+    if Code.ensure_loaded?(Ecto) do
+      Mix.shell.info """
+      Before moving on, configure your database in config/dev.exs and run:
+
+      mix ecto.create
+      """
+    end
   end
 end


### PR DESCRIPTION
@josevalim let me know if I'm on the right track here.  This closes #1280.

Output:

`$ mix phoenix.server`

```shell
Before moving on, configure your database in config/dev.exs and run:

mix ecto.create

[info] Running ExampleTest.Endpoint with Cowboy on http://localhost:4000

> @ brunch-watch /Users/sean/Projects/phoenix/installer/example_test
> brunch watch --stdin

15 Oct 09:10:20 - info: compiled 5 files into 2 files, copied 3 in 1329ms
```