### PR TITLE
Update brunch-config.js documentaion links

### DIFF
--- a/installer/templates/static/brunch/brunch-config.js
+++ b/installer/templates/static/brunch/brunch-config.js
@@ -5,14 +5,13 @@ exports.config = {
       joinTo: "js/app.js"
 
       // To use a separate vendor.js bundle, specify two files path
-      // https://github.com/brunch/brunch/blob/master/docs/config.md#files
+      // http://brunch.io/docs/config#-files-
       // joinTo: {
       //  "js/app.js": /^(web\/static\/js)/,
       //  "js/vendor.js": /^(web\/static\/vendor)|(deps)/
       // }
       //
       // To change the order of concatenation of files, explicitly mention here
-      // https://github.com/brunch/brunch/tree/master/docs#concatenation
       // order: {
       //   before: [
       //     "web/static/vendor/js/jquery-2.1.1.js",


### PR DESCRIPTION
The current link [https://github.com/brunch/brunch/blob/stable/docs/config.md#files](url) to the Brunch documentation in brunch-config.js does not work anymore due to

> The docs were moved to the Brunch website: http://brunch.io/docs/config

this pull request updates the link to the "Files" section. Also it removes the link [https://github.com/brunch/brunch/tree/master/docs#concatenation](url) as there is no direct reference to this topic in the current Brunch documentation.

