### PR TITLE
Fix scrub_params/2 typespec

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -664,7 +664,7 @@ defmodule Phoenix.Controller do
       iex> scrub_params(conn, "user")
 
   """
-  @spec scrub_params(Plug.Conn.t, [String.t]) :: Plug.Conn.t
+  @spec scrub_params(Plug.Conn.t, String.t) :: Plug.Conn.t
   def scrub_params(conn, required_key) when is_binary(required_key) do
     param = Map.get(conn.params, required_key) |> scrub_param()
 


### PR DESCRIPTION
Hello!

I'm not 100% sure I'm correct here, but I think that this typespec stated that this function takes a list of params, but the implementation takes a binary.

Cheers,
Louis