### PR TITLE
Add socket.js tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,21 @@
   },
   "author": "Chris McCord <chris@chrismccord.com> (http://www.phoenixframework.org)",
   "devDependencies": {
-    "brunch": "~2.6.5",
-    "mocha": "~2.4.4",
     "babel-brunch": "~6.0.0",
+    "brunch": "~2.6.5",
+    "jsdom": "9.8.3",
+    "jsdom-global": "2.1.0",
+    "mocha": "~2.4.4",
     "uglify-js-brunch": "~2.0.1"
   },
-  "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js", "web/static/js/phoenix.js"],
+  "files": [
+    "README.md",
+    "LICENSE.md",
+    "package.json",
+    "priv/static/phoenix.js",
+    "web/static/js/phoenix.js"
+  ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha ./web/test/**/*.js --compilers js:babel-register"
+    "test": "./node_modules/.bin/mocha ./web/test/**/*.js --compilers js:babel-register -r jsdom-global/register"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "jsdom-global": "2.1.0",
     "mocha": "~2.4.4",
     "mock-socket": "^6.0.1",
-    "uglify-js-brunch": "~2.0.1",
-    "xmlhttprequest": "^1.8.0"
+    "sinon": "^1.17.6",
+    "uglify-js-brunch": "~2.0.1"
   },
   "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js", "web/static/js/phoenix.js"],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,15 +15,10 @@
     "jsdom": "9.8.3",
     "jsdom-global": "2.1.0",
     "mocha": "~2.4.4",
+    "mock-socket": "^6.0.1",
     "uglify-js-brunch": "~2.0.1"
   },
-  "files": [
-    "README.md",
-    "LICENSE.md",
-    "package.json",
-    "priv/static/phoenix.js",
-    "web/static/js/phoenix.js"
-  ],
+  "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js", "web/static/js/phoenix.js"],
   "scripts": {
     "test": "./node_modules/.bin/mocha ./web/test/**/*.js --compilers js:babel-register -r jsdom-global/register"
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "jsdom-global": "2.1.0",
     "mocha": "~2.4.4",
     "mock-socket": "^6.0.1",
-    "uglify-js-brunch": "~2.0.1"
+    "uglify-js-brunch": "~2.0.1",
+    "xmlhttprequest": "^1.8.0"
   },
   "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js", "web/static/js/phoenix.js"],
   "scripts": {

--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -724,7 +724,7 @@ export class Ajax {
       this.xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback)
     } else {
       let req = window.XMLHttpRequest ?
-                  new XMLHttpRequest() : // IE7+, Firefox, Chrome, Opera, Safari
+                  new window.XMLHttpRequest() : // IE7+, Firefox, Chrome, Opera, Safari
                   new ActiveXObject("Microsoft.XMLHTTP") // IE6, IE5
       this.xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback)
     }

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -251,19 +251,35 @@ describe("connectionState", () => {
     assert.equal(socket.connectionState(), "closed")
   })
 
-  it("returns the valid connection readyState", () => {
+  it("returns connecting", () => {
     socket.connect()
 
     socket.conn.readyState = 0
     assert.equal(socket.connectionState(), "connecting")
+    assert.ok(!socket.isConnected(), "is not connected")
+  })
+
+  it("returns open", () => {
+    socket.connect()
 
     socket.conn.readyState = 1
     assert.equal(socket.connectionState(), "open")
+    assert.ok(socket.isConnected(), "is connected")
+ })
+
+  it("returns closing", () => {
+    socket.connect()
 
     socket.conn.readyState = 2
     assert.equal(socket.connectionState(), "closing")
+    assert.ok(!socket.isConnected(), "is not connected")
+  })
+
+  it("returns closed", () => {
+    socket.connect()
 
     socket.conn.readyState = 3
     assert.equal(socket.connectionState(), "closed")
+    assert.ok(!socket.isConnected(), "is not connected")
   })
 })

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -643,3 +643,44 @@ describe("onConnClose", () => {
     assert.ok(spy.calledWith("phx_error"))
   })
 })
