### PR TITLE
Add an `includes?` method to Presence to check presences by key

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -160,6 +160,11 @@ defmodule Phoenix.Presence do
 
       def fetch(_topic, presences), do: presences
 
+      def includes?(%Phoenix.Socket{topic: topic}, key), do: includes?(topic, key)
+      def includes?(topic, key) do
+        Phoenix.Presence.includes?(__MODULE__, topic, key)
+      end
+
       def list(%Phoenix.Socket{topic: topic}), do: list(topic)
       def list(topic) do
         Phoenix.Presence.list(__MODULE__, topic)
@@ -202,6 +207,13 @@ defmodule Phoenix.Presence do
         Phoenix.PubSub.direct_broadcast!(node_name, pubsub_server, topic, msg)
       end
     end)
+  end
+
+  @doc """
+  Returns true if there's a certain presence for a topic.
+  """
+  def includes?(module, topic, key) do
+    Enum.find(Phoenix.Tracker.list(module, topic), fn {k, _} -> k == key end) != nil
   end
 
   @doc """

--- a/test/phoenix/presence_test.exs
+++ b/test/phoenix/presence_test.exs
@@ -49,6 +49,15 @@ defmodule Phoenix.PresenceTest do
            MyPresence.list(config.topic)
   end
 
+  test "includes?/2 returns true if key is present", config do
+    assert {:ok, _} = MyPresence.track(self(), config.topic, 1, %{name: "u1"})
+    assert MyPresence.includes?(config.topic, 1)
+  end
+
+  test "includes?/2 returns false if key isn't present", config do
+    refute MyPresence.includes?(config.topic, 7)
+  end
+
   test "handle_diff broadcasts events with default fetched data",
     %{topic: topic} = config do
 


### PR DESCRIPTION
I searched around if there was a method like this, but I couldn't find it.

An example usage:
I have a chat and I want to check if a certain user is online in the channel. If it isn't, for instance, send him an email.

Currently, I had to do something like:

```elixir
Presence.list("topic").has_key?(user_id)
```

With this method:

```elixir
Presence.includes?("topic", user_id)
```

Maybe it could be renamed to `exists?` or `any?`.
