### PR TITLE
conntest: include body in json_response errors

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -354,7 +354,7 @@ defmodule Phoenix.ConnTest do
     if given == status do
       body
     else
-      raise "expected response with status #{given}, got: #{status}"
+      raise "expected response with status #{given}, got: #{status}, with body:\n#{body}"
     end
   end
 

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -200,7 +200,7 @@ defmodule Phoenix.Test.ConnTest do
     end
 
     assert_raise RuntimeError,
-                 "expected response with status 200, got: 404", fn ->
+                 "expected response with status 200, got: 404, with body:\noops", fn ->
       build_conn(:get, "/") |> resp(404, "oops") |> response(200)
     end
   end
@@ -240,6 +240,13 @@ defmodule Phoenix.Test.ConnTest do
                  "could not decode JSON body, invalid token \"o\" in body:\n\nok", fn ->
       build_conn(:get, "/") |> put_resp_content_type("application/json")
                       |> resp(200, "ok") |> json_response(200)
+    end
+
+    assert_raise RuntimeError, ~s(expected response with status 200, got: 400, with body:\n{"error": "oh oh"}), fn ->
+      build_conn(:get, "/")
+      |> put_resp_content_type("application/json")
+      |> resp(400, ~s({"error": "oh oh"}))
+      |> json_response(200)
     end
   end
 


### PR DESCRIPTION
(or text_response errors)

What should it do if the body isn't a string or is really long?

~~also, it currently shows the JSON unparsed. maybe not the best~~

ref: https://groups.google.com/forum/#!topic/phoenix-talk/Y5g6cqkPk0o