### PR TITLE
Add :connection module to applications list in mix.exs if Ecto is used.

### DIFF
--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -23,7 +23,7 @@ defmodule <%= application_module %>.Mixfile do
   def application do
     [mod: {<%= application_module %>, []},
      applications: [:phoenix<%= if html do %>, :phoenix_html<% end %>, :cowboy, :logger, :gettext<%= if ecto do %>,
-                    :phoenix_ecto, <%= inspect adapter_app %><% end %>]]
+                    :phoenix_ecto, :connection, <%= inspect adapter_app %><% end %>]]
   end
 
   # Specifies which paths to compile per environment.


### PR DESCRIPTION
Starting in Phoenix 1.1.0, an application crashes due to not having the Connection module in the applications list (see https://github.com/bitwalker/exrm/issues/265.) The crash occurs in Phoenix apps that have been deployed as a release; apps running locally on development machines are unaffected.

Adding the Connection module to the mix.exs template will relieve users of experiencing the crash, having to figure out the problem and then adding it to the list. It is only added if Ecto is used.


