### PR TITLE
Fix a typo in a comment in the installer

### DIFF
--- a/installer/templates/new/priv/gettext/errors.pot
+++ b/installer/templates/new/priv/gettext/errors.pot
@@ -6,7 +6,7 @@
 ##
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here as no
-## effect. edit them in PO (`.po`) files instead.
+## effect: edit them in PO (`.po`) files instead.
 <%= if ecto do %>
 ## From Ecto.Changeset.cast/4
 msgid "can't be blank"


### PR DESCRIPTION
I noticed this when I ported the new informative comments into Gettext (https://github.com/elixir-lang/gettext/commit/c132d0ad1530aaae882993105b7011f99428a634).