### PR TITLE
Update poison (1.3.0 -> 1.5.0)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Phoenix.Mixfile do
   defp deps do
     [{:cowboy, "~> 1.0", optional: true},
      {:plug, "~> 1.0"},
-     {:poison, "~> 1.3"},
+     {:poison, "~> 1.5"},
 
      # Docs dependencies
      {:earmark, "~> 0.1", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,6 @@
   "inch_ex": {:hex, :inch_ex, "0.2.3"},
   "phoenix_html": {:hex, :phoenix_html, "1.2.0"},
   "plug": {:hex, :plug, "1.0.0"},
-  "poison": {:hex, :poison, "1.3.0"},
+  "poison": {:hex, :poison, "1.5.0"},
   "ranch": {:hex, :ranch, "1.1.0"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "f6892c8b55004008ce2d52be7d98b156f3e34569", []}}


### PR DESCRIPTION
Current version of **poison** in phoenix raises warning for depending on elixir `1.0.x`.

Since `1.3.1`, [poison already relaxed this dependency](https://github.com/devinus/poison/commit/b057121ac1bcadc2f938df66ca586d31fc682e20).