### PR TITLE
resolve npm warn regarding SPDX license expression.

### DIFF
--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -1,5 +1,6 @@
 {
   "repository": {},
+  "license": "MIT",
   "scripts": {
     "deploy": "brunch build --production",
     "watch": "brunch watch --stdin"


### PR DESCRIPTION
This PR serves the same purpose as #1683, but without conflicts.