### PR TITLE
Handle empty json in json_response

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -412,6 +412,8 @@ defmodule Phoenix.ConnTest do
         body
       {:error, {:invalid, token}} ->
         raise "could not decode JSON body, invalid token #{inspect token} in body:\n\n#{body}"
+      {:error, :invalid} ->
+        raise "could not decode JSON body, body is empty"
     end
   end
 

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -244,6 +244,13 @@ defmodule Phoenix.Test.ConnTest do
                       |> resp(200, "ok") |> json_response(200)
     end
 
+    assert_raise RuntimeError, "could not decode JSON body, body is empty", fn ->
+      build_conn(:get, "/")
+      |> put_resp_content_type("application/json")
+      |> resp(200, "")
+      |> json_response(200)
+    end
+
     assert_raise RuntimeError, ~s(expected response with status 200, got: 400, with body:\n{"error": "oh oh"}), fn ->
       build_conn(:get, "/")
       |> put_resp_content_type("application/json")


### PR DESCRIPTION
I was trying to send an empty response according to [this](http://www.phoenixframework.org/docs/controllers#section-sending-responses-directly). But in my tests, I was getting `** (CaseClauseError) no case clause matching: {:error, :invalid}`

According to poison `{:error, :invalid}` is a possible response in decode (https://github.com/devinus/poison/blob/master/lib/poison.ex#L66). However, it's just not being handled in `json_response`. I added a clause to handle this scenario.

I ended up using [response/2](https://hexdocs.pm/phoenix/Phoenix.ConnTest.html#response/2) to make the assertion in my test. Should the error message suggest to use this other function?