### PR TITLE
Allow subscribe to multiple topics within the same channel

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -291,6 +291,7 @@ defmodule Phoenix.Channel do
       fastlane: {socket.transport_pid,
                  socket.serializer,
                  socket.channel.__intercepts__()})
+    Phoenix.Channel.Server.push socket.transport_pid, socket.topic, "phx_subscribe", %{topic: topic}, socket.serializer
   end
 
   @doc """
@@ -298,6 +299,7 @@ defmodule Phoenix.Channel do
   """
   def unsubscribe(topic, socket) do
     Phoenix.PubSub.unsubscribe(socket.pubsub_server, self(), topic)
+    Phoenix.Channel.Server.push socket.transport_pid, socket.topic, "phx_unsubscribe", %{topic: topic}, socket.serializer
   end
 
 

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -282,6 +282,26 @@ defmodule Phoenix.Channel do
   end
 
   @doc """
+  Subscribe this channel to another topic, so it will receive broadcasts with
+  that particular topic
+  """
+  def subscribe(topic, socket) do
+    Phoenix.PubSub.subscribe(socket.pubsub_server, self(), topic,
+      link: true,
+      fastlane: {socket.transport_pid,
+                 socket.serializer,
+                 socket.channel.__intercepts__()})
+  end
+
+  @doc """
+  Unsubscribe from a topic
+  """
+  def unsubscribe(topic, socket) do
+    Phoenix.PubSub.unsubscribe(socket.pubsub_server, self(), topic)
+  end
+
+
+  @doc """
   Broadcast an event to all subscribers of the socket topic.
 
   The event's message must be a serializable map.
@@ -303,6 +323,25 @@ defmodule Phoenix.Channel do
   def broadcast!(socket, event, message) do
     %{pubsub_server: pubsub_server, topic: topic} = assert_joined!(socket)
     Server.broadcast! pubsub_server, topic, event, message
+  end
+
+  @doc """
+  Broadcast a message to another topic
+
+  ### Examples
+
+      iex> broadcast socket, "other_topic", "new_message", %{id: 1, content: "hello"}
+      :ok
+  """
+  def broadcast(socket, topic, event, message) do
+    Phoenix.Channel.Server.broadcast socket.pubsub_server, topic, event, message
+  end
+
+  @doc """
+  Same as `broadcast/4` but raises if broadcast fails.
+  """
+  def broadcast!(socket, topic, event, message) do
+    Phoenix.Channel.Server.broadcast! socket.pubsub_server, topic, event, message
   end
 
   @doc """

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -114,7 +114,8 @@ defmodule Phoenix.Channel.ChannelTest do
       use Phoenix.Channel
     end
     Phoenix.PubSub.subscribe(@pubsub, self, "sometopic")
-    socket = %Phoenix.Socket{pubsub_server: @pubsub, topic: "sometopic",
+    socket = %Phoenix.Socket{serializer: Phoenix.ChannelTest.NoopSerializer,
+                             transport_pid: self(), pubsub_server: @pubsub, topic: "sometopic",
                              channel_pid: self(), channel: Channel, joined: true}
 
     subscribe("othertopic", socket)

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -116,9 +116,11 @@ defmodule Phoenix.Channel.ChannelTest do
     Phoenix.PubSub.subscribe(@pubsub, self, "sometopic")
     socket = %Phoenix.Socket{pubsub_server: @pubsub, topic: "sometopic",
                              channel_pid: self(), channel: Channel, joined: true}
+
     subscribe("othertopic", socket)
     broadcast socket, "othertopic", "event", %{key: :val}
     assert_receive %Phoenix.Socket.Broadcast{topic: "othertopic", event: "event", payload: %{key: :val}}
+
     unsubscribe("othertopic", socket)
     refute_receive %Phoenix.Socket.Broadcast{topic: "othertopic", event: "event", payload: %{key: :val}}
   end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -108,4 +108,18 @@ defmodule Phoenix.Channel.ChannelTest do
       socket_ref(%Phoenix.Socket{joined: true})
     end
   end
+
+  test "subscribe to other topic" do
+    defmodule Channel do
+      use Phoenix.Channel
+    end
+    Phoenix.PubSub.subscribe(@pubsub, self, "sometopic")
+    socket = %Phoenix.Socket{pubsub_server: @pubsub, topic: "sometopic",
+                             channel_pid: self(), channel: Channel, joined: true}
+    subscribe("othertopic", socket)
+    broadcast socket, "othertopic", "event", %{key: :val}
+    assert_receive %Phoenix.Socket.Broadcast{topic: "othertopic", event: "event", payload: %{key: :val}}
+    unsubscribe("othertopic", socket)
+    refute_receive %Phoenix.Socket.Broadcast{topic: "othertopic", event: "event", payload: %{key: :val}}
+  end
 end


### PR DESCRIPTION
This will add the capability of:

- Broadcasting to other topics
- Subscribing to other topics within the same channel
- Unsubscribing to these topics

In some applications it can be helpful to do more targeted pubsub within the same channel. There are several advantages:

- Simplifies the client logic (we do not have to join and manage so many channels).
- We can use the same callbacks, if we have differently scoped channels that are receiving the same messages
- The server does not need to have a running process for each topic

I found this capability very helpful in a larger application that does all communications through channels.

I am quite new to Elixir, so pardon my code :). I also think the test can perhaps be more elegant.