### PR TITLE
push socket should be before Presence.track in doc

### DIFF
--- a/priv/templates/phoenix.gen.presence/presence.ex
+++ b/priv/templates/phoenix.gen.presence/presence.ex
@@ -19,10 +19,10 @@ defmodule <%= module %> do
         end
 
         def handle_info(:after_join, socket) do
+          push socket, "presence_state", Presence.list(socket)
           {:ok, _} = Presence.track(socket, socket.assigns.user_id, %{
             online_at: inspect(System.system_time(:seconds))
           })
-          push socket, "presence_state", Presence.list(socket)
           {:noreply, socket}
         end
       end


### PR DESCRIPTION
Hi,
I just started to play with `Phoenix.Presence`.
 I guess the `push` to the socket has to be done after `Phoenix.Presence.track` in the doc, which I guess it would track the data in his own process and *then* send the presence list to the clients
Thanks!