### PR TITLE
feat(Phoenix.Router.Helpers): better errors on path helpers

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -109,6 +109,13 @@ defmodule Phoenix.Router.Helpers do
   def define(env, routes) do
     ast = for {route, exprs} <- routes, do: defhelper(route, exprs)
 
+    catch_all =
+      routes
+      |> Enum.filter(fn {route, _exprs} ->
+        (not is_nil(route.helper) and not (route.kind == :forward)) end)
+      |> Enum.group_by(fn {route, _exprs} -> route.helper end)
+      |> Enum.map(&defhelper_catch_all/1)
+
     # It is in general bad practice to generate large chunks of code
     # inside quoted expressions. However, we can get away with this
     # here for two reasons:
@@ -123,6 +130,8 @@ defmodule Phoenix.Router.Helpers do
       Module with named helpers generated from #{inspect unquote(env.module)}.
       """
       unquote(ast)
+
+      unquote(catch_all)
 
       @doc """
       Generates the connection/endpoint base URL without any path information.
@@ -229,6 +238,56 @@ defmodule Phoenix.Router.Helpers do
         url(conn_or_endpoint) <> unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote_splicing(vars), params)
       end
     end
+  end
+
+  def defhelper_catch_all({helper, routes_and_exprs}) do
+    valid_routes = Enum.map(routes_and_exprs, fn {routes, _exrs} -> routes.opts end)
+    route_vars =
+      routes_and_exprs
+      |> Enum.map(fn {_routes, exprs} -> :lists.unzip(exprs.binding) end)
+      |> Enum.uniq
+
+    for {_, binds} <- route_vars, vars = Enum.map(binds, fn (_) -> {:_, [], nil} end) do
+      arity = Enum.count(vars) + 2
+
+      # We are using -1 to avoid warnings in case a path has already been defined.
+      quote line: -1 do
+        def unquote(:"#{helper}_path")(_conn_or_endpoint, action, unquote_splicing(vars)) do
+          Phoenix.Router.Helpers.raise_route_error("#{unquote(helper)}_path", unquote(arity), action, unquote(valid_routes))
+        end
+
+        def unquote(:"#{helper}_path")(_conn_or_endpoint, action, unquote_splicing(vars), params) do
+          Phoenix.Router.Helpers.raise_route_error("#{unquote(helper)}_path", unquote(arity) + 1, action, unquote(valid_routes))
+        end
+
+        def unquote(:"#{helper}_url")(_conn_or_endpoint, action, unquote_splicing(vars)) do
+          Phoenix.Router.Helpers.raise_route_error("#{unquote(helper)}_url", unquote(arity), action, unquote(valid_routes))
+        end
+
+        def unquote(:"#{helper}_url")(_conn_or_endpoint, action, unquote_splicing(vars), params) do
+          Phoenix.Router.Helpers.raise_route_error("#{unquote(helper)}_url", unquote(arity) + 1, action, unquote(valid_routes))
+        end
+      end
+    end
+  end
+
+  @doc false
+  def raise_route_error(fun, arity, action, valid_routes) do
+    valid_actions = valid_routes |> Enum.sort |> Enum.map(&("\n  * :#{&1}")) |> Enum.join("")
+    message = case action in valid_routes do
+      true ->
+        "No route helper clause for #{fun}/#{arity} " <>
+        "defined for action :#{action} with an arity of #{arity}. Please " <>
+        "check that the function, arity and action are correct.\n" <>
+        "The following #{fun} actions are defined under your router:\n" <>
+        valid_actions
+      _    ->
+        "No route helper clause for #{fun}/#{arity} defined for action :#{action}.\n" <>
+        "The following #{fun} actions are defined under your router:\n" <>
+        valid_actions
+    end
+
+    raise ArgumentError, message: String.strip(message)
   end
 
   defp expand_segments([]), do: "/"

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -154,8 +154,39 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.top_path(__MODULE__, :top, id: 5) == "/posts/top?id=5"
     assert Helpers.top_path(__MODULE__, :top, %{"id" => 5}) == "/posts/top?id=5"
 
