### PR TITLE
fix brunch-config.js in installer to be compatible with 2.9.1

### DIFF
--- a/installer/templates/assets/brunch/brunch-config.js
+++ b/installer/templates/assets/brunch/brunch-config.js
@@ -53,7 +53,7 @@ exports.config = {
 
   modules: {
     autoRequire: {
-      "js/app.js": ["app"]
+      "js/app.js": ["js/app"]
     }
   },
 

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       # Brunch
       assert_file "phx_blog/.gitignore", "/node_modules"
-      assert_file "phx_blog/assets/brunch-config.js", ~s("js/app.js": ["app"])
+      assert_file "phx_blog/assets/brunch-config.js", ~s("js/app.js": ["js/app"])
       assert_file "phx_blog/config/dev.exs", "watchers: [node:"
       assert_file "phx_blog/assets/static/favicon.ico"
       assert_file "phx_blog/assets/static/images/phoenix.png"

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -91,7 +91,7 @@ defmodule Mix.Tasks.Phx.NewUmbrellaTest do
 
       # Brunch
       assert_file web_path(@app, ".gitignore"), "/node_modules"
-      assert_file web_path(@app, "assets/brunch-config.js"), ~s("js/app.js": ["app"])
+      assert_file web_path(@app, "assets/brunch-config.js"), ~s("js/app.js": ["js/app"])
       assert_file web_path(@app, "config/dev.exs"), "watchers: [node:"
       assert_file web_path(@app, "assets/static/favicon.ico")
       assert_file web_path(@app, "assets/static/images/phoenix.png")


### PR DESCRIPTION
In brunch 2.8.2 the following is valid in autoRequire:

  "js/app.js": ["app"]

In brunch 2.9.1 this has to be:

  "js/app.js": ["js/app"]

Otherwise the following error will be logged and the JavaScript will not
execute:

 > Uncaught Error: Cannot find module 'js/app' from '/'

The difference in the compiled JavaScript prior to this change was:

    $ diff /tmp/app-broken.js /tmp/app-working.js
    151c151
    < require.register("js/app.js", function(exports, require, module) {
    ---
    > require.register("app.js", function(exports, require, module) {

I'd appreciate if someone else could validate the solution just to make sure it isn't only happening to me.