### PR TITLE
Skip phoenix_html npm dependency when using --no-html flag

### DIFF
--- a/installer/templates/static/brunch/brunch-config.js
+++ b/installer/templates/static/brunch/brunch-config.js
@@ -65,6 +65,6 @@ exports.config = {
     enabled: true,
     // Whitelist the npm deps to be pulled in as front-end assets.
     // All other deps in package.json will be excluded from the bundle.
-    whitelist: ["phoenix", "phoenix_html"]
+    whitelist: ["phoenix"<%= if html do %>, "phoenix_html"<% end %>]
   }
 };

--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -8,7 +8,7 @@
     "css-brunch": ">= 1.0 < 1.8",
     "javascript-brunch": ">= 1.0 < 1.8",
     "uglify-js-brunch": ">= 1.0 < 1.8",
-    "phoenix": "file:<%= brunch_deps_prefix %><%= phoenix_path %>",
-    "phoenix_html": "file:<%= brunch_deps_prefix %>deps/phoenix_html"
+    "phoenix": "file:<%= brunch_deps_prefix %><%= phoenix_path %>"<%= if html do %>,
+    "phoenix_html": "file:<%= brunch_deps_prefix %>deps/phoenix_html"<% end %>
   }
 }


### PR DESCRIPTION
Fixes #1465 