### PR TITLE
Doc: fix indentation of bullet list in token.ex

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -23,14 +23,14 @@ defmodule Phoenix.Token do
 
   The first argument to both `sign/4` and `verify/4` can be one of:
 
-      * the module name of a Phoenix endpoint (shown above) - where
-        the secret key base is extracted from the endpoint
-      * `Plug.Conn` - where the secret key base is extracted from the
-        endpoint stored in the connection
-      * `Phoenix.Socket` - where the secret key base is extracted from
-        the endpoint stored in the socket
-      * a string, representing the secret key base itself. We recommend
-        a key base with at least 20 characters to provide enough entropy
+    * the module name of a Phoenix endpoint (shown above) - where
+      the secret key base is extracted from the endpoint
+    * `Plug.Conn` - where the secret key base is extracted from the
+      endpoint stored in the connection
+    * `Phoenix.Socket` - where the secret key base is extracted from
+      the endpoint stored in the socket
+    * a string, representing the secret key base itself. We recommend
+      a key base with at least 20 characters to provide enough entropy
 
   ## Usage
 


### PR DESCRIPTION
It was interpreted as code block, not bullet list.

**Before:**
![phoenix_token_before](https://cloud.githubusercontent.com/assets/79138/16563414/319ff7e2-4202-11e6-8457-4473bc8d3736.png)

**After:**
![phoenix_token_after](https://cloud.githubusercontent.com/assets/79138/16563455/6f0339be-4202-11e6-8532-e0b27cbaa770.png)
