### PR TITLE
Make phoenix.js doc consistent with presence.ex

### DIFF
--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -171,7 +171,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 //     }
 //     let presences = {} // client's initial empty presence state
 //     // receive initial presence data from server, sent after join
-//     myChannel.on("presences", state => {
+//     myChannel.on("presence_state", state => {
 //       presences = Presence.syncState(presences, state, onJoin, onLeave)
 //       displayUsers(Presence.list(presences))
 //     })
@@ -1268,4 +1268,3 @@ var Timer = function () {
 }();
 
 })(typeof(exports) === "undefined" ? window.Phoenix = window.Phoenix || {} : exports);
-

--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -156,7 +156,7 @@
 //     }
 //     let presences = {} // client's initial empty presence state
 //     // receive initial presence data from server, sent after join
-//     myChannel.on("presences", state => {
+//     myChannel.on("presence_state", state => {
 //       presences = Presence.syncState(presences, state, onJoin, onLeave)
 //       displayUsers(Presence.list(presences))
 //     })


### PR DESCRIPTION
While trying out the new and exciting Presence feature I've just discovered phoenix.js documentation is wrong. In the example it says you should listen to `presences` room channel event to get the current presence of the room channel after you join it. It seems listening to that event doesn't trigger anything. However changing it to `presence_state` does the job.

Edit: Just realized you can use the event name you prefer in the `handle_info(:after_join)` call. In this case `presence.ex` [doc](https://github.com/phoenixframework/phoenix/blob/f7ea46ea581d96ef40245264085369261d195473/lib/phoenix/presence.ex#L46) says `presence_state` so rather than a documentation fix I'd say this PR is a consistency improvement.