### PR TITLE
Support --binary-id when generating scaffold

### DIFF
--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -25,14 +25,20 @@ defmodule Mix.Tasks.Phoenix.Gen.Html do
   information on attributes and namespaced resources.
   """
   def run(args) do
-    {opts, parsed, _} = OptionParser.parse(args, switches: [model: :boolean])
+    switches = [binary_id: :boolean, model: :boolean]
+
+    {opts, parsed, _} = OptionParser.parse(args, switches: switches)
     [singular, plural | attrs] = validate_args!(parsed)
+
+    default_opts = Application.get_env(:phoenix, :generators, [])
+    opts = Keyword.merge(default_opts, opts)
 
     attrs   = Mix.Phoenix.attrs(attrs)
     binding = Mix.Phoenix.inflect(singular)
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
     binding = binding ++ [plural: plural, route: route, attrs: attrs,
+                          binary_id: opts[:binary_id],
                           inputs: inputs(attrs), params: Mix.Phoenix.params(attrs),
                           template_singular: String.replace(binding[:singular], "_", " "),
                           template_plural: String.replace(plural, "_", " ")]

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -24,14 +24,20 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
   for more information on attributes and namespaced resources.
   """
   def run(args) do
-    {opts, parsed, _} = OptionParser.parse(args, switches: [model: :boolean])
+    switches = [binary_id: :boolean, model: :boolean]
+
+    {opts, parsed, _} = OptionParser.parse(args, switches: switches)
     [singular, plural | attrs] = validate_args!(parsed)
+
+    default_opts = Application.get_env(:phoenix, :generators, [])
+    opts = Keyword.merge(default_opts, opts)
 
     attrs   = Mix.Phoenix.attrs(attrs)
     binding = Mix.Phoenix.inflect(singular)
     path    = binding[:path]
     route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
     binding = binding ++ [plural: plural, route: route,
+                          binary_id: opts[:binary_id],
                           attrs: attrs, params: Mix.Phoenix.params(attrs)]
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")

--- a/priv/templates/phoenix.gen.html/controller_test.exs
+++ b/priv/templates/phoenix.gen.html/controller_test.exs
@@ -34,7 +34,7 @@ defmodule <%= module %>ControllerTest do
 
   test "renders page not found when id is nonexistent", %{conn: conn} do
     assert_error_sent 404, fn ->
-      get conn, <%= singular %>_path(conn, :show, -1)
+      get conn, <%= singular %>_path(conn, :show, <%= if binary_id do %>"11111111-1111-1111-1111-111111111111"<% else %>-1<% end %>)
     end
   end
 

--- a/priv/templates/phoenix.gen.json/controller_test.exs
+++ b/priv/templates/phoenix.gen.json/controller_test.exs
@@ -23,7 +23,7 @@ defmodule <%= module %>ControllerTest do
 
   test "does not show resource and instead throw error when id is nonexistent", %{conn: conn} do
     assert_error_sent 404, fn ->
-      get conn, <%= singular %>_path(conn, :show, -1)
+      get conn, <%= singular %>_path(conn, :show, <%= if binary_id do %>"11111111-1111-1111-1111-111111111111"<% else %>-1<% end %>)
     end
   end
 


### PR DESCRIPTION
Currently if you generate a project with `--binary-id` option, this project is properly using binary IDs almost everywhere by default.

This is, however, not true about the generated tests for the controllers - for both HTML and JSON.

This pull requests fixes the tests so the generated tests are respecting global `binary_id` generators setting. Tests scaffolded using phoenix.gen.json or phoenix.gen.html after this patch do pass correctly when `--binary-id` is used.