### PR TITLE
Refactor to fix dialyzer crash

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -639,15 +639,15 @@ defmodule Phoenix.Endpoint do
     compile = Phoenix.Endpoint.Instrument.strip_caller(__CALLER__) |> Macro.escape()
 
     quote do
-      case unquote(endpoint_or_conn_or_socket) do
-        %Plug.Conn{private: %{phoenix_endpoint: endpoint}} ->
-          endpoint.instrument(unquote(event), unquote(compile), unquote(runtime), unquote(fun))
-        %Phoenix.Socket{endpoint: endpoint} ->
-          endpoint.instrument(unquote(event), unquote(compile), unquote(runtime), unquote(fun))
-        %{__struct__: struct} when struct in [Plug.Conn, Phoenix.Socket] ->
-          unquote(fun).()
-        endpoint ->
-          endpoint.instrument(unquote(event), unquote(compile), unquote(runtime), unquote(fun))
+      endpoint = case unquote(endpoint_or_conn_or_socket) do
+        %Plug.Conn{private: %{phoenix_endpoint: endpoint}} -> endpoint
+        %Phoenix.Socket{endpoint: endpoint} -> endpoint
+        %{__struct__: struct} when struct in [Plug.Conn, Phoenix.Socket] -> nil
+        endpoint -> endpoint
+      end
+      case endpoint do
+        nil -> unquote(fun).()
+        endpoint -> endpoint.instrument(unquote(event), unquote(compile), unquote(runtime), unquote(fun))
       end
     end
   end

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -639,13 +639,7 @@ defmodule Phoenix.Endpoint do
     compile = Phoenix.Endpoint.Instrument.strip_caller(__CALLER__) |> Macro.escape()
 
     quote do
-      endpoint = case unquote(endpoint_or_conn_or_socket) do
-        %Plug.Conn{private: %{phoenix_endpoint: endpoint}} -> endpoint
-        %Phoenix.Socket{endpoint: endpoint} -> endpoint
-        %{__struct__: struct} when struct in [Plug.Conn, Phoenix.Socket] -> nil
-        endpoint -> endpoint
-      end
-      case endpoint do
+      case Phoenix.Endpoint.Instrument.extract_endpoint(unquote(endpoint_or_conn_or_socket)) do
         nil -> unquote(fun).()
         endpoint -> endpoint.instrument(unquote(event), unquote(compile), unquote(runtime), unquote(fun))
       end

--- a/lib/phoenix/endpoint/instrument.ex
+++ b/lib/phoenix/endpoint/instrument.ex
@@ -126,6 +126,18 @@ defmodule Phoenix.Endpoint.Instrument do
   defp form_fa({name, arity}), do: Atom.to_string(name) <> "/" <> Integer.to_string(arity)
   defp form_fa(nil), do: nil
 
+  # called by Phoenix.Endpoint.instrument/4, see docs there
+  @doc false
+  @spec extract_endpoint(Plug.Conn.t | Phoenix.Socket.t | module) :: module | nil
+  def extract_endpoint(endpoint_or_conn_or_socket) do
+    case endpoint_or_conn_or_socket do
+      %Plug.Conn{private: %{phoenix_endpoint: endpoint}} -> endpoint
+      %Phoenix.Socket{endpoint: endpoint} -> endpoint
+      %{__struct__: struct} when struct in [Plug.Conn, Phoenix.Socket] -> nil
+      endpoint -> endpoint
+    end
+  end
+
   # Returns the AST for all the calls to the "start event" callbacks in the given
   # list of `instrumenters`.
   # Each function call looks like this:


### PR DESCRIPTION
The original code triggers an error in dialyzer that causes it to crash. You can verify this by adding: `{:dialyze, "~> 0.2"},` to the phoenix deps and running `mix deps.get && mix compile && mix dialyze` before and after applying this patch.

This also removes the duplication in the case clauses.