### PR TITLE
Extract serialization into a separate class

### DIFF
--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -445,16 +445,12 @@ class JSONSerializer {
 
   binaryType() { return undefined }  
 
-  encode(payload) {
-    return new Promise((resolve) => {
-      resolve(JSON.stringify(payload))
-    })
+  encode(payload, callback) {
+    callback(JSON.stringify(payload))
   }
 
-  decode(payload) {
-    return new Promise((resolve) => {
-      resolve(JSON.parse(payload))
-    })
+  decode(payload, callback) {
+    callback(JSON.parse(payload))
   }
 }
 
@@ -616,7 +612,7 @@ export class Socket {
   push(data){
     let {topic, event, payload, ref} = data
     let callback = () => {
-      this.serializer.encode(data).then((result) => {
+      this.serializer.encode(data, (result) => {
         this.conn.send(result)
       })
     }
@@ -649,7 +645,7 @@ export class Socket {
   }
 
   onConnMessage(rawMessage){
-    this.serializer.decode(rawMessage.data).then((msg) => {
+    this.serializer.decode(rawMessage.data, (msg) => {
       let {topic, event, payload, ref} = msg
       this.log("receive", `${payload.status || ""} ${topic} ${event} ${ref && "(" + ref + ")" || ""}`, payload)
       this.channels.filter( channel => channel.isMember(topic) )
@@ -712,7 +708,7 @@ export class LongPoll {
       switch(status){
         case 200:
           messages.forEach( msg => {
-            this.serializer.encode(msg).then((encoded) => {
+            this.serializer.encode(msg, (encoded) => {
               this.onmessage({data: encoded}) 
             })
           }) 


### PR DESCRIPTION
Extract serialization out so anyone can swap the serialization method. I'm currently using this for MessagePack serialization. It will fallback to JSON if LongPoll is detected.

This would allow someone to write a different serializer such as:

``` javascript
import msgpack from "msgpack-js-v5"

export default class MsgPackSerializer {

  contentType() { return "application/msgpack" }

  isBinary() { return true }

  binaryType() { return "arraybuffer" }  

  encode(payload, callback) {
    callback(msgpack.encode(payload))
  }

  decode(payload, callback) {
    var fileReader = new FileReader()
    fileReader.onload = function(e) {
      let bytes = new Uint8Array(e.target.result.slice(0, e.target.result.byteLength))
      //console.log("about to decode message, that starts with", bytes);
      let msg = msgpack.decode(bytes)        
      callback(msg)
    }
    fileReader.readAsArrayBuffer(payload)
  }
}
```

An example of chat using MessagePack is here: https://github.com/jmerriweather/phoenix_chat
