### PR TITLE
Use clearer language when recommending bang functions in seeds

### DIFF
--- a/installer/templates/ecto/seeds.exs
+++ b/installer/templates/ecto/seeds.exs
@@ -8,4 +8,4 @@
 #     <%= application_module %>.Repo.insert!(%<%= application_module %>.SomeModel{})
 #
 # We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
+# and so on) as they will halt execution if something goes wrong.


### PR DESCRIPTION
A very minor tweak, but I feel like the proposed change is much clearer. The current text in `seeds.exs` is rather redundant.. "as they will fail if something goes wrong" can be said about literally any failure, anywhere. Specifying that execution will be halted if something goes wrong more clearly conveys the intended use of bang functions