### PR TITLE
Fix IE Bug

### DIFF
--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -746,8 +746,8 @@ export class Ajax {
   }
 
   static xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback){
-    req.timeout = timeout
     req.open(method, endPoint, true)
+    req.timeout = timeout
     req.setRequestHeader("Content-Type", accept)
     req.onerror = () => { callback && callback(null) }
     req.onreadystatechange = () => {


### PR DESCRIPTION
If you set xhr.timeout in IE11 before calling open it raises an InvalidStateError.
Relevant documentation: https://msdn.microsoft.com/en-us/library/cc304105(v=vs.85).aspx
This is the reason LongPoll does not work in IE11.