### PR TITLE
Allow user definable class name in `error_tag` helper

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -35,6 +35,7 @@ defmodule Mix.Tasks.Phoenix.New do
     {:eex,  "new/priv/gettext/errors.pot",                   "priv/gettext/errors.pot"},
     {:eex,  "new/priv/gettext/en/LC_MESSAGES/errors.po",     "priv/gettext/en/LC_MESSAGES/errors.po"},
     {:eex,  "new/web/views/error_helpers.ex",                "web/views/error_helpers.ex"},
+    {:eex,  "new/test/views/error_helpers_test.exs",         "test/views/error_helpers_test.exs"}
   ]
 
   @ecto [

--- a/installer/templates/new/test/views/error_helpers_test.exs
+++ b/installer/templates/new/test/views/error_helpers_test.exs
@@ -1,0 +1,25 @@
+defmodule <%= application_module %>.ErrorHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias <%= application_module %>.ErrorHelpers
+
+<%= if html do %>
+  describe ".error_tag/3" do
+    setup do
+      form = %Phoenix.HTML.Form{errors: [title: {"some error message", []}]}
+      %{form: form}
+    end
+
+    test "renders an error tag with default class name", %{form: form} do
+      {:safe, escaped} = ErrorHelpers.error_tag(form, :title)
+      assert Enum.join(escaped) =~ "class=\"help-block\""
+    end
+
+    test "renders an error tag with defined class name", %{form: form} do
+      {:safe, escaped} = ErrorHelpers.error_tag(form, :title, class: "some-class")
+      assert Enum.join(escaped) =~ "class=\"some-class\""
+    end
+  end
+<% end %>
+end
+

--- a/installer/templates/new/web/views/error_helpers.ex
+++ b/installer/templates/new/web/views/error_helpers.ex
@@ -9,10 +9,10 @@ defmodule <%= application_module %>.ErrorHelpers do
   Generates tag for inlined form input errors.
   """
   def error_tag(form, field, opts \\ []) do
-    opts = Keyword.put_new(opts, :class, "help-block")
+    {class_name, _opts} = Keyword.pop(opts, :class, "help-block")
 
     if error = form.errors[field] do
-      content_tag :span, translate_error(error), class: opts[:class]
+      content_tag :span, translate_error(error), class: class_name
     end
   end
 <% end %>

--- a/installer/templates/new/web/views/error_helpers.ex
+++ b/installer/templates/new/web/views/error_helpers.ex
@@ -8,9 +8,11 @@ defmodule <%= application_module %>.ErrorHelpers do
   @doc """
   Generates tag for inlined form input errors.
   """
-  def error_tag(form, field) do
+  def error_tag(form, field, opts \\ []) do
+    opts = Keyword.put_new(opts, :class, "help-block")
+
     if error = form.errors[field] do
-      content_tag :span, translate_error(error), class: "help-block"
+      content_tag :span, translate_error(error), class: opts[:class]
     end
   end
 <% end %>

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -161,6 +161,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "photo_blog/web/web.ex", &refute(&1 =~ ~r"alias PhotoBlog.Repo")
 
       assert_file "photo_blog/web/views/error_helpers.ex", &assert(&1 =~ "def error_tag")
+      assert_file "photo_blog/test/views/error_helpers_test.exs", &assert(&1 =~ "PhotoBlog.ErrorHelpersTest")
 
       # No HTML
       assert File.exists?("photo_blog/test/controllers")
@@ -179,6 +180,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       refute File.exists? "photo_blog/web/templates/page/index.html.eex"
       refute File.exists? "photo_blog/web/views/layout_view.ex"
       refute File.exists? "photo_blog/web/views/page_view.ex"
+      refute File.exists? "photo_blog/test/views/error_helpers_test.exs"
 
       assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_html")
       assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_live_reload")

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -160,6 +160,8 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "photo_blog/config/prod.secret.exs", &refute(&1 =~ config)
       assert_file "photo_blog/web/web.ex", &refute(&1 =~ ~r"alias PhotoBlog.Repo")
 
+      assert_file "photo_blog/web/views/error_helpers.ex", &assert(&1 =~ "def error_tag")
+
       # No HTML
       assert File.exists?("photo_blog/test/controllers")
       refute File.exists?("photo_blog/test/controllers/.keep")

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -182,7 +182,6 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       refute File.exists? "photo_blog/web/templates/page/index.html.eex"
       refute File.exists? "photo_blog/web/views/layout_view.ex"
       refute File.exists? "photo_blog/web/views/page_view.ex"
-      refute File.exists? "photo_blog/test/views/error_helpers_test.exs"
 
       assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_html")
       assert_file "photo_blog/mix.exs", &refute(&1 =~ ~r":phoenix_live_reload")

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -162,6 +162,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
 
       assert_file "photo_blog/web/views/error_helpers.ex", &assert(&1 =~ "def error_tag")
       assert_file "photo_blog/test/views/error_helpers_test.exs", &assert(&1 =~ "PhotoBlog.ErrorHelpersTest")
+      assert_file "photo_blog/test/views/error_helpers_test.exs", &assert(&1 =~ "alias PhotoBlog.ErrorHelpers")
 
       # No HTML
       assert File.exists?("photo_blog/test/controllers")

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -48,8 +48,13 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "photo_blog/test/views/page_view_test.exs"
       assert_file "photo_blog/test/views/error_view_test.exs"
       assert_file "photo_blog/test/views/layout_view_test.exs"
+      assert_file "photo_blog/test/views/error_helpers_test.exs", &assert(&1 =~ "PhotoBlog.ErrorHelpersTest")
+      assert_file "photo_blog/test/views/error_helpers_test.exs", &assert(&1 =~ "alias PhotoBlog.ErrorHelpers")
+      assert_file "photo_blog/test/views/error_helpers_test.exs", &assert(&1 =~ ".error_tag/3")
       assert_file "photo_blog/test/support/conn_case.ex"
       assert_file "photo_blog/test/test_helper.exs"
+
+      assert_file "photo_blog/web/views/error_helpers.ex", &assert(&1 =~ "def error_tag")
 
       assert_file "photo_blog/web/controllers/page_controller.ex",
                   ~r/defmodule PhotoBlog.PageController/
@@ -159,10 +164,6 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert_file "photo_blog/config/test.exs", &refute(&1 =~ config)
       assert_file "photo_blog/config/prod.secret.exs", &refute(&1 =~ config)
       assert_file "photo_blog/web/web.ex", &refute(&1 =~ ~r"alias PhotoBlog.Repo")
-
-      assert_file "photo_blog/web/views/error_helpers.ex", &assert(&1 =~ "def error_tag")
-      assert_file "photo_blog/test/views/error_helpers_test.exs", &assert(&1 =~ "PhotoBlog.ErrorHelpersTest")
-      assert_file "photo_blog/test/views/error_helpers_test.exs", &assert(&1 =~ "alias PhotoBlog.ErrorHelpers")
 
       # No HTML
       assert File.exists?("photo_blog/test/controllers")

--- a/test/mix/tasks/phoenix.new_test.exs
+++ b/test/mix/tasks/phoenix.new_test.exs
@@ -72,7 +72,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
         capture_io(:user, fn ->
           Mix.Task.run("test", ["--no-start", "--no-compile"])
         end)
-      end) =~ ~r"4 tests, 0 failures"
+      end) =~ ~r"6 tests, 0 failures"
     end
   end
 


### PR DESCRIPTION
Pretty much what it says on the tin! This allows a user to define a specific class name (or names) when rendering `error_tag`.

```elixir
<%= error_tag f, :field, class: "error-message" %>
```

Also generates `error_helper_test.exs` with default coverage in `phoenix.new` 