### PR TITLE
Various instrumentations

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -3,6 +3,7 @@ defmodule Phoenix.Controller do
   alias Plug.Conn.AlreadySentError
 
   require Logger
+  require Phoenix.Endpoint
 
   @unsent [:unset, :set]
 
@@ -618,8 +619,6 @@ defmodule Phoenix.Controller do
   end
 
   defp do_render(conn, template, format, assigns) do
-    import Phoenix.Endpoint, only: [instrument: 3, instrument: 4]
-
     assigns = to_map(assigns)
     content_type = Plug.MIME.type(format)
     conn =
@@ -630,7 +629,7 @@ defmodule Phoenix.Controller do
     view = Map.get(conn.private, :phoenix_view) ||
             raise "a view module was not specified, set one with put_view/2"
 
-    data = instrument conn, :phoenix_controller_render, template <> format, fn ->
+    data = Phoenix.Endpoint.instrument conn, :phoenix_controller_render, template <> format, fn ->
       Phoenix.View.render_to_iodata(view, template, Map.put(conn.assigns, :conn, conn))
     end
 

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -630,15 +630,9 @@ defmodule Phoenix.Controller do
     view = Map.get(conn.private, :phoenix_view) ||
             raise "a view module was not specified, set one with put_view/2"
 
-    data =
-      if endpoint = conn.private[:phoenix_endpoint] do
-        instrument endpoint, :phoenix_controller_render, template <> format, fn ->
-          Phoenix.View.render_to_iodata(view, template,
-                                        Map.put(conn.assigns, :conn, conn))
-        end
-      else
-        Phoenix.View.render_to_iodata(view, template, Map.put(conn.assigns, :conn, conn))
-      end
+    data = instrument conn, :phoenix_controller_render, template <> format, fn ->
+      Phoenix.View.render_to_iodata(view, template, Map.put(conn.assigns, :conn, conn))
+    end
 
     send_resp(conn, conn.status || 200, content_type, data)
   end

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -629,7 +629,8 @@ defmodule Phoenix.Controller do
     view = Map.get(conn.private, :phoenix_view) ||
             raise "a view module was not specified, set one with put_view/2"
 
-    data = Phoenix.Endpoint.instrument conn, :phoenix_controller_render, template <> format, fn ->
+    runtime_data = %{template: template, format: format}
+    data = Phoenix.Endpoint.instrument conn, :phoenix_controller_render, runtime_data, fn ->
       Phoenix.View.render_to_iodata(view, template, Map.put(conn.assigns, :conn, conn))
     end
 

--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -103,11 +103,7 @@ defmodule Phoenix.Controller.Pipeline do
                  &(&1 |> Map.put(:phoenix_controller, __MODULE__)
                       |> Map.put(:phoenix_action, action))
 
-        if endpoint = conn.private[:phoenix_endpoint] do
-          Phoenix.Endpoint.instrument endpoint, :phoenix_controller_call, fn ->
-            phoenix_controller_pipeline(conn, action)
-          end
-        else
+        Phoenix.Endpoint.instrument conn, :phoenix_controller_call, fn ->
           phoenix_controller_pipeline(conn, action)
         end
       end

--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -88,6 +88,8 @@ defmodule Phoenix.Controller.Pipeline do
     quote do
       @behaviour Plug
 
+      require Phoenix.Endpoint
+
       import Phoenix.Controller.Pipeline
       Module.register_attribute(__MODULE__, :plugs, accumulate: true)
       @before_compile Phoenix.Controller.Pipeline
@@ -100,7 +102,14 @@ defmodule Phoenix.Controller.Pipeline do
         conn = update_in conn.private,
                  &(&1 |> Map.put(:phoenix_controller, __MODULE__)
                       |> Map.put(:phoenix_action, action))
