### PR TITLE
Add npm-debug.log to gitignore

### DIFF
--- a/installer/templates/assets/brunch/gitignore
+++ b/installer/templates/assets/brunch/gitignore
@@ -7,6 +7,9 @@
 # Generated on crash by the VM
 erl_crash.dump
 
+# Generated on crash by NPM
+npm-debug.log
+
 # Static artifacts
 /assets/node_modules
 


### PR DESCRIPTION
Hey!

I found it very annoying to have to add `npm-debug.log` to my gitignore whenever I created a new project. All I did was add it to `installer/templates/assets/brunch/gitignore`, hopefully thats all I need to do?

Thanks.