### PR TITLE
Use put_req_header correctly in recycle documentation

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -85,8 +85,7 @@ defmodule Phoenix.ConnTest do
       conn = post conn, "/login"
 
       # We can also recycle manually in case we want custom headers
-      conn = recycle(conn)
-      conn = put_req_header("x-special", "nice")
+      conn |> recycle() |> put_req_header("x-special", "nice")
 
       # No recycling as we did it explicitly
       conn = delete conn, "/logout"


### PR DESCRIPTION
The first arg for `put_req_header` should be the `conn` itself. 