### PR TITLE
Fix typo in Phoenix.Transports.LongPoll.Server documentation

### DIFF
--- a/lib/phoenix/transports/long_poll_server.ex
+++ b/lib/phoenix/transports/long_poll_server.ex
@@ -28,7 +28,7 @@ defmodule Phoenix.Transports.LongPoll.Server do
   @doc """
   Starts the Server.
 
-    * `socket` - The `Phoenix.Socket` struct returend from `connect/2`
+    * `socket` - The `Phoenix.Socket` struct returned from `connect/2`
       of the socket handler.
     * `window_ms` - The longpoll session timeout, in milliseconds
 


### PR DESCRIPTION
I am aware that this is not the most useful change in the world, but I've literally just started to read and understand this source code and this is the most I can contribute at this time :)