### PR TITLE
[UNTESTED] Match * to any receive event in phoenix.js

### DIFF
--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -272,7 +272,7 @@ var Push = function () {
           ref = _ref.ref;
 
       this.recHooks.filter(function (h) {
-        return h.status === status;
+        return h.status === status || h.status === "*";
       }).forEach(function (h) {
         return h.callback(response);
       });

--- a/web/static/js/phoenix.js
+++ b/web/static/js/phoenix.js
@@ -242,7 +242,7 @@ class Push {
   // private
 
   matchReceive({status, response, ref}){
-    this.recHooks.filter( h => h.status === status )
+    this.recHooks.filter( h => h.status === status || h.status === "*" )
                  .forEach( h => h.callback(response) )
   }
 


### PR DESCRIPTION
Enables:

```js
channel.push('new:thing', thing)                                                                                                                                                             
       .receive('error', err => this.errors = err.errors)                                                                                                                                               
       .receive('ok', _ => e.target.reset())                                                                                                                                                            
       .receive('*', _ => findButton(e.target).disabled = false)                                                                                                                                                                      
```

I don't think channel behavior is tested at all so proceed with some caution.