### PR TITLE
Adding foreign key to the generated belongs to

### DIFF
--- a/priv/templates/phoenix.gen.model/migration.exs
+++ b/priv/templates/phoenix.gen.model/migration.exs
@@ -5,7 +5,7 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
     create table(:<%= plural %><%= if binary_id do %>, primary_key: false<% end %>) do
 <%= if binary_id do %>      add :id, :binary_id, primary_key: true
 <% end %><%= for {k, v} <- attrs do %>      add <%= inspect k %>, <%= inspect v %><%= migration_defaults[k] %>
-<% end %><%= for {_, i, _, s} <- assocs do %>      add <%= inspect i %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if binary_id do %>, type: :binary_id<% end %>)
+<% end %><%= for {_, i, _, s} <- assocs do %>      add <%= if(String.ends_with?(inspect(i), "_id"), do: inspect(i), else: inspect(i) <> "_id") %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if binary_id do %>, type: :binary_id<% end %>)
 <% end %>
       timestamps()
     end
@@ -13,3 +13,4 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
     <%= index %><% end %>
   end
 end
+

--- a/priv/templates/phoenix.gen.model/model.ex
+++ b/priv/templates/phoenix.gen.model/model.ex
@@ -3,7 +3,7 @@ defmodule <%= module %> do
 
   schema <%= inspect plural %> do
 <%= for {k, _} <- attrs do %>    field <%= inspect k %>, <%= inspect types[k] %><%= schema_defaults[k] %>
-<% end %><%= for {k, _, m, _} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>
+<% end %><%= for {k, _, m, _} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>, foreign_key: <%= inspect(k) <> "_id" %>
 <% end %>
     timestamps()
   end

--- a/priv/templates/phoenix.gen.model/model.ex
+++ b/priv/templates/phoenix.gen.model/model.ex
@@ -3,7 +3,7 @@ defmodule <%= module %> do
 
   schema <%= inspect plural %> do
 <%= for {k, _} <- attrs do %>    field <%= inspect k %>, <%= inspect types[k] %><%= schema_defaults[k] %>
-<% end %><%= for {k, _, m, _} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %>, foreign_key: <%= inspect(k) <> "_id" %>
+<% end %><%= for {k, _, m, _} <- assocs do %>    belongs_to <%= inspect k %>, <%= m %><%= if(String.ends_with?(inspect(k), "_id"), do: "", else: ", foreign_key: " <> inspect(k) <> "_id") %>
 <% end %>
     timestamps()
   end

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -107,7 +107,7 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
         assert file =~ "use Phoenix.Web, :model"
         assert file =~ "schema \"posts\" do"
         assert file =~ "field :title, :string"
-        assert file =~ "belongs_to :user, Phoenix.User"
+        assert file =~ "belongs_to :user, Phoenix.User, foreign_key: :user_id"
       end
     end
   end

--- a/test/mix/tasks/phoenix.gen.model_test.exs
+++ b/test/mix/tasks/phoenix.gen.model_test.exs
@@ -107,6 +107,22 @@ defmodule Mix.Tasks.Phoenix.Gen.ModelTest do
         assert file =~ "use Phoenix.Web, :model"
         assert file =~ "schema \"posts\" do"
         assert file =~ "field :title, :string"
+        assert file =~ "belongs_to :user, Phoenix.User"
+      end
+    end
+  end
+
+  test "generates belongs_to associations with foreign key provided by user" do
+    in_tmp "generates belongs_to associations", fn ->
+      Mix.Tasks.Phoenix.Gen.Model.run ["Post", "posts", "title", "user:references:users"]
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_post.exs")
+
+      assert_file migration, fn file ->
+        assert file =~ "add :user_id, references(:users, on_delete: :nothing)"
+      end
+
+      assert_file "web/models/post.ex", fn file ->
         assert file =~ "belongs_to :user, Phoenix.User, foreign_key: :user_id"
       end
     end


### PR DESCRIPTION
FIX #1605

Adding a foreign_key to the belongs to so that the key can be changed without having to update the migrations

With help from @trevoke