### PR TITLE
Allow non-keyword list in Endpoint http config

### DIFF
--- a/lib/phoenix/endpoint/server.ex
+++ b/lib/phoenix/endpoint/server.ex
@@ -19,14 +19,21 @@ defmodule Phoenix.Endpoint.Server do
     supervise(children, strategy: :one_for_one)
   end
 
-  defp default(config, otp_app, port) do
-    config =
-      config
+  defp default(config, otp_app, port) when is_list(config) do
+    default(Enum.partition(config, &keyword_item?/1), otp_app, port)
+  end
+  defp default({config_keywords, config_other}, otp_app, port) do
+    config_keywords =
+      config_keywords
       |> Keyword.put_new(:otp_app, otp_app)
       |> Keyword.put_new(:port, port)
 
-    Keyword.put(config, :port, to_port(config[:port]))
+    config_keywords = Keyword.put(config_keywords, :port, to_port(config_keywords[:port]))
+
+    config_keywords ++ config_other
   end
+
+  defp keyword_item?(item), do: Keyword.keyword?([item])
 
   defp to_port(nil), do: raise "server can't start because :port in config is nil, please use a valid port number"
   defp to_port(binary)  when is_binary(binary), do: String.to_integer(binary)


### PR DESCRIPTION
For example:

    config :my_app, MyApp.Endpoint,
      http: [{:port, 4000}, :inet6]

Redo of #1932 plus a test