+
+describe("onConnError", () => {
+  let mockServer
+
+  before(() => {
+    mockServer = new WebSocketServer('wss://example.com/')
+  })
+
+  after((done) => {
+    mockServer.stop(() => {
+      window.WebSocket = null
+      done()
+    })
+  })
+
+  beforeEach(() => {
+    socket = new Socket("/socket", {
+      reconnectAfterMs: () => 100000
+    })
+    socket.connect()
+  })
+
+  it("triggers onClose callback", () => {
+    const spy = sinon.spy()
+
+    socket.onError(spy)
+
+    socket.onConnError("error")
+
+    assert.ok(spy.calledWith("error"))
+  })
+
+  it("triggers channel error", () => {
+    const channel = socket.channel("topic")
+    const spy = sinon.spy(channel, "trigger")
+
+    socket.onConnError("error")
+
+    assert.ok(spy.calledWith("phx_error"))
+  })
+})

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -2,8 +2,9 @@ import assert from "assert"
 
 import jsdom from "jsdom"
 import { WebSocket, Server as WebSocketServer } from "mock-socket"
+import { XMLHttpRequest } from "xmlhttprequest"
 
-import {Socket} from "../static/js/phoenix"
+import { Socket, LongPoll } from "../static/js/phoenix"
 
 let socket
 
