### PR TITLE
Change a option of :package from :contributors to :maintainers

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Phoenix.Mixfile do
   end
 
   defp package do
-    [contributors: ["Chris McCord", "José Valim", "Lance Halvorsen",
+    [maintainers: ["Chris McCord", "José Valim", "Lance Halvorsen",
                     "Jason Stiebs", "Eric Meadows-Jönsson", "Sonny Scroggin"],
      licenses: ["MIT"],
      links: %{github: "https://github.com/phoenixframework/phoenix"},


### PR DESCRIPTION
> The :contributors field is deprecated, change to :maintainers

https://github.com/hexpm/hex/blob/9944bb14512235f16a14449dea7c3124b7c580c4/lib/mix/hex/build.ex#L96