### PR TITLE
Fix installer's user_socket code sample

### DIFF
--- a/installer/templates/new/web/channels/user_socket.ex
+++ b/installer/templates/new/web/channels/user_socket.ex
@@ -30,7 +30,7 @@ defmodule <%= application_module %>.UserSocket do
   # Would allow you to broadcast a "disconnect" event and terminate
   # all active sockets and channels for a given user:
   #
-  #     <%= application_module %>.Endpoint.broadcast("users_socket:" <> user.id, "disconnect", %{})
+  #     <%= application_module %>.Endpoint.broadcast("users_socket:#{user.id}", "disconnect", %{})
   #
   # Returning `nil` makes this socket anonymous.
   def id(_socket), do: nil


### PR DESCRIPTION
By default user_id will be an integer and integers are not valid
arguments to Kernel.<>