### PR TITLE
Clear channels after disconnect

### DIFF
--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -403,6 +403,7 @@ export class Socket {
       this.conn.onclose = function(){} // noop
       if(code){ this.conn.close(code, reason || "") } else { this.conn.close() }
       this.conn = null
+      this.channels = []
     }
     callback && callback()
   }


### PR DESCRIPTION
If you do not do this, the socket will end up with stale channels, that cause issues when the socket is reconnected.
This fix solved reconnection issues for me, but there might be a better solution.