### PR TITLE
Add typespec for Phoenix.Template.template_not_found/2

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -132,6 +132,7 @@ defmodule Phoenix.Template do
       By default it raises but can be customized
       to render a particular template.
       """
+      @spec template_not_found(Phoenix.Template.name, map) :: no_return
       def template_not_found(template, assigns) do
         {root, names} = __templates__
         raise UndefinedError,


### PR DESCRIPTION
Without this typespec, running Dialyzer on fresh Phoenix project gives
following warnings:
`layout_view.ex:2: Function template_not_found/2 only terminates with explicit exception`
`page_view.ex:2: Function template_not_found/2 only terminates with explicit exception`

This pull request has two problems:
- added typespec uses built-in `binary` type instead of `Phoenix.Template.name` one.
- typespec is added inside the quoted code of the `__using__` macro. I'm not sure, if it's correct place for it.