### PR TITLE
Allow forwarding twice to a plug with different options

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -650,9 +650,10 @@ defmodule Phoenix.Router do
   defmacro forward(path, plug, plug_opts \\ [], router_opts \\ []) do
     router_opts = Keyword.put(router_opts, :as, nil)
 
-    quote unquote: true, bind_quoted: [path: path, plug: plug] do
-      path_segments = Route.forward_path_segments(path, plug, @phoenix_forwards)
-      @phoenix_forwards Map.put(@phoenix_forwards, plug, path_segments)
+    quote unquote: true, bind_quoted: [path: path, plug: plug, plug_opts: plug_opts] do
+      plug_with_opts = {plug, plug_opts}
+      path_segments = Route.forward_path_segments(path, plug_with_opts, @phoenix_forwards)
+      @phoenix_forwards Map.put(@phoenix_forwards, plug_with_opts, path_segments)
       unquote(add_route(:forward, :*, path, plug, plug_opts, router_opts))
     end
   end

--- a/test/phoenix/router/forward_test.exs
+++ b/test/phoenix/router/forward_test.exs
@@ -84,7 +84,7 @@ defmodule Phoenix.Router.ForwardTest do
       end
     end
 
-    assert_raise ArgumentError, ~r{`Phoenix.Router.ForwardTest.ApiRouter` has already been forwarded}, fn ->
+    assert_raise ArgumentError, ~r(`\{Phoenix.Router.ForwardTest.ApiRouter, \[\]\}` has already been forwarded), fn ->
       Code.eval_quoted(router)
     end
   end
@@ -92,11 +92,11 @@ defmodule Phoenix.Router.ForwardTest do
   test "accumulates phoenix_forwards" do
     conn = call(Router, :get, "admin")
     assert conn.private[Router] == {[], %{
-      Phoenix.Router.ForwardTest.AdminDashboard => ["admin"],
-      Phoenix.Router.ForwardTest.ApiRouter => ["api", "v1"]
+      {Phoenix.Router.ForwardTest.AdminDashboard, []} => ["admin"],
+      {Phoenix.Router.ForwardTest.ApiRouter, []} => ["api", "v1"]
     }}
     assert conn.private[AdminDashboard] ==
-      {["admin"], %{Phoenix.Router.ForwardTest.ApiRouter => ["api-admin"]}}
+      {["admin"], %{{Phoenix.Router.ForwardTest.ApiRouter, []} => ["api-admin"]}}
 
   end
 


### PR DESCRIPTION
I ran into this issue (https://github.com/joshprice/plug_graphql/issues/7) whereby one plug cannot be forwarded to twice, even with different configurations.

There are 2 possible workarounds (and perhaps more):

1. Wrap the plug in another plug which encapsulates its configuration (the options)
2. Use the `get` or `post` macros instead of forward

I went with (2) mainly because it's more concise, but I lose the ability to handle *all* HTTP verbs at that path. The wrapper workaround is arguably more correct but requires a bit more redundant code.

The other possible solution is to allow the configuration to form part of the identity of the plug.

I think this is in keeping with this warning about forwarding twice (https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/router.ex#L635-L638) at least as far as I understand it.

>  Note, however, that we don't advise forwarding to another
>  endpoint. The reason is that plugs defined by your app
>  and the forwarded endpoint would be invoked twice, which
>  may lead to errors.

This PR is a WIP, currently getting this test failure, which I haven't figured out the cause for yet:

```elixir
  1) test helpers cascade script name across forwards based on main router (Phoenix.Router.ForwardTest)
     test/phoenix/router/forward_test.exs:103
     Assertion with == failed
     code: page_path(conn, :stats) == "/admin/stats"
     lhs:  "/stats"
     rhs:  "/admin/stats"
     stacktrace:
       test/phoenix/router/forward_test.exs:108
```

