### PR TITLE
Set application's module name as the default <title> in app layout.

### DIFF
--- a/installer/templates/new/web/templates/layout/app.html.eex
+++ b/installer/templates/new/web/templates/layout/app.html.eex
@@ -7,7 +7,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
 
-    <title>Hello Phoenix!</title>
+    <title>Hello <%= application_module %>!</title>
     <link rel="stylesheet" href="<%%= static_path(@conn, "/css/app.css") %>">
   </head>
 

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -65,6 +65,8 @@ defmodule Mix.Tasks.Phoenix.NewTest do
 
       assert_file "photo_blog/web/router.ex", "defmodule PhotoBlog.Router"
       assert_file "photo_blog/web/web.ex", "defmodule PhotoBlog.Web"
+      assert_file "photo_blog/web/templates/layout/app.html.eex",
+                  "<title>Hello PhotoBlog!</title>"
 
       # Brunch
       assert_file "photo_blog/.gitignore", "/node_modules"


### PR DESCRIPTION
I think this is better than defaulting to "Hello Phoenix!". Rails also does the same. What do you think?