-        phoenix_controller_pipeline(conn, action)
+
+        if endpoint = conn.private[:phoenix_endpoint] do
+          Phoenix.Endpoint.instrument endpoint, :phoenix_controller_call, fn ->
+            phoenix_controller_pipeline(conn, action)
+          end
+        else
+          phoenix_controller_pipeline(conn, action)
+        end
       end
 
       def action(%{private: %{phoenix_action: action}} = conn, _options) do

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -535,11 +535,22 @@ defmodule Phoenix.Endpoint do
 
   @doc """
   Instruments the given function using the instrumentation provided by
-  `endpoint`.
+  the given endpoint.
+
+  To specify the endpoint that will provide instrumentation, the first argument
+  can be:
+
+    * a module name -  the endpoint itself
+    * a `Plug.Conn` struct - this macro will look for the endpoint module in the
+      `:private` field of the connection; if it's not there, `fun` will be
+      executed with no instrumentation
+    * a `Phoenix.Socket` struct - this macro will look for the endpoint module in the
+      `:endpoint` field of the socket; if it's not there, `fun` will be
+      executed with no instrumentation
 
   Usually, users should prefer to instrument events using the `instrument/3`
   macro defined in every Phoenix endpoint. This macro should only be used for
-  cases when the endpoint is dynamic and not known at compile time:
+  cases when the endpoint is dynamic and not known at compile time instead.
 
   ## Examples
 
@@ -547,16 +558,20 @@ defmodule Phoenix.Endpoint do
       Phoenix.Endpoint.instrument endpoint, :render_view, fn -> ... end
 
   """
-  defmacro instrument(endpoint, event, runtime \\ nil, fun) do
-    compile = Phoenix.Endpoint.Instrument.strip_caller(__CALLER__)
+  defmacro instrument(endpoint_or_conn_or_socket, event, runtime \\ nil, fun) do
+    compile = Phoenix.Endpoint.Instrument.strip_caller(__CALLER__) |> Macro.escape()
 
     quote do
-      unquote(endpoint).instrument(
-        unquote(event),
-        unquote(Macro.escape(compile)),
-        unquote(runtime),
-        unquote(fun)
-      )
+      case unquote(endpoint_or_conn_or_socket) do
+        %Plug.Conn{private: %{phoenix_endpoint: endpoint}} ->
+          endpoint.instrument(unquote(event), unquote(compile), unquote(runtime), unquote(fun))
+        %Phoenix.Socket{endpoint: endpoint} ->
+          endpoint.instrument(unquote(event), unquote(compile), unquote(runtime), unquote(fun))
+        %{__struct__: struct} when struct in [Plug.Conn, Phoenix.Socket] ->
+          unquote(fun).()
+        endpoint ->
+          endpoint.instrument(unquote(event), unquote(compile), unquote(runtime), unquote(fun))
+      end
     end
   end
 

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -533,6 +533,33 @@ defmodule Phoenix.Endpoint do
     end
   end
 
+  @doc """
+  Instruments the given function using the instrumentation provided by
+  `endpoint`.
+
+  Usually, users should prefer to instrument events using the `instrument/3`
+  macro defined in every Phoenix endpoint. This macro should only be used for
+  cases when the endpoint is dynamic and not known at compile time:
+
+  ## Examples
+
+      endpoint = MyApp.Endpoint
+      Phoenix.Endpoint.instrument endpoint, :render_view, fn -> ... end
+
+  """
+  defmacro instrument(endpoint, event, runtime \\ nil, fun) do
+    compile = Phoenix.Endpoint.Instrument.strip_caller(__CALLER__)
+
+    quote do
+      unquote(endpoint).instrument(
+        unquote(event),
+        unquote(Macro.escape(compile)),
+        unquote(runtime),
+        unquote(fun)
+      )
+    end
+  end
+
   defp tear_alias({:__aliases__, meta, [h|t]}) do
     alias = {:__aliases__, meta, [h]}
     quote do

