### PR TITLE
Fixing generating ErrorHelpers with `--no-html` option

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -34,7 +34,6 @@ defmodule Mix.Tasks.Phoenix.New do
     {:eex,  "new/web/gettext.ex",                            "web/gettext.ex"},
     {:eex,  "new/priv/gettext/errors.pot",                   "priv/gettext/errors.pot"},
     {:eex,  "new/priv/gettext/en/LC_MESSAGES/errors.po",     "priv/gettext/en/LC_MESSAGES/errors.po"},
-    {:eex,  "new/web/views/error_helpers.ex",                "web/views/error_helpers.ex"},
   ]
 
   @ecto [
@@ -64,6 +63,7 @@ defmodule Mix.Tasks.Phoenix.New do
     {:eex,  "new/web/templates/page/index.html.eex",         "web/templates/page/index.html.eex"},
     {:eex,  "new/web/views/layout_view.ex",                  "web/views/layout_view.ex"},
     {:eex,  "new/web/views/page_view.ex",                    "web/views/page_view.ex"},
+    {:eex,  "new/web/views/error_helpers.ex",                "web/views/error_helpers.ex"},
   ]
 
   @bare [

--- a/installer/templates/new/web/web.ex
+++ b/installer/templates/new/web/web.ex
@@ -59,7 +59,9 @@ defmodule <%= application_module %>.Web do
       use Phoenix.HTML<% end %>
 
       import <%= application_module %>.Router.Helpers
+<%= if html do %>
       import <%= application_module %>.ErrorHelpers
+<% end %>
       import <%= application_module %>.Gettext
     end
   end

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -150,6 +150,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "photo_blog/config/test.exs", &refute(&1 =~ config)
       assert_file "photo_blog/config/prod.secret.exs", &refute(&1 =~ config)
       assert_file "photo_blog/web/web.ex", &refute(&1 =~ ~r"alias PhotoBlog.Repo")
+      assert_file "photo_blog/web/web.ex", &refute(&1 =~ ~r"import PhotoBlog.ErrorHelpers")
 
       # No HTML
       assert File.exists?("photo_blog/test/controllers")
@@ -168,6 +169,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       refute File.exists? "photo_blog/web/templates/page/index.html.eex"
       refute File.exists? "photo_blog/web/views/layout_view.ex"
       refute File.exists? "photo_blog/web/views/page_view.ex"
+      refute File.exists? "photo_blog/web/views/error_helpers.ex"
 
       assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_html")
       assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_live_reload")

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -161,7 +161,7 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
   end
 
   test "uses defaults from :generators configuration" do
-    in_tmp "uses defaults from :generators configuration (migration)", fn ->
+    in_tmp "uses defaults from generators configuration (migration)", fn ->
       with_generators_config [migration: false], fn ->
         Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts"]
 
@@ -169,7 +169,7 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
       end
     end
 
-    in_tmp "uses defaults from :generators configuration (binary_id)", fn ->
+    in_tmp "uses defaults from generators configuration (binary_id)", fn ->
       with_generators_config [binary_id: true], fn ->
         Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts"]
 


### PR DESCRIPTION
The `import MyApp.ErrorHelpers` is being generated for applications that do not depend on the PhoenixHTML.

eg:

```shell
$ mix archive.install https://github.com/phoenixframework/phoenix/releases/download/v1.1.0/phoenix_new-1.1.0.ez
Are you sure you want to install archive "https://github.com/phoenixframework/phoenix/releases/download/v1.1.0/phoenix_new-1.1.0.ez"? [Yn]
* creating /root/.mix/archives/phoenix_new-1.1.0.ez
$ mix phoenix.new my_app --no-brunch --no-ecto --no-html
# ...
$ cd my_app
$ mix compile
# ...
==> my_app

== Compilation error on file web/views/error_view.ex ==
** (CompileError) web/views/error_view.ex:2: module MyApp.ErrorHelpers is not loaded and could not be found
    expanding macro: MyApp.Web.__using__/1
    web/views/error_view.ex:2: MyApp.ErrorView (module)
    (elixir) expanding macro: Kernel.use/2
    web/views/error_view.ex:2: MyApp.ErrorView (module)
    (elixir) lib/kernel/parallel_compiler.ex:100: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/8
```

NOTE: The change in the `test/mix/tasks/phoenix.gen.model_test.exs` avoid problems in creating folders in OS like alpine.