### PR TITLE
Improving error message when invalid redirect to: path

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -308,9 +308,9 @@ defmodule Phoenix.Controller do
     cond do
       to = opts[:to] ->
         case to do
-          "//" <> _ -> raise_invalid_url()
+          "//" <> _ -> raise_invalid_url(to)
           "/" <> _  -> to
-          _         -> raise_invalid_url()
+          _         -> raise_invalid_url(to)
         end
       external = opts[:external] ->
         external
@@ -318,8 +318,8 @@ defmodule Phoenix.Controller do
         raise ArgumentError, "expected :to or :external option in redirect/2"
     end
   end
-  defp raise_invalid_url do
-    raise ArgumentError, "the :to option in redirect expects a path"
+  defp raise_invalid_url(url) do
+    raise ArgumentError, "the :to option in redirect expects a path but was #{inspect url}"
   end
 
   @doc """


### PR DESCRIPTION
When we have an invalid `redirect to:` path, we were getting an error like this:

```
** (exit) an exception was raised:
    ** (ArgumentError) the :to option in redirect expects a path
```
Which was not very helpful. Which didn't give much information about the issue.

I have made a small change that makes it more clear. With this pull request we get a message like this:

```
** (exit) an exception was raised:
    ** (ArgumentError) the :to option in redirect expects a path but was "http://localhost:4000/login"
```
Which gives a better idea where the error came from.

