### PR TITLE
Add assert_sent to ConnTest

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -103,6 +103,7 @@ defmodule Phoenix.ConnTest do
   end
 
   alias Plug.Conn
+  import ExUnit.Assertions, only: [flunk: 1]
 
   @doc """
   Creates a connection to be used in upcoming requests.
@@ -493,5 +494,68 @@ defmodule Phoenix.ConnTest do
   @spec bypass_through(Conn.t, Module.t, :atom | List.t) :: Conn.t
   def bypass_through(conn, router, pipelines \\ []) do
     Plug.Conn.put_private(conn, :phoenix_bypass, {router, List.wrap(pipelines)})
+  end
+
+  @doc """
+  Asserts an error was wrapped with the given status.
+  """
+  def assert_sent(status_int_or_atom, func) do
+    expected_status = Plug.Conn.Status.code(status_int_or_atom)
+    discard_previously_sent()
+
+    func
+    |> wrap_request()
+    |> receive_response(expected_status)
+
+    discard_previously_sent()
+  end
+
+  defp receive_response({:ok, conn}, expected_status) do
+    if conn.state == :sent do
+      flunk "expected error to be rendered with status #{expected_status}, but response sent with #{conn.status} without error"
+    else
+      flunk_not_sent(expected_status)
+    end
+  end
+  defp receive_response({:error, {exception, stack}}, expected_status) do
+    receive do
+      {ref, {^expected_status, _headers, body}} when is_reference(ref) ->
+        body
+
+      {ref, {sent_status, _headers, _body}} when is_reference(ref) ->
+        reraise_error(expected_status, sent_status, exception, stack)
+
+    after 0 -> flunk_not_sent(expected_status)
+    end
+  end
+
+  defp flunk_not_sent(expected_status) do
+    flunk "expected #{expected_status} response but no response sent"
+  end
+
+  defp discard_previously_sent() do
+    receive do
+      {ref, {_, _, _}} when is_reference(ref) -> discard_previously_sent()
+      {:plug_conn, :sent}                     -> discard_previously_sent()
+    after
+      0 -> :ok
+    end
+  end
+
+  defp wrap_request(func) do
+    try do
+      {:ok, func.()}
+    rescue
+      exception -> {:error, {exception, System.stacktrace()}}
+    end
+  end
+
+  defp reraise_error(expected_stat, sent_stat, exception, stack) do
+    wrapper = %ExUnit.AssertionError{message: """
+    expected response status to be #{expected_stat}, but got #{sent_stat} from:
+
+    #{Exception.format_banner(:error, exception)}
+    """}
+    reraise(wrapper, stack)
   end
 end

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -497,30 +497,55 @@ defmodule Phoenix.ConnTest do
   end
 
   @doc """
-  Asserts an error was wrapped with the given status.
+  Asserts an error was wrapped and sent with the given status.
+
+  Useful for testing actions that you expect raise an error and have
+  the response wrapped in an HTTP status, with content usually renered
+  by your ErrorView.
+
+  The function accepts a status either as an integer HTTP status or
+  atom, such as `404` or `:not_found`. If an error is raised, a
+  3-tuple of the wrapped response is returned matching the
+  status, headers, and body of the response:
+
+      {404, [{"conent-type", "text/html"} | _], "Page not found"}
+
+  ## Examples
+
+      assert_error_sent :not_found, fn ->
+        get conn(), "/users/not-found"
+      end
+
+      response = assert_error_sent 404, fn ->
+        get conn(), "/users/not-found"
+      end
+      assert {404, [_h | _t], "Page not found"} = response
   """
-  def assert_sent(status_int_or_atom, func) do
+  @spec assert_error_sent(Integer.t | atom, function) :: {Integer.t, List.t, term}
+  def assert_error_sent(status_int_or_atom, func) do
     expected_status = Plug.Conn.Status.code(status_int_or_atom)
     discard_previously_sent()
-
-    func
-    |> wrap_request()
-    |> receive_response(expected_status)
+    result =
+      func
+      |> wrap_request()
+      |> receive_response(expected_status)
 
     discard_previously_sent()
+
+    result
   end
 
   defp receive_response({:ok, conn}, expected_status) do
     if conn.state == :sent do
-      flunk "expected error to be rendered with status #{expected_status}, but response sent with #{conn.status} without error"
+      flunk "expected error to be sent as #{expected_status} status, but response sent #{conn.status} without error"
     else
       flunk_not_sent(expected_status)
     end
   end
   defp receive_response({:error, {exception, stack}}, expected_status) do
     receive do
-      {ref, {^expected_status, _headers, body}} when is_reference(ref) ->
-        body
+      {ref, {^expected_status, headers, body}} when is_reference(ref) ->
+        {expected_status, headers, body}
 
       {ref, {sent_status, _headers, _body}} when is_reference(ref) ->
         reraise_error(expected_status, sent_status, exception, stack)

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -367,41 +367,43 @@ defmodule Phoenix.Test.ConnTest do
     refute conn.assigns[:catch_all]
   end
 
-  test "assert_sent/2 with expected error response" do
-    assert_sent :not_found, fn ->
+  test "assert_error_sent/2 with expected error response" do
+    response = assert_error_sent :not_found, fn ->
       get(conn(), "/stat", action: fn _ -> raise ConnError, plug_status: 404 end)
     end
+    assert {404, [_h | _t], "404.html from Phoenix.ErrorView"} = response
 
-    assert_sent 400, fn ->
+    response = assert_error_sent 400, fn ->
       get(conn(), "/stat", action: fn _ -> raise ConnError, plug_status: 400 end)
     end
+    assert {400, [_h | _t], "400.html from Phoenix.ErrorView"} = response
   end
 
-  test "assert_sent/2 with failed assertion" do
+  test "assert_error_sent/2 with failed assertion" do
     assert_raise ExUnit.AssertionError, ~r/expected response status to be 400, but got 500.*RuntimeError/s, fn ->
-      assert_sent 400, fn ->
+      assert_error_sent 400, fn ->
         get(conn(), "/stat", action: fn _conn -> raise RuntimeError end)
       end
     end
   end
 
-  test "assert_sent/2 with no response sent" do
+  test "assert_error_sent/2 with no response sent" do
     assert_raise ExUnit.AssertionError, ~r/expected 404 response but no response sent/, fn ->
-      assert_sent 404, fn -> get(conn(), "/") end
+      assert_error_sent 404, fn -> get(conn(), "/") end
     end
   end
 
-  test "assert_sent/2 with successful response and status match" do
+  test "assert_error_sent/2 with successful response and status match" do
     assert_raise ExUnit.AssertionError, ~r/expected error to be rendered with status 400, but response sent with 400 without error/, fn ->
-      assert_sent :bad_request, fn ->
+      assert_error_sent :bad_request, fn ->
         get(conn(), "/stat", action: fn conn -> Plug.Conn.send_resp(conn, 400, "") end)
       end
     end
   end
 
-  test "assert_sent/2 with successful response and status mismatch" do
+  test "assert_error_sent/2 with successful response and status mismatch" do
     assert_raise ExUnit.AssertionError, ~r/expected error to be rendered with status 404, but response sent with 400 without error/, fn ->
-      assert_sent :not_found, fn ->
+      assert_error_sent :not_found, fn ->
         get(conn(), "/stat", action: fn conn -> Plug.Conn.send_resp(conn, 400, "") end)
       end
     end


### PR DESCRIPTION
@josevalim I'd like to rename this to something like `assert_renders_error`, but I'm not liking any alternatives. Thoughts on impl and alternate name?

TODO
* [ ] name
* [ ] docs