### PR TITLE
Fix typos in Phoenix.Presence example docs

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -43,11 +43,11 @@ defmodule Phoenix.Presence do
         end
 
         def handle_info(:after_join, socket) do
-          :ok = Presence.track(socket, socket.assigns.user_id, %{
+          {:ok, _} = Presence.track(socket, socket.assigns.user_id, %{
             online_at: inspect(:os.timestamp())
           })
           push socket, "presence_state", Presence.list(socket)
-          {:noreply, state}
+          {:noreply, socket}
         end
       end
 

--- a/priv/templates/phoenix.gen.presence/presence.ex
+++ b/priv/templates/phoenix.gen.presence/presence.ex
@@ -19,11 +19,11 @@ defmodule <%= module %> do
         end
 
         def handle_info(:after_join, socket) do
-          :ok = Presence.track(socket, socket.assigns.user_id, %{
+          {:ok, _} = Presence.track(socket, socket.assigns.user_id, %{
             online_at: inspect(:os.timestamp())
           })
           push socket, "presence_state", Presence.list(socket)
-          {:noreply, state}
+          {:noreply, socket}
         end
       end
 


### PR DESCRIPTION
The Phoenix.Presence examples in both the source and the generated file use `state` instead of `socket`, and also return a tuple instead of simply `:ok` as stated. This corrects all four instances.