### PR TITLE
Clarify how to use the Phoenix compiler

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -237,7 +237,8 @@ defmodule Phoenix.Template do
     Application.get_env(:phoenix, name) ||
       raise "could not load #{name} configuration for Phoenix. " <>
             "Please ensure you have listed :phoenix under :applications in your " <>
-            "mix.exs file and have enabled the :phoenix compiler under :compilers"
+            "mix.exs file and have enabled the :phoenix compiler under :compilers, " <>
+            "for example: [:phoenix] ++ Mix.compilers"
   end
 
   @doc """


### PR DESCRIPTION
I recently used Phoenix.View in a library which required the Phoenix
compiler. It raised this helpful error, but I wasn't sure how to add it
to compilers. When I did find `Mix.compilers` I did this:

    Mix.compilers ++ [:phoenix]

Which didn't work. It turns out that `phoenix` needs to be first. This
commit adds an example to make things a bit easier.