### PR TITLE
added encode_www_form to make sure the path helpers are properly escaping dynamic segments

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -237,7 +237,7 @@ defmodule Phoenix.Router.Helpers do
   defp expand_segments([h|t], acc) when is_binary(h),
     do: expand_segments(t, quote(do: unquote(acc) <> unquote("/" <> h)))
   defp expand_segments([h|t], acc),
-    do: expand_segments(t, quote(do: unquote(acc) <> "/" <> to_param(unquote(h))))
+    do: expand_segments(t, quote(do: unquote(acc) <> "/" <> URI.encode_www_form(to_param(unquote(h)))))
   defp expand_segments([], acc),
     do: acc
 end

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -233,7 +233,7 @@ defmodule Phoenix.Router.Helpers do
     do: quote(do: "/" <> Enum.join(unquote(segments), "/"))
 
   defp expand_segments([{:|, _, [h, t]}], acc),
-    do: quote(do: unquote(expand_segments([h], acc)) <> "/" <> Enum.join(unquote(t), "/"))
+    do: quote(do: unquote(expand_segments([h], acc)) <> "/" <> Enum.map_join(unquote(t), "/", &URI.encode_www_form/1))
   defp expand_segments([h|t], acc) when is_binary(h),
     do: expand_segments(t, quote(do: unquote(acc) <> unquote("/" <> h)))
   defp expand_segments([h|t], acc),

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -33,7 +33,7 @@ defmodule Phoenix.Router.HelpersTest do
 
     assert extract_defhelper(route, 1) == String.strip """
     def(hello_world_path(conn_or_endpoint, :world, bar, params)) do
-      path(conn_or_endpoint, segments(("" <> "/foo") <> "/" <> Enum.join(bar, "/"), params, ["bar"]))
+      path(conn_or_endpoint, segments(("" <> "/foo") <> "/" <> Enum.map_join(bar, "/", &(URI.encode_www_form() / 1)), params, ["bar"]))
     end
     """
   end
@@ -152,6 +152,22 @@ defmodule Phoenix.Router.HelpersTest do
     end
   end
 
+  test "top-level named routes with complex ids" do
+    assert Helpers.post_path(__MODULE__, :show, "8==D--+") == 
+      "/posts/8%3D%3DD--%2B"
+    assert Helpers.post_path(__MODULE__, :show, "8==D--+", []) == 
+      "/posts/8%3D%3DD--%2B"
+    assert Helpers.top_path(__MODULE__, :top, id: "8==D--+") == 
+      "/posts/top?id=8%3D%3DD--%2B"
+
+    assert Helpers.post_path(__MODULE__, :file, ["8==D--+", ":O.jpg"]) == 
+      "/posts/file/8%3D%3DD--%2B/%3AO.jpg"
+    assert Helpers.post_path(__MODULE__, :file, ["8==D--+", ":O.jpg"], []) == 
+      "/posts/file/8%3D%3DD--%2B/%3AO.jpg"
+    assert Helpers.post_path(__MODULE__, :file, ["8==D--+", ":O.jpg"], xx: "/=+/") == 
+      "/posts/file/8%3D%3DD--%2B/%3AO.jpg?xx=%2F%3D%2B%2F"
+  end
+
   test "resources generates named routes for :index, :edit, :show, :new" do
     assert Helpers.user_path(__MODULE__, :index, []) == "/users"
     assert Helpers.user_path(__MODULE__, :index) == "/users"
@@ -176,6 +192,7 @@ defmodule Phoenix.Router.HelpersTest do
 
     assert Helpers.user_path(__MODULE__, :show, "1a+/31d", [dog: "8d="]) == "/users/1a%2B%2F31d?dog=8d%3D"
     assert Helpers.user_path(__MODULE__, :index, [cat: "=8+/&"]) == "/users?cat=%3D8%2B%2F%26"
+
   end
 
   test "resources generates named routes for :create, :update, :delete" do
@@ -198,6 +215,30 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.user_comment_path(__MODULE__, :show, 123, 2) == "/users/123/comments/2"
     assert Helpers.user_comment_path(__MODULE__, :new, 88, []) == "/users/88/comments/new"
     assert Helpers.user_comment_path(__MODULE__, :new, 88) == "/users/88/comments/new"
+  end
+
+  test "multi-level nested resources generated named routes with complex ids" do
+    assert Helpers.user_comment_path(__MODULE__, :index, "f4/d+~=", []) == 
+      "/users/f4%2Fd%2B~%3D/comments"
+    assert Helpers.user_comment_path(__MODULE__, :index, "f4/d+~=") == 
+      "/users/f4%2Fd%2B~%3D/comments"
+    assert Helpers.user_comment_path(__MODULE__, :edit, "f4/d+~=", "x-+=/", []) == 
+      "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F/edit"
+    assert Helpers.user_comment_path(__MODULE__, :edit, "f4/d+~=", "x-+=/") == 
+      "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F/edit"
+    assert Helpers.user_comment_path(__MODULE__, :show, "f4/d+~=", "x-+=/", []) == 
+      "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F"
+    assert Helpers.user_comment_path(__MODULE__, :show, "f4/d+~=", "x-+=/") == 
+      "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F"
+    assert Helpers.user_comment_path(__MODULE__, :new, "/==/", []) == 
+      "/users/%2F%3D%3D%2F/comments/new"
+    assert Helpers.user_comment_path(__MODULE__, :new, "/==/") == 
+      "/users/%2F%3D%3D%2F/comments/new"
+
+    assert Helpers.user_comment_file_path(__MODULE__, :show, "f4/d+~=", "/==/", "x-+=/", []) ==
+      "/users/f4%2Fd%2B~%3D/comments/%2F%3D%3D%2F/files/x-%2B%3D%2F"
+    assert Helpers.user_comment_file_path(__MODULE__, :show, "f4/d+~=", "/==/", "x-+=/") ==
+      "/users/f4%2Fd%2B~%3D/comments/%2F%3D%3D%2F/files/x-%2B%3D%2F"
   end
 
   test "2-Level nested resources generates nested named routes for :index, :edit, :show, :new" do

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -153,19 +153,19 @@ defmodule Phoenix.Router.HelpersTest do
   end
 
   test "top-level named routes with complex ids" do
