### PR TITLE
write actual addr in server's log

### DIFF
--- a/lib/phoenix/endpoint/cowboy_handler.ex
+++ b/lib/phoenix/endpoint/cowboy_handler.ex
@@ -112,7 +112,7 @@ defmodule Phoenix.Endpoint.CowboyHandler do
 
   defp info(scheme, endpoint, ref) do
     {addr,port} = :ranch.get_addr(ref)
-    addr_str = :inet_parse.ntoa(addr)
+    addr_str = :inet.ntoa(addr)
     "Running #{inspect endpoint} with Cowboy using #{scheme}://#{addr_str}:#{port}"
   end
 end

--- a/lib/phoenix/endpoint/cowboy_handler.ex
+++ b/lib/phoenix/endpoint/cowboy_handler.ex
@@ -112,6 +112,7 @@ defmodule Phoenix.Endpoint.CowboyHandler do
 
   defp info(scheme, endpoint, ref) do
     port = :ranch.get_port(ref)
-    "Running #{inspect endpoint} with Cowboy using #{scheme}://localhost:#{port}"
+    {{a,b,c,d},_port} = :ranch.get_addr(ref)
+    "Running #{inspect endpoint} with Cowboy using #{scheme}://#{a}.#{b}.#{c}.#{d}:#{port}"
   end
 end

--- a/lib/phoenix/endpoint/cowboy_handler.ex
+++ b/lib/phoenix/endpoint/cowboy_handler.ex
@@ -111,8 +111,8 @@ defmodule Phoenix.Endpoint.CowboyHandler do
   end
 
   defp info(scheme, endpoint, ref) do
-    port = :ranch.get_port(ref)
-    {{a,b,c,d},_port} = :ranch.get_addr(ref)
-    "Running #{inspect endpoint} with Cowboy using #{scheme}://#{a}.#{b}.#{c}.#{d}:#{port}"
+    {addr,port} = :ranch.get_addr(ref)
+    addr_str = :inet_parse.ntoa(addr)
+    "Running #{inspect endpoint} with Cowboy using #{scheme}://#{addr_str}:#{port}"
   end
 end


### PR DESCRIPTION
write actual addr in log

bug describe:

server's log always show `localhost`, even it's setuped by user, like that:

```
[info] Running Demo.Endpoint with Cowboy using http://localhost:4000
```

It will make user confused.