### PR TITLE
Don't include Ecto gettext translations if --no-ecto

### DIFF
--- a/installer/templates/new/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/installer/templates/new/priv/gettext/en/LC_MESSAGES/errors.po
@@ -4,7 +4,7 @@
 ## --merge` or `mix gettext.merge` to merge POT files into PO files.
 msgid ""
 msgstr ""
-"Language: en\n"
+"Language: en\n"<%= if ecto do %>
 
 ## From Ecto.Changeset.cast/4
 msgid "can't be blank"
@@ -96,4 +96,4 @@ msgstr[1] ""
 msgid "must be equal to %{count}"
 msgid_plural "must be equal to %{count}"
 msgstr[0] ""
-msgstr[1] ""
+msgstr[1] ""<% end %>

--- a/installer/templates/new/priv/gettext/errors.pot
+++ b/installer/templates/new/priv/gettext/errors.pot
@@ -3,6 +3,7 @@
 ## translations that can't be statically extracted. Run `mix
 ## gettext.extract` to bring this file up to date. Leave `msgstr`s empty as
 ## changing them here as no effect; edit them in PO (`.po`) files instead.
+<%= if ecto do %>
 ## From Ecto.Changeset.cast/4
 msgid "can't be blank"
 msgstr ""
@@ -93,4 +94,4 @@ msgstr[1] ""
 msgid "must be equal to %{count}"
 msgid_plural "must be equal to %{count}"
 msgstr[0] ""
-msgstr[1] ""
+msgstr[1] ""<% end %>


### PR DESCRIPTION
If the project is generated with --no-ecto we don't want to include the
changeset error translations in .po* files.

* If the project is generated with `--no-html` and `--no-ecto` should we completely remove the `ErrorHelpers` module?
* The `phoenix.gen.json` task relies on the `ErrorHelpers.translate_error` to exist. It won't if the project is generated with `--no-ecto`, is that ok?