### PR TITLE
List assigns keys on template mismatch errors

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -121,7 +121,7 @@ defmodule Phoenix.Template do
         <> available_templates(exception.available)
         <> "\nAssigns:\n\n"
         <> inspect(exception.assigns)
-        <> "\n"
+        <> "\n\nAssigned keys: #{inspect Map.keys(exception.assigns)}\n"
     end
 
     defp available_templates([]), do: "No templates were compiled for this module."


### PR DESCRIPTION
Following the discussion on the mailing list: https://groups.google.com/d/msg/phoenix-core/mElIxJkO8RU/5zYSjqUBDQAJ