### PR TITLE
Potential fix for issue 1605

### DIFF
--- a/priv/templates/phoenix.gen.model/model.ex
+++ b/priv/templates/phoenix.gen.model/model.ex
@@ -3,7 +3,7 @@ defmodule <%= module %> do
 
   schema <%= inspect plural %> do
 <%= for {k, _} <- attrs do %>    field <%= inspect k %>, <%= inspect types[k] %><%= schema_defaults[k] %>
-<% end %><%= for {k, _, m, _} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>
+<% end %><%= for {k, k_id, m, _} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %><%= if !String.ends_with?(Atom.to_string(k_id), "_id") do %>, define_field: false, foreign_key: <%= inspect k %><% end %>
 <% end %>
     timestamps
   end


### PR DESCRIPTION
If the key_id doesn't end with "_id", define_field will be set to false to avoid auto-generation, and will instead be set in the foreign_key option.

`mix phoenix.gen.html Room rooms author:references:users` will now set:

`belongs_to :author, Module.Author, define_field: false, foreign_key: :author`

`mix phoenix.gen.html Room rooms author_id:references:users` will still follow default behavior.