### PR TITLE
Rename catch-all verb test to any verb

### DIFF
--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -13,7 +13,7 @@ defmodule Phoenix.Router.RoutingTest do
     def not_found(conn, _params), do: text(put_status(conn, :not_found), "not found")
     def image(conn, _params), do: text(conn, conn.params["path"] || "show files")
     def move(conn, _params), do: text(conn, "users move")
-    def catch_all(conn, _params), do: text(conn, "users catch-all")
+    def any(conn, _params), do: text(conn, "users any")
   end
 
   defmodule Router do
@@ -33,7 +33,7 @@ defmodule Phoenix.Router.RoutingTest do
     options "/options", UserController, :options
     connect "/connect", UserController, :connect
     match :move, "/move", UserController, :move
-    match :*, "/catch_all", UserController, :catch_all
+    match :*, "/any", UserController, :any
 
     get "/users/:user_id/files/:id", UserController, :image
     get "/*path", UserController, :not_found
@@ -150,15 +150,15 @@ defmodule Phoenix.Router.RoutingTest do
     assert conn.resp_body == "users move"
   end
 
-  test "catch-all verb matches" do
-    conn = call(Router, :get, "/catch_all")
+  test "any verb matches" do
+    conn = call(Router, :get, "/any")
     assert conn.method == "GET"
     assert conn.status == 200
-    assert conn.resp_body == "users catch-all"
+    assert conn.resp_body == "users any"
 
-    conn = call(Router, :put, "/catch_all")
+    conn = call(Router, :put, "/any")
     assert conn.method == "PUT"
     assert conn.status == 200
-    assert conn.resp_body == "users catch-all"
+    assert conn.resp_body == "users any"
   end
 end


### PR DESCRIPTION
@chrismccord After reviewing my last merged PR (thanks!) I couldn't resist going back and giving it the more elegant name: "any" verb instead of "catch_all". This matches the example of `:*` you added to the router docs.

Superficial change, I know, but I hope you agree it reads better this way. :)