### PR TITLE
Expose code_change for channels. Fixes #1336

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -180,6 +180,10 @@ defmodule Phoenix.Channel do
                        topic :: binary, ref :: binary}
 
 
+  defcallback code_change(old_vsn, Socket.t, extra :: term) ::
+              {:ok, Socket.t} |
+              {:error, reason :: term} when old_vsn: term | {:down, term}
+
   defcallback join(topic :: binary, auth_msg :: map, Socket.t) ::
               {:ok, Socket.t} |
               {:ok, map, Socket.t} |
@@ -210,6 +214,8 @@ defmodule Phoenix.Channel do
       import unquote(__MODULE__)
       import Phoenix.Socket, only: [assign: 3]
 
+      def code_change(_old, socket, _extra), do: {:ok, socket}
+
       def handle_in(_event, _message, socket) do
         {:noreply, socket}
       end
@@ -218,7 +224,7 @@ defmodule Phoenix.Channel do
 
       def terminate(_reason, _socket), do: :ok
 
-      defoverridable handle_info: 2, handle_in: 3, terminate: 2
+      defoverridable code_change: 3, handle_info: 2, handle_in: 3, terminate: 2
     end
   end
 

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -186,6 +186,11 @@ defmodule Phoenix.Channel.Server do
     end
   end
 
+  @doc false
+  def code_change(old, socket, extra) do
+    socket.channel.code_change(old, socket, extra)
+  end
+
   defp join(socket, reply, parent, ref) do
     PubSub.subscribe(socket.pubsub_server, self(), socket.topic,
       link: true,


### PR DESCRIPTION
Proxy the Channel.Server code_change function to the overridable Channel
code_change callback.