### PR TITLE
Add .svg to default gzippable_exts

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule Phoenix.Mixfile do
            generators: [],
            filter_parameters: ["password"],
            serve_endpoints: false,
-           gzippable_exts: ~w(.js .css .txt .text .html .json)]]
+           gzippable_exts: ~w(.js .css .txt .text .html .json .svg)]]
   end
 
   defp deps do


### PR DESCRIPTION
This change allows `.svg` files to be gzipped along with the rest of the text based assets (like js and css). Please let me know what you think and if I need to update anything else.