### PR TITLE
Move brunch packages to `devDependencies`.

### DIFF
--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -2,13 +2,15 @@
   "repository": {
   },
   "dependencies": {
+    "phoenix": "file:<%= brunch_deps_prefix %><%= phoenix_path %>"<%= if html do %>,
+    "phoenix_html": "file:<%= brunch_deps_prefix %>deps/phoenix_html"<% end %>
+  },
+  "devDependencies": {
     "babel-brunch": "~6.0.0",
     "brunch": "~2.2.3",
     "clean-css-brunch": "~2.0.0",
     "css-brunch": "~2.0.0",
     "javascript-brunch": "~2.0.0",
-    "uglify-js-brunch": "~2.0.1",
-    "phoenix": "file:<%= brunch_deps_prefix %><%= phoenix_path %>"<%= if html do %>,
-    "phoenix_html": "file:<%= brunch_deps_prefix %>deps/phoenix_html"<% end %>
+    "uglify-js-brunch": "~2.0.1"
   }
 }


### PR DESCRIPTION
Brunch related dependencies are meant for app development only, and we can leave
the `dependencies` group for runtime deps like `phoenix_html` and other packages
added by developers during development.