### PR TITLE
Filter payload on channel join

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,4 +4,6 @@ use Mix.Config
 config :logger, :console, colors: [enabled: false]
 
 # Use higher stacktrace depth.
-config :phoenix, :stacktrace_depth, 20
+config :phoenix,
+  stacktrace_depth: 20,
+  filter_parameters: ["password"]

--- a/lib/phoenix/endpoint/instrument.ex
+++ b/lib/phoenix/endpoint/instrument.ex
@@ -195,4 +195,21 @@ defmodule Phoenix.Endpoint.Instrument do
   defp build_result_variable(index) when is_integer(index) do
     "res#{index}" |> String.to_atom() |> Macro.var(nil)
   end
+
+  def filter_values(%{__struct__: mod} = struct, _filter_params) when is_atom(mod) do
+    struct
+  end
+  def filter_values(%{} = map, filter_params) do
+    Enum.into map, %{}, fn {k, v} ->
+      if is_binary(k) && String.contains?(k, filter_params) do
+        {k, "[FILTERED]"}
+      else
+        {k, filter_values(v, filter_params)}
+      end
+    end
+  end
+  def filter_values([_|_] = list, filter_params) do
+    Enum.map(list, &filter_values(&1, filter_params))
+  end
+  def filter_values(other, _filter_params), do: other
 end

--- a/test/phoenix/controller/logger_test.exs
+++ b/test/phoenix/controller/logger_test.exs
@@ -36,67 +36,13 @@ defmodule Phoenix.Controller.LoggerTest do
   end
 
   test "filter parameter" do
-    filter_parameters = Application.get_env(:phoenix, :filter_parameters)
-
-    try do
-      Application.put_env(:phoenix, :filter_parameters, ["PASS"])
-
-      output = capture_log fn ->
-        conn(:get, "/", password: "should_show", PASS: "should_not_show")
-        |> fetch_query_params
-        |> action
-      end
-
-      assert output =~ "Parameters: %{\"PASS\" => \"[FILTERED]\", \"password\" => \"should_show\"}"
-    after
-      Application.put_env(:phoenix, :filter_parameters, filter_parameters)
-    end
-  end
-
-  test "filter parameter when a map has secret key" do
     output = capture_log fn ->
-      conn(:get, "/", foo: "bar", map: %{password: "should_not_show"})
+      conn(:get, "/", foo: "bar", password: "should_not_show")
       |> fetch_query_params
       |> action
     end
 
-    assert output =~ "Parameters: %{\"foo\" => \"bar\", \"map\" => %{\"password\" => \"[FILTERED]\"}}"
-  end
-
-  test "filter parameter when a list has a map with secret" do
-    output = capture_log fn ->
-      conn(:get, "/", foo: "bar", list: [%{password: "should_not_show"}])
-      |> fetch_query_params
-      |> action
-    end
-
-    assert output =~ "Parameters: %{\"foo\" => \"bar\", \"list\" => [%{\"password\" => \"[FILTERED]\"}]}"
-  end
-
-  test "does not filter structs" do
-    output = capture_log fn ->
-      conn(:get, "/", %{foo: "bar", file: %Plug.Upload{}})
-      |> fetch_query_params
-      |> action
-    end
-    assert output =~ "Parameters: %{\"file\" => %Plug.Upload{content_type: nil, filename: nil, path: nil}, \"foo\" => \"bar\"}"
-
-    output = capture_log fn ->
-      conn(:get, "/", %{foo: "bar", file: %{__struct__: "s"}})
-      |> fetch_query_params
-      |> action
-    end
-    assert output =~ "Parameters: %{\"file\" => %{\"__struct__\" => \"s\"}, \"foo\" => \"bar\"}"
-  end
-
-  test "does not fail on atomic keys" do
-    output = capture_log fn ->
-      conn(:get, "/", %{password: "should_not_show"})
-      |> fetch_query_params
-      |> Map.update!(:params, &Dict.put(&1, :foo, "bar"))
-      |> action
-    end
-    assert output =~ "Parameters: %{:foo => \"bar\", \"password\" => \"[FILTERED]\"}"
+    assert output =~ "Parameters: %{\"foo\" => \"bar\", \"password\" => \"[FILTERED]\"}"
   end
 
   test "does not filter unfetched parameters" do

--- a/test/phoenix/endpoint/instrument_test.exs
+++ b/test/phoenix/endpoint/instrument_test.exs
@@ -3,6 +3,8 @@ defmodule Phoenix.Endpoint.InstrumentTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
 
+  alias Phoenix.Endpoint.Instrument
+
   @config [instrumenters: [__MODULE__.MyInstrumenter, __MODULE__.MyOtherInstrumenter]]
   Application.put_env(:phoenix, __MODULE__.Endpoint, @config)
 
@@ -139,5 +141,33 @@ defmodule Phoenix.Endpoint.InstrumentTest do
     assert stop_data.res == :ok
     assert is_integer(stop_data.duration)
     assert stop_data.duration >= 0
+  end
+
+  test "filter_values" do
+    assert Instrument.filter_values(%{"foo" => "bar", "password" => "should_not_show"}, ["password"]) ==
+           %{"foo" => "bar", "password" => "[FILTERED]"}
+  end
+
+  test "filter_values when a map has secret key" do
+    assert Instrument.filter_values(%{"foo" => "bar", "map" => %{"password" => "should_not_show"}}, ["password"]) ==
+           %{"foo" => "bar", "map" => %{"password" => "[FILTERED]"}}
+  end
+
+  test "filter_values when a list has a map with secret" do
+    assert Instrument.filter_values(%{"foo" => "bar", "list" => [%{"password" => "should_not_show"}]}, ["password"]) ==
+           %{"foo" => "bar", "list" => [%{"password" => "[FILTERED]"}]}
+  end
+
+  test "filter_values does not filter structs" do
+    assert Instrument.filter_values(%{"foo" => "bar", "file" => %Plug.Upload{}}, ["password"]) ==
+           %{"foo" => "bar", "file" => %Plug.Upload{}}
+
+    assert Instrument.filter_values(%{"foo" => "bar", "file" => %{__struct__: "s"}}, ["password"]) ==
+           %{"foo" => "bar", "file" => %{:__struct__ => "s"}}
+  end
+
+  test "filter_values does not fail on atomic keys" do
+    assert Instrument.filter_values(%{:foo => "bar", "password" => "should_not_show"}, ["password"]) ==
+           %{:foo => "bar", "password" => "[FILTERED]"}
   end
 end


### PR DESCRIPTION
I'm not entirely happy with this PR but I thought I'd gather feedback before going any further:

* Although I think we should be DRY and not duplicate the `filter_value/2` in two different places `Phoenix.Logger.Filter` doesn't feel like the right module name for that. Any suggestions?
* I kept the tests for filtering in `test/phoenix/controller/logger_test.exs`, although they are a bit redundant with the tests I have in `test/phoenix/logger/filter_test.exs` I still feels better having them here.
* That being said I should probably have equivalent tests for `lib/phoenix/socket/transport.ex`

Let me know your thoughts and I'll fix the PR.