### PR TITLE
Add conn to runtime data in render instrumentation

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -637,7 +637,7 @@ defmodule Phoenix.Controller do
     view = Map.get(conn.private, :phoenix_view) ||
             raise "a view module was not specified, set one with put_view/2"
 
-    runtime_data = %{view: view, template: template, format: format}
+    runtime_data = %{view: view, template: template, format: format, conn: conn}
     data = Phoenix.Endpoint.instrument conn, :phoenix_controller_render, runtime_data, fn ->
       Phoenix.View.render_to_iodata(view, template, Map.put(conn.assigns, :conn, conn))
     end

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -343,7 +343,8 @@ defmodule Phoenix.Endpoint do
       controller. The map of runtime metadata passed to instrumentation
       callbacks has the `:view` key - for the name of the view, e.g. `HexWeb.ErrorView`,
       the `:template` key - for the name of the template, e.g.,
-      `"index.html"` and the `:format` key - for the format of the template.
+      `"index.html"`, the `:format` key - for the format of the template, and
+      the `:conn` key - containing the `%Plug.Conn{}`.
     * `:phoenix_channel_join` - the joining of a channel. The `%Phoenix.Socket{}`
       and join params are passed as runtime metadata via `:socket` and `:params`.
     * `:phoenix_channel_receive` - the receipt of an incoming message over a


### PR DESCRIPTION
Hi, I was just digging into the instrumentation and thought this would be a nice addition to the event data for `:phoenix_controller_render`. In particular I think it would enable correlation of render/call events and make it much simpler to get any custom data to the render instrumentation in the future.

If this is acceptable I will also update the Endpoint documentation.