### PR TITLE
Updates docs per singular topic convention for channels

### DIFF
--- a/installer/templates/new/web/channels/user_socket.ex
+++ b/installer/templates/new/web/channels/user_socket.ex
@@ -2,7 +2,7 @@ defmodule <%= application_module %>.UserSocket do
   use Phoenix.Socket
 
   ## Channels
-  # channel "rooms:*", <%= application_module %>.RoomChannel
+  # channel "room:*", <%= application_module %>.RoomChannel
 
   ## Transports
   transport :websocket, Phoenix.Transports.WebSocket

--- a/lib/mix/tasks/phoenix.gen.channel.ex
+++ b/lib/mix/tasks/phoenix.gen.channel.ex
@@ -6,10 +6,9 @@ defmodule Mix.Tasks.Phoenix.Gen.Channel do
   @moduledoc """
   Generates a Phoenix channel.
 
-      mix phoenix.gen.channel Room rooms
+      mix phoenix.gen.channel Room
 
-  The first argument is the module name for the channel.
-  The second argument is the plural used as the topic.
+  Accepts the module name for the channel
 
   The generated model will contain:
 

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -13,19 +13,19 @@ defmodule Phoenix.Channel do
   approach pairs nicely with the `Phoenix.Socket.channel/2` allowing you to
   match on all topics starting with a given prefix:
 
-      channel "rooms:*", MyApp.RoomChannel
+      channel "room:*", MyApp.RoomChannel
 
-  Any topic coming into the router with the `"rooms:"` prefix would dispatch
+  Any topic coming into the router with the `"room:"` prefix would dispatch
   to `MyApp.RoomChannel` in the above example. Topics can also be pattern
   matched in your channels' `join/3` callback to pluck out the scoped pattern:
 
       # handles the special `"lobby"` subtopic
-      def join("rooms:lobby", _auth_message, socket) do
+      def join("room:lobby", _auth_message, socket) do
         {:ok, socket}
       end
 
-      # handles any other subtopic as the room ID, for example `"rooms:12"`, `"rooms:34"`
-      def join("rooms:" <> room_id, auth_message, socket) do
+      # handles any other subtopic as the room ID, for example `"room:12"`, `"room:34"`
+      def join("room:" <> room_id, auth_message, socket) do
         {:ok, socket}
       end
 
@@ -138,7 +138,7 @@ defmodule Phoenix.Channel do
       def handle_in("new_msg", %{"uid" => uid, "body" => body}, socket) do
         ...
         broadcast_from! socket, "new_msg", %{uid: uid, body: body}
-        MyApp.Endpoint.broadcast_from! self(), "rooms:superadmin",
+        MyApp.Endpoint.broadcast_from! self(), "room:superadmin",
           "new_msg", %{uid: uid, body: body}
         {:noreply, socket}
       end
@@ -146,8 +146,8 @@ defmodule Phoenix.Channel do
       # within controller
       def create(conn, params) do
         ...
-        MyApp.Endpoint.broadcast! "rooms:" <> rid, "new_msg", %{uid: uid, body: body}
-        MyApp.Endpoint.broadcast! "rooms:superadmin", "new_msg", %{uid: uid, body: body}
+        MyApp.Endpoint.broadcast! "room:" <> rid, "new_msg", %{uid: uid, body: body}
+        MyApp.Endpoint.broadcast! "room:superadmin", "new_msg", %{uid: uid, body: body}
         redirect conn, to: "/"
       end
 

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -18,7 +18,7 @@ defmodule Phoenix.Socket do
   The command above means incoming socket connections can be done via
   the WebSocket transport. Events are routed by topic to channels:
 
-      channel "rooms:lobby", MyApp.LobbyChannel
+      channel "room:lobby", MyApp.LobbyChannel
 
   See `Phoenix.Channel` for more information on channels. Check each
   transport module to check the options specific to each transport.
@@ -40,7 +40,7 @@ defmodule Phoenix.Socket do
         use Phoenix.Socket
 
         transport :websocket, Phoenix.Transports.WebSocket
-        channel "rooms:*", MyApp.RoomChannel
+        channel "room:*", MyApp.RoomChannel
 
         def connect(params, socket) do
           {:ok, assign(socket, :user_id, params["user_id"])}
@@ -63,7 +63,7 @@ defmodule Phoenix.Socket do
     * `joined` - If the socket has effectively joined the channel
     * `pubsub_server` - The registered name of the socket's pubsub server
     * `ref` - The latest ref sent by the client
-    * `topic` - The string topic, for example `"rooms:123"`
+    * `topic` - The string topic, for example `"room:123"`
     * `transport` - The socket's transport, for example: `Phoenix.Transports.WebSocket`
     * `transport_pid` - The pid of the socket's transport process
     * `transport_name` - The socket's transport, for example: `:websocket`
@@ -228,7 +228,7 @@ defmodule Phoenix.Socket do
   @doc """
   Defines a channel matching the given topic and transports.
 
