### PR TITLE
Fixed Small Typo

### DIFF
--- a/installer/templates/new/config/prod.secret.exs
+++ b/installer/templates/new/config/prod.secret.exs
@@ -3,5 +3,5 @@ use Mix.Config
 # In this file, we keep production configuration that
 # you likely want to automate and keep it away from
 # your version control system.
-config :<%= application_name %>, <%= application_module %>.Endpoint,
+config: <%= application_name %>, <%= application_module %>.Endpoint,
   secret_key_base: "<%= prod_secret_key_base %>"


### PR DESCRIPTION
So that users who start with this as a base have the correct syntax. `config:`