### PR TITLE
Add support for unique arrays and foreign keys in the phoenix.gen.model mix task

### DIFF
--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -29,11 +29,13 @@ defmodule Mix.Tasks.Phoenix.Gen.Html do
     [singular, plural | attrs] = validate_args!(parsed)
 
     attrs   = Mix.Phoenix.attrs(attrs)
+    params  = Mix.Phoenix.params(attrs)
+    attrs   = Mix.Phoenix.strip_unique_tags(attrs)
     binding = Mix.Phoenix.inflect(singular)
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
     binding = binding ++ [plural: plural, route: route, attrs: attrs,
-                          inputs: inputs(attrs), params: Mix.Phoenix.params(attrs),
+                          inputs: inputs(attrs), params: params,
                           template_singular: String.replace(binding[:singular], "_", " "),
                           template_plural: String.replace(plural, "_", " ")]
 

--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -28,15 +28,15 @@ defmodule Mix.Tasks.Phoenix.Gen.Html do
     {opts, parsed, _} = OptionParser.parse(args, switches: [model: :boolean])
     [singular, plural | attrs] = validate_args!(parsed)
 
-    attrs   = Mix.Phoenix.attrs(attrs)
-    untagged_attrs = Mix.Phoenix.strip_unique_tags(attrs)
-    binding = Mix.Phoenix.inflect(singular)
-    path    = binding[:path]
-    route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
-    binding = binding ++ [plural: plural, route: route, attrs: untagged_attrs,
-                          inputs: inputs(untagged_attrs), params: Mix.Phoenix.params(attrs), 
-                          template_singular: String.replace(binding[:singular], "_", " "),
-                          template_plural: String.replace(plural, "_", " ")]
+    {attrs, _, _} = Mix.Phoenix.unique_attrs(attrs)
+    attrs         = Mix.Phoenix.attrs(attrs)
+    binding       = Mix.Phoenix.inflect(singular)
+    path          = binding[:path]
+    route         = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
+    binding       = binding ++ [plural: plural, route: route, attrs: attrs,
+                                inputs: inputs(attrs), params: Mix.Phoenix.params(attrs), 
+                                template_singular: String.replace(binding[:singular], "_", " "),
+                                template_plural: String.replace(plural, "_", " ")]
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")

--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -29,13 +29,12 @@ defmodule Mix.Tasks.Phoenix.Gen.Html do
     [singular, plural | attrs] = validate_args!(parsed)
 
     attrs   = Mix.Phoenix.attrs(attrs)
-    params  = Mix.Phoenix.params(attrs)
-    attrs   = Mix.Phoenix.strip_unique_tags(attrs)
+    untagged_attrs = Mix.Phoenix.strip_unique_tags(attrs)
     binding = Mix.Phoenix.inflect(singular)
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
-    binding = binding ++ [plural: plural, route: route, attrs: attrs,
-                          inputs: inputs(attrs), params: params,
+    binding = binding ++ [plural: plural, route: route, attrs: untagged_attrs,
+                          inputs: inputs(untagged_attrs), params: Mix.Phoenix.params(attrs), 
                           template_singular: String.replace(binding[:singular], "_", " "),
                           template_plural: String.replace(plural, "_", " ")]
 

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -27,12 +27,13 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
     {opts, parsed, _} = OptionParser.parse(args, switches: [model: :boolean])
     [singular, plural | attrs] = validate_args!(parsed)
 
-    attrs   = Mix.Phoenix.attrs(attrs)
-    binding = Mix.Phoenix.inflect(singular)
-    path    = binding[:path]
-    route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
-    binding = binding ++ [plural: plural, attrs: Mix.Phoenix.strip_unique_tags(attrs), 
-                          route: route, params: Mix.Phoenix.params(attrs)]
+    {attrs, _, _} = Mix.Phoenix.unique_attrs(attrs)
+    attrs         = Mix.Phoenix.attrs(attrs)
+    binding       = Mix.Phoenix.inflect(singular)
+    path          = binding[:path]
+    route         = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
+    binding       = binding ++ [plural: plural, attrs: attrs, route: route,
+                                params: Mix.Phoenix.params(attrs)]
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -28,11 +28,13 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
     [singular, plural | attrs] = validate_args!(parsed)
 
     attrs   = Mix.Phoenix.attrs(attrs)
+    params  = Mix.Phoenix.params(attrs)
+    attrs   = Mix.Phoenix.strip_unique_tags(attrs)
     binding = Mix.Phoenix.inflect(singular)
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
     binding = binding ++ [plural: plural, route: route,
-                          attrs: attrs, params: Mix.Phoenix.params(attrs)]
+                          attrs: attrs, params: params]
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -28,13 +28,11 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
     [singular, plural | attrs] = validate_args!(parsed)
 
     attrs   = Mix.Phoenix.attrs(attrs)
-    params  = Mix.Phoenix.params(attrs)
-    attrs   = Mix.Phoenix.strip_unique_tags(attrs)
     binding = Mix.Phoenix.inflect(singular)
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
-    binding = binding ++ [plural: plural, route: route,
-                          attrs: attrs, params: params]
+    binding = binding ++ [plural: plural, attrs: Mix.Phoenix.strip_unique_tags(attrs), 
+                          route: route, params: Mix.Phoenix.params(attrs)]
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")

