### PR TITLE
Fix socket.ex docu

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -50,7 +50,7 @@ defmodule Phoenix.Socket do
       end
 
       # Disconnect all user's socket connections and their multiplexed channels
-      MyApp.Endpoint.broadcast("users_socket:" <> user.id, "disconnect")
+      MyApp.Endpoint.broadcast("users_socket:" <> user.id, "disconnect", %{})
 
   ## Socket Fields
 


### PR DESCRIPTION
`MyApp.Endpoint.broadcast/2` is not generated by default by the endpoint, needs to have a 3rd parameter as well.