### PR TITLE
docs(Phoenix.Channel): use ChangesetView to render changeset errors

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -80,7 +80,8 @@ defmodule Phoenix.Channel do
           Repo.insert!(changeset)
           {:reply, {:ok, changeset}, socket}
         else
-          {:reply, {:error, changeset.errors}, socket}
+          {:reply,{:error, MyApp.ChangesetView.render("errors.json",
+            %{changeset: changeset}), socket}
         end
       end
 


### PR DESCRIPTION
@chrismccord Just wanted to check that you were happy with the use of `MyApp` and the line break before pushing into master.