### PR TITLE
Fix placement of period within quotes in static cache manifest warning.

### DIFF
--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -258,7 +258,7 @@ defmodule Phoenix.Endpoint.Adapter do
       else
         Logger.error "Could not find static manifest at #{inspect outer}. " <>
                      "Run \"mix phoenix.digest\" after building your static files " <>
-                     "or remove the configuration from \"config/prod.exs.\""
+                     "or remove the configuration from \"config/prod.exs\"."
       end
     else
       %{}


### PR DESCRIPTION
This may seem a bit pedantic, but it's potentially confusing because the current warning message looks like the period is part of the file name.