### PR TITLE
Introduce current_path and current_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3-dev
 
 * Enhancements
+  * [Controller] Add `current_path` and `current_url` to generate a connection's path and url
   * [Channel] Add ability to configure channel event logging with `:log_join` and `:log_handle_in` options
   * [Channel] Warn on unhandled `handle_info/2` messages
 

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1092,6 +1092,73 @@ defmodule Phoenix.Controller do
     put_private(conn, :phoenix_flash, value)
   end
 
+  @doc """
+  Returns the current request path, with and without query params.
+
+  By default, the connection's query params are included in
+  the generated path. Custom query params may be used instead
+  by providing a map of your own params. You may also retrieve
+  only the request path by passing an empty map of params.
+
+  ## Examples
+
+      iex> current_path(conn)
+      "/users/123?existing=param"
+
+      iex> current_path(conn, %{new: "param"})
+      "/users/123?new=param"
+
+      iex> current_path(conn, %{})
+      "/users/123"
+  """
+  def current_path(%Plug.Conn{query_params: params} = conn) do
+    current_path(conn, params)
+  end
+  def current_path(%Plug.Conn{} = conn, params) when params == %{} do
+    conn.request_path
+  end
+  def current_path(%Plug.Conn{} = conn, params) do
+    conn.request_path <> "?" <> URI.encode_query(params)
+  end
+
+  @doc """
+  Returns the current request URL, with and without query params.
+
+  See `current_path/1` for details on how the request path
+  is generated. By default, the connection's endpoint will be
+  used for URL generation, but the endpoint may also be
+  explicitly provided to geneerate a URL with the connection's
+  request path, but for an endpoint that the connection did
+  not originate from.
+
+  ## Examples
+
+      iex> current_url(conn)
+      "www.endpoint1.example.com/users/123?existing=param"
+
+      iex> current_url(conn, %{new: "param"})
+      "www.endpoint1.example.com/users/123?new=param"
+
+      iex> current_path(conn, %{})
+      "www.endpoint1.example.com/users/123"
+
+      iex> current_path(conn, Endpoint2, %{})
+      "www.endpoint2.example.com/users/123"
+  """
+  def current_url(%Plug.Conn{} = conn) do
+    current_url(conn, endpoint_module(conn))
+  end
+  def current_url(%Plug.Conn{} = conn, %{} = params) do
+    current_url(conn, endpoint_module(conn), params)
+  end
+  def current_url(%Plug.Conn{} = conn, endpoint) when is_atom(endpoint) do
+    Path.join(endpoint.url(), current_path(conn))
+  end
+  def current_url(%Plug.Conn{} = conn, endpoint, %{} = params) when is_atom(endpoint) do
+    Path.join(endpoint.url(), current_path(conn, params))
+  end
+
+
   @doc false
   def __view__(controller_module) do
     controller_module

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -134,8 +134,8 @@ defmodule Phoenix.Controller.ControllerTest do
 
   test "allow_jsonp/2 returns json when no callback param is present" do
     conn = conn(:get, "/")
-           |> fetch_query_params
-           |> allow_jsonp
+           |> fetch_query_params()
+           |> allow_jsonp()
            |> json(%{foo: "bar"})
     assert conn.resp_body == "{\"foo\":\"bar\"}"
     assert get_resp_content_type(conn) == "application/json"
@@ -144,8 +144,8 @@ defmodule Phoenix.Controller.ControllerTest do
 
   test "allow_jsonp/2 returns json when callback name is left empty" do
     conn = conn(:get, "/?callback=")
-           |> fetch_query_params
-           |> allow_jsonp
+           |> fetch_query_params()
+           |> allow_jsonp()
            |> json(%{foo: "bar"})
     assert conn.resp_body == "{\"foo\":\"bar\"}"
     assert get_resp_content_type(conn) == "application/json"
@@ -456,5 +456,69 @@ defmodule Phoenix.Controller.ControllerTest do
 
   defp sent_conn do
     conn(:get, "/") |> send_resp(:ok, "")
