### PR TITLE
Drop inner in favor of explicit render

### DIFF
--- a/installer/templates/new/web/templates/layout/app.html.eex
+++ b/installer/templates/new/web/templates/layout/app.html.eex
@@ -26,7 +26,7 @@
       <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
 
       <main role="main">
-        <%%= @inner %>
+        <%%= render @view_module, @view_template, assigns %>
       </main>
 
     </div> <!-- /container -->

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -158,7 +158,10 @@ defmodule Phoenix.Controller do
   (or nil if no template was rendered).
   """
   @spec view_template(Plug.Conn.t) :: binary | nil
-  def view_template(conn), do: conn.private[:phoenix_template]
+  def view_template(conn) do
+    IO.puts :stderr, "[deprecation] view_template/1 has been deprecated in favor of the @view_template assign"
+    conn.private[:phoenix_template]
+  end
 
   defp get_json_encoder do
     Application.get_env(:phoenix, :format_encoders)
@@ -352,6 +355,7 @@ defmodule Phoenix.Controller do
   """
   @spec view_module(Plug.Conn.t) :: atom
   def view_module(conn) do
+    IO.puts :stderr, "[deprecation] view_module/1 has been deprecated in favor of the @view_module assign"
     conn.private.phoenix_view
   end
 

--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -192,19 +192,20 @@ defmodule Phoenix.View do
     |> render_within(module, template)
   end
 
-  defp render_within({{layout_mod, layout_tpl}, assigns}, inner_mod, template) do
-    template
-    |> inner_mod.render(assigns)
-    |> render_layout(layout_mod, layout_tpl, assigns)
+  defp render_within({{layout_mod, layout_tpl}, assigns}, inner_mod, inner_tpl) do
+    assigns =
+      assigns
+      |> Map.put(:view_module, inner_mod)
+      |> Map.put(:view_template, inner_tpl)
+
+    render_layout(layout_mod, layout_tpl, assigns)
   end
 
   defp render_within({false, assigns}, module, template) do
-    template
-    |> module.render(assigns)
+    module.render(template, Map.drop(assigns, [:view_module, :view_template]))
   end
 
-  defp render_layout(inner_content, layout_mod, layout_tpl, assigns) do
-    assigns = Map.put(assigns, :inner, inner_content)
+  defp render_layout(layout_mod, layout_tpl, assigns) do
     layout_mod.render(layout_tpl, assigns)
   end
 

--- a/test/fixtures/templates/layout/app.html.eex
+++ b/test/fixtures/templates/layout/app.html.eex
@@ -1,4 +1,4 @@
 <html>
   <title><%= @title || default_title %></title>
-  <%= @inner %>
+  <%= render @view_module, @view_template, assigns %>
 </html>

--- a/test/fixtures/views.exs
+++ b/test/fixtures/views.exs
@@ -44,9 +44,9 @@ defmodule MyApp.UserView do
   def render("existing.html", _), do: "rendered existing"
 
   def render("inner.html", assigns) do
-    if assigns[:view_module] || assigns[:view_template] do
-      raise "view module/template shouldn't be set"
-    end
+    """
+    View module is #{assigns.view_module} and view template is #{assigns.view_template}
+    """
   end
 end
 

--- a/test/fixtures/views.exs
+++ b/test/fixtures/views.exs
@@ -42,6 +42,12 @@ defmodule MyApp.UserView do
   end
 
   def render("existing.html", _), do: "rendered existing"
+
+  def render("inner.html", assigns) do
+    if assigns[:view_module] || assigns[:view_template] do
+      raise "view module/template shouldn't be set"
+    end
+  end
 end
 
 defmodule MyApp.Templates.UserView do

--- a/test/phoenix/controller/render_test.exs
+++ b/test/phoenix/controller/render_test.exs
@@ -66,8 +66,14 @@ defmodule Phoenix.Controller.RenderTest do
     assert html_response?(conn)
   end
 
-  test "render does not forward inner view assigns with no layout" do
-    assert render(conn, "inner.html", title: "Hello", layout: {MyApp.LayoutView, :app})
+  test "render with layout sets view_module/template for layout and inner view" do
+    conn = render(conn, "inner.html", title: "Hello", layout: {MyApp.LayoutView, :app})
+    assert conn.resp_body == "<html>\n  <title>Hello</title>\n  View module is Elixir.MyApp.UserView and view template is inner.html\n\n</html>\n"
+  end
+
+  test "render without layout sets inner view_module/template assigns" do
+    conn = render(conn, "inner.html", [])
+    assert conn.resp_body == "View module is Elixir.MyApp.UserView and view template is inner.html\n"
   end
 
   test "renders with conn status code" do

--- a/test/phoenix/controller/render_test.exs
+++ b/test/phoenix/controller/render_test.exs
@@ -66,6 +66,10 @@ defmodule Phoenix.Controller.RenderTest do
     assert html_response?(conn)
   end
 
+  test "render does not forward inner view assigns with no layout" do
+    assert render(conn, "inner.html", title: "Hello", layout: {MyApp.LayoutView, :app})
+  end
+
   test "renders with conn status code" do
     conn = %Plug.Conn{conn | status: 404}
     conn = render(conn, "index.html", title: "Hello", layout: {MyApp.LayoutView, "app.html"})


### PR DESCRIPTION
@josevalim I still need to bump the docs, but I'm PR'ing now because I think I'll have to convince you this is the way to go :) There is some necessary coupling b/w the inner view and layout that the `conn` approach made murky. This PR introduces two new "magic" assigns, but it does it the clearest way, with the clearest coupling. It also avoids coupling the rendering to the `%Conn{}`, which may not always be present.