### PR TITLE
restart Watcher when it crashes

### DIFF
--- a/lib/phoenix/endpoint/watcher.ex
+++ b/lib/phoenix/endpoint/watcher.ex
@@ -12,12 +12,19 @@ defmodule Phoenix.Endpoint.Watcher do
     :ok = validate(cmd, args, merged_opts)
 
     try do
-      System.cmd(cmd, args, merged_opts)
+      {_, 0} = System.cmd(cmd, args, merged_opts)
     catch
       :error, :enoent ->
         relative = Path.relative_to_cwd(cmd)
         Logger.error "Could not start watcher #{inspect relative} from #{inspect cd(merged_opts)}, executable does not exist"
         exit(:shutdown)
+    rescue
+      MatchError ->
+        # System.cmd returned a non-zero exit code
+        # sleep for a couple seconds before exiting to ensure this doesn't
+        # hit the supervisor's max_restarts / max_seconds limit
+        Process.sleep(2000)
+        exit(:watcher_command_error)
     end
   end
 

--- a/lib/phoenix/endpoint/watcher.ex
+++ b/lib/phoenix/endpoint/watcher.ex
@@ -12,14 +12,16 @@ defmodule Phoenix.Endpoint.Watcher do
     :ok = validate(cmd, args, merged_opts)
 
     try do
-      {_, 0} = System.cmd(cmd, args, merged_opts)
+      System.cmd(cmd, args, merged_opts)
     catch
       :error, :enoent ->
         relative = Path.relative_to_cwd(cmd)
         Logger.error "Could not start watcher #{inspect relative} from #{inspect cd(merged_opts)}, executable does not exist"
         exit(:shutdown)
-    rescue
-      MatchError ->
+    else
+      {_, 0} ->
+        :ok
+      {_, _} ->
         # System.cmd returned a non-zero exit code
         # sleep for a couple seconds before exiting to ensure this doesn't
         # hit the supervisor's max_restarts / max_seconds limit


### PR DESCRIPTION
fixes issue #1870 

If System.cmd returns a non-zero exit code in watcher this will sleep a few seconds (to avoid hitting the max restarts / max seconds of the supervisor) and then exits and is restarted.

I'd spoken with Chris last week about logging something when we do this but after having played with it I think the output from brunch is probably sufficient for the user to understand what's happening.

Example:
```
/Users/adamkittelson/Code/apathy-drive-ex/brunch-config.js:11
          'web/static/js/app/jquery-1.10.2.min.js':
                                                  ^
Error: couldn't load config /Users/adamkittelson/Code/apathy-drive-ex/brunch-config.js. SyntaxError: Unexpected token :
  at Object.exports.loadConfig (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/lib/helpers.js:592:13)
  at initialize (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/lib/watch.js:461:18)
  at new BrunchWatcher (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/lib/watch.js:650:5)
  at module.exports.watch (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/lib/watch.js:716:10)
  at start (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/lib/index.js:15:31)
  at Command.listener (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/node_modules/commander/index.js:289:8)
  at Command.emit (events.js:98:17)
  at Command.parseArgs (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/node_modules/commander/index.js:572:12)
  at Command.parse (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/node_modules/commander/index.js:438:21)
  at Object.exports.run (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/lib/cli.js:63:11)
  at Object.<anonymous> (/Users/adamkittelson/Code/apathy-drive-ex/node_modules/brunch/bin/brunch:11:22)
  at Module._compile (module.js:456:26)
  at Object.Module._extensions..js (module.js:474:10)
  at Module.load (module.js:356:32)
  at Function.Module._load (module.js:312:12)
  at Function.Module.runMain (module.js:497:10)
  at startup (node.js:119:16)
  at node.js:929:3

[error] Task #PID<0.1302.0> started from ApathyDrive.Endpoint terminating
** (stop) :watcher_command_error
    (phoenix) lib/phoenix/endpoint/watcher.ex:26: Phoenix.Endpoint.Watcher.watch/3
    (elixir) lib/task/supervised.ex:94: Task.Supervised.do_apply/2
    (stdlib) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: &Phoenix.Endpoint.Watcher.watch/3
    Args: ["node", ["node_modules/brunch/bin/brunch", "watch", "--stdin"], [cd: "/Users/adamkittelson/Code/apathy-drive-ex"]]
```

Normally I'd probably match on the result with `case` or something but since we're already in a `try` block I just went with a `rescue`

Thanks!
Adam