### PR TITLE
Add :view key to phoenix_controller_render event metadata

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -637,7 +637,7 @@ defmodule Phoenix.Controller do
     view = Map.get(conn.private, :phoenix_view) ||
             raise "a view module was not specified, set one with put_view/2"
 
-    runtime_data = %{template: template, format: format}
+    runtime_data = %{view: view, template: template, format: format}
     data = Phoenix.Endpoint.instrument conn, :phoenix_controller_render, runtime_data, fn ->
       Phoenix.View.render_to_iodata(view, template, Map.put(conn.assigns, :conn, conn))
     end

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -338,8 +338,9 @@ defmodule Phoenix.Endpoint do
       The `%Plug.Conn{}` is passed as runtime metadata.
     * `:phoenix_controller_render` - the rendering of a view from a
       controller. The map of runtime metadata passed to instrumentation
-      callbacks has the `:template` key - for the name of the template, e.g.,
-      `"index.html"` - and the `:format` key - for the format of the template.
+      callbacks has the `:view` key - for the name of the view, e.g. `HexWeb.ErrorView`,
+      the `:template` key - for the name of the template, e.g.,
+      `"index.html"` and the `:format` key - for the format of the template.
     * `:phoenix_channel_join` - the joining of a channel. The `%Phoenix.Socket{}`
       and join params are passed as runtime metadata via `:socket` and `:params`.
     * `:phoenix_channel_receive` - the receipt of an incoming message over a


### PR DESCRIPTION
Hi,

Currently there no way to distinguish views and this patch fixes this.
When applied metadata looks like this:

```elixir
%{format: "json-api", template: "index.json-api", view: Api.UserView}
```

Can this be applied to 1.2 branch as well? 

Thank you.