### PR TITLE
Add configurable logging to channels

### DIFF
--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -38,15 +38,11 @@ defmodule Phoenix.Logger do
   end
   def phoenix_channel_join(:stop, _compile, :ok), do: :ok
 
-  defp log_join("phoenix" <> _, _socket, _params), do: :ok
-  defp log_join(topic, socket, params) do
-    filtered_params = filter_values(params)
-    Logger.info fn ->
-      "JOIN #{topic} to #{inspect(socket.channel)}\n" <>
-      "  Transport:  #{inspect socket.transport}\n" <>
-      "  Parameters: #{inspect filtered_params}"
-    end
+  def phoenix_channel_receive(:start, _compile, meta) do
+    %{socket: socket, params: params, event: event} = meta
+    log_receive(socket.topic, event, socket, params)
   end
+  def phoenix_channel_receive(:stop, _compile, :ok), do: :ok
 
   @doc false
   def filter_values(values, params \\ Application.get_env(:phoenix, :filter_parameters))
@@ -72,5 +68,31 @@ defmodule Phoenix.Logger do
     params
     |> filter_values()
     |> inspect()
+  end
+
+  defp log_receive("phoenix" <> _, _event, _socket, _params), do: :ok
+  defp log_receive(topic, event, socket, params) do
+    channel_log(:log_handle_in, socket, fn ->
+      "INCOMING #{inspect event} on #{inspect topic} to #{inspect(socket.channel)}\n" <>
+      "  Transport:  #{inspect socket.transport}\n" <>
+      "  Parameters: #{inspect filter_values(params)}"
+    end)
+  end
+
+  defp log_join("phoenix" <> _, _socket, _params), do: :ok
+  defp log_join(topic, socket, params) do
+    channel_log(:log_join, socket, fn ->
+      "JOIN #{inspect topic} to #{inspect(socket.channel)}\n" <>
+      "  Transport:  #{inspect socket.transport}\n" <>
+      "  Parameters: #{inspect filter_values(params)}"
+    end)
+  end
+
+  defp channel_log(log_option, socket, message_or_func) do
+    case Map.fetch(socket, log_option) do
+      {:ok, false} -> :ok
+      {:ok, level} -> Logger.log(level, message_or_func)
+    end
+    :ok
   end
 end

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -133,7 +133,9 @@ defmodule Phoenix.Socket do
                      transport: atom,
                      transport_name: atom,
                      serializer: atom,
-                     transport_pid: pid}
+                     transport_pid: pid,
+                     log_join: atom | false,
+                     log_handle_in: atom | false}
 
   defstruct id: nil,
             assigns: %{},
@@ -148,7 +150,9 @@ defmodule Phoenix.Socket do
             transport: nil,
             transport_pid: nil,
             transport_name: nil,
-            serializer: nil
+            serializer: nil,
+            log_join: false,
+            log_handle_in: false
 
   defmacro __using__(_) do
     quote do

--- a/test/phoenix/integration/long_poll_test.exs
+++ b/test/phoenix/integration/long_poll_test.exs
@@ -11,6 +11,7 @@ defmodule Phoenix.Integration.LongPollTest do
   alias Phoenix.PubSub.Local
   alias __MODULE__.Endpoint
 
+  @moduletag :capture_log
   @port 5808
   @pool_size 1
 
@@ -23,7 +24,7 @@ defmodule Phoenix.Integration.LongPollTest do
   ])
 
   defmodule RoomChannel do
-    use Phoenix.Channel
+    use Phoenix.Channel, log_join: :info, log_handle_in: :info
 
     intercept ["new_msg"]
 

--- a/test/phoenix/logger_test.exs
+++ b/test/phoenix/logger_test.exs
@@ -100,6 +100,36 @@ defmodule Phoenix.LoggerTest do
            %{:foo => "bar", "password" => "[FILTERED]"}
   end
 
+  test "logs phoenix_channel_join as configured by the channel" do
+
+    log = capture_log(fn ->
+      socket = %Phoenix.Socket{log_join: :info}
+      Phoenix.Logger.phoenix_channel_join(:start, %{}, %{socket: socket, params: %{}})
+    end)
+    assert log =~ "JOIN"
+
+    log = capture_log(fn ->
+      socket = %Phoenix.Socket{log_join: false}
+      Phoenix.Logger.phoenix_channel_join(:start, %{}, %{socket: socket, params: %{}})
+    end)
+    assert log == ""
+  end
+
+  test "logs phoenix_channel_receive as configured by the channel" do
+    log = capture_log(fn ->
+      socket = %Phoenix.Socket{log_handle_in: :debug}
+      Phoenix.Logger.phoenix_channel_receive(:start, %{}, %{socket: socket, event: "e", params: %{}})
+    end)
+    assert log =~ "INCOMING"
+
+    log = capture_log(fn ->
+      socket = %Phoenix.Socket{log_handle_in: false}
+      Phoenix.Logger.phoenix_channel_receive(:start, %{}, %{socket: socket, event: "e", params: %{}})
+    end)
+    assert log == ""
+  end
+
+
   defp action(conn) do
     LoggerController.call(conn, LoggerController.init(:index))
   end


### PR DESCRIPTION
/cc @josevalim 

We can also ditch the clauses in the Phoenix.Logger that match on the "phoenix" topic since they are there to silence the live reloader channel, which can now simply do `log: false` internally.