### PR TITLE
add mime as standalone dependency

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -617,7 +617,7 @@ defmodule Phoenix.Controller do
 
   defp do_render(conn, template, format, assigns) do
     assigns = to_map(assigns)
-    content_type = Plug.MIME.type(format)
+    content_type = MIME.type(format)
     conn =
       conn
       |> put_private(:phoenix_template, template)

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Phoenix.Mixfile do
 
   def application do
     [mod: {Phoenix, []},
-     applications: [:plug, :poison, :logger, :eex],
+     applications: [:plug, :poison, :logger, :eex, :mime],
      env: [stacktrace_depth: nil,
            template_engines: [],
            format_encoders: [],
@@ -44,6 +44,7 @@ defmodule Phoenix.Mixfile do
      {:phoenix_pubsub, "~> 1.0.0-rc"},
      {:poison, "~> 1.5 or ~> 2.0"},
      {:gettext, "~> 0.8", only: :test},
+     {:mime, "~> 1.0"},
 
      # Docs dependencies
      {:earmark, "~> 0.1", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,7 @@
   "ex_doc": {:hex, :ex_doc, "0.11.2"},
   "gettext": {:hex, :gettext, "0.8.0"},
   "inch_ex": {:hex, :inch_ex, "0.2.3"},
+  "mime": {:hex, :mime, "1.0.0"},
   "phoenix_html": {:hex, :phoenix_html, "2.5.1"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.0-rc.0"},
   "plug": {:hex, :plug, "1.1.1"},


### PR DESCRIPTION
Current plug has ugly deprecated warnings when using Plug.MIME.
Using mime here as a seperate dependency omits those warnings and is backwards compatible with old plug versions.