### PR TITLE
fix phoenix channel doc Subscribing to external topics

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -231,6 +231,7 @@ defmodule Phoenix.Channel do
             else
               :ok = MyApp.Endpoint.subscribe(topic)
               assign(acc, :topics, [topic | topics])
+              acc
             end
           end)
         end

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -226,12 +226,12 @@ defmodule Phoenix.Channel do
 
         defp put_new_topics(socket, topics) do
           Enum.reduce(topics, socket, fn topic, acc ->
-            if topic in acc.assigns.topics do
+            topics = acc.assigns.topics
+            if topic in topics do
               acc
             else
               :ok = MyApp.Endpoint.subscribe(topic)
               assign(acc, :topics, [topic | topics])
-              acc
             end
           end)
         end


### PR DESCRIPTION
`Enum.reduce` has to return the accumulator otherwise in this example `MyApp.Endpoint` just subscribe 1 `topic` in list `topics`.
Example:
topics = ["user:1", "user:2"]

without return `acc`:
`iex> "user:1"`
and return `acc`:
`iex>"user:1"`
`iex>"user:2"`