@@ -65,6 +66,7 @@ describe("connect with WebSocket", () => {
 
   after(() => {
     mockServer.stop()
+    window.WebSocket = null
   })
 
   it("establishes websocket connection with endpoint", () => {
@@ -99,6 +101,63 @@ describe("connect with WebSocket", () => {
     assert.equal(lastError, "error")
 
     socket.conn.onmessage[0]({data: '{"topic":"topic","event":"event","payload":"message","status":"ok"}'})
+    assert.equal(lastMessage, "message")
+  })
+
+  it("is idempotent", () => {
+    socket = new Socket("/socket")
+    socket.connect()
+
+    let conn = socket.conn
+
+    socket.connect()
+
+    assert.deepStrictEqual(conn, socket.conn)
+  })
+})
+
+describe("connect with long poll", () => {
+  before(() => {
+    window.XMLHttpRequest = XMLHttpRequest
+  })
+
+  after(() => {
+    window.XMLHttpRequest = null
+  })
+
+  it("establishes long poll connection with endpoint", () => {
+    socket = new Socket("/socket")
+    socket.connect()
+
+    let conn = socket.conn
+    assert.ok(conn instanceof LongPoll)
+    assert.equal(conn.pollEndpoint, "http://example.com/socket/longpoll?vsn=1.0.0")
+    assert.equal(conn.timeout, 20000)
+  })
+
+  it("sets callbacks for connection", () => {
+    socket = new Socket("/socket")
+    let opens = 0
+    socket.onOpen(() => ++opens)
+    let closes = 0
+    socket.onClose(() => ++closes)
+    let lastError
+    socket.onError((error) => lastError = error)
+    let lastMessage
+    socket.onMessage((message) => lastMessage = message.payload)
+
+    socket.connect()
+
+    socket.conn.onopen()
+    assert.equal(opens, 1)
+
+    socket.conn.onclose()
+    assert.equal(closes, 1)
+
+    socket.conn.onerror("error")
+    assert.equal(lastError, "error")
+
+    socket.conn.onmessage({data: '{"topic":"topic","event":"event","payload":"message","status":"ok"}'})
     assert.equal(lastMessage, "message")
   })
 

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -59,17 +59,15 @@ describe("connect with WebSocket", () => {
   let mockServer
 
   before(() => {
-    jsdom.changeURL(window, "http://example.com/");
     mockServer = new WebSocketServer('wss://example.com/')
+    jsdom.changeURL(window, "http://example.com/");
   })
 
   after(() => {
     mockServer.stop()
   })
 
-  describe("establishes websocket connection with endpoint", () => {
-    const mockServer = new WebSocketServer('wss://example.com/')
-
+  it("establishes websocket connection with endpoint", () => {
     socket = new Socket("/socket")
     socket.connect()
 
@@ -78,7 +76,7 @@ describe("connect with WebSocket", () => {
     assert.equal(conn.url, socket.endPointURL())
   })
 
-  describe("sets callbacks for connection", () => {
+  it("sets callbacks for connection", () => {
     socket = new Socket("/socket")
     let opens = 0
     socket.onOpen(() => ++opens)
@@ -102,5 +100,16 @@ describe("connect with WebSocket", () => {
 
     socket.conn.onmessage[0]({data: '{"topic":"topic","event":"event","payload":"message","status":"ok"}'})
     assert.equal(lastMessage, "message")
+  })
+
+  it("is idempotent", () => {
+    socket = new Socket("/socket")
+    socket.connect()
+
+    let conn = socket.conn
+
+    socket.connect()
+
+    assert.deepStrictEqual(conn, socket.conn)
   })
 })

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -168,3 +168,48 @@ describe("connect with long poll", () => {
     assert.deepStrictEqual(conn, socket.conn)
   })
 })
+
+describe("disconnect", () => {
+  let mockServer
+
+  before(() => {
+    mockServer = new WebSocketServer('wss://example.com/')
+    jsdom.changeURL(window, "http://example.com/");
+    socket = new Socket("/socket")
+  })
+
+  after(() => {
+    mockServer.stop()
+    window.WebSocket = null
+  })
+
+  it("removes existing connection", () => {
+    socket.connect()
+    socket.disconnect()
+
+    assert.equal(socket.conn, null)
+  })
+
+  it("calls callback", () => {
+    let count = 0
+    socket.connect()
+    socket.disconnect(() => count++)
+
+    assert.equal(count, 1)
+  })
+
+  it("calls connection close callback", () => {
+    socket.connect()
+    const spy = sinon.spy(socket.conn, "close")
+
+    socket.disconnect(null, "code", "reason")
+
+    assert(spy.calledWith("code", "reason"))
+  })
+
+  it("does not throw when no connection", () => {
+    assert.doesNotThrow(() => {
+      socket.disconnect()
+    })
+  })
+})

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -1,5 +1,7 @@
 import assert from "assert"
+
 import jsdom from "jsdom"
+import { WebSocket, Server as WebSocketServer } from "mock-socket"
 
 import {Socket} from "../static/js/phoenix"
 
@@ -53,3 +55,52 @@ describe("endpointURL", () => {
   })
 })
 
+describe("connect with WebSocket", () => {
+  let mockServer
+
+  before(() => {
+    jsdom.changeURL(window, "http://example.com/");
+    mockServer = new WebSocketServer('wss://example.com/')
+  })
+
+  after(() => {
+    mockServer.stop()
+  })
+
+  describe("establishes websocket connection with endpoint", () => {
+    const mockServer = new WebSocketServer('wss://example.com/')
+
+    socket = new Socket("/socket")
+    socket.connect()
+
+    let conn = socket.conn
+    assert.ok(conn instanceof WebSocket)
+    assert.equal(conn.url, socket.endPointURL())
+  })
+
+  describe("sets callbacks for connection", () => {
+    socket = new Socket("/socket")
+    let opens = 0
+    socket.onOpen(() => ++opens)
+    let closes = 0
+    socket.onClose(() => ++closes)
+    let lastError
+    socket.onError((error) => lastError = error)
+    let lastMessage
+    socket.onMessage((message) => lastMessage = message.payload)
+
+    socket.connect()
+
+    socket.conn.onopen[0]()
+    assert.equal(opens, 1)
+
+    socket.conn.onclose[0]()
+    assert.equal(closes, 1)
+
+    socket.conn.onerror[0]("error")
+    assert.equal(lastError, "error")
+
+    socket.conn.onmessage[0]({data: '{"topic":"topic","event":"event","payload":"message","status":"ok"}'})
+    assert.equal(lastMessage, "message")
+  })
+})

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -62,6 +62,7 @@ describe("connect with WebSocket", () => {
   before(() => {
     mockServer = new WebSocketServer('wss://example.com/')
     jsdom.changeURL(window, "http://example.com/");
+    socket = new Socket("/socket")
   })
 
   after(() => {
@@ -70,7 +71,6 @@ describe("connect with WebSocket", () => {
   })
 
   it("establishes websocket connection with endpoint", () => {
-    socket = new Socket("/socket")
     socket.connect()
 
     let conn = socket.conn
@@ -79,7 +79,6 @@ describe("connect with WebSocket", () => {
   })
 
   it("sets callbacks for connection", () => {
-    socket = new Socket("/socket")
     let opens = 0
     socket.onOpen(() => ++opens)
     let closes = 0
@@ -105,7 +104,6 @@ describe("connect with WebSocket", () => {
   })
 
   it("is idempotent", () => {
-    socket = new Socket("/socket")
     socket.connect()
 
     let conn = socket.conn
@@ -127,7 +125,6 @@ describe("connect with long poll", () => {
   })
 
   it("establishes long poll connection with endpoint", () => {
-    socket = new Socket("/socket")
     socket.connect()
 
     let conn = socket.conn
@@ -137,7 +134,6 @@ describe("connect with long poll", () => {
   })
 
   it("sets callbacks for connection", () => {
-    socket = new Socket("/socket")
     let opens = 0
     socket.onOpen(() => ++opens)
     let closes = 0
@@ -163,7 +159,6 @@ describe("connect with long poll", () => {
   })
 
   it("is idempotent", () => {
-    socket = new Socket("/socket")
     socket.connect()
 
     let conn = socket.conn

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -9,7 +9,7 @@ import { Socket, LongPoll } from "../static/js/phoenix"
 let socket
 
 describe("protocol", () => {
-  before(() => {
+  beforeEach(() => {
     socket = new Socket("/socket")
   })
 
@@ -62,12 +62,17 @@ describe("connect with WebSocket", () => {
   before(() => {
     mockServer = new WebSocketServer('wss://example.com/')
     jsdom.changeURL(window, "http://example.com/");
-    socket = new Socket("/socket")
   })
 
-  after(() => {
-    mockServer.stop()
-    window.WebSocket = null
+  after((done) => {
+    mockServer.stop(() => {
+      done()
+      window.WebSocket = null
+    })
+  })
+
+  beforeEach(() => {
+    socket = new Socket("/socket")
   })
 
   it("establishes websocket connection with endpoint", () => {
@@ -117,11 +122,14 @@ describe("connect with WebSocket", () => {
 describe("connect with long poll", () => {
   before(() => {
     window.XMLHttpRequest = sinon.useFakeXMLHttpRequest()
-    socket = new Socket("/socket")
   })
 
   after(() => {
     window.XMLHttpRequest = null
+  })
+
+  beforeEach(() => {
+    socket = new Socket("/socket")
   })
 
   it("establishes long poll connection with endpoint", () => {
@@ -175,12 +183,17 @@ describe("disconnect", () => {
   before(() => {
     mockServer = new WebSocketServer('wss://example.com/')
     jsdom.changeURL(window, "http://example.com/");
-    socket = new Socket("/socket")
   })
 
-  after(() => {
-    mockServer.stop()
-    window.WebSocket = null
+  after((done) => {
+    mockServer.stop(() => {
+      done()
+      window.WebSocket = null
+    })
+  })
+
+  beforeEach(() => {
+    socket = new Socket("/socket")
   })
 
   it("removes existing connection", () => {
@@ -215,9 +228,16 @@ describe("disconnect", () => {
 })
 
 describe("connectionState", () => {
+  before(() => {
+    window.XMLHttpRequest = sinon.useFakeXMLHttpRequest()
+  })
+
+  after(() => {
+    window.XMLHttpRequest = null
+  })
+
   beforeEach(() => {
     socket = new Socket("/socket")
-    window.XMLHttpRequest = sinon.useFakeXMLHttpRequest()
   })
 
   it("defaults to closed", () => {

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -1,0 +1,55 @@
+import assert from "assert"
+import jsdom from "jsdom"
+
+import {Socket} from "../static/js/phoenix"
+
+let socket
+
+describe("protocol", () => {
+  before(() => {
+    socket = new Socket("/socket")
+  })
+
+  it("returns wss when location.protocal is https", () => {
+    jsdom.changeURL(window, "https://example.com/");
+
+    assert.equal(socket.protocol(), "wss")
+  })
+
+  it("returns ws when location.protocal is http", () => {
+    jsdom.changeURL(window, "http://example.com/");
+
+    assert.equal(socket.protocol(), "ws")
+  })
+})
+
+describe("endpointURL", () => {
+  it("returns endpoint for given full url", () => {
+    jsdom.changeURL(window, "https://example.com/");
+    socket = new Socket("wss://example.org/chat")
+
+    assert.equal(socket.endPointURL(), "wss://example.org/chat/websocket?vsn=1.0.0")
+  })
+
+  it("returns endpoint for given protocol-relative url", () => {
+    jsdom.changeURL(window, "https://example.com/");
+    socket = new Socket("//example.org/chat")
+
+    assert.equal(socket.endPointURL(), "wss://example.org/chat/websocket?vsn=1.0.0")
+  })
+
+  it("returns endpoint for given path on https host", () => {
+    jsdom.changeURL(window, "https://example.com/");
+    socket = new Socket("/socket")
+
+    assert.equal(socket.endPointURL(), "wss://example.com/socket/websocket?vsn=1.0.0")
+  })
+
+  it("returns endpoint for given path on http host", () => {
+    jsdom.changeURL(window, "http://example.com/");
+    socket = new Socket("/socket")
+
+    assert.equal(socket.endPointURL(), "ws://example.com/socket/websocket?vsn=1.0.0")
+  })
+})
+

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -83,13 +83,13 @@ describe("protocol", () => {
     socket = new Socket("/socket")
   })
 
-  it("returns wss when location.protocal is https", () => {
+  it("returns wss when location.protocol is https", () => {
     jsdom.changeURL(window, "https://example.com/");
 
     assert.equal(socket.protocol(), "wss")
   })
 
-  it("returns ws when location.protocal is http", () => {
+  it("returns ws when location.protocol is http", () => {
     jsdom.changeURL(window, "http://example.com/");
 
     assert.equal(socket.protocol(), "ws")

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -131,7 +131,6 @@ describe("connect with WebSocket", () => {
 
   before(() => {
     mockServer = new WebSocketServer('wss://example.com/')
-    jsdom.changeURL(window, "http://example.com/");
   })
 
   after((done) => {
@@ -253,7 +252,6 @@ describe("disconnect", () => {
 
   before(() => {
     mockServer = new WebSocketServer('wss://example.com/')
-    jsdom.changeURL(window, "http://example.com/");
   })
 
   after((done) => {
@@ -549,7 +547,6 @@ describe("onConnOpen", () => {
 
   before(() => {
     mockServer = new WebSocketServer('wss://example.com/')
-    jsdom.changeURL(window, "http://example.com/");
   })
 
   after((done) => {

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -1,8 +1,8 @@
 import assert from "assert"
 
 import jsdom from "jsdom"
+import sinon from "sinon"
 import { WebSocket, Server as WebSocketServer } from "mock-socket"
-import { XMLHttpRequest } from "xmlhttprequest"
 
 import { Socket, LongPoll } from "../static/js/phoenix"
 
@@ -118,7 +118,8 @@ describe("connect with WebSocket", () => {
 
 describe("connect with long poll", () => {
   before(() => {
-    window.XMLHttpRequest = XMLHttpRequest
+    window.XMLHttpRequest = sinon.useFakeXMLHttpRequest()
+    socket = new Socket("/socket")
   })
 
   after(() => {

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -213,3 +213,37 @@ describe("disconnect", () => {
     })
   })
 })
+
+describe("connectionState", () => {
+  beforeEach(() => {
+    socket = new Socket("/socket")
+    window.XMLHttpRequest = sinon.useFakeXMLHttpRequest()
+  })
+
+  it("defaults to closed", () => {
+    assert.equal(socket.connectionState(), "closed")
+  })
+
+  it("returns closed if readyState unrecognized", () => {
+    socket.connect()
+
+    socket.conn.readyState = 5678
+    assert.equal(socket.connectionState(), "closed")
+  })
+
+  it("returns the valid connection readyState", () => {
+    socket.connect()
+
+    socket.conn.readyState = 0
+    assert.equal(socket.connectionState(), "connecting")
+
+    socket.conn.readyState = 1
+    assert.equal(socket.connectionState(), "open")
+
+    socket.conn.readyState = 2
+    assert.equal(socket.connectionState(), "closing")
+
+    socket.conn.readyState = 3
+    assert.equal(socket.connectionState(), "closed")
+  })
+})

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -66,8 +66,8 @@ describe("constructor", () => {
 
     after((done) => {
       mockServer.stop(() => {
-        done()
         window.WebSocket = null
+        done()
       })
     })
 
@@ -136,8 +136,8 @@ describe("connect with WebSocket", () => {
 
   after((done) => {
     mockServer.stop(() => {
-      done()
       window.WebSocket = null
+      done()
     })
   })
 
@@ -258,8 +258,8 @@ describe("disconnect", () => {
 
   after((done) => {
     mockServer.stop(() => {
-      done()
       window.WebSocket = null
+      done()
     })
   })
 

--- a/web/test/socket_test.js
+++ b/web/test/socket_test.js
@@ -283,3 +283,28 @@ describe("connectionState", () => {
     assert.ok(!socket.isConnected(), "is not connected")
   })
 })
+
+describe("channel", () => {
+  let channel
+
+  beforeEach(() => {
+    socket = new Socket("/socket")
+  })
+
+  it("returns channel with given topic and params", () => {
+    channel = socket.channel("topic", { one: "two" })
+
+    assert.deepStrictEqual(channel.socket, socket)
+    assert.equal(channel.topic, "topic")
+    assert.deepEqual(channel.params, { one: "two" })
+  })
+
+  it("adds channel to sockets channels list", () => {
+    assert.equal(socket.channels.length, 0)
+
+    channel = socket.channel("topic", { one: "two" })
+
+    assert.equal(socket.channels.length, 1)
+    assert.deepStrictEqual(socket.channels[0], channel)
+  })
+})


### PR DESCRIPTION
This PR adds a few mocha tests for the `Socket` object in `phoenix.js`.

I'm opening this PR as a potential starting point for building out a suite of unit tests for the javascript functionality provided by `phoenix.js`. Though only just a few tests, there are already a few key decision points where I'm looking for feedback before I get too far.

Though `phoenix.js` touches a few browser APIs, I decided to stick with the Node.js context for the tests for simplicity. This means introducing a few libraries, e.g., `jsdom`, `jsdom-global`, `mock-socket`, to mock out those dependencies. We could certainly run the tests in a browser-based runner, e.g., karma, testem, etc., instead (or do both!), though the approach I went with was consistent with the existing presence tests. Looking for comments.

I've only added a few tests to get a proof-of-concept going for the mocking approach. If we like this direction, let me know your thoughts on how to tackle remaining tests: merge small sets of tests as I go vs build out an entire suite in one PR. Certainly, if you have any comments on the tests I've written so far, I'd be happy to address.

Another decision would be when to add the node tests to the travis build.

Finally, there's never enough love to go around, so thanks for all your hard work on Phoenix! 
💜💜💜