### PR TITLE
Document dispatch behaviour for struct params

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -202,6 +202,9 @@ defmodule Phoenix.ConnTest do
       set the content-type to multipart. The map or list may contain
       other lists or maps and all entries will be normalized to string
       keys
+
+    * a struct - unlike other maps, a struct will be passed through as-is
+      without normalizing its entries
   """
   def dispatch(conn, endpoint, method, path_or_action, params_or_body \\ nil)
   def dispatch(%Plug.Conn{} = conn, endpoint, method, path_or_action, params_or_body) do


### PR DESCRIPTION
Took me a little bit to debug what was going wrong with my tests where I was being lazy and passing a model as a param. Ended up finding that the Plug test adapter does not normalize structs, and thought that documenting that in Phoenix might be useful for others who run into the situation.