### PR TITLE
The LiveReloader and CodeReloader are now decoupled 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## 1.2.0-dev
+* Enhancments
+  * [Endpoint] Live reloader is now broken out to its own config option. Set `live_reloader = true` in your endpoint to turn it on.
 
 ## 1.1.4 (2016-1-25)
 

--- a/installer/templates/new/config/dev.exs
+++ b/installer/templates/new/config/dev.exs
@@ -10,6 +10,7 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
   http: [port: 4000],
   debug_errors: true,
   code_reloader: true,
+  live_reloader: true,
   check_origin: false,
   watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin"]]<% else %>[]<% end %>
 

--- a/installer/templates/new/lib/application_name/endpoint.ex
+++ b/installer/templates/new/lib/application_name/endpoint.ex
@@ -13,10 +13,15 @@ defmodule <%= application_module %>.Endpoint do
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
-  if code_reloading? do<%= if html do %>
+  if code_reloading? do
+    plug Phoenix.CodeReloader
+  end
+
+  # Live reloading can be explicitly enabled under the
+  # :live_reloader configuration of your endpoint.
+  if live_reloading? do<%= if html do %>
     socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
     plug Phoenix.LiveReloader<% end %>
-    plug Phoenix.CodeReloader
   end
 
   plug Plug.RequestId

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -63,6 +63,8 @@ defmodule Phoenix.Endpoint do
 
     * `:code_reloader` - when `true`, enables code reloading functionality
 
+    * `:live_reloader` - when `true`, enables live reloading functionality
+
     * `:debug_errors` - when `true`, uses `Plug.Debugger` functionality for
       debugging failures in the application. Recommended to be set to `true`
       only in development as it allows listing of the application source
@@ -370,10 +372,14 @@ defmodule Phoenix.Endpoint do
     quote do
       @otp_app unquote(opts)[:otp_app] || raise "endpoint expects :otp_app to be given"
       var!(config) = Adapter.config(@otp_app, __MODULE__)
-      var!(code_reloading?) = var!(config)[:code_reloader]
 
+      var!(code_reloading?) = var!(config)[:code_reloader]
       # Avoid unused variable warnings
       _ = var!(code_reloading?)
+
+      var!(live_reloading?) = var!(config)[:live_reloader]
+      # Avoid unused variable warnings
+      _ = var!(live_reloading?)
     end
   end
 

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -110,6 +110,7 @@ defmodule Phoenix.Endpoint.Adapter do
 
      # Compile-time config
      code_reloader: false,
+     live_reloader: false,
      debug_errors: false,
      render_errors: [view: render_errors(module), accepts: ~w(html)],
 

--- a/test/phoenix/code_reloader_test.exs
+++ b/test/phoenix/code_reloader_test.exs
@@ -5,6 +5,7 @@ defmodule Phoenix.CodeReloaderTest do
   Application.put_env(:phoenix, __MODULE__.Endpoint,
     root: File.cwd!,
     code_reloader: true,
+    live_reloader: true,
     reloadable_paths: ["web"],
     live_reload: [url: "ws://localhost:4000", patterns: [~r/some\/path/]])
 

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -8,6 +8,7 @@ defmodule Phoenix.Endpoint.EndpointTest do
            force_ssl: [subdomains: true],
            cache_static_manifest: "../../../../test/fixtures/manifest.json",
            pubsub: [adapter: Phoenix.PubSub.PG2, name: :endpoint_pub]]
+
   Application.put_env(:phoenix, __MODULE__.Endpoint, @config)
 
   defmodule Endpoint do
@@ -17,6 +18,7 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert is_list(config)
     assert @otp_app == :phoenix
     assert code_reloading? == false
+    assert live_reloading? == false
   end
 
   setup_all do


### PR DESCRIPTION
There are now two separate config options `code_reloading` and `live_reloading` to be overridden in the Endpoint. 