### PR TITLE
pipe_through now only accepts lists

### DIFF
--- a/lib/phoenix/router/scope.ex
+++ b/lib/phoenix/router/scope.ex
@@ -38,9 +38,7 @@ defmodule Phoenix.Router.Scope do
   @doc """
   Appends the given pipes to the current scope pipe through.
   """
-  def pipe_through(module, pipes) do
-    pipes = List.wrap(pipes)
-
+  def pipe_through(module, pipes) when is_list(pipes) do
     update_stack(module, fn [scope|stack] ->
       scope = put_in scope.pipes, scope.pipes ++ pipes
       [scope|stack]


### PR DESCRIPTION
This PR changes `pipe_through/2` to only allow lists. This change was prompted by a comment that @josevalim made on my [attempted ecto PR](https://github.com/elixir-lang/ecto/pull/1191) which essentially said that we should avoid the rails trait of allowing a function to take all sorts of different types of arguments.

This change would break a lot of people's applications so this PR is simply meant to start a conversation on if/how we should be about making such a change.

*note: I actually didn't know that pipe_through could take a list until I saw it used in the Programming Phoenix book. I think this change might also make it more apparent to newcomers as well*  