--- a/lib/phoenix/endpoint/instrument.ex
+++ b/lib/phoenix/endpoint/instrument.ex
@@ -26,7 +26,7 @@ defmodule Phoenix.Endpoint.Instrument do
           end
 
       """
-      defmacro instrument(event, runtime \\ nil, fun) do
+      defmacro instrument(event, runtime \\ Macro.escape(%{}), fun) do
         compile = Macro.escape(Phoenix.Endpoint.Instrument.strip_caller(__CALLER__))
 
         quote do
@@ -61,7 +61,7 @@ defmodule Phoenix.Endpoint.Instrument do
 
       for {event, instrumenters} <- app_instrumenters do
         def instrument(unquote(event), var!(compile), var!(runtime), fun)
-            when is_map(var!(compile)) and is_function(fun, 0) do
+            when is_map(var!(compile)) and is_map(var!(runtime)) and is_function(fun, 0) do
           unquote(Phoenix.Endpoint.Instrument.compile_start_callbacks(event, instrumenters))
           start = current_time()
           try do
@@ -74,8 +74,8 @@ defmodule Phoenix.Endpoint.Instrument do
       end
 
       # Catch-all clause
-      def instrument(_event, compile, _runtime, fun)
-          when is_map(compile) and is_function(fun, 0) do
+      def instrument(event, compile, runtime, fun)
+          when is_atom(event) and is_map(compile) and is_map(runtime) and is_function(fun, 0) do
         fun.()
       end
 

--- a/test/phoenix/endpoint/instrument_test.exs
+++ b/test/phoenix/endpoint/instrument_test.exs
@@ -44,7 +44,7 @@ defmodule Phoenix.Endpoint.InstrumentTest do
   test "basic usage of instrument/3" do
     import Endpoint
 
-    return_value = instrument :my_event, :runtime, fn ->
+    return_value = instrument :my_event, %{run: :time}, fn ->
       send self(), :inside_instrument_block
       :normal_return_value
     end
@@ -53,7 +53,7 @@ defmodule Phoenix.Endpoint.InstrumentTest do
 
     assert_receive {__MODULE__.MyInstrumenter, {:my_event_start, start_data}}
     assert start_data.compile_meta.file == __ENV__.file
-    assert start_data.runtime_meta == :runtime
+    assert start_data.runtime_meta == %{run: :time}
 
     assert_receive :inside_instrument_block
 
@@ -122,14 +122,14 @@ defmodule Phoenix.Endpoint.InstrumentTest do
     require Phoenix.Endpoint
     endpoint = Endpoint
 
-    :ok = Phoenix.Endpoint.instrument endpoint, :my_event, :runtime, fn ->
+    :ok = Phoenix.Endpoint.instrument endpoint, :my_event, %{run: :time}, fn ->
       send self(), :inside_instrument_block
       :ok
     end
 
     assert_receive {__MODULE__.MyInstrumenter, {:my_event_start, start_data}}
     assert start_data.compile_meta.file == __ENV__.file
-    assert start_data.runtime_meta == :runtime
+    assert start_data.runtime_meta == %{run: :time}
 
     assert_receive :inside_instrument_block
 


### PR DESCRIPTION
This PR adds a bunch of stuff:

- `instrument/3-4` macros to `Phoenix.Endpoint`: we need this because we often don't have the endpoint at compile time, so we can't call `endpoint.instrument`
- instrumentation for controller dispatching
- instrumentation for controller rendering

(this is what @josevalim suggested for now)

This works but I don't think it's very pretty. I can't think of a better way to do it now, but I feel we need generic instrumentation very strongly :( I would love to do

```elixir
config :phoenix, instrumenters: [...]

# and also, for my custom instrumentations
config :my_app, MyApp.Endpoint, instrumenters: [...]

# and, why not
config :postgrex, instrumenters: [...]

# and so on
```

Just to write this down somewhere where it won't get buried (instead of IRC), the problem with this is that if I change the `:instrumenter` config for the `:phoenix` app (which is a dependency of `:my_app`), then phoenix will (obviously) not be recompiled. :( I think this problems extends to all dependencies that would want to use configuration at compile time, so maybe finding a solution could benefit more things other than instrumentation.

Still, let's see how this goes!