### PR TITLE
refactor(Phoenix): use Elixir 1.2 alias syntax

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -172,8 +172,7 @@ defmodule Phoenix.Channel do
   is invoked. This practice is not encouraged though.
   """
 
-  alias Phoenix.Socket
-  alias Phoenix.Channel.Server
+  alias Phoenix.{Socket, Channel.Server}
 
   @type reply :: status :: atom | {status :: atom, response :: map}
   @type socket_ref :: {transport_pid :: Pid, serializer :: Module.t,

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -2,11 +2,8 @@ defmodule Phoenix.Channel.Server do
   use GenServer
   require Logger
 
-  alias Phoenix.PubSub
-  alias Phoenix.Socket
-  alias Phoenix.Socket.Broadcast
-  alias Phoenix.Socket.Message
-  alias Phoenix.Socket.Reply
+  alias Phoenix.{PubSub, Socket}
+  alias Phoenix.Socket.{Broadcast, Message, Reply}
 
   @moduledoc false
 

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -161,10 +161,7 @@ defmodule Phoenix.Router do
 
   """
 
-  alias Phoenix.Router.Resource
-  alias Phoenix.Router.Scope
-  alias Phoenix.Router.Route
-  alias Phoenix.Router.Helpers
+  alias Phoenix.Router.{Resource, Scope, Route, Helpers}
 
   @http_methods [:get, :post, :put, :patch, :delete, :options, :connect, :trace, :head]
 

--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -151,12 +151,8 @@ defmodule Phoenix.ChannelTest do
       assert_receive {:DOWN, _, _, _, :normal}
   """
 
-  alias Phoenix.Socket
-  alias Phoenix.Socket.Message
-  alias Phoenix.Socket.Broadcast
-  alias Phoenix.Socket.Reply
-  alias Phoenix.Socket.Transport
-  alias Phoenix.Channel.Server
+  alias Phoenix.{Socket, Channel.Server}
+  alias Phoenix.Socket.{Message, Broadcast, Reply, Transport}
 
   defmodule NoopSerializer do
     @behaviour Phoenix.Transports.Serializer

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -56,8 +56,7 @@ defmodule Phoenix.Token do
   password resets, e-mail confirmation and more.
   """
 
-  alias Plug.Crypto.KeyGenerator
-  alias Plug.Crypto.MessageVerifier
+  alias Plug.Crypto.{KeyGenerator, MessageVerifier}
 
   @doc """
   Encodes data and signs it resulting in a token you can send down to clients.

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -52,9 +52,8 @@ defmodule Phoenix.Transports.LongPoll do
 
   import Plug.Conn
 
-  alias Phoenix.Socket.Message
+  alias Phoenix.Socket.{Message, Transport}
   alias Phoenix.Transports.LongPoll
-  alias Phoenix.Socket.Transport
 
   @doc false
   def init(opts) do

--- a/lib/phoenix/transports/long_poll_serializer.ex
+++ b/lib/phoenix/transports/long_poll_serializer.ex
@@ -3,9 +3,7 @@ defmodule Phoenix.Transports.LongPollSerializer do
 
   @behaviour Phoenix.Transports.Serializer
 
-  alias Phoenix.Socket.Reply
-  alias Phoenix.Socket.Message
-  alias Phoenix.Socket.Broadcast
+  alias Phoenix.Socket.{Reply, Message, Broadcast}
 
   @doc """
   Translates a `Phoenix.Socket.Broadcast` into a `Phoenix.Socket.Message`.

--- a/lib/phoenix/transports/long_poll_server.ex
+++ b/lib/phoenix/transports/long_poll_server.ex
@@ -21,9 +21,7 @@ defmodule Phoenix.Transports.LongPoll.Server do
   use GenServer
 
   alias Phoenix.PubSub
-  alias Phoenix.Socket.Transport
-  alias Phoenix.Socket.Broadcast
-  alias Phoenix.Socket.Message
+  alias Phoenix.Socket.{Transport, Broadcast, Message}
 
   @doc """
   Starts the Server.

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -50,8 +50,7 @@ defmodule Phoenix.Transports.WebSocket do
 
   import Plug.Conn, only: [fetch_query_params: 1, send_resp: 3]
 
-  alias Phoenix.Socket.Broadcast
-  alias Phoenix.Socket.Transport
+  alias Phoenix.Socket.{Broadcast, Transport}
 
   @doc false
   def init(%Plug.Conn{method: "GET"} = conn, {endpoint, handler, transport}) do

--- a/lib/phoenix/transports/websocket_serializer.ex
+++ b/lib/phoenix/transports/websocket_serializer.ex
@@ -3,9 +3,7 @@ defmodule Phoenix.Transports.WebSocketSerializer do
 
   @behaviour Phoenix.Transports.Serializer
 
-  alias Phoenix.Socket.Reply
-  alias Phoenix.Socket.Message
-  alias Phoenix.Socket.Broadcast
+  alias Phoenix.Socket.{Reply, Message, Broadcast}
 
   @doc """
   Translates a `Phoenix.Socket.Broadcast` into a `Phoenix.Socket.Message`.

--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -5,8 +5,7 @@ defmodule Phoenix.Integration.EndpointTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
 
-  alias Phoenix.Integration.AdapterTest.ProdEndpoint
-  alias Phoenix.Integration.AdapterTest.DevEndpoint
+  alias Phoenix.Integration.AdapterTest.{ProdEndpoint, DevEndpoint}
 
   Application.put_env(:endpoint_int, ProdEndpoint,
       http: [port: "4807"], url: [host: "example.com"], server: true)

--- a/test/phoenix/integration/long_poll_test.exs
+++ b/test/phoenix/integration/long_poll_test.exs
@@ -5,10 +5,7 @@ defmodule Phoenix.Integration.LongPollTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
 
-  alias Phoenix.Integration.HTTPClient
-  alias Phoenix.Transports.LongPoll
-  alias Phoenix.Socket.Broadcast
-  alias Phoenix.PubSub.Local
+  alias Phoenix.{Integration.HTTPClient, Transports.LongPoll, Socket.Broadcast, PubSub.Local}
   alias __MODULE__.Endpoint
 
   @port 5808

--- a/test/phoenix/socket_test.exs
+++ b/test/phoenix/socket_test.exs
@@ -2,8 +2,7 @@ defmodule Phoenix.SocketTest do
   use ExUnit.Case, async: true
 
   import Phoenix.Socket
-  alias Phoenix.Socket.Message
-  alias Phoenix.Socket.InvalidMessageError
+  alias Phoenix.Socket.{Message, InvalidMessageError}
 
   defmodule UserSocket do
     use Phoenix.Socket

--- a/test/phoenix/transports/transport_test.exs
+++ b/test/phoenix/transports/transport_test.exs
@@ -2,8 +2,7 @@ defmodule Phoenix.Transports.TransportTest do
   use ExUnit.Case, async: true
   use RouterHelper
 
-  alias Phoenix.Socket.Transport
-  alias Phoenix.Socket.Message
+  alias Phoenix.Socket.{Transport, Message}
 
   Application.put_env :phoenix, __MODULE__.Endpoint,
     force_ssl: [],


### PR DESCRIPTION
In places where it is more readable to do so, the elixir 1.2 alias
syntax is used instead of spreading the alias over multiple lines.