### PR TITLE
Phoenix.Naming.camelize behavior similar to Macro.camelize for strings like 'module_name_N' where N is a digit

### DIFF
--- a/lib/phoenix/naming.ex
+++ b/lib/phoenix/naming.ex
@@ -148,6 +148,10 @@ defmodule Phoenix.Naming do
     <<to_upper_char(h)>> <> do_camelize(t, :upper)
   end
 
+  defp do_camelize(<<?_, h, t :: binary>>, case) when h in ?0..?9 do
+    <<h>> <> do_camelize(t, case)
+  end
+
   defp do_camelize(<<?_>>, _atom) do
     <<>>
   end

--- a/lib/phoenix/naming.ex
+++ b/lib/phoenix/naming.ex
@@ -93,6 +93,7 @@ defmodule Phoenix.Naming do
   @spec camelize(String.t) :: String.t
   def camelize(value), do: Macro.camelize(value)
 
+  @spec camelize(String.t, :lower) :: String.t
   def camelize("", :lower), do: ""
   def camelize(<<?_, t :: binary>>, :lower) do
     camelize(t, :lower)

--- a/lib/phoenix/naming.ex
+++ b/lib/phoenix/naming.ex
@@ -65,31 +65,7 @@ defmodule Phoenix.Naming do
   """
   @spec underscore(String.t) :: String.t
 
-  def underscore(""), do: ""
-
-  def underscore(<<h, t :: binary>>) do
-    <<to_lower_char(h)>> <> do_underscore(t, h)
-  end
-
-  defp do_underscore(<<h, t, rest :: binary>>, _) when h in ?A..?Z and not (t in ?A..?Z or t == ?.) do
-    <<?_, to_lower_char(h), t>> <> do_underscore(rest, t)
-  end
-
-  defp do_underscore(<<h, t :: binary>>, prev) when h in ?A..?Z and not prev in ?A..?Z do
-    <<?_, to_lower_char(h)>> <> do_underscore(t, h)
-  end
-
-  defp do_underscore(<<?., t :: binary>>, _) do
-    <<?/>> <> underscore(t)
-  end
-
-  defp do_underscore(<<h, t :: binary>>, _) do
-    <<to_lower_char(h)>> <> do_underscore(t, h)
-  end
-
-  defp do_underscore(<<>>, _) do
-    <<>>
-  end
+  def underscore(value), do: Macro.underscore(value)
 
   defp to_lower_char(char) when char in ?A..?Z, do: char + 32
   defp to_lower_char(char), do: char
@@ -115,61 +91,16 @@ defmodule Phoenix.Naming do
 
   """
   @spec camelize(String.t) :: String.t
-  def camelize(""), do: ""
+  def camelize(value), do: Macro.camelize(value)
 
-  def camelize(<<?_, t :: binary>>) do
-    camelize(t)
-  end
-
-  def camelize(<<h, t :: binary>>) do
-    <<to_upper_char(h)>> <> do_camelize(t, :upper)
-  end
-
-  @spec camelize(String.t, :lower) :: String.t
   def camelize("", :lower), do: ""
-
   def camelize(<<?_, t :: binary>>, :lower) do
     camelize(t, :lower)
   end
-
-  def camelize(<<h, t :: binary>>, :lower) do
-    <<to_lower_char(h)>> <> do_camelize(t, :upper)
+  def camelize(<<h, _t :: binary>> = value, :lower) do
+    <<_first, rest :: binary>> = camelize(value)
+    <<to_lower_char(h)>> <> rest
   end
