### PR TITLE
Resolve join/leave race conditions from the client. Closes #1485

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -212,13 +212,6 @@ defmodule Phoenix.Channel.Server do
     handle_result({:stop, {:shutdown, :closed}, socket}, :handle_in)
   end
 
-  @doc false
-  def handle_info(%Message{topic: topic, event: "phx_join"}, %{topic: topic} = socket) do
-    Logger.info fn -> "#{inspect socket.channel} received join event with topic \"#{topic}\" but channel already joined" end
-
-    handle_result({:reply, {:error, %{reason: "already joined"}}, socket}, :handle_in)
-  end
-
   def handle_info(%Message{topic: topic, event: "phx_leave", ref: ref}, %{topic: topic} = socket) do
     handle_result({:stop, {:shutdown, :left}, :ok, put_in(socket.ref, ref)}, :handle_in)
   end

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -68,7 +68,7 @@ defmodule Phoenix.Socket.Transport do
   must trap exists and correctly handle the `{:EXIT, _, _}` messages
   arriving from channels, relaying the proper response to the client.
 
-  The function `on_exit_message/2` should aid with that.
+  The function `on_exit_message/3` should aid with that.
 
   ## Security
 
@@ -237,6 +237,13 @@ defmodule Phoenix.Socket.Transport do
     end
   end
 
+  defp do_dispatch(pid, %{event: "phx_join"} = msg, socket) when is_pid(pid) do
+    Logger.debug "Duplicate channel join for topic \"#{msg.topic}\" in #{inspect(socket.handler)}. " <>
+                 "Closing existing channel for new join."
+    :ok = Phoenix.Channel.Server.close(pid)
+    do_dispatch(nil, msg, socket)
+  end
+
   defp do_dispatch(nil, msg, socket) do
     reply_ignore(msg, socket)
   end
@@ -258,12 +265,17 @@ defmodule Phoenix.Socket.Transport do
   @doc """
   Returns the message to be relayed when a channel exists.
   """
+  # TODO remove 2-arity on next major release
   def on_exit_message(topic, reason) do
+    IO.write :stderr, "Phoenix.Transport.on_exit_message/2 is deprecated. Use on_exit_message/3 instead."
+    on_exit_message(topic, nil, reason)
+  end
+  def on_exit_message(topic, join_ref, reason) do
     case reason do
-      :normal        -> %Message{topic: topic, event: "phx_close", payload: %{}}
-      :shutdown      -> %Message{topic: topic, event: "phx_close", payload: %{}}
-      {:shutdown, _} -> %Message{topic: topic, event: "phx_close", payload: %{}}
-      _              -> %Message{topic: topic, event: "phx_error", payload: %{}}
+      :normal        -> %Message{ref: join_ref, topic: topic, event: "phx_close", payload: %{}}
+      :shutdown      -> %Message{ref: join_ref, topic: topic, event: "phx_close", payload: %{}}
+      {:shutdown, _} -> %Message{ref: join_ref, topic: topic, event: "phx_close", payload: %{}}
+      _              -> %Message{ref: join_ref, topic: topic, event: "phx_error", payload: %{}}
     end
   end
 

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -111,7 +111,7 @@ defmodule Phoenix.Transports.WebSocket do
       {:reply, reply_msg} ->
         encode_reply(reply_msg, state)
       {:joined, channel_pid, reply_msg} ->
-        encode_reply(reply_msg, put(state, msg.topic, channel_pid))
+        encode_reply(reply_msg, put(state, msg.topic, msg.ref, channel_pid))
       {:error, _reason, error_reply_msg} ->
         encode_reply(error_reply_msg, state)
     end
@@ -121,9 +121,9 @@ defmodule Phoenix.Transports.WebSocket do
   def ws_info({:EXIT, channel_pid, reason}, state) do
     case Map.get(state.channels_inverse, channel_pid) do
       nil   -> {:ok, state}
-      topic ->
+      {topic, join_ref} ->
         new_state = delete(state, topic, channel_pid)
