### PR TITLE
Omit `ecto_repos` config when generating with `--no-ecto`

### DIFF
--- a/installer/templates/new/config/config.exs
+++ b/installer/templates/new/config/config.exs
@@ -5,12 +5,12 @@
 # is restricted to this project.
 use Mix.Config
 
-# General application configuration
-config :<%= application_name %>,<%= if namespaced? do %>
-  app_namespace: <%= application_module %>,<% end %>
-  ecto_repos: [<%= application_module %>.Repo]
+<%= if namespaced? or ecto do %># General application configuration
+config :<%= application_name %><%= if namespaced? do %>,
+  app_namespace: <%= application_module %><% end %><%= if ecto do %>,
+  ecto_repos: [<%= application_module %>.Repo]<% end %>
 
-# Configures the endpoint
+<% end %># Configures the endpoint
 config :<%= application_name %>, <%= application_module %>.Endpoint,
   url: [host: "localhost"],
   root: Path.dirname(__DIR__),

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -32,6 +32,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       end
 
       assert_file "photo_blog/config/config.exs", fn file ->
+        assert file =~ "ecto_repos: [PhotoBlog.Repo]"
         refute file =~ "app_namespace"
         refute file =~ "config :phoenix, :generators"
       end
@@ -146,7 +147,12 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       refute File.exists?("photo_blog/lib/photo_blog/repo.ex")
 
       assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_ecto")
-      assert_file "photo_blog/config/config.exs", &refute(&1 =~ "config :phoenix, :generators")
+
+      assert_file "photo_blog/config/config.exs", fn file ->
+        refute file =~ "config :phoenix, :generators"
+        refute file =~ "ecto_repos:"
+      end
+
       assert_file "photo_blog/config/dev.exs", &refute(&1 =~ config)
       assert_file "photo_blog/config/test.exs", &refute(&1 =~ config)
       assert_file "photo_blog/config/prod.secret.exs", &refute(&1 =~ config)


### PR DESCRIPTION
I generated an app today (from `master`) w/ the `--no-ecto` option and I noticed that the `config.exs` file still contained the `ecto_repos: [MyApp.Repo]` config.

Thanks for the project! 