### PR TITLE
#1564 Migrate to Ecto 2.0 - replace test_transaction by ecto sandbox

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -441,8 +441,6 @@ defmodule Mix.Tasks.Phoenix.New do
      test: [username: user, password: pass, database: "#{app}_test", hostname: "localhost",
             pool: Ecto.Adapters.SQL.Sandbox],
      prod: [username: user, password: pass, database: "#{app}_prod"],
-     
-     # should this be specific to Postgres for now and default to the old behavior for other drivers?
      test_begin: "Ecto.Adapters.SQL.Sandbox.mode(Paywall.Repo, :manual)",
      test_restart: ":ok = Ecto.Adapters.SQL.Sandbox.checkout(#{module}.Repo)"]
   end

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -418,8 +418,8 @@ defmodule Mix.Tasks.Phoenix.New do
       dev:  [database: "db/#{app}_dev.sqlite"],
       test: [database: "db/#{app}_test.sqlite", pool: Ecto.Adapters.SQL.Sandbox],
       prod: [database: "db/#{app}_prod.sqlite"],
-      test_begin: "Ecto.Adapters.SQL.begin_test_transaction(#{module}.Repo)",
-      test_restart: "Ecto.Adapters.SQL.restart_test_transaction(#{module}.Repo, [])"}
+      test_begin: "Ecto.Adapters.SQL.Sandbox.mode(Paywall.Repo, :manual)",
+      test_restart: ":ok = Ecto.Adapters.SQL.Sandbox.checkout(#{module}.Repo)"}
   end
   defp get_ecto_adapter("mongodb", app, module) do
     {:mongodb_ecto, Mongo.Ecto,

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -441,8 +441,10 @@ defmodule Mix.Tasks.Phoenix.New do
      test: [username: user, password: pass, database: "#{app}_test", hostname: "localhost",
             pool: Ecto.Adapters.SQL.Sandbox],
      prod: [username: user, password: pass, database: "#{app}_prod"],
-     test_begin: "Ecto.Adapters.SQL.begin_test_transaction(#{module}.Repo)",
-     test_restart: "Ecto.Adapters.SQL.restart_test_transaction(#{module}.Repo, [])"]
+     
+     # should this be specific to Postgres for now and default to the old behavior for other drivers?
+     test_begin: "Ecto.Adapters.SQL.Sandbox.mode(Paywall.Repo, :manual)",
+     test_restart: ":ok = Ecto.Adapters.SQL.Sandbox.checkout(#{module}.Repo)"]
   end
 
   defp kw_to_config(kw) do

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -255,11 +255,11 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "custom_path/config/prod.secret.exs", [~r/Ecto.Adapters.MySQL/, ~r/username: "root"/, ~r/password: ""/]
 
       assert_file "custom_path/test/support/conn_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
       assert_file "custom_path/test/support/channel_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
       assert_file "custom_path/test/support/model_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
     end
   end
 
@@ -356,11 +356,11 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "custom_path/config/prod.secret.exs", [~r/Ecto.Adapters.Postgres/, ~r/username: "postgres"/, ~r/password: "postgres"/]
 
       assert_file "custom_path/test/support/conn_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
       assert_file "custom_path/test/support/channel_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
       assert_file "custom_path/test/support/model_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
     end
   end
 

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -274,11 +274,11 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "custom_path/config/prod.secret.exs", ~r/Tds.Ecto/
 
       assert_file "custom_path/test/support/conn_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
       assert_file "custom_path/test/support/channel_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
       assert_file "custom_path/test/support/model_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
     end
   end
 
@@ -305,11 +305,11 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       end
 
       assert_file "custom_path/test/support/conn_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
       assert_file "custom_path/test/support/channel_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
       assert_file "custom_path/test/support/model_case.ex",
-        ~r/Ecto.Adapters.SQL.restart_test_transaction/
+        ~r/Ecto.Adapters.SQL.Sandbox.checkout/
     end
   end
 


### PR DESCRIPTION
Covers a very small part of #1564 but might be useful.  Tests are also updated and pass. 

Is the sandbox supported for all database drivers?

This is my first little attempt to help so I hope I haven't messed anything up too badly :+1: 