### PR TITLE
replace `milli_seconds` with `milliseconds`

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -161,5 +161,5 @@ defmodule Phoenix.Token do
     KeyGenerator.generate(secret_key_base, salt, key_opts)
   end
 
-  defp now_ms, do: System.system_time(:milli_seconds)
+  defp now_ms, do: System.system_time(:milliseconds)
 end

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -132,7 +132,7 @@ defmodule Phoenix.Transports.LongPoll do
     priv_topic =
       "phx:lp:"
       <> Base.encode64(:crypto.strong_rand_bytes(16))
-      <> (System.system_time(:milli_seconds) |> Integer.to_string)
+      <> (System.system_time(:milliseconds) |> Integer.to_string)
 
     args = [endpoint, handler, transport, __MODULE__, serializer,
             conn.params, opts[:window_ms], priv_topic]

--- a/lib/phoenix/transports/long_poll_server.ex
+++ b/lib/phoenix/transports/long_poll_server.ex
@@ -162,7 +162,7 @@ defmodule Phoenix.Transports.LongPoll.Server do
     {:noreply, %{state | buffer: [msg | state.buffer]}}
   end
 
-  defp now_ms, do: System.system_time(:milli_seconds)
+  defp now_ms, do: System.system_time(:milliseconds)
 
   defp schedule_inactive_shutdown(window_ms) do
     Process.send_after(self(), :shutdown_if_inactive, window_ms)


### PR DESCRIPTION
Elixir spec for `System.time_unit` doesn't include underscore versions (though they still work at runtime). Therefore, in a Phoenix dependent project dialyzer will generate errors (e.g. when invoking `Phoenix.Token.sign`).

Looking at Elixir docs, it seems that the decision to not support underscore style of units is deliberate. Therefore, it seems reasonable to use Elixir style of time units in Phoenix.