### PR TITLE
Support System.cmd options for watchers instead of root config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 * Enhancements
   * [View] Add `:path` and `:pattern` options to allow wildcard template inclusion as well as customized template directory locations
 
+* Deprecations
+  * [Watcher] Using the `:root` endpoint configuration for watchers is deprecated. Pass the :cd option at the end of your watcher argument list in config/dev.exs. For example:
+
+      ```elixir
+      watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
+                 cd: Path.expand("../", __DIR__)]]
+      ```
+
 ## 1.2.0-rc.0 (2016-4-28)
 
 See these [`1.1.x` to `1.2.0` upgrade instructions](https://gist.github.com/chrismccord/29100e16d3990469c47f851e3142f766) to bring your existing apps up to speed.

--- a/installer/templates/new/config/config.exs
+++ b/installer/templates/new/config/config.exs
@@ -13,7 +13,6 @@ config :<%= application_name %><%= if namespaced? do %>,
 <% end %># Configures the endpoint
 config :<%= application_name %>, <%= application_module %>.Endpoint,
   url: [host: "localhost"],
-  root: Path.dirname(__DIR__),
   secret_key_base: "<%= secret_key_base %>",
   render_errors: [view: <%= application_module %>.ErrorView, accepts: ~w(<%= if html do %>html <% end %>json)],
   pubsub: [name: <%= application_module %>.PubSub,

--- a/installer/templates/new/config/dev.exs
+++ b/installer/templates/new/config/dev.exs
@@ -12,7 +12,7 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
   code_reloader: true,
   check_origin: false,
   watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
-                    cd: Path.dirname(__DIR__)]]<% else %>[]<% end %>
+                    cd: Path.expand("../", __DIR__)]]<% else %>[]<% end %>
 
 
 <%= if html do %># Watch static and templates for browser reloading.

--- a/installer/templates/new/config/dev.exs
+++ b/installer/templates/new/config/dev.exs
@@ -11,7 +11,9 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin"]]<% else %>[]<% end %>
+  watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
+                    cd: Path.dirname(__DIR__)]]<% else %>[]<% end %>
+
 
 <%= if html do %># Watch static and templates for browser reloading.
 config :<%= application_name %>, <%= application_module %>.Endpoint,

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -69,10 +69,8 @@ defmodule Phoenix.Endpoint.Adapter do
     end
   end
   defp watcher_args(cmd, cmd_args, conf) do
-    case Enum.split_while(cmd_args, &is_binary(&1)) do
-      {args, []}   -> [cmd, args, [cd: root!(conf)]]
-      {args, opts} -> [cmd, args, opts]
-    end
+    {args, opts} = Enum.split_while(cmd_args, &is_binary(&1))
+    [cmd, args, Keyword.put_new_lazy(opts, :cd, fn -> root!(conf) end)]
   end
 
   defp code_reloader_children(mod, conf) do

--- a/lib/phoenix/endpoint/watcher.ex
+++ b/lib/phoenix/endpoint/watcher.ex
@@ -8,7 +8,7 @@ defmodule Phoenix.Endpoint.Watcher do
 
   def watch(cmd, args, opts) do
     merged_opts = Keyword.merge(
-      [cd: File.cwd!(), into: IO.stream(:stdio, :line), stderr_to_stdout: true], opts)
+      [into: IO.stream(:stdio, :line), stderr_to_stdout: true], opts)
     :ok = validate(cmd, args, merged_opts)
 
     try do
@@ -16,7 +16,7 @@ defmodule Phoenix.Endpoint.Watcher do
     catch
       :error, :enoent ->
         relative = Path.relative_to_cwd(cmd)
-        Logger.error "Could not start watcher #{inspect relative} from #{inspect merged_opts[:cd]}, executable does not exist"
+        Logger.error "Could not start watcher #{inspect relative} from #{inspect cd(merged_opts)}, executable does not exist"
         exit(:shutdown)
     end
   end
