### PR TITLE
Remove handle_out/3 from generated channel

### DIFF
--- a/priv/templates/phoenix.gen.channel/channel.ex
+++ b/priv/templates/phoenix.gen.channel/channel.ex
@@ -22,14 +22,6 @@ defmodule <%= module %>Channel do
     {:noreply, socket}
   end
 
-  # This is invoked every time a notification is being broadcast
-  # to the client. The default implementation is just to push it
-  # downstream but one could filter or change the event.
-  def handle_out(event, payload, socket) do
-    push socket, event, payload
-    {:noreply, socket}
-  end
-
   # Add authorization logic here as required.
   defp authorized?(_payload) do
     true

--- a/test/mix/tasks/phoenix.gen.channel_test.exs
+++ b/test/mix/tasks/phoenix.gen.channel_test.exs
@@ -26,9 +26,6 @@ defmodule Mix.Tasks.Phoenix.Gen.ChannelTest do
         assert file =~ ~S|def handle_in("shout", payload, socket) do|
         assert file =~ ~S|broadcast socket, "shout", payload|
         assert file =~ ~S|{:noreply, socket}|
-
-        assert file =~ ~S|def handle_out(event, payload, socket) do|
-        assert file =~ ~S|push socket, event, payload|
       end
 
       assert_file "test/channels/room_channel_test.exs", fn file ->


### PR DESCRIPTION
## Problem

The generated test of handle_out/3 was passing for the wrong reason. The generated version of handle_out/3 was never invoked, because the "broadcast" event was not being intercepted.

## Solution

~~Add `intercept` call to generated channel module, so that the test continues to pass, now for the right reason. That reason being, the generated version of handle_out/3 is invoked which pushes the payload back to the socket.~~

The handle_out/3 function is not needed in many cases and is generally considered an advanced feature. No need to generate it with all channels.

h/t @nathanl for pairing