### PR TITLE
(configurable) Endpoint Handler Behaviour

### DIFF
--- a/lib/phoenix/endpoint/cowboy_handler.ex
+++ b/lib/phoenix/endpoint/cowboy_handler.ex
@@ -52,7 +52,7 @@ defmodule Phoenix.Endpoint.CowboyHandler do
   It is also important to specify your handlers first, otherwise
   Phoenix will intercept the requests before they get to your handler.
   """
-
+  @behaviour Phoenix.Endpoint.Handler
   require Logger
 
   @doc """

--- a/lib/phoenix/endpoint/handler.ex
+++ b/lib/phoenix/endpoint/handler.ex
@@ -1,0 +1,22 @@
+defmodule Phoenix.Endpoint.Handler do
+  @moduledoc """
+  API for exporting webserver plug adapter child spec
+
+  A handler will need to implement a child_spec/3
+  function which takes
+
+    * the schme of the endpoint :http or :https
+    * phoenix top-most endpoint module
+    * phoenix app configuration for the specified scheme
+
+  it has to return a child_spec
+  """
+  use Behaviour
+
+  @doc """
+  provides the children specification to be passed
+  to Phoenix.Endpoint.Server supervisor
+  """
+  @callback child_spec(scheme :: atom, endpoint :: module, config :: Keyword.t) :: Supervisor.Spec.spec
+
+end

--- a/lib/phoenix/endpoint/server.ex
+++ b/lib/phoenix/endpoint/server.ex
@@ -1,7 +1,6 @@
 defmodule Phoenix.Endpoint.Server do
   # The supervisor for the underlying handlers.
   @moduledoc false
-  @handler Phoenix.Endpoint.CowboyHandler
 
   use Supervisor
   require Logger
@@ -14,14 +13,14 @@ defmodule Phoenix.Endpoint.Server do
     children = []
 
     if config = endpoint.config(:http) do
-      children =
-        [@handler.child_spec(:http, endpoint, default(config, otp_app, 4000))|children]
+      config = default(config, otp_app, 4000)
+      children = [config[:handler].child_spec(:http, endpoint, config)|children]
     end
 
     if config = endpoint.config(:https) do
       {:ok, _} = Application.ensure_all_started(:ssl)
-      children =
-        [@handler.child_spec(:https, endpoint, default(config, otp_app, 4040))|children]
+      config = default(config, otp_app, 4040)
+      children = [config[:handler].child_spec(:https, endpoint, config)|children]
     end
 
     supervise(children, strategy: :one_for_one)
@@ -30,6 +29,7 @@ defmodule Phoenix.Endpoint.Server do
   defp default(config, otp_app, port) do
     config =
       config
+      |> Keyword.put_new(:handler, Phoenix.Endpoint.CowboyHandler)
       |> Keyword.put_new(:otp_app, otp_app)
       |> Keyword.put_new(:port, port)
 


### PR DESCRIPTION
- allow configuring Endpoint Handler via application config,
  to pass a custom childspec to Phoenix.Endpoint.Server supervisor

- defaults to Phoenix.Endpoint.CowboyHandler