### PR TITLE
Babel 6 ES2015 compilation issue

### DIFF
--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -481,9 +481,9 @@ export class Socket {
   }
 
   channel(topic, chanParams = {}){
-    let channel = new Channel(topic, chanParams, this)
-    this.channels.push(channel)
-    return channel
+    let channelInstance = new Channel(topic, chanParams, this)
+    this.channels.push(channelInstance)
+    return channelInstance
   }
 
   push(data){


### PR DESCRIPTION
This fixes an issue where the Phoenix JavaScript lib won't compile with Babel 6 and the ES2015 presets.

As of Babel 6.0, ES2015 transpiling has been moved to a preset plugin. Here's the the 6.0 [blog post](https://babeljs.io/blog/2015/10/29/6.0.0/) with some more details.

To reproduce,

```bash
npm i -g babel # to install Babel 6.0 and the `babel` binary
npm i babel-preset-es2015 # installs ES2015 preset (it isn't found when installed globally, must be local)

cd web/static/js
babel --presets "es2015" phoenix.js

TypeError: phoenix.js: Duplicate declaration "channel"
  482 |
  483 |   channel(topic, chanParams = {}){
> 484 |     let channel = new Channel(topic, chanParams, this)
      |         ^
  485 |     this.channels.push(channel)
  486 |     return channel
  487 |   }
    at File.buildCodeFrameError (/usr/local/lib/node_modules/babel-cli/node_modules/babel-core/lib/transformation/file/index.js:408:15)
    at Scope.checkBlockScopedCollisions (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/scope/index.js:428:27)
    at Scope.registerBinding (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/scope/index.js:611:16)
    at Scope.registerDeclaration (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/scope/index.js:515:14)
    at Object.BlockScoped (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/scope/index.js:165:28)
    at Object.newFn (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/visitors.js:279:17)
    at NodePath._call (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/context.js:72:18)
    at NodePath.call (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/context.js:40:14)
    at NodePath.visit (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/path/context.js:102:12)
    at TraversalContext.visitQueue (/usr/local/lib/node_modules/babel-cli/node_modules/babel-traverse/lib/context.js:151:16)