### PR TITLE
Update phoenix.new installed .gitignore

### DIFF
--- a/installer/templates/static/bare/.gitignore
+++ b/installer/templates/static/bare/.gitignore
@@ -3,6 +3,7 @@
 /db
 /deps
 /*.ez
+mix.lock
 
 # Generate on crash by the VM
 erl_crash.dump


### PR DESCRIPTION
When you install phoenix as a mix archive, it becomes logical to create a new git repository for any phoenix project. That git repository should probably ignore mix.lock.