### PR TITLE
Do not import phonix_html when generating with --no-html

### DIFF
--- a/installer/templates/assets/brunch/app.js
+++ b/installer/templates/assets/brunch/app.js
@@ -11,7 +11,7 @@
 //
 // If you no longer want to use a dependency, remember
 // to also remove its path from "config.paths.watched".
-import "phoenix_html"
+<%= if html do %>import "phoenix_html"<% end %>
 
 // Import local files
 //

--- a/installer/templates/static/brunch/app.js
+++ b/installer/templates/static/brunch/app.js
@@ -11,7 +11,7 @@
 //
 // If you no longer want to use a dependency, remember
 // to also remove its path from "config.paths.watched".
-import "phoenix_html"
+<%= if html do %>import "phoenix_html"<% end %>
 
 // Import local files
 //


### PR DESCRIPTION
Currently when generating a phoenix app with `--no-html`, it will still try to import the phoenix_html javascript dependency.

```
Resolving deps of web/static/js/app.js failed. Could not load module 'phoenix_html' from '.../web/static/js'. Possible solution: add 'phoenix_html' to package.json and `npm install`.
```