### PR TITLE
handle 3-element :noreply tuple results the Channel server handle_info callback

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -310,6 +310,7 @@ defmodule Phoenix.Channel.Server do
     Expected `handle_in/3` to return one of:
 
         {:noreply, Socket.t} |
+        {:noreply, Socket.t, timeout | :hibernate} |
         {:reply, {status :: atom, response :: map}, Socket.t} |
         {:reply, status :: atom, Socket.t} |
         {:stop, reason :: term, Socket.t} |

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -301,6 +301,10 @@ defmodule Phoenix.Channel.Server do
     {:noreply, put_in(socket.ref, nil)}
   end
 
+  defp handle_result({:noreply, socket, timeout_or_hibernate}, _callback) do
+    {:noreply, put_in(socket.ref, nil), timeout_or_hibernate}
+  end
+
   defp handle_result(result, :handle_in) do
     raise """
     Expected `handle_in/3` to return one of:
@@ -321,6 +325,7 @@ defmodule Phoenix.Channel.Server do
     Expected `#{callback}` to return one of:
 
         {:noreply, Socket.t} |
+        {:noreply, Socket.t, timeout | :hibernate} |
         {:stop, reason :: term, Socket.t} |
 
     got #{inspect result}


### PR DESCRIPTION
I noticed the other day that if I returned `{:noreply, socket, :hibernate}` in a handle_info callback in one of my Channels that I received an error. I spoke briefly with @chrismccord about it this afternoon to check if it was a design decision and he invited me to make a PR.

Thanks!
Adam