### PR TITLE
Remove empty line after indexes in migrations

### DIFF
--- a/priv/templates/phoenix.gen.model/migration.exs
+++ b/priv/templates/phoenix.gen.model/migration.exs
@@ -9,7 +9,7 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
 <% end %>
       timestamps()
     end
-<%= for index <- indexes do %>    <%= index %>
-<% end %>
+<%= for index <- indexes do %>
+    <%= index %><% end %>
   end
 end


### PR DESCRIPTION
It's just a small thing that has been bugging me for while.

When generating a migration, an empty line is added after the last `create index`. This removes the empty line added after the indexes creation and adds one just before.

Old behaviour:

```elixir
defmodule MyApp.Repo.Migrations.CreateMyTable do
  use Ecto.Migration

  def change do
    create table(:my_table) do
      # ...
    end
    create index(:my_table, [:col_a])
    create index(:my_table, [:col_b])

  end
end
```

New behaviour:

```elixir
# ...
    end

    create index(:my_table, [:col_a])
    create index(:my_table, [:col_b])
  end
end
```