### PR TITLE
Change errors to match Ecto nomalised format

### DIFF
--- a/installer/templates/new/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/installer/templates/new/priv/gettext/en/LC_MESSAGES/errors.po
@@ -77,27 +77,17 @@ msgstr[0] ""
 msgstr[1] ""
 
 ## From Ecto.Changeset.validate_number/3
-msgid "must be less than %{count}"
-msgid_plural "must be less than %{count}"
-msgstr[0] ""
-msgstr[1] ""
+msgid "must be less than %{number}"
+msgstr ""
 
-msgid "must be greater than %{count}"
-msgid_plural "must be greater than %{count}"
-msgstr[0] ""
-msgstr[1] ""
+msgid "must be greater than %{number}"
+msgstr ""
 
-msgid "must be less than or equal to %{count}"
-msgid_plural "must be less than or equal to %{count}"
-msgstr[0] ""
-msgstr[1] ""
+msgid "must be less than or equal to %{number}"
+msgstr ""
 
-msgid "must be greater than or equal to %{count}"
-msgid_plural "must be greater than or equal to %{count}"
-msgstr[0] ""
-msgstr[1] ""
+msgid "must be greater than or equal to %{number}"
+msgstr ""
 
-msgid "must be equal to %{count}"
-msgid_plural "must be equal to %{count}"
-msgstr[0] ""
-msgstr[1] ""<% end %>
+msgid "must be equal to %{number}"
+msgstr ""<% end %>

--- a/installer/templates/new/priv/gettext/errors.pot
+++ b/installer/templates/new/priv/gettext/errors.pot
@@ -75,27 +75,17 @@ msgstr[0] ""
 msgstr[1] ""
 
 ## From Ecto.Changeset.validate_number/3
-msgid "must be less than %{count}"
-msgid_plural "must be less than %{count}"
-msgstr[0] ""
-msgstr[1] ""
+msgid "must be less than %{number}"
+msgstr ""
 
-msgid "must be greater than %{count}"
-msgid_plural "must be greater than %{count}"
-msgstr[0] ""
-msgstr[1] ""
+msgid "must be greater than %{number}"
+msgstr ""
 
-msgid "must be less than or equal to %{count}"
-msgid_plural "must be less than or equal to %{count}"
-msgstr[0] ""
-msgstr[1] ""
+msgid "must be less than or equal to %{number}"
+msgstr ""
 
-msgid "must be greater than or equal to %{count}"
-msgid_plural "must be greater than or equal to %{count}"
-msgstr[0] ""
-msgstr[1] ""
+msgid "must be greater than or equal to %{number}"
+msgstr ""
 
-msgid "must be equal to %{count}"
-msgid_plural "must be equal to %{count}"
-msgstr[0] ""
-msgstr[1] ""<% end %>
+msgid "must be equal to %{number}"
+msgstr ""<% end %>

--- a/installer/templates/new/web/views/error_helpers.ex
+++ b/installer/templates/new/web/views/error_helpers.ex
@@ -21,15 +21,20 @@ defmodule <%= application_module %>.ErrorHelpers do
     # Because error messages were defined within Ecto, we must
     # call the Gettext module passing our Gettext backend. We
     # also use the "errors" domain as translations are placed
-    # in the errors.po file. On your own code and templates,
-    # this could be written simply as:
+    # in the errors.po file.
+    # Ecto will pass the :count keyword if the error message is
+    # meant to be pluralized.
+    # On your own code and templates, depending on whether you
+    # need the message to be pluralized or not, this could be
+    # written simply as:
     #
     #     dngettext "errors", "1 file", "%{count} files", count
+    #     dgettext "errors", "is invalid"
     #
-    Gettext.dngettext(<%= application_module %>.Gettext, "errors", msg, msg, opts[:count], opts)
-  end
-
-  def translate_error(msg) do
-    Gettext.dgettext(<%= application_module %>.Gettext, "errors", msg)
+    if count = opts[:count] do
+      Gettext.dngettext(<%= application_module %>.Gettext, "errors", msg, msg, count, opts)
+    else
+      Gettext.dgettext(<%= application_module %>.Gettext, "errors", msg, opts)
+    end
   end
 end


### PR DESCRIPTION
As we are changing Ecto error messages from strings to tuples and the key for `validate_number` (see elixir-lang/ecto#1308), this updates Phoenix to be aware of those changes.