### PR TITLE
Phoenix.Channel docs: Add a note about not using splat when broadcasting

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -150,6 +150,9 @@ defmodule Phoenix.Channel do
         redirect conn, to: "/"
       end
 
+  Note: You cannot use a splat when broadcasting via your endpoint.
+  For example, broadcasting to `"rooms:*"` wouldn't work here.
+
   ## Terminate
 
   On termination, the channel callback `terminate/2` will be invoked with


### PR DESCRIPTION
While building my first phoenix application I tried to broadcast via endpoint using a splat like `rooms:*`, which doesn't work.

I'm glad the community helped me out on this one, so I want to prevent others from making the same mistake.

Feel free to rephrase/reformat as you see fit.