### PR TITLE
Update HTML layout to use sectioning elements

### DIFF
--- a/installer/templates/new/web/templates/layout/app.html.eex
+++ b/installer/templates/new/web/templates/layout/app.html.eex
@@ -12,18 +12,22 @@
   </head>
 
   <body>
-    <div class="container" role="main">
-      <div class="header">
-        <ul class="nav nav-pills pull-right">
-          <li><a href="http://www.phoenixframework.org/docs">Get Started</a></li>
-        </ul>
+    <div class="container">
+      <header class="header">
+        <nav role="navigation">
+          <ul class="nav nav-pills pull-right">
+            <li><a href="http://www.phoenixframework.org/docs">Get Started</a></li>
+          </ul>
+        </nav>
         <span class="logo"></span>
-      </div>
+      </header>
 
       <p class="alert alert-info" role="alert"><%%= get_flash(@conn, :info) %></p>
       <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
 
-      <%%= @inner %>
+      <main role="main">
+        <%%= @inner %>
+      </main>
 
     </div> <!-- /container -->
     <script src="<%%= static_path(@conn, "/js/app.js") %>"></script>


### PR DESCRIPTION
This commit improves accessibility in the default layout by incorporating HTML5 sectioning elements instead of `div` elements. It adds additional elements but does not change the appearance.

* Replace `div` for header with `header` element
* Add `nav` element with `role="navigation"`
* Wrap import with `main` element
* Move `role="main"` from outer `div` to new `main` element as `main` role is for the main content of the document.

I have left the `class` attributes intact so as not to break the CSS.