--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -171,7 +171,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
     Enum.partition attrs, fn
       {_, {:references, _}} ->
         true
-      {_, {:references, _, _}} ->
+      {_, {:references, _, :unique}} ->
         true
       {key, :references} ->
         Mix.raise """

--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -102,10 +102,10 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
     
     binding = binding ++
               [attrs: attrs, plural: plural, types: types(attrs),
-               assocs: assocs(assocs, unique_keys), indexes: indexes(plural, assocs, unique_fields, unique_keys),
-               defaults: defaults(attrs), params: params, binary_id: opts[:binary_id], unique_constraints: unique_constraints,
-               required_fields: required_fields(attrs, unique_keys)
-               ]
+               defaults: defaults(attrs), params: params, assocs: assocs(assocs, unique_keys), 
+               indexes: indexes(plural, assocs, unique_fields, unique_keys),
+               binary_id: opts[:binary_id], unique_constraints: unique_constraints,
+               required_attrs: required_attrs(attrs, unique_keys)]
 
     files = [
       {:eex, "model.ex",       "web/models/#{path}.ex"},
@@ -209,7 +209,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
     end)
   end
 
-  defp required_fields(attrs, unique_keys) do
+  defp required_attrs(attrs, unique_keys) do
     Enum.map_join(Enum.concat(attrs, unique_keys), " ", &elem(elem(&1, 1), 0))
   end
 

--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
   If no data type is given, it defaults to a string. This also works for 
   unique foreign keys and arrays:
 
-    mix phoenix.gen.model UserInfo user_info user_id:references:users:unique nicknames:array:string:unique
+      mix phoenix.gen.model UserInfo user_info user_id:references:users:unique nicknames:array:string:unique
 
   ## Namespaced resources
 
@@ -98,7 +98,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
 
     {uniques, attrs} = extract_uniques(attrs)
     {assocs, attrs} = partition_attrs_and_assocs(attrs)
-    
+
     binding = binding ++
               [attrs: attrs, plural: plural, types: types(attrs), uniques: uniques,
                assocs: assocs(assocs), indexes: indexes(plural, assocs, uniques),

--- a/priv/templates/phoenix.gen.model/migration.exs
+++ b/priv/templates/phoenix.gen.model/migration.exs
@@ -4,8 +4,8 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
   def change do
     create table(:<%= plural %><%= if binary_id do %>, primary_key: false<% end %>) do
 <%= if binary_id do %>      add :id, :binary_id, primary_key: true
-<% end %><%= for {k, v} <- attrs do %>      add <%= inspect k %>, <%= inspect v %><%= defaults[k] %>
-<% end %><%= for {_, i, _, s} <- assocs do %>      add <%= inspect i %>, references(<%= inspect(s) %><%= if binary_id do %>, type: :binary_id<% end %>)
+<% end %><%= for {_, {k, v}} <- attrs do %>      add <%= inspect k %>, <%= inspect v %><%= defaults[k] %>
+<% end %><%= for {_, {_, i, _, s}} <- assocs do %>      add <%= inspect i %>, references(<%= inspect(s) %><%= if binary_id do %>, type: :binary_id<% end %>)
 <% end %>
       timestamps
     end

--- a/priv/templates/phoenix.gen.model/migration.exs
+++ b/priv/templates/phoenix.gen.model/migration.exs
@@ -4,8 +4,8 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
   def change do
     create table(:<%= plural %><%= if binary_id do %>, primary_key: false<% end %>) do
 <%= if binary_id do %>      add :id, :binary_id, primary_key: true
-<% end %><%= for {_, {k, v}} <- attrs do %>      add <%= inspect k %>, <%= inspect v %><%= defaults[k] %>
-<% end %><%= for {_, {_, i, _, s}} <- assocs do %>      add <%= inspect i %>, references(<%= inspect(s) %><%= if binary_id do %>, type: :binary_id<% end %>)
+<% end %><%= for {k, v} <- attrs do %>      add <%= inspect k %>, <%= inspect v %><%= defaults[k] %>
+<% end %><%= for {_, i, _, s} <- assocs do %>      add <%= inspect i %>, references(<%= inspect(s) %><%= if binary_id do %>, type: :binary_id<% end %>)
 <% end %>
       timestamps
     end

--- a/priv/templates/phoenix.gen.model/migration.exs
+++ b/priv/templates/phoenix.gen.model/migration.exs
@@ -9,6 +9,7 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
 <% end %>
       timestamps
     end
+
 <%= for index <- indexes do %>    <%= index %>
 <% end %>
   end

--- a/priv/templates/phoenix.gen.model/model.ex
+++ b/priv/templates/phoenix.gen.model/model.ex
@@ -2,13 +2,13 @@ defmodule <%= module %> do
   use <%= base %>.Web, :model
 
   schema <%= inspect plural %> do
-<%= for {k, _} <- attrs do %>    field <%= inspect k %>, <%= inspect types[k] %><%= defaults[k] %>
-<% end %><%= for {k, _, m, _} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>
+<%= for {_, {k, _}} <- attrs do %>    field <%= inspect k %>, <%= inspect types[k] %><%= defaults[k] %>
+<% end %><%= for {_, {k, _, m, _}} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>
 <% end %>
     timestamps
   end
 
-  @required_fields ~w(<%= Enum.map_join(Enum.concat(attrs, required_unique_keys), " ", &elem(&1, 0)) %>)
+  @required_fields ~w(<%= required_fields %>)
   @optional_fields ~w()
 
   @doc """
