### PR TITLE
Change generated changeset default to :empty

### DIFF
--- a/priv/templates/phoenix.gen.model/model.ex
+++ b/priv/templates/phoenix.gen.model/model.ex
@@ -11,7 +11,7 @@ defmodule <%= module %> do
   @doc """
   Builds a changeset based on the `struct` and `params`.
   """
-  def changeset(struct, params \\ %{}) do
+  def changeset(struct, params \\ :empty) do
     struct
     |> cast(params, [<%= Enum.map_join(attrs, ", ", &inspect(elem(&1, 0))) %>])
     |> validate_required([<%= Enum.map_join(attrs, ", ", &inspect(elem(&1, 0))) %>])

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
         assert file =~ "field :desc, :string"
         assert file =~ "field :blob, :binary"
         assert file =~ "timestamps()"
-        assert file =~ "def changeset"
+        assert file =~ "def changeset(struct, params \\\\ :empty)"
         assert file =~ "[:name, :age, :nicks, :famous, :born_at, :secret, :desc, :blob]"
       end
 


### PR DESCRIPTION
Hey guys, I've just started learning about Phoenix and so far it's been an amazing ride. Thanks for creating this! I'm just running to a discrepancy with the generator versus what's been said in the Phoenix book. I guess the generated model should use `:empty` as the default?