### PR TITLE
Enable {:system, "ENV_VAR"} on :url and :static_url endpoint config options

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -119,8 +119,9 @@ defmodule Phoenix.Endpoint do
       task automatically sets this to `true`.
 
     * `:url` - configuration for generating URLs throughout the app.
-      Accepts the `:host`, `:scheme`, `:path` and `:port` options. All
-      keys except `:path` can be changed at runtime. Defaults to:
+      Accepts the `:host`, `:scheme`, `:path` and `:port` options as integers,
+      strings or `{:system, "ENV_VAR"}`. All keys except `:path` can be changed
+      at runtime. Defaults to:
 
           [host: "localhost", path: "/"]
 

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -197,8 +197,8 @@ defmodule Phoenix.Endpoint.Adapter do
           {"http", 80}
       end
 
-    scheme = url[:scheme] || scheme
-    host   = url[:host]
+    scheme = get_scheme(url[:scheme]) || scheme
+    host   = get_url(url[:host])
     port   = port_to_integer(url[:port] || port)
 
     %URI{scheme: scheme, port: port, host: host}
@@ -220,6 +220,12 @@ defmodule Phoenix.Endpoint.Adapter do
   def static_path(_endpoint, path) when is_binary(path) do
     raise ArgumentError, "static_path/2 expects a path starting with / as argument"
   end
+
+  defp get_scheme({:system, env_var}), do: System.get_env(env_var)
+  defp get_scheme(scheme), do: scheme
+
+  defp get_url({:system, env_var}), do: System.get_env(env_var)
+  defp get_url(url), do: url
 
   defp port_to_integer({:system, env_var}), do: port_to_integer(System.get_env(env_var))
   defp port_to_integer(port) when is_binary(port), do: String.to_integer(port)


### PR DESCRIPTION
The :port endpoint config allows you to pass in a ENV variable as
{:system, "ENV_VAR"}, but the configuration of :url and :static_url
require that you use System.get_env("ENV_VAR"), which isn't consistent.