### PR TITLE
Set host and secret_key_base from ENVs if provided

### DIFF
--- a/installer/templates/new/config/prod.exs
+++ b/installer/templates/new/config/prod.exs
@@ -6,6 +6,8 @@ use Mix.Config
 #
 # You should also configure the url host to something
 # meaningful, we use this information when generating URLs.
+# You can either replace the `host` value below, or
+# set the APP_HOSTNAME environment variable.
 #
 # Finally, we also include the path to a manifest
 # containing the digested version of static files. This
@@ -13,7 +15,8 @@ use Mix.Config
 # which you typically run after static files are built.
 config :<%= application_name %>, <%= application_module %>.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [host: "example.com", port: 80],
+  url: [host: (System.get_env("APP_HOSTNAME") || "example.com"),
+        port: 80],
   cache_static_manifest: "priv/static/manifest.json"
 
 # Do not print debug messages in production

--- a/installer/templates/new/config/prod.secret.exs
+++ b/installer/templates/new/config/prod.secret.exs
@@ -8,5 +8,9 @@ use Mix.Config
 # file or create a script for recreating it, since it's
 # kept out of version control and might be hard to recover
 # or recreate for your teammates (or you later on).
+#
+# Alternatively, you can use the provided environment variables
+# for configuration. Make sure to remove the secret values from
+# this file, and remove the file from .gitignore so you can commit it.
 config :<%= application_name %>, <%= application_module %>.Endpoint,
-  secret_key_base: "<%= prod_secret_key_base %>"
+  secret_key_base: (System.get_env("SECRET_KEY_BASE") || "<%= prod_secret_key_base %>")


### PR DESCRIPTION
What do you think about doing something along these lines to make e.g. Heroku and Dokku deploys even easier?

I like that it makes those deploys easier while not changing behaviour if you don't want to use ENVs.

I think the `host` part is more clear cut than the secret key part, since that one is still a bit fiddly: having to unignore the file, probably wanting to remove the fallback value. Maybe we could think of some clever way to make this even easier?

I intend this as the starting point of a discussion - I don't expect that you'd want to merge this as-is.