### PR TITLE
Fix Phoenix.Endpoint instrument example

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -329,7 +329,7 @@ defmodule Phoenix.Endpoint do
   called like this:
 
       require MyApp.Endpoint
-      MyApp.Endpoint.instrument :render_view, "index.html", fn ->
+      MyApp.Endpoint.instrument :render_view, %{view: "index.html"}, fn ->
         # actual view rendering
       end
 


### PR DESCRIPTION
The example at https://github.com/phoenixframework/phoenix/blob/4d4f1b77/lib/phoenix/endpoint.ex#L332 uses the binary "index.html" as argument to Endpoint.Instrument, but this fails as the generated instrument function(s) have a is_map guard on the runtime argument. This changes the example to use a map instead.