### PR TITLE
Optimization for PG2 ETS insertion

### DIFF
--- a/lib/phoenix/pubsub/local.ex
+++ b/lib/phoenix/pubsub/local.ex
@@ -144,7 +144,7 @@ defmodule Phoenix.PubSub.Local do
   end
 
   def init({local, gc}) do
-    ^local = :ets.new(local, [:bag, :named_table, :public,
+    ^local = :ets.new(local, [:duplicate_bag, :named_table, :public,
                               read_concurrency: true, write_concurrency: true])
     Process.flag(:trap_exit, true)
     {:ok, gc}


### PR DESCRIPTION
ETS :bag insertion for elements with the same key grows linearly (on the number of elements with same key). On the other hand :duplicate_bag insertion is constant.
This change does not increase the size of the ETS and there is no performance degradation for lookups and deletions.
I was able to replicate insertion timeouts when there are lots of elements with same key using :bag but it does not happen using :duplicate_bag.