-    * `topic_pattern` - The string pattern, for example "rooms:*", "users:*", "system"
+    * `topic_pattern` - The string pattern, for example "room:*", "users:*", "system"
     * `module` - The channel module handler, for example `MyApp.RoomChannel`
     * `opts` - The optional list of options, see below
 

--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -18,7 +18,7 @@ defmodule Phoenix.ChannelTest do
 
       {:ok, _, socket} =
         socket("user:id", %{some_assigns: 1})
-        |> subscribe_and_join(RoomChannel, "rooms:lobby", %{"id" => 3})
+        |> subscribe_and_join(RoomChannel, "room:lobby", %{"id" => 3})
 
   You usually want to set the same ID and assigns your
   `UserSocket.connect/2` callback would set. Alternatively,
@@ -26,10 +26,10 @@ defmodule Phoenix.ChannelTest do
   callback and initialize the socket with the socket id:
 
       {:ok, socket} = connect(UserSocket, %{"some" => "params"})
-      {:ok, _, socket} = subscribe_and_join(socket, "rooms:lobby", %{"id" => 3})
+      {:ok, _, socket} = subscribe_and_join(socket, "room:lobby", %{"id" => 3})
 
   Once called, `subscribe_and_join/4` will subscribe the
-  current test process to the "rooms:lobby" topic and start a
+  current test process to the "room:lobby" topic and start a
   channel in another process. It returns `{:ok, reply, socket}`
   or `{:error, reply}`.
 

--- a/test/phoenix/integration/websocket_test.exs
+++ b/test/phoenix/integration/websocket_test.exs
@@ -60,7 +60,7 @@ defmodule Phoenix.Integration.WebSocketTest do
   defmodule UserSocket do
     use Phoenix.Socket
 
-    channel "rooms:*", RoomChannel
+    channel "room:*", RoomChannel
 
     transport :websocket, Phoenix.Transports.WebSocket,
       check_origin: ["//example.com"], timeout: 200
@@ -82,7 +82,7 @@ defmodule Phoenix.Integration.WebSocketTest do
   defmodule LoggingSocket do
     use Phoenix.Socket
 
-    channel "rooms:*", RoomChannel
+    channel "room:*", RoomChannel
 
     transport :websocket, Phoenix.Transports.WebSocket,
       check_origin: ["//example.com"], timeout: 200
@@ -115,54 +115,54 @@ defmodule Phoenix.Integration.WebSocketTest do
 
   test "endpoint handles mulitple mount segments" do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws/admin/websocket")
-    WebsocketClient.join(sock, "rooms:admin-lobby", %{})
+    WebsocketClient.join(sock, "room:admin-lobby", %{})
     assert_receive %Message{event: "phx_reply",
                             payload: %{"response" => %{}, "status" => "ok"},
-                            ref: "1", topic: "rooms:admin-lobby"}
+                            ref: "1", topic: "room:admin-lobby"}
   end
 
   test "join, leave, and event messages" do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws/websocket")
-    WebsocketClient.join(sock, "rooms:lobby1", %{})
+    WebsocketClient.join(sock, "room:lobby1", %{})
 
     assert_receive %Message{event: "phx_reply",
                             payload: %{"response" => %{}, "status" => "ok"},
-                            ref: "1", topic: "rooms:lobby1"}
+                            ref: "1", topic: "room:lobby1"}
 
     assert_receive %Message{event: "joined", payload: %{"status" => "connected",
                                                         "user_id" => nil}}
     assert_receive %Message{event: "user_entered",
                             payload: %{"user" => nil},
-                            ref: nil, topic: "rooms:lobby1"}
+                            ref: nil, topic: "room:lobby1"}
 
