### PR TITLE
created destroyer tasks for JSON and HTML resources and models refs issue #1597

### DIFF
--- a/lib/mix/tasks/phoenix.des.html.ex
+++ b/lib/mix/tasks/phoenix.des.html.ex
@@ -1,0 +1,140 @@
+defmodule Mix.Tasks.Phoenix.Des.Html do
+  use Mix.Task
+
+  @shortdoc "Destroys controller, model and views for an HTML based resource"
+
+  @moduledoc """
+  Destroys a Phoenix resource.
+
+      mix phoenix.des.html User users
+
+  The first argument is the module name followed by
+  its plural name (used for resources and schema).
+
+  The resources destroyed are:
+
+    * the model in web/models
+    * the view in web/views
+    * the controller in web/controllers
+    * the migration file for the repository  (note: this task does not rollback the migration)
+    * default CRUD templates in web/templates
+    * the generated test files for the model and controller
+
+  Removal of the model can be skipped with `--no-model`.
+  Read the documentation for `phoenix.des.model` for more
+  information on namespaced resources.
+  """
+  def run(args) do
+    switches = [binary_id: :boolean, model: :boolean]
+
+    {opts, parsed, _} = OptionParser.parse(args, switches: switches)
+    [singular, plural | attrs] = validate_args!(parsed)
+
+    default_opts = Application.get_env(:phoenix, :generators, [])
+    opts = Keyword.merge(default_opts, opts)
+
+    attrs   = Mix.Phoenix.attrs(attrs)
+    binding = Mix.Phoenix.inflect(singular)
+    path    = binding[:path]
+    route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
+    binding = binding ++ [plural: plural, route: route, attrs: attrs,
+                          binary_id: opts[:binary_id],
+                          inputs: inputs(attrs), params: Mix.Phoenix.params(attrs),
+                          template_singular: String.replace(binding[:singular], "_", " "),
+                          template_plural: String.replace(plural, "_", " ")]
+
+    Mix.shell.info("""
+
+      WARNING: mix phoenix.des.html will DELETE the following files:
+
+    """)
+
+    files = [
+      "web/controllers/#{path}_controller.ex",
+      "web/templates/#{path}/edit.html.eex",
+      "web/templates/#{path}/form.html.eex",
+      "web/templates/#{path}/index.html.eex",
+      "web/templates/#{path}/new.html.eex",
+      "web/templates/#{path}/show.html.eex",
+      "web/views/#{path}_view.ex",
+      "test/controllers/#{path}_controller_test.exs"
+    ]
+    if opts[:model] != false do
+      files = List.flatten(files, Mix.Tasks.Phoenix.Des.Model.files(path, true))
+    end
+    Enum.each(files, fn(x) -> Mix.shell.info(x) end)
+    Mix.shell.info ""
+
+    if Mix.shell.yes?("Are you sure you want these files destroyed?") do
+      Enum.each(files, fn(x) -> File.rm!(x) end)
+      instructions = """
+
+      Also, remember to remove the resource from your browser scope in web/router.ex:
+
+          resources "/#{route}", #{binding[:scoped]}Controller
+      """
+      Mix.shell.info instructions
+    else
+      Mix.shell.info "Operation canceled, no files removed."
+    end
+  end
+
+  defp validate_args!([_, plural | _] = args) do
+    cond do
+      String.contains?(plural, ":") ->
+        raise_with_help
+      plural != Phoenix.Naming.underscore(plural) ->
+        Mix.raise "expected the second argument, #{inspect plural}, to be all lowercase using snake_case convention"
+      true ->
+        args
+    end
+  end
+
+  defp validate_args!(_) do
+    raise_with_help
+  end
+
+  defp raise_with_help do
+    Mix.raise """
+    mix phoenix.des.html expects both singular and plural names
+    of the resource:
+
+        mix phoenix.des.html User users
+    """
+  end
+
+  defp inputs(attrs) do
+    Enum.map attrs, fn
+      {_, {:array, _}} ->
+        {nil, nil, nil}
+      {_, {:references, _}} ->
+        {nil, nil, nil}
+      {key, :integer}    ->
+        {label(key), ~s(<%= number_input f, #{inspect(key)}, class: "form-control" %>), error(key)}
+      {key, :float}      ->
+        {label(key), ~s(<%= number_input f, #{inspect(key)}, step: "any", class: "form-control" %>), error(key)}
+      {key, :decimal}    ->
+        {label(key), ~s(<%= number_input f, #{inspect(key)}, step: "any", class: "form-control" %>), error(key)}
+      {key, :boolean}    ->
+        {label(key), ~s(<%= checkbox f, #{inspect(key)}, class: "form-control" %>), error(key)}
+      {key, :text}       ->
+        {label(key), ~s(<%= textarea f, #{inspect(key)}, class: "form-control" %>), error(key)}
+      {key, :date}       ->
+        {label(key), ~s(<%= date_select f, #{inspect(key)}, class: "form-control" %>), error(key)}
+      {key, :time}       ->
+        {label(key), ~s(<%= time_select f, #{inspect(key)}, class: "form-control" %>), error(key)}
+      {key, :datetime}   ->
+        {label(key), ~s(<%= datetime_select f, #{inspect(key)}, class: "form-control" %>), error(key)}
+      {key, _}           ->
+        {label(key), ~s(<%= text_input f, #{inspect(key)}, class: "form-control" %>), error(key)}
+    end
+  end
+
+  defp label(key) do
+    ~s(<%= label f, #{inspect(key)}, class: "control-label" %>)
+  end
+
+  defp error(field) do
+    ~s(<%= error_tag f, #{inspect(field)} %>)
+  end
+end

--- a/lib/mix/tasks/phoenix.des.json.ex
+++ b/lib/mix/tasks/phoenix.des.json.ex
@@ -1,0 +1,113 @@
+defmodule Mix.Tasks.Phoenix.Des.Json do
+  use Mix.Task
+
+  @shortdoc "Destroys a controller and model for a JSON based resource"
+
+  @moduledoc """
+  Destroys a Phoenix resource.
+
+      mix phoenix.des.json User users name:string age:integer
+
+  The first argument is the module name followed by
+  its plural name.
+
+  The resource files destroyed include:
+
+    * a schema in web/models
+    * a view in web/views
+    * a controller in web/controllers
+    * a migration file for the repository
+    * test files for generated model and controller
+
+  To keep the model specify the `--no-model` option.
+  Read the documentation for `phoenix.des.model`
+  for more information on namespaced resources.
+  """
+  def run(args) do
+    switches = [binary_id: :boolean, model: :boolean]
+
+    {opts, parsed, _} = OptionParser.parse(args, switches: switches)
+    [singular, plural | attrs] = validate_args!(parsed)
+
+    default_opts = Application.get_env(:phoenix, :generators, [])
+    opts = Keyword.merge(default_opts, opts)
+
+    attrs   = Mix.Phoenix.attrs(attrs)
+    binding = Mix.Phoenix.inflect(singular)
+    path    = binding[:path]
+    route   = String.split(path, "/") |> Enum.drop(-1) |> Kernel.++([plural]) |> Enum.join("/")
+    binding = binding ++ [plural: plural, route: route,
+                          sample_id: sample_id(opts),
+                          attrs: attrs, params: Mix.Phoenix.params(attrs)]
+
+    Mix.shell.info("""
+
+      WARNING: mix phoenix.des.json will DELETE the following files:
+
+    """)
+
+    files = [
+      "web/controllers/#{path}_controller.ex",
+      "web/views/#{path}_view.ex",
+      "test/controllers/#{path}_controller_test.exs"
+    ] ++ changeset_view()
+    if opts[:model] != false do
+      files = List.flatten(files, Mix.Tasks.Phoenix.Des.Model.files(path, true))
+    end
+    Enum.each(files, fn(x) -> Mix.shell.info(x) end)
+    Mix.shell.info ""
+
+    if Mix.shell.yes?("Are you sure you want these files destroyed?") do
+      Enum.each(files, fn(x) -> File.rm!(x) end)
+      instructions = """
+
+      Also, remember to remove the resource from your browser scope in web/router.ex:
+
+          resources "/#{route}", #{binding[:scoped]}Controller
+      """
+      Mix.shell.info instructions
+    else
+      Mix.shell.info "Operation canceled, no files removed."
+    end
+  end
+
+  defp sample_id(opts) do
+    if Keyword.get(opts, :binary_id, false) do
+      Keyword.get(opts, :sample_binary_id, "11111111-1111-1111-1111-111111111111")
+    else
+      -1
+    end
+  end
+
+  defp changeset_view do
+    if File.exists?("web/views/changeset_view.ex") do
+      []
+    else
+      ["web/views/changeset_view.ex"]
+    end
+  end
+
+  defp validate_args!([_, plural | _] = args) do
+    cond do
+      String.contains?(plural, ":") ->
+        raise_with_help
+      plural != Phoenix.Naming.underscore(plural) ->
+        Mix.raise "Expected the second argument, #{inspect plural}, to be all lowercase using snake_case convention"
+      true ->
+        args
+    end
+  end
+
+  defp validate_args!(_) do
+    raise_with_help
+  end
+
+  defp raise_with_help do
+    Mix.raise """
+    mix phoenix.des.json expects both singular and plural names
+    of the resource:
+
+        mix phoenix.des.json User users
+    """
+  end
+end

--- a/lib/mix/tasks/phoenix.des.model.ex
+++ b/lib/mix/tasks/phoenix.des.model.ex
@@ -1,0 +1,107 @@
+defmodule Mix.Tasks.Phoenix.Des.Model do
+  use Mix.Task
+
+  @shortdoc "Destroys an Ecto model"
+
+  @moduledoc """
+  Destroys an Ecto model in your Phoenix application.
+
+      mix phoenix.des.model User
+
+  or
+
+      mix phoenix.des.model User users
+
+  The first argument is the module name (optionally followed by its plural
+  name).
+
+  The destroyed model files include:
+
+    * a model in web/models
+    * a migration file for the repository  (note: this task does not rollback the migration)
+
+  Destroying the migration can be skipped with `--no-migration`.
+
+  ## Namespaced resources
+
+  Resources can be namespaced, for such, it is just necessary
+  to namespace the first argument of the task:
+
+      mix phoenix.des.model Admin.User users
+
+  ## Default options
+
+  This task uses default options provided in the `:generators` configuration
+  of the `:phoenix` application. You can override those options providing
+  corresponding switches, e.g. `--no-migration` to force removal of the migration.
+
+  """
+  def run(args) do
+    switches = [migration: :boolean, binary_id: :boolean, instructions: :string]
+
+    {opts, parsed, _} = OptionParser.parse(args, switches: switches)
+    [singular | _] = validate_args!(parsed)
+
+    default_opts = Application.get_env(:phoenix, :generators, [])
+    opts = Keyword.merge(default_opts, opts)
+
+    binding   = Mix.Phoenix.inflect(singular)
+    path      = binding[:path]
+
+    files = files(path, opts[:migration])
+    Mix.shell.info("""
+
+      WARNING: mix phoenix.des.model will DELETE the following files:
+
+    """)
+
+    Enum.each(files, fn(x) -> Mix.shell.info(x) end)
+    Mix.shell.info " "
+
+    if Mix.shell.yes?("Are you sure you want these files destroyed?") do
+      Enum.each(files, fn(x) -> File.rm!(x) end)
+      Mix.shell.info "Files successfully removed."
+    else
+      Mix.shell.info "Operation canceled, no files removed."
+    end
+  end
+
+  def files(path, remove_migration) do
+    migration = String.replace(path, "/", "_")
+    files = [
+      "web/models/#{path}.ex",
+      "test/models/#{path}_test.exs"
+    ]
+
+    if remove_migration != false do
+      files =
+        List.flatten(Path.wildcard("priv/repo/migrations/*_create_#{migration}.exs"), files)
+    end
+    files
+  end
+
+  defp validate_args!([_, plural | _] = args) do
+    cond do
+      String.contains?(plural, ":") ->
+        raise_with_help
+      plural != Phoenix.Naming.underscore(plural) ->
+        Mix.raise "expected the second argument, #{inspect plural}, to be all lowercase using snake_case convention"
+      true ->
+        args
+    end
+  end
+  defp validate_args!(args), do: args
+
+  defp raise_with_help do
+    Mix.raise """
+    mix phoenix.des.model expects the singular name
+    of the resource:
+
+        mix phoenix.des.model User
+
+    or the singular and plural names of the resource:
+
+        mix phoenix.des.model User users
+    """
+  end
+end

--- a/test/mix/tasks/phoenix.des.html_test.exs
+++ b/test/mix/tasks/phoenix.des.html_test.exs
@@ -1,0 +1,89 @@
+Code.require_file "../../../installer/test/mix_helper.exs", __DIR__
+
+defmodule Mix.Tasks.Phoenix.Des.HtmlTest do
+  use ExUnit.Case
+  import MixHelper
+
+  setup do
+    Mix.Task.clear
+    :ok
+  end
+
+  test "destroys html resource" do
+    in_tmp "destroys html resource", fn ->
+      Mix.Tasks.Phoenix.Gen.Html.run ["user", "users", "name", "age:integer", "height:decimal",
+                                      "nicks:array:text", "famous:boolean", "born_at:datetime",
+                                      "secret:uuid", "first_login:date", "alarm:time",
+                                      "address_id:references:addresses"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Html.run ["user", "users"]
+
+      refute_file migration
+      refute_file "web/models/user.ex"
+      refute_file "test/models/user_test.exs"
+      refute_file "web/controllers/user_controller.ex"
+      refute_file "web/views/user_view.ex"
+      refute_file "web/templates/user/edit.html.eex"
+      refute_file "web/templates/user/form.html.eex"
+      refute_file "web/templates/user/index.html.eex"
+      refute_file "web/templates/user/new.html.eex"
+      refute_file "web/templates/user/show.html.eex"
+      refute_file "test/controllers/user_controller_test.exs"
+    end
+  end
+
+  test "destroys nested resource" do
+    in_tmp "destroys nested resource", fn ->
+      Mix.Tasks.Phoenix.Gen.Html.run ["Admin.SuperUser", "super_users", "name:string"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_admin_super_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Html.run ["Admin.SuperUser", "super_users", "name:string"]
+
+      refute_file migration
+      refute_file "web/models/admin/super_user.ex"
+      refute_file "web/controllers/admin/super_user_controller.ex"
+      refute_file "web/views/admin/super_user_view.ex"
+      refute_file "web/templates/admin/super_user/edit.html.eex"
+      refute_file "web/templates/admin/super_user/form.html.eex"
+      refute_file "web/templates/admin/super_user/index.html.eex"
+      refute_file "web/templates/admin/super_user/new.html.eex"
+      refute_file "web/templates/admin/super_user/show.html.eex"
+      refute_file "test/controllers/admin/super_user_controller_test.exs"
+    end
+  end
+
+  test "destroys html resource without model" do
+    in_tmp "destroys html resource without model", fn ->
+      Mix.Tasks.Phoenix.Gen.Html.run ["Admin.User", "users", "name:string"]
+
+      assert_file "web/models/admin/user.ex"
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Html.run ["Admin.User", "users", "--no-model"]
+
+      assert_file "web/models/admin/user.ex"
+      refute_file "web/templates/admin/user/form.html.eex"
+    end
+  end
+
+  test "plural can't contain a colon" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Des.Html.run ["Admin.User", "name:string", "foo:string"]
+    end
+  end
+
+  test "plural can't have uppercased characters or camelized format" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Des.Html.run ["Admin.User", "Users", "foo:string"]
+    end
+
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Des.Html.run ["Admin.User", "AdminUsers", "foo:string"]
+    end
+  end
+end

--- a/test/mix/tasks/phoenix.des.json_test.exs
+++ b/test/mix/tasks/phoenix.des.json_test.exs
@@ -1,0 +1,79 @@
+Code.require_file "../../../installer/test/mix_helper.exs", __DIR__
+
+defmodule Mix.Tasks.Phoenix.Des.JsonTest do
+  use ExUnit.Case
+  import MixHelper
+
+  setup do
+    Mix.Task.clear
+    :ok
+  end
+
+  test "destroys json resource" do
+    in_tmp "destroys json resource", fn ->
+      Mix.Tasks.Phoenix.Gen.Json.run ["user", "users", "name", "age:integer", "height:decimal",
+                                      "nicks:array:text", "famous:boolean", "born_at:datetime",
+                                      "secret:uuid", "first_login:date", "alarm:time"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Json.run ["user", "users"]
+
+      refute_file migration
+      refute_file "web/models/user.ex"
+      refute_file "test/models/user_test.exs"
+      refute_file "web/controllers/user_controller.ex"
+      refute_file "web/views/user_view.ex"
+      refute_file "test/controllers/user_controller_test.exs"
+    end
+  end
+
+  test "destroys nested resource" do
+    in_tmp "destroys nested resource", fn ->
+      Mix.Tasks.Phoenix.Gen.Json.run ["Admin.User", "users", "name:string"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_admin_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Json.run ["Admin.User", "users"]
+
+      refute_file migration
+      refute_file "web/models/admin/user.ex"
+      refute_file "web/controllers/admin/user_controller.ex"
+      refute_file "web/views/admin/user_view.ex"
+    end
+  end
+
+  test "skips model destruction if asked" do
+    in_tmp "skips model destruction if asked", fn ->
+      Mix.Tasks.Phoenix.Gen.Json.run ["API.V1.User", "users", "name:string"]
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_api_v1_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Json.run ["API.V1.User", "users", "--no-model"]
+
+      assert_file migration
+      assert_file "web/models/api/v1/user.ex"
+
+      refute_file "web/controllers/api/v1/user_controller.ex"
+      refute_file "web/views/api/v1/user_view.ex"
+    end
+  end
+
+  test "plural can't contain a colon" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Gen.Json.run ["Admin.User", "name:string", "foo:string"]
+    end
+  end
+
+  test "plural can't have uppercased characters or camelized format" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Gen.Html.run ["Admin.User", "Users", "foo:string"]
+    end
+
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Gen.Html.run ["Admin.User", "AdminUsers", "foo:string"]
+    end
+  end
+end

--- a/test/mix/tasks/phoenix.des.model_test.exs
+++ b/test/mix/tasks/phoenix.des.model_test.exs
@@ -1,0 +1,155 @@
+Code.require_file "../../../installer/test/mix_helper.exs", __DIR__
+
+defmodule Mix.Tasks.Phoenix.Des.ModelTest do
+  use ExUnit.Case
+  import MixHelper
+
+  setup do
+    Mix.Task.clear
+    :ok
+  end
+
+  test "destroys model" do
+    in_tmp "destroys model", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["user", "users", "name", "age:integer", "nicks:array:text",
+                                       "famous:boolean", "born_at:datetime", "secret:uuid", "desc:text",
+                                       "blob:binary"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Model.run ["user", "users"]
+
+      refute_file migration
+      refute_file "web/models/user.ex"
+      refute_file "test/models/user_test.exs"
+    end
+  end
+
+  test "does not destroy model in prompt declined" do
+    in_tmp "destroys model", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["user", "users", "name", "age:integer", "nicks:array:text",
+                                       "famous:boolean", "born_at:datetime", "secret:uuid", "desc:text",
+                                       "blob:binary"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, false}
+      Mix.Tasks.Phoenix.Des.Model.run ["user", "users"]
+
+      assert_file migration
+      assert_file "web/models/user.ex"
+      assert_file "test/models/user_test.exs"
+    end
+  end
+
+  test "destroys nested model" do
+    in_tmp "destroys nested model", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Admin.User", "users", "name:string"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_admin_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Model.run ["Admin.User", "users"]
+
+      refute_file migration
+      refute_file "web/models/admin/user.ex"
+    end
+  end
+
+  test "destroys model with details" do
+    in_tmp "destroys model with details", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Admin.User", "users", "name:string"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_admin_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Model.run ["Admin.User", "users", "name:string"]
+
+      refute_file migration
+      refute_file "web/models/admin/user.ex"
+    end
+  end
+
+  test "destroys model with only singular arg" do
+    in_tmp "destroys model with only singular arg", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Admin.User", "users", "name:string"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_admin_user.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Model.run ["Admin.User"]
+
+      refute_file migration
+      refute_file "web/models/admin/user.ex"
+    end
+  end
+
+  test "skips destroying migration with --no-migration option" do
+    in_tmp "skips destroying migration with -no-migration option", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Model.run ["Post", "posts", "--no-migration"]
+
+      assert_file migration
+    end
+  end
+
+  test "destroys model even if migration missing" do
+    in_tmp "destroys model even if migration missing", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts", "--no-migration"]
+
+      assert [] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
+      assert_file "web/models/post.ex"
+
+      send self(), {:mix_shell_input, :yes?, true}
+      Mix.Tasks.Phoenix.Des.Model.run ["Post", "posts"]
+
+      refute_file "web/models/post.ex"
+    end
+  end
+
+  test "uses defaults from :generators configuration for destroying" do
+    in_tmp "uses defaults from generators configuration (migration) for destroying", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
+
+      with_generators_config [migration: false], fn ->
+        send self(), {:mix_shell_input, :yes?, true}
+        Mix.Tasks.Phoenix.Des.Model.run ["Post", "posts"]
+
+        assert_file migration
+      end
+    end
+  end
+
+  test "plural can't contain a colon" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Des.Model.run ["Admin.User", "name:string", "foo:string"]
+    end
+  end
+
+  test "plural can't have uppercased characters or camelized format" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Des.Html.run ["Admin.User", "Users", "foo:string"]
+    end
+
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.Des.Html.run ["Admin.User", "AdminUsers", "foo:string"]
+    end
+  end
+
+  defp with_generators_config(config, fun) do
+    old_value = Application.get_env(:phoenix, :generators, [])
+    try do
+      Application.put_env(:phoenix, :generators, config)
+      fun.()
+    after
+      Application.put_env(:phoenix, :generators, old_value)
+    end
+  end
+end


### PR DESCRIPTION
Possible solution to issue #1597 

These "anti-generators" remove the files created by `phoenix.gen.json`, `phoenix.gen.html`, and `phoenix.gen.model`.