### PR TITLE
Bump brunch to 2.0.0

### DIFF
--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -2,7 +2,7 @@
   "repository": {
   },
   "dependencies": {
-    "brunch": "^1.8.5",
+    "brunch": "^2.0.0",
     "babel-brunch": "^5.1.1",
     "clean-css-brunch": ">= 1.0 < 1.8",
     "css-brunch": ">= 1.0 < 1.8",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "repository": {
   },
   "dependencies": {
-    "brunch": "^1.8.1",
+    "brunch": "^2.0.0",
     "babel-brunch": "^5.1.1",
     "clean-css-brunch": ">= 1.0 < 1.8",
     "css-brunch": ">= 1.0 < 1.8",


### PR DESCRIPTION
I'm thinking I must have missed something obvious because everything just worked.

- [x] Brunch still listen to stdin and shuts down when we close Phoenix
- [x] Generated JS works as expected
- [x] Generated config works as expected
- [x] Live reloading of assets works as expected after a change
