### PR TITLE
Improve phoenix.new with Mix.shell.cmd/2 and error handling

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -382,12 +382,7 @@ defmodule Mix.Tasks.Phoenix.New do
 
   defp cmd(cmd) do
     Mix.shell.info [:green, "* running ", :reset, cmd]
-
-    # We use :os.cmd/1 because there is a bug in OTP
-    # where we cannot execute .cmd files on Windows.
-    # We could use Mix.shell.cmd/1 but that automatically
-    # outputs to the terminal and we don't want that.
-    :os.cmd(String.to_char_list(cmd))
+    Mix.shell.cmd(cmd, [quiet: true])
   end
 
   defp check_application_name!(name, from_app_flag) do

--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -382,7 +382,14 @@ defmodule Mix.Tasks.Phoenix.New do
 
   defp cmd(cmd) do
     Mix.shell.info [:green, "* running ", :reset, cmd]
-    Mix.shell.cmd(cmd, [quiet: true])
+    case Mix.shell.cmd(cmd, [quiet: true]) do
+      0 ->
+        true
+      _ ->
+        Mix.shell.error [:red, "* error ", :reset, "command failed to execute, " <>
+          "please run the following command again after installation: \"#{cmd}\""]
+        false
+    end
   end
 
   defp check_application_name!(name, from_app_flag) do


### PR DESCRIPTION
In this pull request I've changed the phoenix.new script to now use Mix.shell.cmd/2 instead of :os.cmd/1, because according to the comments it caused some problems on Windows systems. This is possible now because the Mix.shell.cmd/2 function supports the 'quiet: true' option.

I've also added error handling where the return code of the shell command is checked. 
Because I reside in China at the moment, on numerous occasions my 'mix deps.get' command failed because of the Chinese firewall randomly dropping connections without the phoenix.new script informing me that the command failed.

Up for debate is still how to properly handle the error. Instead of printing an error message we could of course also stop the script, but this might be a little bit too intrusive since just running the command again might solve the problem.

Let me know what you think,

Bas