### PR TITLE
Expose source es6 file too in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "phoenix",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "The official JavaScript client for the Phoenix web framework.",
   "license": "MIT",
   "main": "./priv/static/phoenix.js",
@@ -15,7 +15,7 @@
     "babel-brunch": "~6.0.0",
     "uglify-js-brunch": "~2.0.1"
   },
-  "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js"],
+  "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js", "web/static/js/phoenix.js"],
   "scripts": {
     "test": "./node_modules/.bin/mocha ./web/test/**/*.js --compilers js:babel-register"
   }


### PR DESCRIPTION
Packages published to NPM better include its original source files, as the they are not meant to be served directly. (although can be, through npmcdn or other services)

Including the original es6 code enables all sorts of nice functions in build tools.