### PR TITLE
Added default unprocessable entity behavior on create and update action templates when there is no match for the namespace on user's payload

### DIFF
--- a/priv/templates/phoenix.gen.html/controller.ex
+++ b/priv/templates/phoenix.gen.html/controller.ex
@@ -25,6 +25,10 @@ defmodule <%= module %>Controller do
         render(conn, "new.html", changeset: changeset)
     end
   end
+  def create(conn, _) do
+    changeset = <%= alias %>.changeset(%<%= alias %>{}, %{})
+    render(conn, "new.html", changeset: changeset)
+  end
 
   def show(conn, %{"id" => id}) do
     <%= singular %> = Repo.get!(<%= alias %>, id)
@@ -49,6 +53,10 @@ defmodule <%= module %>Controller do
       {:error, changeset} ->
         render(conn, "edit.html", <%= singular %>: <%= singular %>, changeset: changeset)
     end
+  end
+  def update(conn, _) do
+    changeset = <%= alias %>.changeset(<%= singular %>, %{})
+    render(conn, "edit.html", <%= singular %>: <%= singular %>, changeset: changeset)
   end
 
   def delete(conn, %{"id" => id}) do

--- a/priv/templates/phoenix.gen.html/controller_test.exs
+++ b/priv/templates/phoenix.gen.html/controller_test.exs
@@ -26,6 +26,11 @@ defmodule <%= module %>ControllerTest do
     assert html_response(conn, 200) =~ "New <%= template_singular %>"
   end
 
+  test "does not create resource and renders errors when namespace is missing", %{conn: conn} do
+    conn = post conn, <%= singular %>_path(conn, :create), %{}
+    assert html_response(conn, 200) =~ "New <%= template_singular %>"
+  end
+
   test "shows chosen resource", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = get conn, <%= singular %>_path(conn, :show, <%= singular %>)
@@ -54,6 +59,12 @@ defmodule <%= module %>ControllerTest do
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_attrs
+    assert html_response(conn, 200) =~ "Edit <%= template_singular %>"
+  end
+
+  test "does not update chosen resource and renders errors when namespace is missing", %{conn: conn} do
+    <%= singular %> = Repo.insert! %<%= alias %>{}
+    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), %{}
     assert html_response(conn, 200) =~ "Edit <%= template_singular %>"
   end
 

--- a/priv/templates/phoenix.gen.json/controller.ex
+++ b/priv/templates/phoenix.gen.json/controller.ex
@@ -23,6 +23,12 @@ defmodule <%= module %>Controller do
         |> render(<%= base %>.ChangesetView, "error.json", changeset: changeset)
     end
   end
+  def create(conn, _) do
+    changeset = <%= alias %>.changeset(%<%= alias %>{}, %{})
+    conn
+    |> put_status(:unprocessable_entity)
+    |> render(<%= base %>.ChangesetView, "error.json", changeset: changeset)
+  end
 
   def show(conn, %{"id" => id}) do
     <%= singular %> = Repo.get!(<%= alias %>, id)
@@ -41,6 +47,12 @@ defmodule <%= module %>Controller do
         |> put_status(:unprocessable_entity)
         |> render(<%= base %>.ChangesetView, "error.json", changeset: changeset)
     end
+  end
+  def update(conn, _) do
+    changeset = <%= alias %>.changeset(<%= singular %>, %{})
+    conn
+    |> put_status(:unprocessable_entity)
+    |> render(<%= base %>.ChangesetView, "error.json", changeset: changeset)
   end
 
   def delete(conn, %{"id" => id}) do

--- a/priv/templates/phoenix.gen.json/controller_test.exs
+++ b/priv/templates/phoenix.gen.json/controller_test.exs
@@ -38,6 +38,11 @@ defmodule <%= module %>ControllerTest do
     assert json_response(conn, 422)["errors"] != %{}
   end
 
+  test "does not create resource and renders errors when namespace is missing", %{conn: conn} do
+    conn = post conn, <%= singular %>_path(conn, :create), %{}
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
   test "updates and renders chosen resource when data is valid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @valid_attrs
@@ -48,6 +53,12 @@ defmodule <%= module %>ControllerTest do
   test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
     <%= singular %> = Repo.insert! %<%= alias %>{}
     conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), <%= singular %>: @invalid_attrs
+    assert json_response(conn, 422)["errors"] != %{}
+  end
+
+  test "does not update chosen resource and renders errors when namespace is missing", %{conn: conn} do
+    <%= singular %> = Repo.insert! %<%= alias %>{}
+    conn = put conn, <%= singular %>_path(conn, :update, <%= singular %>), %{}
     assert json_response(conn, 422)["errors"] != %{}
   end
 


### PR DESCRIPTION
Added default unprocessable entity behavior on create and update action templates when there is no match for the namespace on user's payload

**Description**
This PR adds two new pattern matches for create/update action templates to handle RESTful pattern. 

**Story**
When a user forgets to add namespace on payload, on create/update endpoints(generally on API endpoints), the user gets HTTP status 400 with text "Internal server error", instead of HTTP status code 422 and missing fields. In the RESTFul approach, we should response with 422 instead of 400 and valid JSON. 

**Tasks**
- [x] Add create action to the controller and controller test templates with any params and return 422
- [x] Add update action to the controller and controller test templates with any params and return 422  
