### PR TITLE
Fix binary-id generator location in config/config.exs

### DIFF
--- a/installer/templates/new/config/config.exs
+++ b/installer/templates/new/config/config.exs
@@ -22,7 +22,7 @@ config :<%= application_name %>, <%= application_module %>.Endpoint,
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]
-
+<%= generator_config %>
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"


### PR DESCRIPTION
Previously the config for the phoenix generators was appended to the
file. This is technically not a problem, however the comment for the
`import_config "#{Mix.env}.exs" explicitly states that it should be at
the bottom of the file.

Before:

    # Import environment specific config. This must remain at the bottom
    # of this file so it overrides the configuration defined above.
    import_config "#{Mix.env}.exs"

    # Configure phoenix generators
    config :phoenix, :generators,
      binary_id: true

After:

    # Configure phoenix generators
    config :phoenix, :generators,
      binary_id: true

    # Import environment specific config. This must remain at the bottom
    # of this file so it overrides the configuration defined above.
    import_config "#{Mix.env}.exs"

The spacing in the template is deliberate to ensure there is only a
single space between the blocks.