### PR TITLE
Add Endpoint.version comment for OTP hot upgrade

### DIFF
--- a/installer/templates/new/config/prod.exs
+++ b/installer/templates/new/config/prod.exs
@@ -55,10 +55,11 @@ config :logger, level: :info
 #
 #     config :<%= application_name %>, <%= application_module %>.Endpoint, server: true
 #
-# You will also need to set the application root to `.` in order
+# You will also need to set the application root to `.` and the endpoint version in order 
 # for the new static assets to be served after a hot upgrade:
 #
 #     config :<%= application_name %>, <%= application_module %>.Endpoint, root: "."
+#     config :<%= application_name %>, <%= application_module %>.Endpoint, version: Mix.Project.config(:version)
 
 # Finally import the config/prod.secret.exs
 # which should be versioned separately.


### PR DESCRIPTION
As per https://github.com/bitwalker/exrm/issues/206,
set the Endpoint.version to trigger code change callback when performing hot upgrade.