### PR TITLE
Phoenix.NotAcceptableError contains accepts field

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -868,7 +868,8 @@ defmodule Phoenix.Controller do
       put_format(conn, format)
     else
       raise Phoenix.NotAcceptableError,
-        message: "unknown format #{inspect format}, expected one of #{inspect accepted}"
+        message: "unknown format #{inspect format}, expected one of #{inspect accepted}",
+        accepts: accepted
     end
   end
 
@@ -938,7 +939,8 @@ defmodule Phoenix.Controller do
 
   defp refuse(conn, accepted) do
     raise Phoenix.NotAcceptableError,
-      message: "no supported media type in accept header, expected one of #{inspect accepted}"
+      message: "no supported media type in accept header, expected one of #{inspect accepted}",
+      accepts: accepted
   end
 
   @doc """

--- a/lib/phoenix/exceptions.ex
+++ b/lib/phoenix/exceptions.ex
@@ -8,10 +8,11 @@ defmodule Phoenix.NotAcceptableError do
 
   If you are seeing this error, you should check if you are listing
   the desired formats in your `:accepts` plug or if you are setting
-  the proper accept header in the client.
+  the proper accept header in the client. The exception contains the
+  acceptable mime types in the `accepts` field.
   """
 
-  defexception message: nil, plug_status: 406
+  defexception message: nil, accepts: [], plug_status: 406
 end
 
 defmodule Phoenix.MissingParamError do

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -269,6 +269,7 @@ defmodule Phoenix.Controller.ControllerTest do
       accepts conn(:get, "/", _format: "json"), ~w(html)
     end
     assert Plug.Exception.status(exception) == 406
+    assert exception.accepts == ["html"]
   end
 
   test "accepts/2 uses first accepts on empty or catch-all header" do
@@ -332,6 +333,7 @@ defmodule Phoenix.Controller.ControllerTest do
       accepts with_accept("text/html; q=0.7, application/json; q=0.8"), ~w(xml)
     end
     assert Plug.Exception.status(exception) == 406
+    assert exception.accepts == ["xml"]
   end
 
   test "scrub_params/2 raises Phoenix.MissingParamError for missing key" do


### PR DESCRIPTION
This is useful to render a helpful error entity for the client which includes
the acceptable mime types.

RFC 2616: "Unless it was a HEAD request, the response SHOULD include an entity containing a list of available entity characteristics and location(s) from which the user or user agent can choose the one most appropriate."

Follow up from #1521