### PR TITLE
Accept media-range with empty subtype

### DIFF
--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -282,6 +282,12 @@ defmodule Phoenix.Controller.ControllerTest do
     assert conn.params["_format"] == nil
   end
 
+  test "accepts/2 uses first matching accepts on empty subtype" do
+    conn = accepts with_accept("text/*"), ~w(json text css)
+    assert get_format(conn) == "text"
+    assert conn.params["_format"] == nil
+  end
+
   test "accepts/2 on non-empty */*" do
     # Fallbacks to HTML due to browsers behavior
     conn = accepts with_accept("application/json, */*"), ~w(html json)

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -306,11 +306,19 @@ defmodule Phoenix.Controller.ControllerTest do
     conn = accepts with_accept("text/plain, application/json, */*"), ~w(json text)
     assert get_format(conn) == "text"
     assert conn.params["_format"] == nil
+
+    conn = accepts with_accept("text/*, application/*, */*"), ~w(json text)
+    assert get_format(conn) == "text"
+    assert conn.params["_format"] == nil
   end
 
   test "accepts/2 ignores invalid media types" do
     conn = accepts with_accept("foo/bar, bar baz, application/json"), ~w(html json)
     assert get_format(conn) == "json"
+    assert conn.params["_format"] == nil
+
+    conn = accepts with_accept("foo/*, */bar, text/*"), ~w(json html)
+    assert get_format(conn) == "html"
     assert conn.params["_format"] == nil
   end
 
@@ -333,6 +341,14 @@ defmodule Phoenix.Controller.ControllerTest do
 
     conn = accepts with_accept("text/html; q=0.7, application/json; q=0.8"), ~w(html json)
     assert get_format(conn) == "json"
+    assert conn.params["_format"] == nil
+
+    conn = accepts with_accept("text/*; q=0.7, application/json"), ~w(html json)
+    assert get_format(conn) == "json"
+    assert conn.params["_format"] == nil
+
+    conn = accepts with_accept("application/json; q=0.7, text/*; q=0.8"), ~w(json html)
+    assert get_format(conn) == "html"
     assert conn.params["_format"] == nil
 
     exception = assert_raise Phoenix.NotAcceptableError, ~r/no supported media type in accept/, fn ->


### PR DESCRIPTION
HTTP Accept headers with media range without subtype should be accepted if the Plug accepts a media-type matching the base type specified in the header.

eg. Accept text/* should be accepted for text/html, text/plain etc.

RFC: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

This change doesn't affect the order in which types are currently processed in the content negotiation, just adds the ability to match media types with an empty subtype.