### PR TITLE
Fix flaky installer tests

### DIFF
--- a/installer/lib/phoenix_new.ex
+++ b/installer/lib/phoenix_new.ex
@@ -166,7 +166,7 @@ defmodule Mix.Tasks.Phoenix.New do
 
     case argv do
       [] ->
-        Mix.Task.run "help", ["phoenix.new"]
+        Mix.Tasks.Help.run ["phoenix.new"]
       [path|_] ->
         app = opts[:app] || Path.basename(Path.expand(path))
         check_application_name!(app, !!opts[:app])

--- a/installer/lib/phx_new.ex
+++ b/installer/lib/phx_new.ex
@@ -73,7 +73,7 @@ defmodule Mix.Tasks.Phx.New do
 
     case argv do
       [] ->
-        Mix.Task.run "help", ["phx.new"]
+        Mix.Tasks.Help.run ["phx.new"]
       [base_path | _] ->
         generator = if opts[:umbrella], do: Umbrella, else: Single
         {app, app_mod, app_path} = generator.app(base_path, opts)


### PR DESCRIPTION
Looks like this change fixes the random build failures.

I'm still not exactly sure what's causing this, but it looks like calling the task directly (rather than going through Mix.TasksServer) fixes it - some race conditions, silent failure maybe? At the very least I was able to get a consistent repro test, see this commit message & content: https://github.com/wojtekmach/phoenix/commit/552b00a55c1924ae82f1fb0957d8ed1c4014dfde - perhaps someone more experienced might have better luck tracking it down :-)