### PR TITLE
Mark pipeline generated functions as `@doc false`

### DIFF
--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -94,10 +94,12 @@ defmodule Phoenix.Controller.Pipeline do
       Module.register_attribute(__MODULE__, :plugs, accumulate: true)
       @before_compile Phoenix.Controller.Pipeline
 
+      @doc false
       def init(action) when is_atom(action) do
         action
       end
 
+      @doc false
       def call(conn, action) do
         conn = update_in conn.private,
                  &(&1 |> Map.put(:phoenix_controller, __MODULE__)
@@ -108,6 +110,7 @@ defmodule Phoenix.Controller.Pipeline do
         end
       end
 
+      @doc false
       def action(%{private: %{phoenix_action: action}} = conn, _options) do
         apply(__MODULE__, action, [conn, conn.params])
       end


### PR DESCRIPTION
It's annoying to see these generated functions show up in ExDoc documentation for Phoenix controllers. It would be better to only see the functions I defined on my `Phoenix.Controller` in ExDoc, because those are the only ones I can write documentation for.