### PR TITLE
Fix namespace option for generators

### DIFF
--- a/installer/templates/new/config/config.exs
+++ b/installer/templates/new/config/config.exs
@@ -7,7 +7,7 @@ use Mix.Config
 
 <%= if namespaced? or ecto do %># General application configuration
 config :<%= application_name %><%= if namespaced? do %>,
-  app_namespace: <%= application_module %><% end %><%= if ecto do %>,
+  namespace: <%= application_module %><% end %><%= if ecto do %>,
   ecto_repos: [<%= application_module %>.Repo]<% end %>
 
 <% end %># Configures the endpoint

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
 
       assert_file "photo_blog/config/config.exs", fn file ->
         assert file =~ "ecto_repos: [PhotoBlog.Repo]"
-        refute file =~ "app_namespace"
+        refute file =~ "namespace"
         refute file =~ "config :phoenix, :generators"
       end
 
@@ -225,7 +225,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "custom_path/.gitignore"
       assert_file "custom_path/mix.exs", ~r/app: :photo_blog/
       assert_file "custom_path/lib/photo_blog/endpoint.ex", ~r/app: :photo_blog/
-      assert_file "custom_path/config/config.exs", ~r/app_namespace: PhoteuxBlog/
+      assert_file "custom_path/config/config.exs", ~r/namespace: PhoteuxBlog/
       assert_file "custom_path/web/web.ex", ~r/use Phoenix.Controller, namespace: PhoteuxBlog/
     end
   end

--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -136,7 +136,7 @@ defmodule Mix.Phoenix do
   Returns the module base name based on the configuration value.
 
       config :my_app
-        app_namespace: My.App
+        namespace: My.App
 
   """
   def base do

--- a/lib/mix/tasks/phoenix.routes.ex
+++ b/lib/mix/tasks/phoenix.routes.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Phoenix.Routes do
   the configuration:
 
       config :my_app,
-        app_namespace: My.App
+        namespace: My.App
 
   will exhibit the routes for `My.App.Router` when this
   task is invoked without arguments.


### PR DESCRIPTION
When using generators, `Mix.Phoenix.base/0` looks for the `:namespace` config option not `:app_namespace`.

https://github.com/phoenixframework/phoenix/blob/master/lib/mix/phoenix.ex#L145

This not only fixes a bug but also makes this option consistent with the `:namespace` option for views.