-
-  defp do_camelize(<<?_, ?_, t :: binary>>, atom) do
-    do_camelize(<< ?_, t :: binary >>, atom)
-  end
-
-  defp do_camelize(<<?_, h, t :: binary>>, :lower) when h in ?A..?Z do
-    <<to_lower_char(h)>> <> do_camelize(t, :upper)
-  end
-
-  defp do_camelize(<<?_, h, t :: binary>>, :upper) when h in ?a..?z do
-    <<to_upper_char(h)>> <> do_camelize(t, :upper)
-  end
-
-  defp do_camelize(<<?_, h, t :: binary>>, case) when h in ?0..?9 do
-    <<h>> <> do_camelize(t, case)
-  end
-
-  defp do_camelize(<<?_>>, _atom) do
-    <<>>
-  end
-
-  defp do_camelize(<<?/, t :: binary>>, atom) do
-    <<?.>> <> camelize(t, atom)
-  end
-
-  defp do_camelize(<<h, t :: binary>>, atom) do
-    <<h>> <> do_camelize(t, atom)
-  end
-
-  defp do_camelize(<<>>, _atom) do
-    <<>>
-  end
-
-  defp to_upper_char(char) when char in ?a..?z, do: char - 32
-  defp to_upper_char(char), do: char
 
   @doc """
   Converts an attribute/form field into its humanize version.

--- a/test/phoenix/naming_test.exs
+++ b/test/phoenix/naming_test.exs
@@ -10,6 +10,9 @@ defmodule Phoenix.NamingTest do
     assert Naming.underscore("APIWorld") == "api_world"
     assert Naming.underscore("ErlangVM") == "erlang_vm"
     assert Naming.underscore("API.V1.User") == "api/v1/user"
+    assert Naming.underscore("") == ""
+    assert Naming.underscore("FooBar1") == "foo_bar1"
+    assert Naming.underscore("fooBar1") == "foo_bar1"
   end
 
   test "camelize/1 converts Strings to camel case" do
@@ -21,6 +24,9 @@ defmodule Phoenix.NamingTest do
     assert Naming.camelize("_FooBar") == "FooBar"
     assert Naming.camelize("foobar_") == "Foobar"
     assert Naming.camelize("foobar_1") == "Foobar1"
+    assert Naming.camelize("") == ""
+    assert Naming.camelize("_foo_bar") == "FooBar"
+    assert Naming.camelize("foo_bar_1") == "FooBar1"
   end
 
   test "camelize/2 converts Strings to lower camel case" do
@@ -32,5 +38,8 @@ defmodule Phoenix.NamingTest do
     assert Naming.camelize("_FooBar", :lower) == "fooBar"
     assert Naming.camelize("foobar_", :lower) == "foobar"
     assert Naming.camelize("foobar_1", :lower) == "foobar1"
+    assert Naming.camelize("", :lower) == ""
+    assert Naming.camelize("_foo_bar", :lower) == "fooBar"
+    assert Naming.camelize("foo_bar_1", :lower) == "fooBar1"
   end
 end

--- a/test/phoenix/naming_test.exs
+++ b/test/phoenix/naming_test.exs
@@ -20,6 +20,7 @@ defmodule Phoenix.NamingTest do
     assert Naming.camelize("__foobar") == "Foobar"
     assert Naming.camelize("_FooBar") == "FooBar"
     assert Naming.camelize("foobar_") == "Foobar"
+    assert Naming.camelize("foobar_1") == "Foobar1"
   end
 
   test "camelize/2 converts Strings to lower camel case" do
@@ -30,5 +31,6 @@ defmodule Phoenix.NamingTest do
     assert Naming.camelize("__foobar", :lower) == "foobar"
     assert Naming.camelize("_FooBar", :lower) == "fooBar"
     assert Naming.camelize("foobar_", :lower) == "foobar"
+    assert Naming.camelize("foobar_1", :lower) == "foobar1"
   end
 end


### PR DESCRIPTION
I noticed an issue when I created a new phoenix application with:
`mix phoenix.new channel_test_2`, which produced modules named `ChannelTest2...`
but when I created a new channel like:
`mix phoenix.gen.channel Room`, the channel and test module were named `ChannelTest_2.RoomChannel` and `ChannelTest_2.RoomChannelTest`.

I dug into this and noticed that `phoenix.new` uses `Macro.camelize`, while `phoenix.gen.channel` uses  `Phoenix.Naming.camelize`, which didn't handle the `_2` case the same as `Macro.camelize`. This PR makes `Phoenix.Naming.camelize` behave similarly, at least for the _[some digit] case.

`Phoenix.Naming.underscore` already behaves in a manner similar to `Macro.underscore`, so no changes were needed there.

**Note**
Camelizing _[digit] is a little weird, as formatting will be lost when coverting back to underscores for the some_module_1 case:
```Elixir
iex(1)> Phoenix.Naming.camelize("some_module_1")
"SomeModule1"
iex(2)> Phoenix.Naming.camelize("some_module1")
"SomeModule1"
iex(3)> Phoenix.Naming.underscore("SomeModule1")
"some_module1"
```
This behavior is identical to `Macro.camelize` and `Macro.underscore`, though:
```Elixir
iex(1)> Macro.camelize("some_module_1")
"SomeModule1"
iex(2)> Macro.camelize("some_module1")
"SomeModule1"
iex(3)> Macro.underscore("SomeModule1")
"some_module1"

```