### PR TITLE
Allow async replies. Closes #1324

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * [Router] Enable defining routes for custom http methods with a new `match` macro
   * [CodeReloader] The socket transports now trigger the code reloader when enabled for external clients that only connect to channels without trigger a recompile through the normal page request.
   * [phoenix.digest] The `phoenix.digest` task now digests asset urls in stylesheets automatically
+  * [Channel] Add `Phoenix.Channel.reply/3` to reply asynchronously to a channel push
 
 * Bug fixes
   * [LongPoll] force application/json content-type to fix blank JSON bodies on older IE clients using xdomain

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -350,6 +350,12 @@ defmodule Phoenix.Channel do
   another process and reply when finished by generating a reference to the push
   with `socket_ref/1`.
 
+  *Note*: In such cases, a `socket_ref` should be generated and
+  passed to the external process, so the `socket` itself is not leaked outside
+  the channel. The `socket` holds information such as assigns and transport
+  configuration, so it's important to not copy this information outside of the
+  channel that owns it.
+
   ## Examples
 
       def handle_in("work", payload, socket) do

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -247,7 +247,7 @@ defmodule Phoenix.Channel.Server do
 
   defp handle_result({:reply, reply, %Socket{} = socket}, callback) do
     handle_reply(socket, reply, callback)
-    {:noreply, socket}
+    {:noreply, put_in(socket.ref, nil)}
   end
 
   defp handle_result({:stop, reason, reply, socket}, callback) do
@@ -260,7 +260,7 @@ defmodule Phoenix.Channel.Server do
   end
 
   defp handle_result({:noreply, socket}, _callback) do
-    {:noreply, socket}
+    {:noreply, put_in(socket.ref, nil)}
   end
 
   defp handle_result(result, :handle_in) do

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -141,6 +141,20 @@ defmodule Phoenix.Channel.Server do
   end
   def push(_, _, _, _), do: raise_invalid_message
 
+  @doc """
+  Replies to a given ref to the transport process.
+  """
+  def reply(pid, ref, topic, {status, payload}, serializer)
+      when is_binary(topic) and is_map(payload) do
+
+    send pid, serializer.encode!(
+      %Reply{topic: topic, ref: ref, status: status, payload: payload}
+    )
+    :ok
+  end
+  def reply(_, _, _, _, _), do: raise_invalid_message
+
+
   defp raise_invalid_message do
     raise ArgumentError, "topic and event must be strings, message must be a map"
   end
@@ -280,9 +294,8 @@ defmodule Phoenix.Channel.Server do
   defp handle_reply(socket, {status, payload}, :handle_in)
        when is_atom(status) and is_map(payload) do
 
-    send socket.transport_pid, socket.serializer.encode!(
-      %Reply{topic: socket.topic, ref: socket.ref, status: status, payload: payload}
-    )
+    reply(socket.transport_pid, socket.ref, socket.topic, {status, payload},
+          socket.serializer)
   end
 
   defp handle_reply(socket, status, :handle_in) when is_atom(status) do

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -94,16 +94,18 @@ defmodule Phoenix.Channel.ChannelTest do
   test "replying to transport" do
     socket = %Phoenix.Socket{serializer: Phoenix.ChannelTest.NoopSerializer, ref: "123",
                              topic: "sometopic", transport_pid: self(), joined: true,}
-    reply(socket, "123", {:ok, %{key: :val}})
+    ref = socket_ref(socket)
+    reply(ref, {:ok, %{key: :val}})
     assert_receive %Phoenix.Socket.Reply{
       payload: %{key: :val}, ref: "123", status: :ok, topic: "sometopic"}
   end
 
-  test "replying when not joined" do
-    socket = %Phoenix.Socket{joined: false}
-
-    assert_raise RuntimeError, ~r"join", fn ->
-      reply(socket, "123", {:ok, %{key: :val}})
+  test "socket_ref raises ArgumentError when socket is not joined or has no ref" do
+    assert_raise ArgumentError, ~r"join", fn ->
+      socket_ref(%Phoenix.Socket{joined: false})
+    end
+    assert_raise ArgumentError, ~r"ref", fn ->
+      socket_ref(%Phoenix.Socket{joined: true})
     end
   end
 end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -90,4 +90,20 @@ defmodule Phoenix.Channel.ChannelTest do
       push(socket, "event", %{key: :val})
     end
   end
+
+  test "replying to transport" do
+    socket = %Phoenix.Socket{serializer: Phoenix.ChannelTest.NoopSerializer, ref: "123",
+                             topic: "sometopic", transport_pid: self(), joined: true,}
+    reply(socket, "123", {:ok, %{key: :val}})
+    assert_receive %Phoenix.Socket.Reply{
+      payload: %{key: :val}, ref: "123", status: :ok, topic: "sometopic"}
+  end
+
+  test "replying when not joined" do
+    socket = %Phoenix.Socket{joined: false}
+
+    assert_raise RuntimeError, ~r"join", fn ->
+      reply(socket, "123", {:ok, %{key: :val}})
+    end
+  end
 end

--- a/test/phoenix/test/channel_test.exs
+++ b/test/phoenix/test/channel_test.exs
@@ -57,8 +57,8 @@ defmodule Phoenix.Test.ChannelTest do
     end
 
     def handle_in("async_reply", %{"req" => arg}, socket) do
-      ref = socket.ref
-      Task.start(fn -> reply(socket, ref, {:ok, %{"async_resp" => arg}}) end)
+      ref = socket_ref(socket)
+      Task.start(fn -> reply(ref, {:ok, %{"async_resp" => arg}}) end)
       {:noreply, socket}
     end
 


### PR DESCRIPTION
@josevalim I'd like to get your sign-off on this one. I think it's time we can bring back `reply` in the channel API. If you remember, we had `reply`, which we renamed to `push` when we added true replies with the 3-tuple `{:reply, ..., socket}`. We've had the first use-case of needing to async reply to a push so it's time to add this feature. I think it has been plenty long since the name change that this won't cause problems. This is analogous to `GenServer.reply`.