### PR TITLE
Make channel `log_join` and `log_handle_in` configs work with ChannelTest

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -223,7 +223,8 @@ defmodule Phoenix.Socket.Transport do
     |> do_dispatch(msg, socket)
   end
 
-  defp build_channel_socket(%Socket{} = socket, channel, topic) do
+  @doc false
+  def build_channel_socket(%Socket{} = socket, channel, topic) do
     %Socket{socket |
             topic: topic,
             channel: channel,

--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -325,7 +325,7 @@ defmodule Phoenix.ChannelTest do
   """
   def join(%Socket{} = socket, channel, topic, payload \\ %{})
       when is_atom(channel) and is_binary(topic) and is_map(payload) do
-    socket = %Socket{socket | topic: topic, channel: channel}
+    socket = Transport.build_channel_socket(socket, channel, topic)
 
     case Server.join(socket, payload) do
       {:ok, reply, pid} ->


### PR DESCRIPTION
This fixes following messages while testing channels:
```
12:33:32.295 application=app [error] Instrumenter Phoenix.Logger.phoenix_channel_join/3 failed.
** (CaseClauseError) no case clause matching: :error
    (phoenix) lib/phoenix/logger.ex:94: Phoenix.Logger.channel_log/3
    (vok_web) lib/vok_web/endpoint.ex:1: VOKWeb.Endpoint.instrument/4
    (phoenix) lib/phoenix/test/channel_test.ex:330: Phoenix.ChannelTest.join/4
    test/channels/transport_channel_test.exs:11: VOKWeb.TransportChannelTest.__ex_unit_setup_1/1
    test/channels/transport_channel_test.exs:1: VOKWeb.TransportChannelTest.__ex_unit__/2
    (ex_unit) lib/ex_unit/runner.ex:289: ExUnit.Runner.exec_test_setup/2
    (ex_unit) lib/ex_unit/runner.ex:247: anonymous fn/2 in ExUnit.Runner.spawn_test/3
    (stdlib) timer.erl:166: :timer.tc/1
    (ex_unit) lib/ex_unit/runner.ex:246: anonymous fn/3 in ExUnit.Runner.spawn_test/3
```