### PR TITLE
Use Phoenix.HTML tag helpers in layout template

### DIFF
--- a/installer/templates/new/web/templates/layout/app.html.eex
+++ b/installer/templates/new/web/templates/layout/app.html.eex
@@ -8,7 +8,7 @@
     <meta name="author" content="">
 
     <title>Hello <%= application_module %>!</title>
-    <link rel="stylesheet" href="<%%= static_path(@conn, "/css/app.css") %>">
+    <%%= tag :link, rel: "stylesheet", href: static_path(@conn, "/css/app.css") %>
   </head>
 
   <body>
@@ -30,6 +30,6 @@
       </main>
 
     </div> <!-- /container -->
-    <script src="<%%= static_path(@conn, "/js/app.js") %>"></script>
+    <%%= content_tag :script, "", src: static_path(@conn, "/js/app.js") %>
   </body>
 </html>


### PR DESCRIPTION
This is mostly a style change. So we don't need to interpolate
static_path/2 inside HTML tags anymore.

It will also be a good step in helping new Phoenix users to get
acquainted with Phoenix.HTML.