### PR TITLE
Add required babel presets to static template

### DIFF
--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -15,6 +15,8 @@
     "clean-css-brunch": "~2.0.0",
     "css-brunch": "~2.0.0",
     "javascript-brunch": "~2.0.0",
-    "uglify-js-brunch": "~2.0.1"
+    "uglify-js-brunch": "~2.0.1",
+    "babel-preset-es2015": "~6.0.0",
+    "babel-preset-es2016": "~6.0.0"
   }
 }


### PR DESCRIPTION
`package.json` is currently missing packages used by babel. These packages are nog longer bundled with babel itself.