-    assert Helpers.post_path(__MODULE__, :show, "8==D--+") == 
-      "/posts/8%3D%3DD--%2B"
-    assert Helpers.post_path(__MODULE__, :show, "8==D--+", []) == 
-      "/posts/8%3D%3DD--%2B"
-    assert Helpers.top_path(__MODULE__, :top, id: "8==D--+") == 
-      "/posts/top?id=8%3D%3DD--%2B"
+    assert Helpers.post_path(__MODULE__, :show, "==d--+") == 
+      "/posts/%3D%3Dd--%2B"
+    assert Helpers.post_path(__MODULE__, :show, "==d--+", []) == 
+      "/posts/%3D%3Dd--%2B"
+    assert Helpers.top_path(__MODULE__, :top, id: "==d--+") == 
+      "/posts/top?id=%3D%3Dd--%2B"
 
-    assert Helpers.post_path(__MODULE__, :file, ["8==D--+", ":O.jpg"]) == 
-      "/posts/file/8%3D%3DD--%2B/%3AO.jpg"
-    assert Helpers.post_path(__MODULE__, :file, ["8==D--+", ":O.jpg"], []) == 
-      "/posts/file/8%3D%3DD--%2B/%3AO.jpg"
-    assert Helpers.post_path(__MODULE__, :file, ["8==D--+", ":O.jpg"], xx: "/=+/") == 
-      "/posts/file/8%3D%3DD--%2B/%3AO.jpg?xx=%2F%3D%2B%2F"
+    assert Helpers.post_path(__MODULE__, :file, ["==d--+", ":O.jpg"]) == 
+      "/posts/file/%3D%3Dd--%2B/%3AO.jpg"
+    assert Helpers.post_path(__MODULE__, :file, ["==d--+", ":O.jpg"], []) == 
+      "/posts/file/%3D%3Dd--%2B/%3AO.jpg"
+    assert Helpers.post_path(__MODULE__, :file, ["==d--+", ":O.jpg"], xx: "/=+/") == 
+      "/posts/file/%3D%3Dd--%2B/%3AO.jpg?xx=%2F%3D%2B%2F"
   end
 
   test "resources generates named routes for :index, :edit, :show, :new" do

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -17,7 +17,7 @@ defmodule Phoenix.Router.HelpersTest do
 
     assert extract_defhelper(route, 1) == String.strip """
     def(hello_world_path(conn_or_endpoint, :world, bar, params)) do
-      path(conn_or_endpoint, segments(("" <> "/foo") <> "/" <> to_param(bar), params, ["bar"]))
+      path(conn_or_endpoint, segments(("" <> "/foo") <> "/" <> URI.encode_www_form(to_param(bar)), params, ["bar"]))
     end
     """
   end
@@ -161,6 +161,21 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.user_path(__MODULE__, :show, 123) == "/users/123"
     assert Helpers.user_path(__MODULE__, :new, []) == "/users/new"
     assert Helpers.user_path(__MODULE__, :new) == "/users/new"
+  end
+
+  test "resources generated named routes with complex ids" do
+    assert Helpers.user_path(__MODULE__, :edit, "1a+/31d", []) == "/users/1a%2B%2F31d/edit"
+    assert Helpers.user_path(__MODULE__, :edit, "1a+/31d") == "/users/1a%2B%2F31d/edit"
+    assert Helpers.user_path(__MODULE__, :show, "1a+/31d", []) == "/users/1a%2B%2F31d"
+    assert Helpers.user_path(__MODULE__, :show, "1a+/31d") == "/users/1a%2B%2F31d"
+
+    assert Helpers.message_path(__MODULE__, :update, "8=/=d", []) == "/admin/messages/8%3D%2F%3Dd"
+    assert Helpers.message_path(__MODULE__, :update, "8=/=d") == "/admin/messages/8%3D%2F%3Dd"
+    assert Helpers.message_path(__MODULE__, :delete, "8=/=d", []) == "/admin/messages/8%3D%2F%3Dd"
+    assert Helpers.message_path(__MODULE__, :delete, "8=/=d") == "/admin/messages/8%3D%2F%3Dd"
+
+    assert Helpers.user_path(__MODULE__, :show, "1a+/31d", [dog: "8d="]) == "/users/1a%2B%2F31d?dog=8d%3D"
+    assert Helpers.user_path(__MODULE__, :index, [cat: "=8+/&"]) == "/users?cat=%3D8%2B%2F%26"
   end
 
   test "resources generates named routes for :create, :update, :delete" do


### PR DESCRIPTION
This is in reference to:

https://github.com/phoenixframework/phoenix/issues/1286

@josevalim suggested to put the `encode_www_form` inside `to_param`, however, because we already use `to_param` to properly encode querystrings, doing so resulted in a double encoding. The next best place was to place the `encode_www_form` directly inside the `expand_segments` function.

Admittedly, I am a little surprised all the tests passed despite the fact I didn't also add `encode_www_form` to L238. I can spend a little more time trying to break into corner cases, but here's the working pr for now.

