### PR TITLE
Test and document Router catch-all verb matches

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -367,6 +367,8 @@ defmodule Phoenix.Router do
 
   #{Enum.map_join(@http_methods, ", ", &"`#{&1}`")}
 
+  The catch-all verb `:*` will match all HTTP methods for the route.
+
   ## Examples
 
       match(:move, "/events/:id", EventController, :move)

--- a/test/phoenix/router/route_test.exs
+++ b/test/phoenix/router/route_test.exs
@@ -38,6 +38,13 @@ defmodule Phoenix.Router.RouteTest do
     assert Macro.to_string(exprs.host) == "\"foo.com\""
   end
 
+  test "builds a catch-all verb_match for match routes" do
+    route = build(:match, :*, "/foo/:bar", nil, __MODULE__, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"})
+    assert route.verb == :*
+    assert route.kind == :match
+    assert exprs(route).verb_match == {:_verb, [], nil}
+  end
+
   test "builds a catch-all verb_match for forwarded routes" do
     route = build(:forward, :*, "/foo/:bar", nil, __MODULE__, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"})
     assert route.verb == :*

--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -13,6 +13,7 @@ defmodule Phoenix.Router.RoutingTest do
     def not_found(conn, _params), do: text(put_status(conn, :not_found), "not found")
     def image(conn, _params), do: text(conn, conn.params["path"] || "show files")
     def move(conn, _params), do: text(conn, "users move")
+    def catch_all(conn, _params), do: text(conn, "users catch-all")
   end
 
   defmodule Router do
@@ -32,6 +33,7 @@ defmodule Phoenix.Router.RoutingTest do
     options "/options", UserController, :options
     connect "/connect", UserController, :connect
     match :move, "/move", UserController, :move
+    match :*, "/catch_all", UserController, :catch_all
 
     get "/users/:user_id/files/:id", UserController, :image
     get "/*path", UserController, :not_found
@@ -146,5 +148,12 @@ defmodule Phoenix.Router.RoutingTest do
     assert conn.method == "MOVE"
     assert conn.status == 200
     assert conn.resp_body == "users move"
+  end
+
+  test "catch-all verb matches" do
+    conn = call(Router, :put, "/catch_all")
+    assert conn.method == "PUT"
+    assert conn.status == 200
+    assert conn.resp_body == "users catch-all"
   end
 end


### PR DESCRIPTION
This adds some tests and a note in the Router documentation about using `:*` as an HTTP method catch-all in the `match` macro. The behavior already existed but was not documented. Thanks @chrismccord for pointing this out!

Addresses issue #977.