### PR TITLE
Raise not acceptable error & fall back to first acceptable format on error

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -813,8 +813,9 @@ defmodule Phoenix.Controller do
     * the accept header specified more than one media type preceeded
       or followed by the wildcard media type "`*/*`"
 
-  This function will send a 406 response and log whenever the server
-  cannot serve a response in any of the formats expected by the client.
+  This function raises `Phoenix.NotAcceptableError`, which is rendered
+  with status 406, whenever the server cannot serve a response in any
+  of the formats expected by the client.
 
   ## Examples
 
@@ -866,9 +867,8 @@ defmodule Phoenix.Controller do
     if format in accepted do
       put_format(conn, format)
     else
-      Logger.debug "Unknown format #{inspect format} in plug :accepts, " <>
-                   "expected one of #{inspect accepted}"
-      conn |> send_resp(406, "") |> halt()
+      raise Phoenix.NotAcceptableError,
+        message: "unknown format #{inspect format}, expected one of #{inspect accepted}"
     end
   end
 
@@ -937,9 +937,8 @@ defmodule Phoenix.Controller do
   defp find_format(exts, accepted),  do: Enum.find(exts, &(&1 in accepted))
 
   defp refuse(conn, accepted) do
-    Logger.debug "No supported media type in accept header in plug :accepts, " <>
-                 "expected one of #{inspect accepted}"
-    conn |> send_resp(406, "") |> halt()
+    raise Phoenix.NotAcceptableError,
+      message: "no supported media type in accept header, expected one of #{inspect accepted}"
   end
 
   @doc """

--- a/lib/phoenix/endpoint/render_errors.ex
+++ b/lib/phoenix/endpoint/render_errors.ex
@@ -95,9 +95,14 @@ defmodule Phoenix.Endpoint.RenderErrors do
   end
 
   defp fetch_format(conn, opts) do
-    case get_format(conn) do
-      format when is_binary(format) -> conn
-      _ -> conn |> fetch_query_params |> accepts(Keyword.fetch!(opts, :accepts))
+    try do
+      case get_format(conn) do
+        format when is_binary(format) -> conn
+        _ -> conn |> fetch_query_params |> accepts(Keyword.fetch!(opts, :accepts))
+      end
+    rescue
+      Phoenix.NotAcceptableError ->
+        put_format(conn, Keyword.fetch!(opts, :accepts) |> List.first())
     end
   end
 

--- a/lib/phoenix/exceptions.ex
+++ b/lib/phoenix/exceptions.ex
@@ -1,3 +1,19 @@
+defmodule Phoenix.NotAcceptableError do
+  @moduledoc """
+  Raised when one of the `accept*` headers is not accepted by the server.
+
+  This exception is commonly raised by `Phoenix.Controller.accepts/2`
+  which negotiates the media types the server is able to serve with
+  the contents the client is able to render.
+
+  If you are seeing this error, you should check if you are listing
+  the desired formats in your `:accepts` plug or if you are setting
+  the proper accept header in the client.
+  """
+
+  defexception message: nil, plug_status: 406
+end
+
 defmodule Phoenix.MissingParamError do
   @moduledoc """
   Raised when a key is expected to be present in the request parameters,

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -265,9 +265,10 @@ defmodule Phoenix.Controller.ControllerTest do
     assert get_format(conn) == "json"
     assert conn.params["_format"] == "json"
 
-    conn = accepts conn(:get, "/", _format: "json"), ~w(html)
-    assert conn.status == 406
-    assert conn.halted
+    exception = assert_raise Phoenix.NotAcceptableError, ~r/unknown format "json"/, fn ->
+      accepts conn(:get, "/", _format: "json"), ~w(html)
+    end
+    assert Plug.Exception.status(exception) == 406
   end
 
   test "accepts/2 uses first accepts on empty or catch-all header" do
@@ -327,9 +328,10 @@ defmodule Phoenix.Controller.ControllerTest do
     assert get_format(conn) == "json"
     assert conn.params["_format"] == nil
 
-    conn = accepts with_accept("text/html; q=0.7, application/json; q=0.8"), ~w(xml)
-    assert conn.halted
-    assert conn.status == 406
+    exception = assert_raise Phoenix.NotAcceptableError, ~r/no supported media type in accept/, fn ->
+      accepts with_accept("text/html; q=0.7, application/json; q=0.8"), ~w(xml)
+    end
+    assert Plug.Exception.status(exception) == 406
   end
 
   test "scrub_params/2 raises Phoenix.MissingParamError for missing key" do

--- a/test/phoenix/endpoint/render_errors_test.exs
+++ b/test/phoenix/endpoint/render_errors_test.exs
@@ -170,7 +170,7 @@ defmodule Phoenix.Endpoint.RenderErrorsTest do
       |> put_req_header("accept", "unknown/unknown")
       |> render([], fn -> throw :hello end)
 
-    assert conn.status == 406
-    assert conn.resp_body == ""
+    assert conn.status == 500
+    assert conn.resp_body == "Got 500 from throw with GET"
   end
 end


### PR DESCRIPTION
As discussed in #1521:

1. Raise Phoenix.NotAcceptableError in Phoenix.Controller.accepts instead of halting the connection with a 406 status
2. Rescue Phoenix.NotAcceptableError in RenderErrors.fetch_format/2 and render original error with first acceptable format.

I am not sure if this is the best place to rescue the error. And: is the halted:true-line at https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/endpoint/render_errors.ex#L69 still needed?