### PR TITLE
Tweaked `Phoenix.Token` documentation.

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -15,8 +15,8 @@ defmodule Phoenix.Token do
   the id from a database. For example:
 
       iex> user_id = 1
-      iex> token = Phoenix.Token.sign(MyApp.Endpoint, "tokensalt123", user_id)
-      iex> Phoenix.Token.verify(MyApp.Endpoint, "tokensalt123", token)
+      iex> token = Phoenix.Token.sign(MyApp.Endpoint, "user salt", user_id)
+      iex> Phoenix.Token.verify(MyApp.Endpoint, "user salt", token)
       {:ok, 1}
 
   In that example we have a user's id, we generate a token and
@@ -46,14 +46,14 @@ defmodule Phoenix.Token do
   One is via the meta tag:
 
       <%= tag :meta, name: "channel_token",
-                     content: Phoenix.Token.sign(@conn, "tokensalt123", @current_user.id) %>
+                     content: Phoenix.Token.sign(@conn, "user salt", @current_user.id) %>
 
   Or an endpoint that returns it:
 
       def create(conn, params) do
         user = User.create(params)
         render conn, "user.json",
-               %{token: Phoenix.Token.sign(conn, "tokensalt123", user.id), user: user}
+               %{token: Phoenix.Token.sign(conn, "user salt", user.id), user: user}
       end
 
   Once the token is sent, the client may now send it back to the server
@@ -65,7 +65,7 @@ defmodule Phoenix.Token do
 
         def connect(%{"token" => token}, socket) do
           # Max age of 2 weeks (1209600 seconds)
-          case Phoenix.Token.verify(socket, "tokensalt123", token, max_age: 1209600) do
+          case Phoenix.Token.verify(socket, "user salt", token, max_age: 1209600) do
             {:ok, user_id} ->
               socket = assign(socket, :user, Repo.get!(User, user_id))
               {:ok, socket}

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -15,7 +15,7 @@ defmodule Phoenix.Token do
   the id from a database. For example:
 
       iex> user_id = 1
-      iex> token = Phoenix.Token.sign(MyApp.Endpoint, "user", user_id)
+      iex> token = Phoenix.Token.sign(MyApp.Endpoint, "tokensalt123", user_id)
       iex> Phoenix.Token.verify(MyApp.Endpoint, "user", token)
       {:ok, 1}
 
@@ -34,6 +34,10 @@ defmodule Phoenix.Token do
     * a string, representing the secret key base itself. A key base
       with at least 20 randomly generated characters should be used
       to provide adequate entropy.
+
+  The second argument is a [cryptographic salt](https://en.wikipedia.org/wiki/Salt_(cryptography)) which must be the same in both calls to `sign/4` and `verify/4`.
+
+  The third argument can be any Elixir term (string, int, list, etc.) that you wish to codify into the token. Upon valid verification, this same term will be extracted from the token.
 
   ## Usage
 
@@ -61,7 +65,7 @@ defmodule Phoenix.Token do
 
         def connect(%{"token" => token}, socket) do
           # Max age of 2 weeks (1209600 seconds)
-          case Phoenix.Token.verify(socket, "user", token, max_age: 1209600) do
+          case Phoenix.Token.verify(socket, "tokensalt123", token, max_age: 1209600) do
             {:ok, user_id} ->
               socket = assign(socket, :user, Repo.get!(User, user_id))
               {:ok, socket}

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -16,7 +16,7 @@ defmodule Phoenix.Token do
 
       iex> user_id = 1
       iex> token = Phoenix.Token.sign(MyApp.Endpoint, "tokensalt123", user_id)
-      iex> Phoenix.Token.verify(MyApp.Endpoint, "user", token)
+      iex> Phoenix.Token.verify(MyApp.Endpoint, "tokensalt123", token)
       {:ok, 1}
 
   In that example we have a user's id, we generate a token and
@@ -46,14 +46,14 @@ defmodule Phoenix.Token do
   One is via the meta tag:
 
       <%= tag :meta, name: "channel_token",
-                     content: Phoenix.Token.sign(@conn, "user", @current_user.id) %>
+                     content: Phoenix.Token.sign(@conn, "tokensalt123", @current_user.id) %>
 
   Or an endpoint that returns it:
 
       def create(conn, params) do
         user = User.create(params)
         render conn, "user.json",
-               %{token: Phoenix.Token.sign(conn, "user", user.id), user: user}
+               %{token: Phoenix.Token.sign(conn, "tokensalt123", user.id), user: user}
       end
 
   Once the token is sent, the client may now send it back to the server


### PR DESCRIPTION
* I found it very confusing to have "user" as the salt argument.
  * Changed the salt from "user" to "tokensalt123".
  * Added documentation briefly describing the salt with a link
    to wikipedia entry.
  * Added documentation briefly describing the fact that the third
    argument can be any Elixir term which was very useful for me
    but not obvious since the functions do not have specs.