### PR TITLE
Fix spacing between generated Edit and Back links.

### DIFF
--- a/priv/templates/phoenix.gen.html/edit.html.eex
+++ b/priv/templates/phoenix.gen.html/edit.html.eex
@@ -3,4 +3,4 @@
 <%= "<%=" %> render "form.html", changeset: @changeset,
                         action: <%= singular %>_path(@conn, :update, @<%= singular %>) <%= "%\>" %>
 
-<%= "<%=" %> link "Back", to: <%= singular %>_path(@conn, :index) <%= "%\>" %>
+<span><%= "<%=" %> link "Back", to: <%= singular %>_path(@conn, :index) <%= "%\>" %></span>

--- a/priv/templates/phoenix.gen.html/index.html.eex
+++ b/priv/templates/phoenix.gen.html/index.html.eex
@@ -14,13 +14,13 @@
 <%= for {k, _} <- attrs do %>      <td><%= "<%=" %> <%= singular %>.<%= k %> <%= "%\>" %></td>
 <% end %>
       <td class="text-right">
-        <%= "<%=" %> link "Show", to: <%= singular %>_path(@conn, :show, <%= singular %>), class: "btn btn-default btn-xs" <%= "%\>" %>
-        <%= "<%=" %> link "Edit", to: <%= singular %>_path(@conn, :edit, <%= singular %>), class: "btn btn-default btn-xs" <%= "%\>" %>
-        <%= "<%=" %> link "Delete", to: <%= singular %>_path(@conn, :delete, <%= singular %>), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" <%= "%\>" %>
+        <span><%= "<%=" %> link "Show", to: <%= singular %>_path(@conn, :show, <%= singular %>), class: "btn btn-default btn-xs" <%= "%\>" %></span>
+        <span><%= "<%=" %> link "Edit", to: <%= singular %>_path(@conn, :edit, <%= singular %>), class: "btn btn-default btn-xs" <%= "%\>" %></span>
+        <span><%= "<%=" %> link "Delete", to: <%= singular %>_path(@conn, :delete, <%= singular %>), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" <%= "%\>" %></span>
       </td>
     </tr>
 <%% end %>
   </tbody>
 </table>
 
-<%= "<%=" %> link "New <%= template_singular %>", to: <%= singular %>_path(@conn, :new) %>
+<span><%= "<%=" %> link "New <%= template_singular %>", to: <%= singular %>_path(@conn, :new) %></span>

--- a/priv/templates/phoenix.gen.html/new.html.eex
+++ b/priv/templates/phoenix.gen.html/new.html.eex
@@ -3,4 +3,4 @@
 <%= "<%=" %> render "form.html", changeset: @changeset,
                         action: <%= singular %>_path(@conn, :create) <%= "%\>" %>
 
-<%= "<%=" %> link "Back", to: <%= singular %>_path(@conn, :index) <%= "%\>" %>
+<span><%= "<%=" %> link "Back", to: <%= singular %>_path(@conn, :index) <%= "%\>" %></span>

--- a/priv/templates/phoenix.gen.html/show.html.eex
+++ b/priv/templates/phoenix.gen.html/show.html.eex
@@ -9,5 +9,5 @@
 <% end %>
 </ul>
 
-<%= "<%=" %> link "Edit", to: <%= singular %>_path(@conn, :edit, @<%= singular %>) <%= "%\>" %>
-<%= "<%=" %> link "Back", to: <%= singular %>_path(@conn, :index) <%= "%\>" %>
+<span><%= "<%=" %> link "Edit", to: <%= singular %>_path(@conn, :edit, @<%= singular %>) <%= "%\>" %></span>
+<span><%= "<%=" %> link "Back", to: <%= singular %>_path(@conn, :index) <%= "%\>" %></span>


### PR DESCRIPTION
Just some simple span tags around it fixes it on the 3.x and 4.x CDN versions of Bootstrap I've tested.