### PR TITLE
Make Presence.handle_diff overridable

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -172,7 +172,7 @@ defmodule Phoenix.Presence do
         {:ok, state}
       end
 
-      defoverridable fetch: 2
+      defoverridable [fetch: 2, handle_diff: 2]
     end
   end
 


### PR DESCRIPTION
I'm using `Presence` to track online counts in a high performance application, where I would like to save the bandwidth consumed by the `presence_diff`s (my client's don't need them).

I didn't find an intuitive solution for that. Instead I had to copy the `Presence` module and change `handle_diff`.

Allowing to override `handle_diff`would allow this and other custom `presence_diff`s.