-        encode_reply Transport.on_exit_message(topic, reason), new_state
+        encode_reply Transport.on_exit_message(topic, join_ref, reason), new_state
     end
   end
 
@@ -152,14 +152,19 @@ defmodule Phoenix.Transports.WebSocket do
     end
   end
 
-  defp put(state, topic, channel_pid) do
+  defp put(state, topic, join_ref, channel_pid) do
     %{state | channels: Map.put(state.channels, topic, channel_pid),
-              channels_inverse: Map.put(state.channels_inverse, channel_pid, topic)}
+              channels_inverse: Map.put(state.channels_inverse, channel_pid, {topic, join_ref})}
   end
 
   defp delete(state, topic, channel_pid) do
-    %{state | channels: Map.delete(state.channels, topic),
-              channels_inverse: Map.delete(state.channels_inverse, channel_pid)}
+    case Map.fetch(state.channels, topic) do
+      {:ok, ^channel_pid} ->
+        %{state | channels: Map.delete(state.channels, topic),
+                  channels_inverse: Map.delete(state.channels_inverse, channel_pid)}
+      {:ok, _newer_pid} ->
+        %{state | channels_inverse: Map.delete(state.channels_inverse, channel_pid)}
+    end
   end
 
   defp encode_reply(reply, state) do

