### PR TITLE
Warn on router paths without leading slash

### DIFF
--- a/test/phoenix/router/resources_test.exs
+++ b/test/phoenix/router/resources_test.exs
@@ -47,7 +47,7 @@ defmodule Phoenix.Router.ResourcesTest do
 
     resources "/admin", UserController, param: "slug", name: "admin", only: [:show], alias: Api do
       resources "/comments", CommentController, param: "key", name: "post", except: [:delete]
-      resources "files", FileController, only: [:show, :index, :new]
+      resources "/files", FileController, only: [:show, :index, :new]
     end
   end
 


### PR DESCRIPTION
### What's this PR do?
This shows a warning anytime you declare a path that doesn't start with a `/` in a `Router`. This is only for consistency in router files. Not including the `/` still works. Closes #1438.

#### Scope.route/7
All of the router macros (http verbs, trace, options, connect, match, and resources) go through the `Scope.route/7` function, so I thought that'd be a good place to put the validation. Otherwise, all slashes are removed and reconstructed in the `Scope.join_path/2` function which is called inside `Scope.route/7`.

#### Scope.push/2
The `scope` macro doesn't go through `Scope.route/7`, so it gets its own validation. I wasn't sure how to do it via pattern matching with the `opts` in `push(module, opts)`, so I just used an `if` statement. Any feedback here?

### Gotchas
I was torn on splitting up the `router_test` and `scope_test` that I added. On one hand, it seemed like the two test suites were already broken up this way. On the other hand, I had to remove the `async: true` in order to break up the tests this way. Do you think this is alright?

It seems like `test/phoenix/router/scope_test.exs` isn't a unit test suite, but integration. Also the [module name is inconsistent with the filename](https://github.com/phoenixframework/phoenix/blob/master/test/phoenix/router/scope_test.exs#L1). I would've added these tests as unit tests but I had no idea how to set that up.

All feedback welcome. Thanks for the awesome framework!