### PR TITLE
Fix the brunch configuration documentation link

### DIFF
--- a/installer/templates/static/brunch/brunch-config.js
+++ b/installer/templates/static/brunch/brunch-config.js
@@ -5,7 +5,7 @@ exports.config = {
       joinTo: "js/app.js"
 
       // To use a separate vendor.js bundle, specify two files path
-      // https://github.com/brunch/brunch/blob/stable/docs/config.md#files
+      // https://github.com/brunch/brunch/blob/master/docs/config.md#files
       // joinTo: {
       //  "js/app.js": /^(web\/static\/js)/,
       //  "js/vendor.js": /^(web\/static\/vendor)|(deps)/


### PR DESCRIPTION
It was pointing to `stable` and 404'ing on GitHub. Switching it to
master fixes it.