### PR TITLE
Stringify parameter keys pushed to a channel in test

### DIFF
--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -241,7 +241,7 @@ defmodule Phoenix.ChannelTest do
     if endpoint = Module.get_attribute(__CALLER__.module, :endpoint) do
       quote do
         Transport.connect(unquote(endpoint), unquote(handler), :channel_test,
-                          unquote(__MODULE__), NoopSerializer, unquote(params))
+                          unquote(__MODULE__), NoopSerializer, Phoenix.ChannelTest.__stringify__(unquote(params)))
       end
     else
       raise "module attribute @endpoint not set for socket/2"
@@ -349,7 +349,7 @@ defmodule Phoenix.ChannelTest do
   def push(socket, event, payload \\ %{}) do
     ref = make_ref()
     send(socket.channel_pid,
-         %Message{event: event, topic: socket.topic, ref: ref, payload: payload})
+         %Message{event: event, topic: socket.topic, ref: ref, payload: __stringify__(payload)})
     ref
   end
 
@@ -537,4 +537,13 @@ defmodule Phoenix.ChannelTest do
       _ -> raise "no channel found for topic #{inspect topic} in #{inspect socket.handler}"
     end
   end
+
+  @doc false
+  def __stringify__(%{} = params),
+    do: Enum.into(params, %{}, &stringify_kv/1)
+  def __stringify__(other),
+    do: other
+
+  defp stringify_kv({k, v}),
+    do: {to_string(k), __stringify__(v)}
 end

--- a/test/phoenix/test/channel_test.exs
+++ b/test/phoenix/test/channel_test.exs
@@ -286,6 +286,17 @@ defmodule Phoenix.Test.ChannelTest do
     assert_broadcast "broadcast", %{"foo" => "bar"}
   end
 
+  test "pushes atom parameter keys as strings" do
+    {:ok, _, socket} = join(socket(), Channel, "foo:ok")
+
+    ref = push socket, "reply", %{req: %{parameter: 1}}
+    assert_reply ref, :ok, %{"resp" => %{"parameter" => 1}}
+  end
+
+  test "connects with atom parameter keys as strings" do
+    :error = connect(UserSocket, %{reject: true})
+  end
+
   ## handle_out
 
   test "push broadcasts by default" do


### PR DESCRIPTION
This uses code lifted from `Plug.Adapters.Test.Conn` to stringify map keys pushed to a channel under test. See: https://groups.google.com/forum/#!topic/phoenix-core/keDSxYg_jSQ

