### PR TITLE
Silence unused warnings in support test cases

### DIFF
--- a/installer/templates/new/test/support/channel_case.ex
+++ b/installer/templates/new/test/support/channel_case.ex
@@ -37,6 +37,8 @@ defmodule <%= application_module %>.ChannelCase do
     unless tags[:async] do
       <%= adapter_config[:test_async] %>
     end
+<% else %>
+    _ = tags
 <% end %>
     :ok
   end

--- a/installer/templates/new/test/support/conn_case.ex
+++ b/installer/templates/new/test/support/conn_case.ex
@@ -38,6 +38,8 @@ defmodule <%= application_module %>.ConnCase do
     unless tags[:async] do
       <%= adapter_config[:test_async] %>
     end
+<% else %>
+    _ = tags
 <% end %>
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end


### PR DESCRIPTION
When generating with the `--no-ecto` option, both `ConnCase` and `ChannelCase` were issuing an unused variable warning.