### PR TITLE
Add only one index

### DIFF
--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -175,12 +175,13 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
 
   defp indexes(plural, assocs, uniques) do
     Enum.concat(
-      Enum.map(assocs, fn {key, _} ->
-        "create index(:#{plural}, [:#{key}])"
-      end),
-      Enum.map(uniques, fn key ->
-        "create unique_index(:#{plural}, [:#{key}])"
-      end))
+      Enum.map(uniques, fn key -> {key, true} end),
+      Enum.map(assocs, fn {key, _} -> {key, false} end))
+    |> Enum.uniq_by(fn {key, _} -> key end)
+    |> Enum.map(fn
+      {key, false} -> "create index(:#{plural}, [:#{key}])"
+      {key, true}  -> "create unique_index(:#{plural}, [:#{key}])"
+    end)
   end
 
   defp migration(false, _path), do: []


### PR DESCRIPTION
`mix phoenix.gen.model Score scores score:integer user_id:references:users:unique` currently creates two indices (with the same name)

When running the created migration this gives an error

```
00:32:35.055 [info]  == Running EcPredictions.Repo.Migrations.CreateScore.change/0 forward

00:32:35.056 [info]  create table scores

00:32:35.077 [info]  create index scores_user_id_index

00:32:35.078 [info]  create index scores_user_id_index
** (Postgrex.Error) ERROR (duplicate_table): relation "scores_user_id_index" already exists
```

This pull requests filters out the normal index you get with an association.

Also adds a test for the fact that an index is added when adding a belongs_to field