### PR TITLE
Set minimum length to mix phoenix.gen.secret

### DIFF
--- a/lib/mix/tasks/phoenix.gen.secret.ex
+++ b/lib/mix/tasks/phoenix.gen.secret.ex
@@ -8,6 +8,9 @@ defmodule Mix.Tasks.Phoenix.Gen.Secret do
 
       mix phoenix.gen.secret [length]
 
+  By default, mix phoenix.gen.secret generates a key 64 characters long.
+
+  The minimum value for `length` is 32.
   """
   def run([]),    do: run(["64"])
   def run([int]), do: int |> parse! |> random_string |> Mix.shell.info
@@ -20,9 +23,10 @@ defmodule Mix.Tasks.Phoenix.Gen.Secret do
     end
   end
 
-  defp random_string(length) do
+  defp random_string(length) when length > 31 do
     :crypto.strong_rand_bytes(length) |> Base.encode64 |> binary_part(0, length)
   end
+  defp random_string(_), do: Mix.raise "the secret should be at least 32 characters long"
 
   defp invalid_args! do
     Mix.raise "mix phoenix.gen.secret expects a length as integer or no argument at all"

--- a/test/mix/tasks/phoenix.gen.secret_test.exs
+++ b/test/mix/tasks/phoenix.gen.secret_test.exs
@@ -21,4 +21,10 @@ defmodule Mix.Tasks.Phoenix.Gen.SecretTest do
     assert_raise Mix.Error, message, fn -> run ["32bad"] end
     assert_raise Mix.Error, message, fn -> run ["32", "bad"] end
   end
+
+  test "raises when length is too short" do
+    message = "the secret should be at least 32 characters long"
+    assert_raise Mix.Error, message, fn -> run ["0"] end
+    assert_raise Mix.Error, message, fn -> run ["31"] end
+  end
 end


### PR DESCRIPTION
Regarding #1587 set a minimum length to mix phoenix.gen.secret.

I've set the minimum length to 32 characters, and it will raise on anything shorter.