### PR TITLE
New feature: Force WebSocket transport garbage collection

### DIFF
--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -36,6 +36,15 @@ defmodule Phoenix.Transports.WebSocket do
 
   The `encode!/1` function must return a tuple in the format
   `{:socket_push, :text | :binary, String.t | binary}`.
+
+  ## Garbage collection
+
+  It's possible to force garbage collection in the transport process after
+  processing large messages.
+
+  Send `:garbage_collect` clause to the transport process:
+
+      send socket.transport_pid, :garbage_collect
   """
 
   @behaviour Phoenix.Socket.Transport

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -136,6 +136,12 @@ defmodule Phoenix.Transports.WebSocket do
     format_reply(msg, state)
   end
 
+  @doc false
+  def ws_info(:garbage_collect, state) do
+    :erlang.garbage_collect(self())
+    {:ok, state}
+  end
+
   def ws_info(_, state) do
     {:ok, state}
   end


### PR DESCRIPTION
Allow to force WebSocket transport process garbage collection with `send socket.transport_pid, :garbage_collect`. Could be useful after processing large messages.