### PR TITLE
Fixes Mix.Tasks.Phoenix.Gen.Model w/:binary types

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -3,8 +3,8 @@ defmodule Mix.Phoenix do
   @moduledoc false
 
   @valid_attributes [:integer, :float, :decimal, :boolean, :map, :string,
-                     :array, :references, :text, :date, :time, :datetime, 
-                     :uuid]
+                     :array, :references, :text, :date, :time, :datetime,
+                     :uuid, :binary]
 
   @doc """
   Copies files from source dir to target dir

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -19,7 +19,8 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
   test "generates model" do
     in_tmp "generates model", fn ->
       Mix.Tasks.Phoenix.Gen.Model.run ["user", "users", "name", "age:integer", "nicks:array:text",
-                                       "famous:boolean", "born_at:datetime", "secret:uuid", "desc:text"]
+                                       "famous:boolean", "born_at:datetime", "secret:uuid", "desc:text",
+                                       "blob:binary"]
 
       assert [migration] = Path.wildcard("priv/repo/migrations/*_create_user.exs")
 
@@ -33,6 +34,7 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
         assert file =~ "add :born_at, :datetime"
         assert file =~ "add :secret, :uuid"
         assert file =~ "add :desc, :text"
+        assert file =~ "add :blob, :binary"
         assert file =~ "timestamps"
       end
 
@@ -47,9 +49,10 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
         assert file =~ "field :born_at, Ecto.DateTime"
         assert file =~ "field :secret, Ecto.UUID"
         assert file =~ "field :desc, :string"
+        assert file =~ "field :blob, :binary"
         assert file =~ "timestamps"
         assert file =~ "def changeset"
-        assert file =~ "~w(name age nicks famous born_at secret desc)"
+        assert file =~ "~w(name age nicks famous born_at secret desc blob)"
       end
 
       assert_file "test/models/user_test.exs", fn file ->


### PR DESCRIPTION
Mix.Tasks.Phoenix.Gen.Model does not allow :binary
typed attributes despite being a valid primitive
type. This commit adds :binary to the list of
valid types in the Phoenix module.

Fixes #1511.