### PR TITLE
Improve default Postgres config

### DIFF
--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -350,9 +350,9 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       Mix.Tasks.Phoenix.New.run([project_path])
 
       assert_file "custom_path/mix.exs", ~r/:postgrex/
-      assert_file "custom_path/config/dev.exs", [~r/Ecto.Adapters.Postgres/, ~r/username: "postgres"/, ~r/password: "postgres"/, ~r/hostname: "localhost"/]
-      assert_file "custom_path/config/test.exs", [~r/Ecto.Adapters.Postgres/, ~r/username: "postgres"/, ~r/password: "postgres"/, ~r/hostname: "localhost"/]
-      assert_file "custom_path/config/prod.secret.exs", [~r/Ecto.Adapters.Postgres/, ~r/username: "postgres"/, ~r/password: "postgres"/]
+      assert_file "custom_path/config/dev.exs", ~r/Ecto.Adapters.Postgres/
+      assert_file "custom_path/config/test.exs", ~r/Ecto.Adapters.Postgres/
+      assert_file "custom_path/config/prod.secret.exs", ~r/Ecto.Adapters.Postgres/
 
       assert_file "custom_path/test/support/conn_case.ex",
         ~r/Ecto.Adapters.SQL.restart_test_transaction/


### PR DESCRIPTION
By not specifying the host, username and password, `mix ecto.create` works out of the box after generating a new application.

This also reduces some duplication by extracting shared configs between sql databases into a `sql_base_config` function.

Closes #1345

@chrismccord Went ahead and took a shot at it. Hope that's OK!