+    error_message = (fn (helper, arity) ->
+    """
+    No route helper clause for #{helper}/#{arity} defined for action :skip.
+    The following #{helper} actions are defined under your router:
+
+      * :file
+      * :show
+
+    """ |> String.strip
+    end)
+
     assert_raise UndefinedFunctionError, fn ->
       Helpers.post_path(__MODULE__, :skip)
+    end
+
+    assert_raise UndefinedFunctionError, fn ->
+      Helpers.post_url(__MODULE__, :skip)
+    end
+
+    assert_raise ArgumentError, error_message.("post_path", 3), fn ->
+      Helpers.post_path(__MODULE__, :skip, 5)
+    end
+
+    assert_raise ArgumentError, error_message.("post_url", 3), fn ->
+      Helpers.post_url(__MODULE__, :skip, 5)
+    end
+
+    assert_raise ArgumentError, error_message.("post_path", 4), fn ->
+      Helpers.post_path(__MODULE__, :skip, 5, foo: "bar", other: "param")
+    end
+
+    assert_raise ArgumentError, error_message.("post_url", 4), fn ->
+      Helpers.post_url(__MODULE__, :skip, 5, foo: "bar", other: "param")
     end
   end
 
@@ -221,6 +252,51 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.user_comment_path(__MODULE__, :show, 123, 2) == "/users/123/comments/2"
     assert Helpers.user_comment_path(__MODULE__, :new, 88, []) == "/users/88/comments/new"
     assert Helpers.user_comment_path(__MODULE__, :new, 88) == "/users/88/comments/new"
+
+    error_message = (fn (helper, arity) ->
+    """
+    No route helper clause for #{helper}/#{arity} defined for action :skip.
+    The following #{helper} actions are defined under your router:
+
+      * :create
+      * :delete
+      * :edit
+      * :index
+      * :new
+      * :show
+      * :update
+    """ |> String.strip
+    end)
+
+    assert_raise ArgumentError, error_message.("user_comment_path", 3), fn ->
+      Helpers.user_comment_path(__MODULE__, :skip, 123)
+    end
+
+    assert_raise ArgumentError, error_message.("user_comment_file_path", 4), fn ->
+      Helpers.user_comment_file_path(__MODULE__, :skip, 123, 456)
+    end
+
+    assert_raise ArgumentError, error_message.("user_comment_file_path", 5), fn ->
+      Helpers.user_comment_file_path(__MODULE__, :skip, 123, 456, foo: "bar")
+    end
+
+    arity_error_message =
+    """
+    No route helper clause for user_comment_path/3 defined for action :show with an arity of 3. Please check that the function, arity and action are correct.
+   The following user_comment_path actions are defined under your router:
+
+      * :create
+      * :delete
+      * :edit
+      * :index
+      * :new
+      * :show
+      * :update
+    """ |> String.strip
+
+    assert_raise ArgumentError, arity_error_message, fn ->
+      Helpers.user_comment_path(__MODULE__, :show, 123)
+    end
   end
 
   test "multi-level nested resources generated named routes with complex ids" do


### PR DESCRIPTION
Instead of simply returning an error when passing an atom to a route
helper that hasn't been defined, the error now prompts the user to input
a defined route instead.

Previously an `UndefinedFunctionError` was raised.

Now an `ArgumentError` is raised with the following message:

    No route helper clause for MyApp.Router.Helpers.foo_path/2 defined
    for action :skip.
    The following foo_path/2 actions are defined under your router:

     * :file
     * :show

The only thing that is missing that I can think of is returning the error for functions which have an `arity` higher than 3.

For example:

user_channel_post_path(conn, :show, user, channel, post, foo: "bar")

**TODO**

 * [x] Add a catch all function for each helper
 * [x] Sort the valid actions alphabetically.
 * [x] Handle an arity > 3
 * [x] Show a different error for a valid action with an invalid arity