### PR TITLE
Add clickable link to server info

### DIFF
--- a/lib/phoenix/endpoint/cowboy_handler.ex
+++ b/lib/phoenix/endpoint/cowboy_handler.ex
@@ -112,6 +112,6 @@ defmodule Phoenix.Endpoint.CowboyHandler do
 
   defp info(scheme, endpoint, ref) do
     port = :ranch.get_port(ref)
-    "Running #{inspect endpoint} with Cowboy using #{scheme} on port #{port}"
+    "Running #{inspect endpoint} with Cowboy using #{scheme} on http://localhost:#{port}"
   end
 end

--- a/lib/phoenix/endpoint/cowboy_handler.ex
+++ b/lib/phoenix/endpoint/cowboy_handler.ex
@@ -112,6 +112,6 @@ defmodule Phoenix.Endpoint.CowboyHandler do
 
   defp info(scheme, endpoint, ref) do
     port = :ranch.get_port(ref)
-    "Running #{inspect endpoint} with Cowboy using #{scheme} on http://localhost:#{port}"
+    "Running #{inspect endpoint} with Cowboy using #{scheme}://localhost:#{port}"
   end
 end


### PR DESCRIPTION
This PR changes the message displayed by running `mix phoenix.server` to include a clickable link. For example, it'd be:

`Running Hello.Endpoint with Cowboy on http://localhost:4000`

Thought this would be a nice feature—let me know what you think. I might've missed some stuff like other domains. Thanks!