### PR TITLE
Fixing `File.Error` could not make directory (with `:`) in alpine

### DIFF
--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -161,7 +161,7 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
   end
 
   test "uses defaults from :generators configuration" do
-    in_tmp "uses defaults from :generators configuration (migration)", fn ->
+    in_tmp "uses defaults from generators configuration (migration)", fn ->
       with_generators_config [migration: false], fn ->
         Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts"]
 
@@ -169,7 +169,7 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
       end
     end
 
-    in_tmp "uses defaults from :generators configuration (binary_id)", fn ->
+    in_tmp "uses defaults from generators configuration (binary_id)", fn ->
       with_generators_config [binary_id: true], fn ->
         Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts"]
 


### PR DESCRIPTION
The change in the `test/mix/tasks/phoenix.gen.model_test.exs` avoid problems in creating folders in OS like alpine.

```shell
/azk/phoenix # mix test test/mix/tasks/phoenix.gen.model_test.exs:163
Including tags: [line: "163"]
Excluding tags: [:test]

  1) test uses defaults from :generators configuration (Mix.Tasks.Phoenix.Gen.ModelTest)
     test/mix/tasks/phoenix.gen.model_test.exs:163
     ** (File.Error) could not make directory (with -p) /azk/phoenix/tmp/uses defaults from :generators configuration (migration): protocol error
     stacktrace:
       (elixir) lib/file.ex:208: File.mkdir_p!/1
       installer/test/mix_helper.exs:15: MixHelper.in_tmp/2
       test/mix/tasks/phoenix.gen.model_test.exs:164

Finished in 0.6 seconds (0.5s on load, 0.04s on tests)
10 tests, 1 failure, 9 skipped
```