### PR TITLE
Remove out of date docs for errors_on

### DIFF
--- a/installer/templates/ecto/model_case.ex
+++ b/installer/templates/ecto/model_case.ex
@@ -49,13 +49,6 @@ defmodule <%= application_module %>.ModelCase do
   You could then write your assertion like:
 
       assert {:password, "is unsafe"} in errors_on(%User{}, %{password: "password"})
-
-  You can also create the changeset manually and retrieve the errors
-  field directly:
-
-      iex> changeset = User.changeset(%User{}, password: "password")
-      iex> {:password, "is unsafe"} in changeset.errors
-      true
   """
   def errors_on(struct, data) do
     struct.__struct__.changeset(struct, data)


### PR DESCRIPTION
With the new error format in Ecto 2, this is no longer true.