@@ -20,6 +20,6 @@ defmodule <%= module %> do
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)
-<%= for {k, _} <- uniques do %>    |> unique_constraint(<%= inspect k %>)
+<%= for {_, {_, k}} <- unique_constraints do %>    |> unique_constraint(<%= inspect k %>)
 <% end %>  end
 end

--- a/priv/templates/phoenix.gen.model/model.ex
+++ b/priv/templates/phoenix.gen.model/model.ex
@@ -2,8 +2,8 @@ defmodule <%= module %> do
   use <%= base %>.Web, :model
 
   schema <%= inspect plural %> do
-<%= for {_, {k, _}} <- attrs do %>    field <%= inspect k %>, <%= inspect types[k] %><%= defaults[k] %>
-<% end %><%= for {_, {k, _, m, _}} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>
+<%= for {k, _} <- attrs do %>    field <%= inspect k %>, <%= inspect types[k] %><%= defaults[k] %>
+<% end %><%= for {k, _, m, _} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>
 <% end %>
     timestamps
   end
@@ -20,6 +20,6 @@ defmodule <%= module %> do
   def changeset(model, params \\ :empty) do
     model
     |> cast(params, @required_fields, @optional_fields)
-<%= for {_, {_, k}} <- unique_constraints do %>    |> unique_constraint(<%= inspect k %>)
+<%= for k <- unique_constraints do %>    |> unique_constraint(<%= inspect k %>)
 <% end %>  end
 end

--- a/priv/templates/phoenix.gen.model/model.ex
+++ b/priv/templates/phoenix.gen.model/model.ex
@@ -8,7 +8,7 @@ defmodule <%= module %> do
     timestamps
   end
 
-  @required_fields ~w(<%= required_fields %>)
+  @required_fields ~w(<%= required_attrs %>)
   @optional_fields ~w()
 
   @doc """

--- a/priv/templates/phoenix.gen.model/model.ex
+++ b/priv/templates/phoenix.gen.model/model.ex
@@ -8,7 +8,7 @@ defmodule <%= module %> do
     timestamps
   end
 
-  @required_fields ~w(<%= Enum.map_join(attrs, " ", &elem(&1, 0)) %>)
+  @required_fields ~w(<%= Enum.map_join(Enum.concat(attrs, required_unique_keys), " ", &elem(&1, 0)) %>)
   @optional_fields ~w()
 
   @doc """

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -111,7 +111,8 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
 
   test "generates unique_index" do
     in_tmp "generates unique_index", fn ->
-      Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts", "title:unique", "unique_int:integer:unique", "unique_float:float:unique"]
+      Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts", "title:unique", "unique_int:integer:unique",
+        "unique_float:float:unique", "user_id:references:users:unique", "unique_array:array:text:unique"]
 
       assert [migration] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
 
@@ -121,9 +122,13 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
         assert file =~ "add :title, :string"
         assert file =~ "add :unique_int, :integer"
         assert file =~ "add :unique_float, :float"
+        assert file =~ "add :unique_array, {:array, :text}"
+        assert file =~ "add :user_id, references(:users)"
         assert file =~ "create unique_index(:posts, [:title])"
         assert file =~ "create unique_index(:posts, [:unique_int])"
         assert file =~ "create unique_index(:posts, [:unique_float])"
+        assert file =~ "create unique_index(:posts, [:user_id])"
+        assert file =~ "create unique_index(:posts, [:unique_array])"
       end
 
       assert_file "web/models/post.ex", fn file ->
@@ -132,8 +137,15 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
         assert file =~ "schema \"posts\" do"
         assert file =~ "field :title, :string"
         assert file =~ "field :unique_int, :integer"
+        assert file =~ "field :unique_float, :float"
+        refute file =~ "field :user_id"
+        assert file =~ "belongs_to :user, Phoenix.User"
+        assert file =~ "@required_fields ~w(title unique_int unique_float unique_array user_id)"
         assert file =~ "|> unique_constraint(:title)"
         assert file =~ "|> unique_constraint(:unique_int)"
+        assert file =~ "|> unique_constraint(:unique_float)"
+        assert file =~ "|> unique_constraint(:user_id)"
+        assert file =~ "|> unique_constraint(:unique_array)"
       end
     end
   end


### PR DESCRIPTION
I've extended the functionality of the code I submitted earlier today to also allow unique foreign keys with "user_id:references:users:unique" and unique arrays with "nicknames:array:string:unique"