### PR TITLE
Fix behavior of `use Phoenix.Endpoint` with wrong otp_app

### DIFF
--- a/lib/phoenix/config.ex
+++ b/lib/phoenix/config.ex
@@ -75,6 +75,17 @@ defmodule Phoenix.Config do
   end
 
   @doc """
+  Reads the configuration for module from the given otp app.
+  Raises an exception if configuration is not found.
+
+  Useful to read a particular value at compilation time.
+  """
+  def from_env!(otp_app, module, defaults) do
+    config = Application.fetch_env!(otp_app, module)
+    merge(defaults, config)
+  end
+
+  @doc """
   Changes the configuration for the given module.
 
   It receives a keyword list with changed config and another

--- a/lib/phoenix/endpoint/adapter.ex
+++ b/lib/phoenix/endpoint/adapter.ex
@@ -87,7 +87,7 @@ defmodule Phoenix.Endpoint.Adapter do
   The endpoint configuration used at compile time.
   """
   def config(otp_app, endpoint) do
-    Phoenix.Config.from_env(otp_app, endpoint, defaults(otp_app, endpoint))
+    Phoenix.Config.from_env!(otp_app, endpoint, defaults(otp_app, endpoint))
   end
 
   @doc """

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -99,6 +99,16 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert StaticEndpoint.static_path("/phoenix.png") =~ "/static/phoenix.png"
   end
 
+  test "raises exception if otp_app is not configured" do
+    Application.put_env(:phoenix, __MODULE__.BuggyEndpoint, [])
+    err_message = "application :not_existing is not loaded, or the configuration parameter #{inspect(__MODULE__.BuggyEndpoint)} is not set"
+    assert_raise ArgumentError, err_message, fn ->
+      defmodule BuggyEndpoint do
+        use Phoenix.Endpoint, otp_app: :not_existing
+      end
+    end
+  end
+
   test "injects pubsub broadcast with configured server" do
     Endpoint.subscribe("sometopic")
     some = spawn fn -> :ok end

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -34,6 +34,7 @@ defmodule Phoenix.Test.ConnTest do
     defexception [message: nil, plug_status: 500]
   end
 
+  Application.put_env(:phoenix, __MODULE__.Endpoint, [])
   defmodule Endpoint do
     use Phoenix.Endpoint, otp_app: :phoenix
     def init(opts), do: opts


### PR DESCRIPTION
When `use Phoenix.Endpoint` is called with an otp_app that does not exist (or the given module is not configured) an error should be raised.

Details: #1815