### PR TITLE
Fixes typo

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 **IMPORTANT**: when building the archive, it must be done in the minimum supported Erlang and Elixir versions.
 
-  1. Check related deps for required version bumps and compatibilitiy (`phoenix_ecto`, `phoenix_pubsub_redis`, `phoenix_html`)
+  1. Check related deps for required version bumps and compatibility (`phoenix_ecto`, `phoenix_pubsub_redis`, `phoenix_html`)
   2. Bump version in related files below
   3. Update `phoenix_dep` in `installer/lib/phoenix_new.ex` to "~> version to be released"
   4. Run tests, commit, push code, packages and docs


### PR DESCRIPTION
Spotted a spelling mistake while reading -
`compatibilitiy` > `compatibility`