### PR TITLE
Use datetime types recognized by phoenix_html in generators

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -192,9 +192,9 @@ defmodule Mix.Phoenix do
         :boolean    -> true
         :map        -> %{}
         :text       -> "some content"
-        :date       -> "2010-04-17"
-        :time       -> "14:00:00"
-        :datetime   -> "2010-04-17 14:00:00"
+        :date       -> %{year: 2010, month: 4, day: 17}
+        :time       -> %{hour: 14, min: 0, sec: 0}
+        :datetime   -> %{year: 2010, month: 4, day: 17, hour: 14, min: 0, sec: 0}
         :uuid       -> "7488a646-e31f-11e4-aace-600308960662"
         _           -> "some content"
     end

--- a/test/mix/phoenix_test.exs
+++ b/test/mix/phoenix_test.exs
@@ -14,4 +14,70 @@ defmodule Mix.PhoenixTest do
   test "modules/0 returns all modules in project" do
     assert Phoenix.Router in Mix.Phoenix.modules
   end
+
+  test "attrs/1 defaults each type" do
+    attrs = [
+      "logins:array:string",
+      "age:integer",
+      "temp:float",
+      "temp_2:decimal",
+      "admin:boolean",
+      "meta:map",
+      "name:text",
+      "date_of_birth:date",
+      "happy_hour:time",
+      "joined:datetime",
+      "token:uuid"
+    ]
+    assert Mix.Phoenix.attrs(attrs) == [
+      logins: {:array, :string},
+      age: :integer,
+      temp: :float,
+      temp_2: :decimal,
+      admin: :boolean,
+      meta: :map,
+      name: :text,
+      date_of_birth: :date,
+      happy_hour: :time,
+      joined: :datetime,
+      token: :uuid
+    ]
+  end
+
+  test "attrs/1 raises with an unknown type" do
+    assert_raise(Mix.Error, "Unknown type `other` given to generator", fn ->
+      Mix.Phoenix.attrs(["other:other"])
+    end)
+  end
+
+  test "params/1 defaults each type" do
+    params = [
+      logins: {:array, :string},
+      age: :integer,
+      temp: :float,
+      temp_2: :decimal,
+      admin: :boolean,
+      meta: :map,
+      name: :text,
+      date_of_birth: :date,
+      happy_hour: :time,
+      joined: :datetime,
+      token: :uuid,
+      other: :other
+    ]
+    assert Mix.Phoenix.params(params) == %{
+      logins: [],
+      age: 42,
+      temp: "120.5",
+      temp_2: "120.5",
+      admin: true,
+      meta: %{},
+      name: "some content",
+      date_of_birth: %{year: 2010, month: 4, day: 17},
+      happy_hour: %{hour: 14, min: 0, sec: 0},
+      joined: %{year: 2010, month: 4, day: 17, hour: 14, min: 0, sec: 0},
+      token: "7488a646-e31f-11e4-aace-600308960662",
+      other: "some content"
+    }
+  end
 end


### PR DESCRIPTION
Previously the dates and times would be passed as "2010-04-17" or
"14:00:00" in the tests. These would not be recognized by phoenix_html
resulting in an "unrecognized date" error.

Fixes #1660