### PR TITLE
Support reading the host from the environment at runtime

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -133,6 +133,10 @@ defmodule Phoenix.Endpoint do
       as a workaround for releases where environment specific information
       is loaded only at compile-time.
 
+      The `:host` option requires a string or {:system, "ENV_VAR"}`. Similar
+      to `:port`, when given a tuple like `{:system, "HOST"}`, the host
+      will be referenced from `System.get_env("HOST")` at runtime.
+
     * `:static_url` - configuration for generating URLs for static files.
       It will fallback to `url` if no option is provided. Accepts the same
       options as `url`.

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -198,7 +198,7 @@ defmodule Phoenix.Endpoint.Adapter do
       end
 
     scheme = url[:scheme] || scheme
-    host   = url[:host]
+    host   = host_to_binary(url[:host])
     port   = port_to_integer(url[:port] || port)
 
     %URI{scheme: scheme, port: port, host: host}
@@ -220,6 +220,9 @@ defmodule Phoenix.Endpoint.Adapter do
   def static_path(_endpoint, path) when is_binary(path) do
     raise ArgumentError, "static_path/2 expects a path starting with / as argument"
   end
+
+  defp host_to_binary({:system, env_var}), do: host_to_binary(System.get_env(env_var))
+  defp host_to_binary(host), do: host
 
   defp port_to_integer({:system, env_var}), do: port_to_integer(System.get_env(env_var))
   defp port_to_integer(port) when is_binary(port), do: String.to_integer(port)

--- a/test/phoenix/endpoint/adapter_test.exs
+++ b/test/phoenix/endpoint/adapter_test.exs
@@ -5,6 +5,7 @@ defmodule Phoenix.Endpoint.AdapterTest do
   setup do
     Application.put_env(:phoenix, AdapterApp.Endpoint, custom: true)
     System.put_env("PHOENIX_PORT", "8080")
+    System.put_env("PHOENIX_HOST", "example.org")
     :ok
   end
 
@@ -34,7 +35,7 @@ defmodule Phoenix.Endpoint.AdapterTest do
   defmodule HTTPEnvVarEndpoint do
     def config(:https), do: false
     def config(:http), do: [port: {:system,"PHOENIX_PORT"}]
-    def config(:url), do: [host: "example.com"]
+    def config(:url), do: [host: {:system,"PHOENIX_HOST"}]
     def config(:otp_app), do: :phoenix
   end
 
@@ -64,7 +65,7 @@ defmodule Phoenix.Endpoint.AdapterTest do
     assert Adapter.url(URLEndpoint) == {:cache, "random://example.com:678"}
     assert Adapter.url(HTTPEndpoint) == {:cache, "http://example.com"}
     assert Adapter.url(HTTPSEndpoint) == {:cache, "https://example.com"}
-    assert Adapter.url(HTTPEnvVarEndpoint) == {:cache, "http://example.com:8080"}
+    assert Adapter.url(HTTPEnvVarEndpoint) == {:cache, "http://example.org:8080"}
   end
 
   test "static_path/2 returns file's path with lookup cache" do


### PR DESCRIPTION
I'm deploying the same code for multiple clients with different URLs. I can solve this with multiple builds, but being able to specify it from the environment (like the port) would be excellent.