-    channel_pid = Process.whereis(:"rooms:lobby1")
+    channel_pid = Process.whereis(:"room:lobby1")
     assert channel_pid
     assert Process.alive?(channel_pid)
 
-    WebsocketClient.send_event(sock, "rooms:lobby1", "new_msg", %{body: "hi!"})
+    WebsocketClient.send_event(sock, "room:lobby1", "new_msg", %{body: "hi!"})
     assert_receive %Message{event: "new_msg", payload: %{"transport" => "Phoenix.Transports.WebSocket", "body" => "hi!"}}
 
-    WebsocketClient.leave(sock, "rooms:lobby1", %{})
+    WebsocketClient.leave(sock, "room:lobby1", %{})
     assert_receive %Message{event: "you_left", payload: %{"message" => "bye!"}}
     assert_receive %Message{event: "phx_reply", payload: %{"status" => "ok"}}
     assert_receive %Message{event: "phx_close", payload: %{}}
     refute Process.alive?(channel_pid)
 
-    WebsocketClient.send_event(sock, "rooms:lobby1", "new_msg", %{body: "Should ignore"})
+    WebsocketClient.send_event(sock, "room:lobby1", "new_msg", %{body: "Should ignore"})
     refute_receive %Message{event: "new_msg"}
     assert_receive %Message{event: "phx_reply", payload: %{"response" => %{"reason" => "unmatched topic"}}}
 
-    WebsocketClient.send_event(sock, "rooms:lobby1", "new_msg", %{body: "Should ignore"})
+    WebsocketClient.send_event(sock, "room:lobby1", "new_msg", %{body: "Should ignore"})
     refute_receive %Message{event: "new_msg"}
   end
 
   test "filter params on join" do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws/logging/websocket")
     log = capture_log fn ->
-      WebsocketClient.join(sock, "rooms:admin-lobby", %{"foo" => "bar", "password" => "shouldnotshow"})
+      WebsocketClient.join(sock, "room:admin-lobby", %{"foo" => "bar", "password" => "shouldnotshow"})
       assert_receive %Message{event: "phx_reply",
                               payload: %{"response" => %{}, "status" => "ok"},
-                              ref: "1", topic: "rooms:admin-lobby"}
+                              ref: "1", topic: "room:admin-lobby"}
     end
     assert log =~ "Parameters: %{\"foo\" => \"bar\", \"password\" => \"[FILTERED]\"}"
   end
@@ -170,24 +170,24 @@ defmodule Phoenix.Integration.WebSocketTest do
   test "sends phx_error if a channel server abnormally exits" do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws/websocket")
 
-    WebsocketClient.join(sock, "rooms:lobby", %{})
+    WebsocketClient.join(sock, "room:lobby", %{})
     assert_receive %Message{event: "phx_reply", ref: "1", payload: %{"response" => %{}, "status" => "ok"}}
     assert_receive %Message{event: "joined"}
     assert_receive %Message{event: "user_entered"}
 
     capture_log fn ->
-      WebsocketClient.send_event(sock, "rooms:lobby", "boom", %{})
-      assert_receive %Message{event: "phx_error", payload: %{}, topic: "rooms:lobby"}
+      WebsocketClient.send_event(sock, "room:lobby", "boom", %{})
+      assert_receive %Message{event: "phx_error", payload: %{}, topic: "room:lobby"}
     end
   end
 
   test "channels are terminated if transport normally exits" do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws/websocket")
 
-    WebsocketClient.join(sock, "rooms:lobby2", %{})
+    WebsocketClient.join(sock, "room:lobby2", %{})
     assert_receive %Message{event: "phx_reply", ref: "1", payload: %{"response" => %{}, "status" => "ok"}}
     assert_receive %Message{event: "joined"}
-    channel = Process.whereis(:"rooms:lobby2")
+    channel = Process.whereis(:"room:lobby2")
     assert channel
     Process.monitor(channel)
     WebsocketClient.close(sock)
