### PR TITLE
Improve helper text in seeds.ex

### DIFF
--- a/installer/templates/ecto/seeds.exs
+++ b/installer/templates/ecto/seeds.exs
@@ -5,7 +5,7 @@
 # Inside the script, you can read and write to any of your
 # repositories directly:
 #
-#     <%= application_module %>.Repo.insert!(%SomeModel{})
+#     <%= application_module %>.Repo.insert!(%<%= application_module %>.SomeModel{})
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.


### PR DESCRIPTION
Hey all!

I just wrote my first `priv/repo/seeds.exs` file for a phoenix project and noticed the helper text above doesn't include the application module name before the model name:

    MyApp.Repo.insert!(%SomeModel{})

This PR changes that helper text to:

    MyApp.Repo.insert!(%MyApp.SomeModel{})

Since we're already spotting the user `MyApp.Repo`, figured it was appropriate to also spot them `MyApp.SomeModel` to make the syntax crystal clear.

Thoughts?