### PR TITLE
Properly encode named params.

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -269,11 +269,14 @@ defmodule Phoenix.Router.Helpers do
     raise ArgumentError, message: String.strip(message)
   end
 
+  @doc false
+  def encode_param(str), do: URI.encode(str, &URI.char_unreserved?/1)
+
   defp expand_segments([]), do: "/"
   defp expand_segments(segments) when is_list(segments),
     do: expand_segments(segments, "")
   defp expand_segments(segments) do
-    quote(do: "/" <> Enum.map_join(unquote(segments), "/", &URI.encode_www_form/1))
+    quote(do: "/" <> Enum.map_join(unquote(segments), "/", &unquote(__MODULE__).encode_param/1))
   end
 
   defp expand_segments([{:|, _, [h, t]}], acc),

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -509,4 +509,9 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.static_url(conn_with_script_name(~w(foo)), "/images/foo.png") ==
            "https://static.example.com/api/images/foo.png"
   end
+
+  test "helpers properly encode named and query string params" do
+    assert Router.Helpers.post_path(__MODULE__, :show, "my path", foo: "my param") ==
+      "/posts/my%20path?foo=my+param"
+  end
 end

--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -77,6 +77,12 @@ defmodule Phoenix.Router.RoutingTest do
 
     conn = call(Router, :get, "/spaced users/hello matey")
     assert conn.params == %{"id" => "hello matey"}
+
+    conn = call(Router, :get, "/users/a%20b")
+    assert conn.params == %{"id" => "a b"}
+
+    conn = call(Router, :get, "/backups/a%20b/c%20d")
+    assert conn.params == %{"path" => ["a b", "c d"]}
   end
 
   test "get to custom action" do


### PR DESCRIPTION
Route helpers encode named param segments with
URI.encode_www_form, but when named params are
received from new requests, the values were not
decoded, leading to a mismatch between how the
helpers encode params and how the route decodes
them. For example, previous behavior:

    profile_path(conn, :show, "my name")
    => "/users/my+name"
    params
    => %{"id" => "my+name"}

Fixed behavior:

    profile_path(conn, :show, "my name")
    => "/users/my+name"
    params
    => %{"id" => "my name"}


@josevalim I'd appreciate a sign-off on this one