### PR TITLE
Fix regex to match urls in compressed stylesheets

### DIFF
--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -112,7 +112,7 @@ defmodule Phoenix.Digester do
     end
   end
 
-  @stylesheet_url_regex ~r{(url\(\s*)(\S+)(\s*\))}
+  @stylesheet_url_regex ~r{(url\(\s*)(\S+?)(\s*\))}
   @quoted_text_regex ~r{\A(['"])(.+)\1\z}
 
   defp digest_asset_references(file, manifest) do

--- a/test/fixtures/digest/priv/static/css/app.css
+++ b/test/fixtures/digest/priv/static/css/app.css
@@ -10,4 +10,6 @@
   background-image: url(http://www.phoenixframework.org/absolute.png);
 }
 
-.absolute_path_logo{background-image:url(/phoenix.png)}.relative_path_logo{background-image:url(../images/relative.png)}.absolute_url_logo{background-image:url(http://www.phoenixframework.org/absolute.png)}
+.absolute_path_logo{background-image:url(/phoenix.png)}
+.relative_path_logo{background-image:url(../images/relative.png)}
+.absolute_url_logo{background-image:url(http://www.phoenixframework.org/absolute.png)}

--- a/test/fixtures/digest/priv/static/css/app.css
+++ b/test/fixtures/digest/priv/static/css/app.css
@@ -9,3 +9,5 @@
 .absolute_url_logo {
   background-image: url(http://www.phoenixframework.org/absolute.png);
 }
+
+.absolute_path_logo{background-image:url(/phoenix.png)}.relative_path_logo{background-image:url(../images/relative.png)}.absolute_url_logo{background-image:url(http://www.phoenixframework.org/absolute.png)}


### PR DESCRIPTION
This PR fixes the regex to match urls in compressed stylesheets generated by brunch or webpack, otherwise stylesheets will reference non-digested versions of assets