### PR TITLE
Replace endpoint manual builder impl with Plug.Builder

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -435,22 +435,13 @@ defmodule Phoenix.Endpoint do
 
   defp plug() do
     quote location: :keep do
-      @behaviour Plug
+      use Plug.Builder
       import Phoenix.Endpoint
 
-      Module.register_attribute(__MODULE__, :plugs, accumulate: true)
       Module.register_attribute(__MODULE__, :phoenix_sockets, accumulate: true)
 
       if force_ssl = Phoenix.Endpoint.__force_ssl__(__MODULE__, var!(config)) do
         plug Plug.SSL, force_ssl
-      end
-
-      def init(opts) do
-        opts
-      end
-
-      def call(conn, _opts) do
-        phoenix_pipeline(conn)
       end
 
       if var!(config)[:debug_errors] do
@@ -464,7 +455,9 @@ defmodule Phoenix.Endpoint do
       @before_compile Phoenix.Endpoint
       @phoenix_render_errors var!(config)[:render_errors]
 
-      defoverridable [init: 1, call: 2]
+      # TODO remove when https://github.com/elixir-lang/plug/pull/450 is released
+      plug :satisfy_plug_builder
+      defp satisfy_plug_builder(conn, _opts), do: conn
     end
   end
 
@@ -593,8 +586,6 @@ defmodule Phoenix.Endpoint do
   @doc false
   defmacro __before_compile__(env) do
     sockets = Module.get_attribute(env.module, :phoenix_sockets)
-    plugs = Module.get_attribute(env.module, :plugs)
-    {conn, body} = Plug.Builder.compile(env, plugs, [])
     otp_app = Module.get_attribute(env.module, :otp_app)
     instrumentation = Phoenix.Endpoint.Instrument.definstrument(otp_app, env.module)
 
@@ -617,8 +608,6 @@ defmodule Phoenix.Endpoint do
         end
       end
 
-      defp phoenix_pipeline(unquote(conn)), do: unquote(body)
-
       @doc """
       Returns all sockets configured in this endpoint.
       """
@@ -629,15 +618,6 @@ defmodule Phoenix.Endpoint do
   end
 
   ## API
-
-  @doc """
-  Stores a plug to be executed as part of the pipeline.
-  """
-  defmacro plug(plug, opts \\ []) do
-    quote do
-      @plugs {unquote(plug), unquote(opts), true}
-    end
-  end
 
   @doc """
   Defines a mount-point for a Socket module to handle channel definitions.


### PR DESCRIPTION
## Background

While recently studying the innards of Phoenix, I noticed that there appears to be partial-implementations of Plug.Builder in a few places. Namely the endpoint and controller code. I thought router may be at fault too, but realized it's a little different with pipelining.

## Solution

The endpoint work was straightforward with a couple small caveats. However, the controller proved me be trickier due to the instrumentation that's happening. Rather than trying to figure that all out, I've opted to offer the endpoint changes which may spark inspiration to dig in other places.

## Caveats

Two of them:

1. As of 1.2, Plug.Builder raises an error when nothing is plugged. By default Phoenix.Endpoint has no plugs. In order to keep it happy, a "dummy" function must be plugged. However, this [has been removed from Plug.Builder](https://github.com/elixir-lang/plug/pull/450).
2. Using Plug.Builder also imports Plug.Conn functions which may be undesirable.

## Summary

What do you think? It's nice to reduce the code and eliminate duplication implementation. Is it a valuable change?