### PR TITLE
Fix a few typos in phoenix.new installer

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -95,7 +95,7 @@ defmodule Mix.Tasks.Phoenix.New do
 
       mix phoenix.new PATH [--module MODULE] [--app APP]
 
-  A project at the given PATH  will be created. The
+  A project at the given PATH will be created. The
   application name and module name will be retrieved
   from the path, unless `--module` or `--app` is given.
 
@@ -107,7 +107,7 @@ defmodule Mix.Tasks.Phoenix.New do
       the generated skeleton
 
     * `--database` - specify the database adapter for ecto.
-      Values can be `postgres` `mysql`, `mssql`, `sqlite` or
+      Values can be `postgres`, `mysql`, `mssql`, `sqlite` or
       `mongodb`. Defaults to `postgres`
 
     * `--no-brunch` - do not generate brunch files


### PR DESCRIPTION
While I was reading the book I found these extra spaces when I ran the installer.