### PR TITLE
reformat JSON entry for repository.

### DIFF
--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -1,6 +1,5 @@
 {
-  "repository": {
-  },
+  "repository": {},
   "scripts": {
     "deploy": "brunch build --production",
     "watch": "brunch watch --stdin"


### PR DESCRIPTION
When installing other packages, `npm` reformats `package.json` to remove the extra line break. This creates more action than necessary in the commit.

This PR cleans up default formatting of `package.json`, making it match more closely to `npm` standards.