@@ -24,7 +24,7 @@ defmodule Phoenix.Endpoint.Watcher do
   # We specially handle node to make sure we
   # provide a good getting started experience.
   defp validate("node", [script|_], merged_opts) do
-    script_path = Path.expand(script, merged_opts[:cd])
+    script_path = Path.expand(script, cd(merged_opts))
 
     cond do
       !System.find_executable("node") ->
@@ -46,4 +46,6 @@ defmodule Phoenix.Endpoint.Watcher do
   defp validate(_cmd, _args, _opts) do
     :ok
   end
+
+  defp cd(opts), do: opts[:cd] || File.cwd!()
 end

--- a/lib/phoenix/endpoint/watcher.ex
+++ b/lib/phoenix/endpoint/watcher.ex
@@ -2,27 +2,31 @@ defmodule Phoenix.Endpoint.Watcher do
   @moduledoc false
   require Logger
 
-  def start_link(root, cmd, args) do
-    Task.start_link(__MODULE__, :watch, [root, to_string(cmd), args])
+  def start_link(cmd, args, opts) do
+    Task.start_link(__MODULE__, :watch, [to_string(cmd), args, opts])
   end
 
-  def watch(root, cmd, args) do
-    :ok = validate(root, cmd, args)
+  def watch(cmd, args, opts) do
+    :ok = validate(cmd, args, opts)
+    opts_with_defaults = Keyword.merge(
+      [into: IO.stream(:stdio, :line), stderr_to_stdout: true], opts)
 
     try do
-      System.cmd(cmd, args, into: IO.stream(:stdio, :line),
-                            stderr_to_stdout: true, cd: root)
+      System.cmd(cmd, args, opts_with_defaults)
     catch
       :error, :enoent ->
         relative = Path.relative_to_cwd(cmd)
-        Logger.error "Could not start watcher #{inspect relative}, executable does not exist"
+        Logger.error "Could not start watcher #{inspect relative} from #{inspect opts[:cd]}, executable does not exist"
         exit(:shutdown)
     end
   end
 
   # We specially handle node to make sure we
   # provide a good getting started experience.
-  defp validate(root, "node", [script|_]) do
+  defp validate("node", [script|_], opts) do
+    cd = Keyword.fetch!(opts, :cd)
+    script_path = Path.expand(script, cd)
+
     cond do
       !System.find_executable("node") ->
         Logger.error "Could not start watcher because \"node\" is not available. Your Phoenix " <>
@@ -30,18 +34,17 @@ defmodule Phoenix.Endpoint.Watcher do
                      "You may fix this by installing \"node\" and then running \"npm install\"."
         exit(:shutdown)
 
-      not File.exists?(Path.expand(script, root)) ->
-        Logger.error "Could not start node watcher because script #{inspect script} does not " <>
+      not File.exists?(script_path) ->
+        Logger.error "Could not start node watcher because script #{inspect script_path} does not " <>
                      "exist. Your Phoenix application is still running, however assets " <>
                      "won't be compiled. You may fix this by running \"npm install\"."
         exit(:shutdown)
 
-      true ->
-        :ok
+      true -> :ok
     end
   end
 
-  defp validate(_root, _cmd, _args) do
+  defp validate(_cmd, _args, _opts) do
     :ok
   end
 end

--- a/test/phoenix/endpoint/watcher_test.exs
+++ b/test/phoenix/endpoint/watcher_test.exs
@@ -6,7 +6,7 @@ defmodule Phoenix.Endpoint.WatcherTest do
 
   test "starts watching and writes to stdio" do
     assert capture_io(fn ->
-      {:ok, pid} = Watcher.start_link(File.cwd!, "echo", ["hello"])
+      {:ok, pid} = Watcher.start_link("echo", ["hello"], cd: File.cwd!())
       ref = Process.monitor(pid)
       assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
     end) == "hello\n"


### PR DESCRIPTION
Closes #1695 