+  end
+
+  describe "path and url generation" do
+    def url(), do: "www.example.com"
+
+    def build_conn_for_path(path) do
+      conn(:get, path)
+      |> fetch_query_params()
+      |> put_private(:phoenix_endpoint, __MODULE__)
+    end
+
+    test "current_path/1 uses the conn's query params" do
+      conn = build_conn_for_path("/")
+      assert current_path(conn) == "/"
+
+      conn = build_conn_for_path("/foo?one=1&two=2")
+      assert current_path(conn) == "/foo?one=1&two=2"
+    end
+
+    test "current_path/2 allows custom query params" do
+      conn = build_conn_for_path("/")
+      assert current_path(conn, %{}) == "/"
+
+      conn = build_conn_for_path("/foo?one=1&two=2")
+      assert current_path(conn, %{}) == "/foo"
+
+      conn = build_conn_for_path("/foo?one=1&two=2")
+      assert current_path(conn, %{three: 3}) == "/foo?three=3"
+    end
+
+    test "current_url/1 with root path does not add extra slash" do
+      conn = build_conn_for_path("/")
+      assert current_url(conn) == "www.example.com"
+    end
+
+    test "current_url/1 users conn's endpoint and query params" do
+      conn = build_conn_for_path("/?foo=bar")
+      assert current_url(conn) == "www.example.com/?foo=bar"
+
+      conn = build_conn_for_path("/foo?one=1&two=2")
+      assert current_url(conn) == "www.example.com/foo?one=1&two=2"
+    end
+
+    test "current_url/2 allows custom query params" do
+      conn = build_conn_for_path("/")
+      assert current_url(conn, %{}) == "www.example.com"
+
+      conn = build_conn_for_path("/foo?one=1&two=2")
+      assert current_url(conn, %{}) == "www.example.com/foo"
+
+      conn = build_conn_for_path("/foo?one=1&two=2")
+      assert current_url(conn, %{three: 3}) == "www.example.com/foo?three=3"
+    end
+
+    test "current_url/2 and current_url/3 allow explicit endpoint" do
+      conn = build_conn_for_path("/")
+      assert current_url(conn, __MODULE__, %{}) == "www.example.com"
+
+      conn = build_conn_for_path("/foo?one=1&two=2")
+      assert current_url(conn, __MODULE__,  %{}) == "www.example.com/foo"
+
+      conn = build_conn_for_path("/foo?one=1&two=2")
+      assert current_url(conn, __MODULE__, %{three: 3}) == "www.example.com/foo?three=3"
+    end
   end
 end

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -459,7 +459,7 @@ defmodule Phoenix.Controller.ControllerTest do
   end
 
   describe "path and url generation" do
-    def url(), do: "www.example.com"
+    def url(), do: "https://www.example.com"
 
     def build_conn_for_path(path) do
       conn(:get, path)
@@ -488,37 +488,26 @@ defmodule Phoenix.Controller.ControllerTest do
 
     test "current_url/1 with root path does not add extra slash" do
       conn = build_conn_for_path("/")
-      assert current_url(conn) == "www.example.com"
+      assert current_url(conn) == "https://www.example.com"
     end
 
     test "current_url/1 users conn's endpoint and query params" do
       conn = build_conn_for_path("/?foo=bar")
-      assert current_url(conn) == "www.example.com/?foo=bar"
+      assert current_url(conn) == "https://www.example.com/?foo=bar"
 
       conn = build_conn_for_path("/foo?one=1&two=2")
-      assert current_url(conn) == "www.example.com/foo?one=1&two=2"
+      assert current_url(conn) == "https://www.example.com/foo?one=1&two=2"
     end
 
     test "current_url/2 allows custom query params" do
       conn = build_conn_for_path("/")
-      assert current_url(conn, %{}) == "www.example.com"
+      assert current_url(conn, %{}) == "https://www.example.com"
 
       conn = build_conn_for_path("/foo?one=1&two=2")
-      assert current_url(conn, %{}) == "www.example.com/foo"
+      assert current_url(conn, %{}) == "https://www.example.com/foo"
 
       conn = build_conn_for_path("/foo?one=1&two=2")
-      assert current_url(conn, %{three: 3}) == "www.example.com/foo?three=3"
-    end
-
-    test "current_url/2 and current_url/3 allow explicit endpoint" do
-      conn = build_conn_for_path("/")
-      assert current_url(conn, __MODULE__, %{}) == "www.example.com"
-
-      conn = build_conn_for_path("/foo?one=1&two=2")
-      assert current_url(conn, __MODULE__,  %{}) == "www.example.com/foo"
-
-      conn = build_conn_for_path("/foo?one=1&two=2")
-      assert current_url(conn, __MODULE__, %{three: 3}) == "www.example.com/foo?three=3"
+      assert current_url(conn, %{three: 3}) == "https://www.example.com/foo?three=3"
     end
   end
 end


### PR DESCRIPTION
@josevalim I wasn't sure the best place for these to live. My first goto was the Router.Helpers, but there is no need for us to inject the functions, and the module itself is private (moduledoc false). They are also more discoverable on Phoenix.Controller, but we'll have to import them in web.ex/view, or have folks import as needed. Wdyt?