### PR TITLE
Alphabetical order in phoenix.new package.json

### DIFF
--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -2,8 +2,8 @@
   "repository": {
   },
   "dependencies": {
-    "brunch": "^2.0.0",
     "babel-brunch": "^5.1.1",
+    "brunch": "^2.0.0",
     "clean-css-brunch": ">= 1.0 < 1.8",
     "css-brunch": ">= 1.0 < 1.8",
     "javascript-brunch": ">= 1.0 < 1.8",


### PR DESCRIPTION
Otherwise when you add a new dependency with `npm install --save`, brunch is alphabetically reordered in the list. This can cause confusion in a git commit.