--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -1,15 +1,15 @@
 (function(exports){
 "use strict";
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
-
-function _typeof(obj) { return obj && typeof Symbol !== "undefined" && obj.constructor === Symbol ? "symbol" : typeof obj; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -179,7 +179,8 @@ var CHANNEL_STATES = {
   closed: "closed",
   errored: "errored",
   joined: "joined",
-  joining: "joining"
+  joining: "joining",
+  leaving: "leaving"
 };
 var CHANNEL_EVENTS = {
   close: "phx_close",
@@ -193,7 +194,7 @@ var TRANSPORTS = {
   websocket: "websocket"
 };
 
-var Push = (function () {
+var Push = function () {
 
   // Initializes the Push
   //
@@ -317,9 +318,9 @@ var Push = (function () {
   }]);
 
   return Push;
-})();
+}();
 
-var Channel = exports.Channel = (function () {
+var Channel = exports.Channel = function () {
   function Channel(topic, params, socket) {
     var _this2 = this;
 
@@ -346,7 +347,7 @@ var Channel = exports.Channel = (function () {
       _this2.pushBuffer = [];
     });
     this.onClose(function () {
-      _this2.socket.log("channel", "close " + _this2.topic);
+      _this2.socket.log("channel", "close " + _this2.topic + " " + _this2.joinRef());
       _this2.state = CHANNEL_STATES.closed;
       _this2.socket.remove(_this2);
     });
@@ -386,9 +387,9 @@ var Channel = exports.Channel = (function () {
         throw "tried to join multiple times. 'join' can only be called a single time per channel instance";
       } else {
         this.joinedOnce = true;
+        this.rejoin(timeout);
+        return this.joinPush;
       }
-      this.rejoin(timeout);
-      return this.joinPush;
     }
   }, {
     key: "onClose",
@@ -458,9 +459,10 @@ var Channel = exports.Channel = (function () {
 
       var timeout = arguments.length <= 0 || arguments[0] === undefined ? this.timeout : arguments[0];
 
+      this.state = CHANNEL_STATES.leaving;
       var onClose = function onClose() {
         _this3.socket.log("channel", "leave " + _this3.topic);
-        _this3.trigger(CHANNEL_EVENTS.close, "leave");
+        _this3.trigger(CHANNEL_EVENTS.close, "leave", _this3.joinRef());
       };
       var leavePush = new Push(this, CHANNEL_EVENTS.leave, {}, timeout);
       leavePush.receive("ok", function () {
@@ -492,6 +494,11 @@ var Channel = exports.Channel = (function () {
       return this.topic === topic;
     }
   }, {
+    key: "joinRef",
+    value: function joinRef() {
+      return this.joinPush.ref;
+    }
+  }, {
     key: "sendJoin",
     value: function sendJoin(timeout) {
       this.state = CHANNEL_STATES.joining;
@@ -501,14 +508,25 @@ var Channel = exports.Channel = (function () {
     key: "rejoin",
     value: function rejoin() {
       var timeout = arguments.length <= 0 || arguments[0] === undefined ? this.timeout : arguments[0];
+      if (this.state === CHANNEL_STATES.leaving) {
+        return;
+      }
       this.sendJoin(timeout);
     }
   }, {
     key: "trigger",
-    value: function trigger(triggerEvent, payload, ref) {
-      this.onMessage(triggerEvent, payload, ref);
+    value: function trigger(event, payload, ref) {
+      var close = CHANNEL_EVENTS.close;
+      var error = CHANNEL_EVENTS.error;
+      var leave = CHANNEL_EVENTS.leave;
+      var join = CHANNEL_EVENTS.join;
+
+      if (ref && [close, error, leave, join].indexOf(event) >= 0 && ref !== this.joinRef()) {
+        return;
+      }
+      this.onMessage(event, payload, ref);
       this.bindings.filter(function (bind) {
-        return bind.event === triggerEvent;
+        return bind.event === event;
       }).map(function (bind) {
         return bind.callback(payload, ref);
       });
@@ -521,9 +539,9 @@ var Channel = exports.Channel = (function () {
   }]);
 
   return Channel;
-})();
+}();
 
-var Socket = exports.Socket = (function () {
+var Socket = exports.Socket = function () {
 
   // Initializes the Socket
   //
@@ -749,7 +767,7 @@ var Socket = exports.Socket = (function () {
     key: "remove",
     value: function remove(channel) {
       this.channels = this.channels.filter(function (c) {
-        return !c.isMember(channel.topic);
+        return c.joinRef() !== channel.joinRef();
       });
     }
   }, {
@@ -836,9 +854,9 @@ var Socket = exports.Socket = (function () {
   }]);
 
   return Socket;
-})();
+}();
 
-var LongPoll = exports.LongPoll = (function () {
+var LongPoll = exports.LongPoll = function () {
   function LongPoll(endPoint) {
     _classCallCheck(this, LongPoll);
 
@@ -943,9 +961,9 @@ var LongPoll = exports.LongPoll = (function () {
   }]);
 
   return LongPoll;
-})();
+}();
 
-var Ajax = exports.Ajax = (function () {
+var Ajax = exports.Ajax = function () {
   function Ajax() {
     _classCallCheck(this, Ajax);
   }
@@ -1041,7 +1059,7 @@ var Ajax = exports.Ajax = (function () {
   }]);
 
   return Ajax;
-})();
+}();
 
 Ajax.states = { complete: 4 };
 
@@ -1093,10 +1111,10 @@ var Presence = exports.Presence = {
     var leaves = _ref2.leaves;
 
     if (!onJoin) {
-      onJoin = function () {};
+      onJoin = function onJoin() {};
     }
     if (!onLeave) {
-      onLeave = function () {};
+      onLeave = function onLeave() {};
     }
 
     this.map(joins, function (key, newPresence) {
@@ -1128,7 +1146,7 @@ var Presence = exports.Presence = {
   },
   list: function list(presences, chooser) {
     if (!chooser) {
-      chooser = function (key, pres) {
+      chooser = function chooser(key, pres) {
         return pres;
       };
     }
@@ -1164,7 +1182,7 @@ var Presence = exports.Presence = {
 //    reconnectTimer.scheduleTimeout() // fires after 1000
 //
 
-var Timer = (function () {
+var Timer = function () {
   function Timer(callback, timerCalc) {
     _classCallCheck(this, Timer);
 
@@ -1198,7 +1216,7 @@ var Timer = (function () {
   }]);
 
   return Timer;
-})();
+}();
 
 
 })(typeof(exports) === "undefined" ? window.Phoenix = window.Phoenix || {} : exports);

--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -61,6 +61,15 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 // Successful joins receive an "ok" status, while unsuccessful joins
 // receive "error".
 //
+// ## Duplicate Join Subscriptions
+//
+// While the client may join any number of topics on any number of channels,
+// the client may only hold a single subcription for each unique topic at any
+// given time. When attempting to create a duplicate subscription,
+// the server will close the existing channel, log a warning, and
+// spawn a new channel for the topic. The client will have their
+// `channel.onClose` callbacks fired for the existing channel, and the new
+// channel join will have its receive hooks processed as normal.
 //
 // ## Pushing Messages
 //

--- a/test/phoenix/integration/long_poll_test.exs
+++ b/test/phoenix/integration/long_poll_test.exs
@@ -328,7 +328,7 @@ defmodule Phoenix.Integration.LongPollTest do
     [_phx_reply, _joined, _user_entered, _you_left_msg, chan_error] = resp.body["messages"]
 
     assert chan_error ==
-      %{"event" => "phx_error", "payload" => %{}, "topic" => "rooms:lobby", "ref" => nil}
+      %{"event" => "phx_error", "payload" => %{}, "topic" => "rooms:lobby", "ref" => "123"}
   end
 
   test "sends phx_close if a channel server normally exits" do
@@ -348,7 +348,7 @@ defmodule Phoenix.Integration.LongPollTest do
     [_phx_reply, _joined, _user_entered, _leave_reply, _you_left_msg, phx_close] = resp.body["messages"]
 
     assert phx_close ==
-      %{"event" => "phx_close", "payload" => %{}, "ref" => nil, "topic" => "rooms:lobby"}
+      %{"event" => "phx_close", "payload" => %{}, "ref" => "123", "topic" => "rooms:lobby"}
   end
 
   test "shuts down when receiving disconnect broadcasts on socket's id" do

--- a/test/phoenix/transports/transport_test.exs
+++ b/test/phoenix/transports/transport_test.exs
@@ -25,15 +25,15 @@ defmodule Phoenix.Transports.TransportTest do
 
   ## on_exit_message
 
-  test "on_exit_message/2" do
-    assert Transport.on_exit_message("foo", :normal) ==
-           %Message{event: "phx_close", payload: %{}, topic: "foo"}
-    assert Transport.on_exit_message("foo", :shutdown) ==
-           %Message{event: "phx_close", payload: %{}, topic: "foo"}
-    assert Transport.on_exit_message("foo", {:shutdown, :whatever}) ==
-           %Message{event: "phx_close", payload: %{}, topic: "foo"}
-    assert Transport.on_exit_message("foo", :oops) ==
-           %Message{event: "phx_error", payload: %{}, topic: "foo"}
+  test "on_exit_message/3" do
+    assert Transport.on_exit_message("foo", "1", :normal) ==
+           %Message{ref: "1", event: "phx_close", payload: %{}, topic: "foo"}
+    assert Transport.on_exit_message("foo", "1", :shutdown) ==
+           %Message{ref: "1", event: "phx_close", payload: %{}, topic: "foo"}
+    assert Transport.on_exit_message("foo", "1", {:shutdown, :whatever}) ==
+           %Message{ref: "1", event: "phx_close", payload: %{}, topic: "foo"}
+    assert Transport.on_exit_message("foo", "1", :oops) ==
+           %Message{ref: "1", event: "phx_error", payload: %{}, topic: "foo"}
   end
 
   ## Check origin

--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -46,6 +46,15 @@
 // Successful joins receive an "ok" status, while unsuccessful joins
 // receive "error".
 //
+// ## Duplicate Join Subscriptions
+//
+// While the client may join any number of topics on any number of channels,
+// the client may only hold a single subcription for each unique topic at any
+// given time. When attempting to create a duplicate subscription,
+// the server will close the existing channel, log a warning, and
+// spawn a new channel for the topic. The client will have their
+// `channel.onClose` callbacks fired for the existing channel, and the new
+// channel join will have its receive hooks processed as normal.
 //
 // ## Pushing Messages
 //


### PR DESCRIPTION
- Transport store join ref with channel pid and relay when channel closes/errors.
- Transport closes existing channel if client races a duplicate join.
- Last join wins and client properly filters channels specific phx_close/phx_error events.

@josevalim if you have time I could use a review here since it will effect @sasa1977's recent work.