### PR TITLE
Add private render_template clauses. Closes #1655

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -22,7 +22,24 @@ defmodule Phoenix.Template do
 
       Templates.render("foo.html", %{name: "John Doe"})
 
-  In practice though, developers rarely use `Phoenix.Template`
+  In some cases, you will want to overide the `render/2` clause
+  to compose the assigns for the template before rendering. In such
+  cases, you can render the template directly by calling the generated
+  private function `render_template/2`. For example:
+
+      # templates/foo.html.eex
+      Hello <%= @name %>
+
+      # templates.ex
+      defmodule Templates do
+        use Phoenix.Template, root: "templates"
+
+        def render("foo.html", %{name: name}) do
+          render_template("foo.html", %{name: String.upcase(name)})
+        end
+      end
+
+  In practice, developers rarely use `Phoenix.Template`
   directly. Instead they use `Phoenix.View` which wraps the template
   functionality and adds some extra conveniences.
 
@@ -328,6 +345,10 @@ defmodule Phoenix.Template do
       defp unquote(defp)(var!(assigns)) do
         _ = var!(assigns)
         unquote(quoted)
+      end
+
+      defp render_template(unquote(name), assigns) do
+        unquote(defp)(assigns)
       end
 
       def render(unquote(name), assigns) do

--- a/test/fixtures/templates/user/render_template.html.eex
+++ b/test/fixtures/templates/user/render_template.html.eex
@@ -1,0 +1,1 @@
+rendered template for <%= @name %>

--- a/test/fixtures/views.exs
+++ b/test/fixtures/views.exs
@@ -48,6 +48,10 @@ defmodule MyApp.UserView do
     View module is #{assigns.view_module} and view template is #{assigns.view_template}
     """
   end
+
+  def render("render_template.html" = tpl, %{name: name}) do
+    render_template(tpl, %{name: String.upcase(name)})
+  end
 end
 
 defmodule MyApp.Templates.UserView do

--- a/test/phoenix/view_test.exs
+++ b/test/phoenix/view_test.exs
@@ -164,4 +164,9 @@ defmodule Phoenix.ViewTest do
     assert render_existing(MyApp.UserView, "existing.html", []) ==
       "rendered existing"
   end
+
+  test "render_template can be called from overridden render/2" do
+    assert render_to_string(MyApp.UserView, "render_template.html", name: "eric") ==
+      "rendered template for ERIC\n"
+  end
 end


### PR DESCRIPTION
Useful for overriding render/2 clauses for precompiled
templates to compose assigns before rendering template