### PR TITLE
Fix unclosed backquotes in Token docs

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -88,7 +88,7 @@ defmodule Phoenix.Token do
     * `:key_length` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to 32;
     * `:key_digest` - option passed to `Plug.Crypto.KeyGenerator`
-      when generating the encryption and signing keys. Defaults to `:sha256';
+      when generating the encryption and signing keys. Defaults to `:sha256`;
   """
   def sign(context, salt, data, opts \\ []) when is_binary(salt) do
     secret = get_key_base(context) |> get_secret(salt, opts)
@@ -113,7 +113,7 @@ defmodule Phoenix.Token do
     * `:key_length` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to 32;
     * `:key_digest` - option passed to `Plug.Crypto.KeyGenerator`
-      when generating the encryption and signing keys. Defaults to `:sha256';
+      when generating the encryption and signing keys. Defaults to `:sha256`;
 
   """
   def verify(context, salt, token, opts \\ [])


### PR DESCRIPTION
Fix warning when generating docs, backquotes were not closed correctly.