### PR TITLE
Adds Presence.get_by_key with default

### DIFF
--- a/test/phoenix/presence_test.exs
+++ b/test/phoenix/presence_test.exs
@@ -49,6 +49,36 @@ defmodule Phoenix.PresenceTest do
            MyPresence.list(config.topic)
   end
 
+  test "get_by_key/2 gets by a string key", config do
+    assert MyPresence.list(config.topic) == %{}
+    assert MyPresence.list(%Phoenix.Socket{topic: config.topic}) == %{}
+    assert {:ok, _} = MyPresence.track(self(), config.topic, "u1", %{name: "u1"})
+    assert %{extra: "extra", metas: [%{name: "u1", phx_ref: _}]} =
+           MyPresence.get_by_key(config.topic, "u1")
+    assert %{extra: "extra", metas: [%{name: "u1", phx_ref: _}]} =
+           MyPresence.get_by_key(%Phoenix.Socket{topic: config.topic}, "u1")
+  end
+
+  test "get_by_key/2 returns an empty map if the key doesn't exist", config do
+    assert MyPresence.list(config.topic) == %{}
+    assert MyPresence.list(%Phoenix.Socket{topic: config.topic}) == %{}
+    assert {:ok, _} = MyPresence.track(self(), config.topic, "u1", %{name: "u1"})
+    assert %{} ==
+           MyPresence.get_by_key(config.topic, "u2")
+    assert %{} ==
+           MyPresence.get_by_key(%Phoenix.Socket{topic: config.topic}, "u2")
+  end
+
+  test "get_by_key/3 returns the provided default when the key doesn't exist", config do
+    assert MyPresence.list(config.topic) == %{}
+    assert MyPresence.list(%Phoenix.Socket{topic: config.topic}) == %{}
+    assert {:ok, _} = MyPresence.track(self(), config.topic, "u1", %{name: "u1"})
+    assert :default ==
+           MyPresence.get_by_key(config.topic, "u2", :default)
+    assert :default ==
+           MyPresence.get_by_key(%Phoenix.Socket{topic: config.topic}, "u2", :default)
+  end
+
   test "handle_diff broadcasts events with default fetched data",
     %{topic: topic} = config do
 


### PR DESCRIPTION
Sometimes we want just a single piece of information out of the Presence
tracker. In order to facilitate that we want to be able to grab from the
tracker with a key and not get the entire map. I mapped this to the same
behavior as `Map.get` so it would have the ability to give a default if
one doesn't exist. By default `Map.get` returns `nil` if something isn't
in the map. Since we are expecting map to come back from Presence I
decided to make this default into an empty map.

I'm not sure if this is what was looked for in issue ##1777, but that is what I was trying to address. Is this the right track?

Amos King @adkron <amos@binarynoggin.com>