### PR TITLE
Future JavaScript, done right

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "phoenix",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The official JavaScript client for the Phoenix web framework.",
   "license": "MIT",
   "main": "./priv/static/phoenix.js",
+  "jsnext:main": "./web/static/js/phoenix.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/phoenixframework/phoenix.git"
@@ -15,7 +16,6 @@
     "babel-brunch": "~6.0.0",
     "uglify-js-brunch": "~2.0.1"
   },
-  "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js", "web/static/js/phoenix.js"],
   "scripts": {
     "test": "./node_modules/.bin/mocha ./web/test/**/*.js --compilers js:babel-register"
   }


### PR DESCRIPTION
For starters, [many files are automatically ignored by npm](https://docs.npmjs.com/files/package.json), so we don't need to manually specify the `files` that we wish to include.

Secondly, `main` and `jsnext:main` are all that's required of phoenix.js. These basic fields in `package.json` allow us to be compatible with the widest selection of client side bundlers.