### PR TITLE
resolve npm warn regarding SPDX license expression.

### DIFF
--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -1,6 +1,7 @@
 {
   "repository": {
   },
+  "license": "MIT",
   "scripts": {
     "deploy": "brunch build --production",
     "watch": "brunch watch --stdin"


### PR DESCRIPTION
When installing modules, `npm` issues a warning, indicating that `package.json` does not conform to spec. It should have a `license` field, set to a value from the [SPDX](http://spdx.org/licenses/) license directory.

This PR resolves that warning.