### PR TITLE
Fix extra 204 response when 404 error and debug_errors enabled

### DIFF
--- a/lib/phoenix/endpoint/render_errors.ex
+++ b/lib/phoenix/endpoint/render_errors.ex
@@ -52,6 +52,7 @@ defmodule Phoenix.Endpoint.RenderErrors do
 
   defp __catch__(_conn, :error, %Phoenix.Router.NoRouteError{} = reason, stack, opts) do
     maybe_render(reason.conn, :error, reason, stack, opts)
+    :erlang.raise(:error, reason, stack)
   end
 
   defp __catch__(conn, kind, reason, stack, opts) do

--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -10,7 +10,7 @@ defmodule Phoenix.Integration.EndpointTest do
   alias Phoenix.Integration.AdapterTest.ProdInet6Endpoint
 
   Application.put_env(:endpoint_int, ProdEndpoint,
-      http: [port: "4807"], url: [host: "example.com"], server: true)
+      http: [port: "4807"], url: [host: "example.com"], server: true, render_errors: [accepts: ~w(html json)])
   Application.put_env(:endpoint_int, DevEndpoint,
       http: [port: "4808"], debug_errors: true)
   Application.put_env(:endpoint_int, ProdInet6Endpoint,
@@ -112,6 +112,10 @@ defmodule Phoenix.Integration.EndpointTest do
       {:ok, resp} = HTTPClient.request(:get, "http://127.0.0.1:#{@prod}/unknown", %{})
       assert resp.status == 404
       assert resp.body == "404.html from Phoenix.ErrorView"
+
+      {:ok, resp} = HTTPClient.request(:get, "http://127.0.0.1:#{@prod}/unknown?_format=json", %{})
+      assert resp.status == 404
+      assert resp.body |> Poison.decode!() == %{"error" => "Got 404 from error with GET"}
 
       assert capture_log(fn ->
         {:ok, resp} = HTTPClient.request(:get, "http://127.0.0.1:#{@prod}/oops", %{})

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,6 +6,10 @@ Application.ensure_all_started(:cowboy)
 # Used whenever a router fails. We default to simply
 # rendering a short string.
 defmodule Phoenix.ErrorView do
+  def render("404.json", %{kind: kind, reason: _reason, stack: _stack, conn: conn}) do
+    %{error: "Got 404 from #{kind} with #{conn.method}"}
+  end
+
   def render(template, %{conn: conn}) do
     unless conn.private.phoenix_endpoint do
       raise "no endpoint in error view"


### PR DESCRIPTION
Potential fix for #1920 

![extra_204_response_on_404](https://cloud.githubusercontent.com/assets/1169424/18796192/ce4d2368-81d0-11e6-849d-dc43b3df3b86.png)

On screenshot displayed traffic for 2 get requests which render 404 page.
First request was made before fix and contains one extra 204 response,
second request was made after fix and contains only one response.
