### PR TITLE
Add Elixir 1.4 to travis allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,15 @@ matrix:
       elixir: 1.3.2
     - otp_release: 19.0
       elixir: 1.3.2
+    - otp_release: 18.3
+      elixir: 1.4.0-rc.1
+    - otp_release: 19.0
+      elixir: 1.4.0-rc.1
+  allow_failures:
+    - otp_release: 18.3
+      elixir: 1.4.0-rc.1
+    - otp_release: 19.0
+      elixir: 1.4.0-rc.1
 services:
   - redis-server
 sudo: false


### PR DESCRIPTION
It looks like we'll get 1.4 soon, and I thought adding the release
candidate to the travis matrix as an allowed failure might help in
finding and squashing any bugs in the release candidate, as well as
give folks time to make any updates or address any deprecations that
might be coming in 1.4.