### PR TITLE
Add docs for URI argument in Router url helpers

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -71,7 +71,13 @@ defmodule Phoenix.Router do
       "/dynamic/something"
 
   The url generated in the named url helpers is based on the configuration for
-  `:url`, `:http` and `:https`.
+  `:url`, `:http` and `:https`. However, if for some reason you need to manually
+  control the URL generation, the url helpers also allow you to pass in a [`URI`](http://elixir-lang.org/docs/stable/elixir/URI.html)
+  struct:
+
+      uri = %URI{scheme: "https", host: "other.example.com"}
+      MyApp.Router.Helpers.page_url(uri, :show, "hello")
+      "https://other.example.com/pages/hello"
 
   The named helper can also be customized with the `:as` option. Given
   the route:


### PR DESCRIPTION
This is a proposal to add a check for the `scheme` field of the Plug.Conn when generating URLs with the Router Helpers.

My use case was the following:
I have a phoenix server running behind an SSL proxy (ELB in this case) and I wanted to return URLs with a scheme based on the protocol the client uses. (Which is set through "x-forwarded-proto")

Thoughts? :smile: 