### PR TITLE
test_helper.exs: get rid of extra blank line

### DIFF
--- a/installer/templates/new/test/test_helper.exs
+++ b/installer/templates/new/test/test_helper.exs
@@ -2,5 +2,4 @@ ExUnit.start
 <%= if ecto do %>
 Mix.Task.run "ecto.create", ["--quiet"]
 Mix.Task.run "ecto.migrate", ["--quiet"]
-<%= adapter_config[:test_begin] %>
-<% end %>
+<%= adapter_config[:test_begin] %><% end %>


### PR DESCRIPTION
I have git hooks that warn me about extra blank lines at the end of files, and it reacted to this one.

I'm not sure if moving up the "end" is the nicest way. Would it be better to use [the trim mode](https://github.com/elixir-lang/elixir/pull/3194/files) for all templates? Seems a fairly new addition so maybe not backwards compatible.