### PR TITLE
Update Endpoint docs to better explain force_ssl config

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -110,6 +110,9 @@ defmodule Phoenix.Endpoint do
       By default, it redirects http requests and sets the
       "strict-transport-security" header for https ones.
 
+      The `:host` option is taken directly from the `:url` config; to
+      dynamically redirect to `%Conn.host`, set ':host' to `nil`.
+
     * `:secret_key_base` - a secret key used as a base to generate secrets
       for encrypting and signing data. For example, cookies and tokens
       are signed by default, but they may also be encrypted if desired.


### PR DESCRIPTION
Specify that `Plug.SSL` is forwarded `:host` from `:url`'s config
Describe how to use `Plug.SSL`'s default host value by setting to `nil`

See #1571 