@@ -198,11 +198,11 @@ defmodule Phoenix.Integration.WebSocketTest do
   test "refuses websocket events that haven't joined" do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws/websocket")
 
-    WebsocketClient.send_event(sock, "rooms:lobby", "new_msg", %{body: "hi!"})
+    WebsocketClient.send_event(sock, "room:lobby", "new_msg", %{body: "hi!"})
     refute_receive %Message{event: "new_msg"}
     assert_receive %Message{event: "phx_reply", payload: %{"response" => %{"reason" => "unmatched topic"}}}
 
-    WebsocketClient.send_event(sock, "rooms:lobby1", "new_msg", %{body: "Should ignore"})
+    WebsocketClient.send_event(sock, "room:lobby1", "new_msg", %{body: "Should ignore"})
     refute_receive %Message{event: "new_msg"}
  end
 
@@ -225,16 +225,16 @@ defmodule Phoenix.Integration.WebSocketTest do
   test "shuts down when receiving disconnect broadcasts on socket's id" do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws/websocket?user_id=1001")
 
-    WebsocketClient.join(sock, "rooms:wsdisconnect1", %{})
-    assert_receive %Message{topic: "rooms:wsdisconnect1", event: "phx_reply",
+    WebsocketClient.join(sock, "room:wsdisconnect1", %{})
+    assert_receive %Message{topic: "room:wsdisconnect1", event: "phx_reply",
                             ref: "1", payload: %{"response" => %{}, "status" => "ok"}}
-    WebsocketClient.join(sock, "rooms:wsdisconnect2", %{})
-    assert_receive %Message{topic: "rooms:wsdisconnect2", event: "phx_reply",
+    WebsocketClient.join(sock, "room:wsdisconnect2", %{})
+    assert_receive %Message{topic: "room:wsdisconnect2", event: "phx_reply",
                             ref: "2", payload: %{"response" => %{}, "status" => "ok"}}
 
-    chan1 = Process.whereis(:"rooms:wsdisconnect1")
+    chan1 = Process.whereis(:"room:wsdisconnect1")
     assert chan1
-    chan2 = Process.whereis(:"rooms:wsdisconnect2")
+    chan2 = Process.whereis(:"room:wsdisconnect2")
     assert chan2
     Process.monitor(sock)
     Process.monitor(chan1)
@@ -249,15 +249,15 @@ defmodule Phoenix.Integration.WebSocketTest do
 
   test "duplicate join event closes existing channel" do
     {:ok, sock} = WebsocketClient.start_link(self, "ws://127.0.0.1:#{@port}/ws/websocket?user_id=1001")
-    WebsocketClient.join(sock, "rooms:joiner", %{})
-    assert_receive %Message{topic: "rooms:joiner", event: "phx_reply",
+    WebsocketClient.join(sock, "room:joiner", %{})
+    assert_receive %Message{topic: "room:joiner", event: "phx_reply",
                             ref: "1", payload: %{"response" => %{}, "status" => "ok"}}
 
-    WebsocketClient.join(sock, "rooms:joiner", %{})
-    assert_receive %Message{topic: "rooms:joiner", event: "phx_reply",
+    WebsocketClient.join(sock, "room:joiner", %{})
+    assert_receive %Message{topic: "room:joiner", event: "phx_reply",
                             ref: "2", payload: %{"response" => %{}, "status" => "ok"}}
 
-    assert_receive %Message{topic: "rooms:joiner", event: "phx_close",
+    assert_receive %Message{topic: "room:joiner", event: "phx_close",
                             ref: "1", payload: %{}}
   end
 

--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -23,7 +23,7 @@
 // events are listened for, messages are pushed to the server, and
 // the channel is joined with ok/error/timeout matches:
 //
-//     let channel = socket.channel("rooms:123", {token: roomToken})
+//     let channel = socket.channel("room:123", {token: roomToken})
 //     channel.on("new_msg", msg => console.log("Got message", msg) )
 //     $input.onEnter( e => {
 //       channel.push("new_msg", {body: e.target.val}, 10000)


### PR DESCRIPTION
Makes use of singular topic names for docs and tests per convention for naming channels as mentioned here: [#1696](https://github.com/phoenixframework/phoenix/issues/1696)