### PR TITLE
example for a path helper for glob-like patterns

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -64,6 +64,12 @@ defmodule Phoenix.Router do
       MyApp.Router.Helpers.page_url(conn_or_endpoint, :show, "hello", some: "query")
       "http://example.com/pages/hello?some=query"
 
+  If the route contains glob-like patterns, parameters for those have to be given as
+  list:
+
+      MyApp.Router.Helpers.dynamic_path(conn_or_endpoint, :show, ["dynamic", "something"])
+      "/dynamic/something"
+
   The url generated in the named url helpers is based on the configuration for
   `:url`, `:http` and `:https`.
 


### PR DESCRIPTION
It wasn't obvious to me how to use path helpers for routes with glob-like patterns. This adds a short paragraph with an example about that to the router documentation.

see  #1396 