### PR TITLE
removed destructured 'ref' from push.matchReceive

### DIFF
--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -241,7 +241,7 @@ class Push {
 
   // private
 
-  matchReceive({status, response, ref}){
+  matchReceive({status, response}){
     this.recHooks.filter( h => h.status === status )
                  .forEach( h => h.callback(response) )
   }


### PR DESCRIPTION
Was going over the JS and spotted an unused variable.

Cheers.