### PR TITLE
Support broadcasts to individual destination nodes

### DIFF
--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -30,16 +30,13 @@ defmodule Phoenix.PubSub.PG2 do
   end
 
   @doc false
-  def init([server, opts]) when is_atom(server) do
-    init([{server, node()}, opts])
-  end
-  def init([{server, node_name}, opts]) do
+  def init([server, opts]) do
     pool_size = Keyword.fetch!(opts, :pool_size)
     dispatch_rules = [{:broadcast, Phoenix.PubSub.PG2Server, [server, pool_size]}]
 
     children = [
       supervisor(Phoenix.PubSub.LocalSupervisor, [server, pool_size, dispatch_rules]),
-      worker(Phoenix.PubSub.PG2Server, [{server, node_name}]),
+      worker(Phoenix.PubSub.PG2Server, [server]),
     ]
 
     supervise children, strategy: :rest_for_one

--- a/lib/phoenix/pubsub/pg2.ex
+++ b/lib/phoenix/pubsub/pg2.ex
@@ -7,11 +7,15 @@ defmodule Phoenix.PubSub.PG2 do
   To use it as your PubSub adapter, simply add it to your Endpoint's config:
 
       config :my_app, MyApp.Endpoint,
-        pubsub: [adapter: Phoenix.PubSub.PG2]
+        pubsub: [name: MyApp.PubSub,
+                 adapter: Phoenix.PubSub.PG2]
 
   ## Options
 
-    * `:name` - The name to register the PubSub processes, ie: `MyApp.PubSub`
+    * `:name` - The registered name and optional node name to for the PubSub
+      processes, for example: `MyApp.PubSub`, `{MyApp.PubSub, :node@host}`.
+      When only a server name is provided, the node name defaults to `node()`.
+
     * `:pool_size` - Both the size of the local pubsub server pool and subscriber
       shard size. Defaults `1`. A single pool is often enough for most use-cases,
       but for high subscriber counts on a single topic or greater than 1M
@@ -26,13 +30,16 @@ defmodule Phoenix.PubSub.PG2 do
   end
 
   @doc false
-  def init([server, opts]) do
+  def init([server, opts]) when is_atom(server) do
+    init([{server, node()}, opts])
+  end
+  def init([{server, node_name}, opts]) do
     pool_size = Keyword.fetch!(opts, :pool_size)
     dispatch_rules = [{:broadcast, Phoenix.PubSub.PG2Server, [server, pool_size]}]
 
     children = [
       supervisor(Phoenix.PubSub.LocalSupervisor, [server, pool_size, dispatch_rules]),
-      worker(Phoenix.PubSub.PG2Server, [server]),
+      worker(Phoenix.PubSub.PG2Server, [{server, node_name}]),
     ]
 
     supervise children, strategy: :rest_for_one

--- a/lib/phoenix/pubsub/pg2_server.ex
+++ b/lib/phoenix/pubsub/pg2_server.ex
@@ -4,18 +4,20 @@ defmodule Phoenix.PubSub.PG2Server do
   use GenServer
   alias Phoenix.PubSub.Local
 
-  def start_link({server_name, node_name}) do
-    GenServer.start_link __MODULE__, {server_name, node_name}, name: server_name
+  def start_link(server_name) do
+    GenServer.start_link __MODULE__, server_name, name: server_name
   end
 
   def broadcast(server_name, pool_size, dest_node, from_pid, topic, msg) do
-    case :pg2.get_members(pg2_namespace(server_name, dest_node)) do
+    case get_members(server_name, dest_node) do
       {:error, {:no_such_group, _}} ->
         {:error, :no_such_group}
 
       pids when is_list(pids) ->
         Enum.each(pids, fn
-          pid when node(pid) == node() ->
+          pid when is_pid(pid) and node(pid) == node() ->
+            Local.broadcast(server_name, pool_size, from_pid, topic, msg)
+          {^server_name, dest_node} when dest_node == node() ->
             Local.broadcast(server_name, pool_size, from_pid, topic, msg)
           pid ->
             send(pid, {:forward_to_local, from_pid, pool_size, topic, msg})
@@ -24,13 +26,10 @@ defmodule Phoenix.PubSub.PG2Server do
     end
   end
 
-  def init({server_name, node_name}) do
-    public_pg2_namespace = pg2_namespace(server_name, :global)
-    private_pg2_namespace = pg2_namespace(server_name, node_name)
-    :ok = :pg2.create(public_pg2_namespace)
-    :ok = :pg2.create(private_pg2_namespace)
-    :ok = :pg2.join(public_pg2_namespace, self)
-    :ok = :pg2.join(private_pg2_namespace, self)
+  def init(server_name) do
+    pg2_group = pg2_namespace(server_name)
+    :ok = :pg2.create(pg2_group)
+    :ok = :pg2.join(pg2_group, self)
 
     {:ok, server_name}
   end
@@ -42,5 +41,12 @@ defmodule Phoenix.PubSub.PG2Server do
     {:noreply, name}
   end
 
-  defp pg2_namespace(server_name, node_name), do: {:phx, server_name, node_name}
+  defp get_members(server_name, :global) do
+    :pg2.get_members(pg2_namespace(server_name))
+  end
+  defp get_members(server_name, dest_node) do
+    [{server_name, dest_node}]
+  end
+
+  defp pg2_namespace(server_name), do: {:phx, server_name}
 end

--- a/test/phoenix/pubsub/pubsub_test.exs
+++ b/test/phoenix/pubsub/pubsub_test.exs
@@ -18,7 +18,7 @@ defmodule Phoenix.PubSub.PubSubTest do
     :ok
   end
 
-  def broadcast(error, _, _, _) do
+  def broadcast(error, _, _, _, _) do
     {:error, error}
   end
 

--- a/test/shared/pubsub_test.exs
+++ b/test/shared/pubsub_test.exs
@@ -103,6 +103,18 @@ defmodule Phoenix.PubSubTest do
     end
 
     @tag pool_size: size
+    test "pool #{size}: broadcasts can target a specific node", config do
+      PubSub.subscribe(config.test, self, "topic9")
+      :ok = PubSub.broadcast({config.test, node()}, "topic9", :ping)
+      assert_receive :ping
+      :ok = PubSub.broadcast!({config.test, node()}, "topic9", :ping)
+      assert_receive :ping
+
+      PubSub.broadcast({config.test, :another@host}, "topic9", :ping)
+      refute_receive :ping
+    end
+
+    @tag pool_size: size
     test "pool #{size}: broadcast/3 does not publish message to other topic subscribers", config do
       PubSub.subscribe(config.test, self, "topic9")
 


### PR DESCRIPTION
Support for scoping a broadcast is needed for Phoenix.Presence features. This PR adds scoped broadcasts via tuple to mirror the `send` api. @josevalim I could use your opinion on the API choices and configuration options. We could also make these changes backwards compatible by only invoking the adapters broadcast/5 if we have a target node, but this PR as written will break existing pubsub adapters. 

My test is also pretty weak, but without standing up a 2nd VM, I think it's the best we've got.