### PR TITLE
Run `npm cache clean` before running `npm install`

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -293,7 +293,7 @@ defmodule Mix.Tasks.Phoenix.New do
   end
 
   defp install_brunch(install?) do
-    maybe_cmd "npm install && npm run brunch-build",
+    maybe_cmd "npm cache clean && npm install && npm run brunch-build",
               File.exists?("brunch-config.js"), install? && System.find_executable("npm")
   end
 


### PR DESCRIPTION
Sometimes, `npm` will fail to install some packages because its cache
gets in some weird state. Running `npm cache clean` ensures that the
installation is done with fresh packages instead of the cached ones.