### PR TITLE
Update issue tracker link to reference correct link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ API documentation is available at [http://hexdocs.pm/phoenix](http://hexdocs.pm/
 
 ## Contributing
 
-We appreciate any contribution to Phoenix. Check our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and [CONTRIBUTING.md](CONTRIBUTING.md) guides for more information. We usually keep a list of features and bugs [in the issue tracker][2].
+We appreciate any contribution to Phoenix. Check our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and [CONTRIBUTING.md](CONTRIBUTING.md) guides for more information. We usually keep a list of features and bugs [in the issue tracker][4].
 
 ### Running a Phoenix master project
 


### PR DESCRIPTION
Replaces wrong link 2 (freenode) with the correct link 4 (github issue tracker).