### PR TITLE
Fix dialyzer warning in put_new_layout

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -421,7 +421,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if the conn was already sent.
   """
-  @spec put_new_layout(Plug.Conn.t, {atom, binary} | false) :: Plug.Conn.t
+  @spec put_new_layout(Plug.Conn.t, {atom, binary | atom} | false) :: Plug.Conn.t
   def put_new_layout(%Plug.Conn{state: state} = conn, layout)
       when (is_tuple(layout) and tuple_size(layout) == 2) or layout == false do
     if state in @unsent do


### PR DESCRIPTION
The @spec said the tuple should be {atom, binary} but in `__using__` the second part of the tuple is the symbol `:app`. Seems like a symbol should be allowed so this commit adjusts the spec.