### PR TITLE
Fixes channel process not closing when websocket client times out

### DIFF
--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -146,8 +146,8 @@ defmodule Phoenix.Transports.WebSocket do
   end
 
   @doc false
-  def ws_terminate(_reason, _state) do
-    :ok
+  def ws_terminate(_reason, state) do
+    {:shutdown, state}
   end
 
   @doc false


### PR DESCRIPTION
Thoughts? Is this the correct fix? Was this actually a bug, or should the channel process remain running if the client times out? This was creating an issue for me where channel processes where not getting cleaned up.

Thanks!