### PR TITLE
Update errors_on in model_case to refelct Ecto 2.0.0 errors changes

### DIFF
--- a/installer/templates/ecto/model_case.ex
+++ b/installer/templates/ecto/model_case.ex
@@ -59,5 +59,6 @@ defmodule <%= application_module %>.ModelCase do
   """
   def errors_on(struct, data) do
     struct.__struct__.changeset(struct, data).errors
+    |> Enum.map(fn {field, {message, _opts}} -> {field, message} end)
   end
 end

--- a/installer/templates/ecto/model_case.ex
+++ b/installer/templates/ecto/model_case.ex
@@ -59,6 +59,6 @@ defmodule <%= application_module %>.ModelCase do
   """
   def errors_on(struct, data) do
     struct.__struct__.changeset(struct, data).errors
-    |> Enum.map(fn {field, {message, _opts}} -> {field, message} end)
+    |> Ecto.Changeset.traverse_errors(&<%= application_module %>.ErrorHelpers.translate_error/1)
   end
 end


### PR DESCRIPTION
In Ecto 2.0.0 (currently in RC), errors take on a different format and look like this:

```elixir
[username: {"can't be blank", []}]
```
[see docs for 2.0.0-rc.5](https://hexdocs.pm/ecto/2.0.0-rc.5/Ecto.Changeset.html)

whereas before, they looked like this:
```elixir
[username: "can't be blank"]
```
[see docs for 1.1.7](https://hexdocs.pm/ecto/Ecto.Changeset.html)

The current function for `errors_on` will not work with this new error format, so I've updated it to parse the errors first so it can be used the same way as before, like this:

 ```elixir
assert {:username, "can't be blank"} in errors_on(%User{}, %{username: nil})
```