### PR TITLE
add phoenix endpoint to the generated ConnCase module

### DIFF
--- a/installer/templates/new/test/support/conn_case.ex
+++ b/installer/templates/new/test/support/conn_case.ex
@@ -41,6 +41,9 @@ defmodule <%= app_module %>.ConnCase do
 <% else %>
     _ = tags
 <% end %>
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    conn = Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_private(:phoenix_endpoint, @endpoint)
+
+    {:ok, conn: conn}
   end
 end

--- a/installer/templates/phx_new/test/support/conn_case.ex
+++ b/installer/templates/phx_new/test/support/conn_case.ex
@@ -39,6 +39,9 @@ defmodule <%= app_module %>.ConnCase do
       <%= adapter_config[:test_async] %>
     end
 <% end %>
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    conn = Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_private(:phoenix_endpoint, @endpoint)
+
+    {:ok, conn: conn}
   end
 end

--- a/installer/templates/phx_umbrella/apps/app_name_web/test/support/conn_case.ex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/test/support/conn_case.ex
@@ -33,6 +33,9 @@ defmodule <%= web_namespace %>.ConnCase do
       <%= adapter_config[:test_async] %>
     end
 <% end %>
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    conn = Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_private(:phoenix_endpoint, @endpoint)
+
+    {:ok, conn: conn}
   end
 end


### PR DESCRIPTION
`conn` may be used in a template, such as when making a reference to a static file using `static_path`:

```
    <link rel="stylesheet" href="<%= static_path(@conn, "/css/bundle.css") %>">
```

I think it would not be exaggerating to define the `phoenix_endpoint` in a generated `ConnCase` so the user do not need to configure this very essential capabilities. Correct me if I am wrong.
