### PR TITLE
Phoenix.Param for maps

### DIFF
--- a/lib/phoenix/param.ex
+++ b/lib/phoenix/param.ex
@@ -10,9 +10,9 @@ defprotocol Phoenix.Param do
   Phoenix knows how to extract the `:id` from `@user` thanks
   to this protocol.
 
-  By default, Phoenix implements this protocol for integers,
-  binaries, atoms, maps and structs. For maps and structs, a
-  key `:id` is looked up.
+  By default, Phoenix implements this protocol for integers, binaries, atoms,
+  and structs. For structs, a key `:id` is assumed, but you may provide a
+  specific implementation.
 
   Nil values cannot be converted to param.
 


### PR DESCRIPTION
## Background

The documentation for `Phoenix.Param` appears to be out of sync with the implementation. It says:

> By default, [Phx] implements this protocol for [...] maps. For maps
> and structs, a key :id is looked up.

However the Map [implementation](https://github.com/phoenixframework/phoenix/blob/655f45bf9cf6cc0b1d85af3d1c9c43afbcacaf1a/lib/phoenix/param.ex#L75-L80) of the protocol raises an error.

## This Solution

The most obvious and easiest solution would be to update the documentation to match the implementation (it [was added](https://github.com/iamvery/phoenix/commit/9f668b05b57e9bc160b30397177a7e96e87b4fb3#diff-bfdd7e816187d8bfe18e7eb889727fcb) before [map support was removed](https://github.com/iamvery/phoenix/commit/870e779d593f19871d32f48e4f2440f25ced939d#diff-bfdd7e816187d8bfe18e7eb889727fcb)) , but rather than taking the easy road, I'd like to inquire more about why the protocol is not supported for maps.

The commit https://github.com/iamvery/phoenix/commit/870e779d593f19871d32f48e4f2440f25ced939d#diff-bfdd7e816187d8bfe18e7eb889727fcb seems to suggest that it was in order to support Plug 0.12. If that were the case, though, I would expect failing tests with map support added back. Is there some incompatibility that is not made obvious by the test suite?

Can you provide more context as to why maps should not be convertible to param? Thanks so much! ❤️ 