### PR TITLE
call the standalone MIME library in all places

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -940,7 +940,7 @@ defmodule Phoenix.Controller do
   end
 
   defp parse_exts("*/*" = type), do: type
-  defp parse_exts(type),         do: Plug.MIME.extensions(type)
+  defp parse_exts(type),         do: MIME.extensions(type)
 
   defp find_format("*/*", accepted), do: Enum.fetch!(accepted, 0)
   defp find_format(exts, accepted),  do: Enum.find(exts, &(&1 in accepted))

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -314,7 +314,7 @@ defmodule Phoenix.ConnTest do
     case parse_content_type(header) do
       {part, subpart} ->
         format = Atom.to_string(format)
-        format in Plug.MIME.extensions(part <> "/" <> subpart) or
+        format in MIME.extensions(part <> "/" <> subpart) or
           format == subpart or String.ends_with?(subpart, "+" <> format)
       _  ->
         false


### PR DESCRIPTION
The Plug.MIME library was still called in some places, which generates ugly warning messages with current Plug.