### PR TITLE
Brunch: lock npm dependency versions

### DIFF
--- a/installer/templates/assets/brunch/package.json
+++ b/installer/templates/assets/brunch/package.json
@@ -10,11 +10,11 @@
     "phoenix_html": "file:<%= brunch_deps_prefix %>deps/phoenix_html"<% end %>
   },
   "devDependencies": {
-    "babel-brunch": "~6.0.0",
-    "brunch": "2.7.4",
-    "clean-css-brunch": "~2.0.0",
-    "css-brunch": "~2.0.0",
-    "javascript-brunch": "~2.0.0",
-    "uglify-js-brunch": "~2.0.1"
+    "babel-brunch": "6.0.6",
+    "brunch": "2.8.2",
+    "clean-css-brunch": "2.0.0",
+    "css-brunch": "2.6.1",
+    "javascript-brunch": "2.0.0",
+    "uglify-js-brunch": "2.0.1"
   }
 }

--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -10,11 +10,11 @@
     "phoenix_html": "file:<%= brunch_deps_prefix %>deps/phoenix_html"<% end %>
   },
   "devDependencies": {
-    "babel-brunch": "~6.0.0",
+    "babel-brunch": "6.0.6",
     "brunch": "2.7.4",
-    "clean-css-brunch": "~2.0.0",
-    "css-brunch": "~2.0.0",
-    "javascript-brunch": "~2.0.0",
-    "uglify-js-brunch": "~2.0.1"
+    "clean-css-brunch": "2.0.0",
+    "css-brunch": "2.6.1",
+    "javascript-brunch": "2.0.0",
+    "uglify-js-brunch": "2.0.1"
   }
 }

--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "babel-brunch": "6.0.6",
-    "brunch": "2.7.4",
+    "brunch": "2.8.2",
     "clean-css-brunch": "2.0.0",
     "css-brunch": "2.6.1",
     "javascript-brunch": "2.0.0",


### PR DESCRIPTION
The are 2 ways to ensure deploy reliability with npm versions:

a. The perfect way: Use [npm-shrinkwrap.json](https://docs.npmjs.com/cli/shrinkwrap); or
b. The "this will do" way: Lock versions of direct dependencies using `--save-exact`.

This does (b), since (a) is a pretty cumbersome thing to maintain, especially to those new to the npm ecosystem. While it's not as perfect as (a), it does the job most of the time.

This protects users from strange behaviors that may be introduced by new versions of Brunch plugins. I don't have an example of that at the moment, but Brunch itself has had many of those from 2.0 to 2.6 (phoenix has had Brunch's version locked already).