### PR TITLE
Remove delete! comment in generated controllers

### DIFF
--- a/priv/templates/phoenix.gen.html/controller.ex
+++ b/priv/templates/phoenix.gen.html/controller.ex
@@ -53,9 +53,6 @@ defmodule <%= module %>Controller do
 
   def delete(conn, %{"id" => id}) do
     <%= singular %> = Repo.get!(<%= alias %>, id)
-
-    # Here we use delete! (with a bang) because we expect
-    # it to always work (and if it does not, it will raise).
     Repo.delete!(<%= singular %>)
 
     conn

--- a/priv/templates/phoenix.gen.json/controller.ex
+++ b/priv/templates/phoenix.gen.json/controller.ex
@@ -45,9 +45,6 @@ defmodule <%= module %>Controller do
 
   def delete(conn, %{"id" => id}) do
     <%= singular %> = Repo.get!(<%= alias %>, id)
-
-    # Here we use delete! (with a bang) because we expect
-    # it to always work (and if it does not, it will raise).
     Repo.delete!(<%= singular %>)
 
     send_resp(conn, :no_content, "")


### PR DESCRIPTION
Was thinking that maybe it could be worth to remove the comments in the generated controllers, since none of the other methods are commented and the comment is regarding the usage of `delete!`.
The comment is added when migrating controllers to Ecto 2 https://github.com/phoenixframework/phoenix/commit/4428e142ffc8c0b6a2ae4bf639244485c9060b13 but the `delete!` was there even before that