### PR TITLE
Change word order in 500 error messages in templates

### DIFF
--- a/installer/templates/new/test/views/error_view_test.exs
+++ b/installer/templates/new/test/views/error_view_test.exs
@@ -11,12 +11,12 @@ defmodule <%= application_module %>.ErrorViewTest do
 
   test "render 500.html" do
     assert render_to_string(<%= application_module %>.ErrorView, "500.html", []) ==
-           "Server internal error"
+           "Internal server error"
   end
 
   test "render any other" do
     assert render_to_string(<%= application_module %>.ErrorView, "505.html", []) ==
-           "Server internal error"
+           "Internal server error"
   end<% else %>test "renders 404.json" do
     assert render(<%= application_module %>.ErrorView, "404.json", []) ==
            %{errors: %{detail: "Page not found"}}
@@ -24,11 +24,11 @@ defmodule <%= application_module %>.ErrorViewTest do
 
   test "render 500.json" do
     assert render(<%= application_module %>.ErrorView, "500.json", []) ==
-           %{errors: %{detail: "Server internal error"}}
+           %{errors: %{detail: "Internal server error"}}
   end
 
   test "render any other" do
     assert render(<%= application_module %>.ErrorView, "505.json", []) ==
-           %{errors: %{detail: "Server internal error"}}
+           %{errors: %{detail: "Internal server error"}}
   end<% end %>
 end

--- a/installer/templates/new/web/views/error_view.ex
+++ b/installer/templates/new/web/views/error_view.ex
@@ -6,7 +6,7 @@ defmodule <%= application_module %>.ErrorView do
   end
 
   def render("500.html", _assigns) do
-    "Server internal error"
+    "Internal server error"
   end
 
   # In case no render clause matches or no
@@ -18,7 +18,7 @@ defmodule <%= application_module %>.ErrorView do
   end
 
   def render("500.json", _assigns) do
-    %{errors: %{detail: "Server internal error"}}
+    %{errors: %{detail: "Internal server error"}}
   end
 
   # In case no render clause matches or no


### PR DESCRIPTION
I'm not sure if it was made intentionally, but when I encountered it in new app it felt weird as everywhere, even in rfc (https://tools.ietf.org/html/rfc2616#section-10.5.1) it is "Internal server error" not "Server internal error".