### PR TITLE
Add a test for re-reading manifest.json on config change.

### DIFF
--- a/test/fixtures/manifest_upgrade.json
+++ b/test/fixtures/manifest_upgrade.json
@@ -1,0 +1,1 @@
+{"foo.css":"foo-ghijkl.css"}

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -72,9 +72,13 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert Endpoint.static_path("/foo.css") == "/foo-abcdef.css?vsn=d"
 
     # Trigger a config change and the cache should be warmed up again
-    assert Endpoint.config_change([{Endpoint, @config}], []) == :ok
+    config =
+      @config
+      |> put_in([:cache_static_manifest], "../../../../test/fixtures/manifest_upgrade.json")
 
-    assert Endpoint.static_path("/foo.css") == "/foo-abcdef.css?vsn=d"
+    assert Endpoint.config_change([{Endpoint, config}], []) == :ok
+
+    assert Endpoint.static_path("/foo.css") == "/foo-ghijkl.css?vsn=d"
   end
 
   test "uses url configuration for static path" do


### PR DESCRIPTION
I thought there was an issue with `Endpoint.static_path(some_path)` not getting updated when there was a config change. This test proves that this isn't the case.

What was actually happening in my case was that `Endpoint.config_change` never got called, and thus the cache was never purged, causing `Endpoint.static_path` to return the stale cached paths. In order to force `config_change` to be called, [I added my app :version to the `Endpoint` config](https://github.com/bitwalker/exrm/issues/206#issuecomment-212538439).