### PR TITLE
Fix installer spec

### DIFF
--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -71,7 +71,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       # Brunch
       assert_file "photo_blog/.gitignore", "/node_modules"
       assert_file "photo_blog/brunch-config.js", ~s["deps/phoenix/web/static"]
-      assert_file "photo_blog/config/dev.exs", "watchers: [npm:"
+      assert_file "photo_blog/config/dev.exs", "watchers: [node:"
       assert_file "photo_blog/web/static/assets/favicon.ico"
       assert_file "photo_blog/web/static/assets/images/phoenix.png"
       assert_file "photo_blog/web/static/css/app.css"


### PR DESCRIPTION
Recently https://github.com/phoenixframework/phoenix/commit/968777244510fa96defd61be7d1e0f7a5ef53462 and https://github.com/phoenixframework/phoenix/commit/6b203d99ccf141abf58b8b19ea8bd15be9851590 were reverted but there was a separate commit for the test https://github.com/phoenixframework/phoenix/commit/8b3a143ec00b451f18e3ff2d35c98af373c0c579.

All the builds have been failing on master since then, this should fix that.