### PR TITLE
Fix brunch crash when file is removed and readded

### DIFF
--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "babel-brunch": "~6.0.0",
-    "brunch": "2.7.4",
+    "brunch": "2.7.7",
     "clean-css-brunch": "~2.0.0",
     "css-brunch": "~2.0.0",
     "javascript-brunch": "~2.0.0",


### PR DESCRIPTION
Brunch version 2.7.4 has a bug that when a file is removed and then readded, brunch crashes. This is fixed in version 2.7.7.

https://github.com/brunch/brunch/issues/1332