### PR TITLE
Start Repo process before accepting HTTP requests

### DIFF
--- a/installer/templates/new/lib/application_name.ex
+++ b/installer/templates/new/lib/application_name.ex
@@ -7,11 +7,11 @@ defmodule <%= application_module %> do
     import Supervisor.Spec
 
     # Define workers and child supervisors to be supervised
-    children = [
-      # Start the endpoint when the application starts
-      supervisor(<%= application_module %>.Endpoint, []),<%= if ecto do %>
+    children = [<%= if ecto do %>
       # Start the Ecto repository
       supervisor(<%= application_module %>.Repo, []),<% end %>
+      # Start the endpoint when the application starts
+      supervisor(<%= application_module %>.Endpoint, []),
       # Start your own worker by calling: <%= application_module %>.Worker.start_link(arg1, arg2, arg3)
       # worker(<%= application_module %>.Worker, [arg1, arg2, arg3]),
     ]


### PR DESCRIPTION
There's a very tiny race condition here on startup, where if you make an
HTTP request right as the Endpoint process has started, but before the
Repo process has started, you'll receive an error saying that the Repo
process hasn't started yet. To avoid these errors let's start the Repo
process first since most Endpoints will most likely depend on access to
the database.