### PR TITLE
Add a disclaimer to static/app.css for new project

### DIFF
--- a/installer/templates/static/app.css
+++ b/installer/templates/static/app.css
@@ -1,3 +1,7 @@
+/* This file contains Bootstrap as well as some default style for the starter
+ * application. You can safely delete all of its content to start fresh.
+ */
+
 /*!
  * Bootstrap v3.3.5 (http://getbootstrap.com)
  * Copyright 2011-2015 Twitter, Inc.


### PR DESCRIPTION
Several people have been confused by the inclusion of Bootstrap and
a few CSS rule-set in static/app.css when creating new project. This
commit addresses that by expliciting stating that the content of this
file is only here for convenience and can be safely deleted.