### PR TITLE
Avoid running compilers not present in the application's compiler list.

### DIFF
--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -142,9 +142,11 @@ defmodule Phoenix.CodeReloader.Server do
   defp mix_compile(compilers) do
     all = Mix.Project.config[:compilers] || Mix.compilers
 
-    for compiler <- compilers, compiler in all do
-      Mix.Task.reenable("compile.#{compiler}")
-    end
+    compilers =
+      for compiler <- compilers, compiler in all do
+        Mix.Task.reenable("compile.#{compiler}")
+        compiler
+      end
 
     # We call build_structure mostly for Windows so new
     # assets in priv are copied to the build directory.


### PR DESCRIPTION
This would cause an error in applications which did not configure their `reloadable_compilers` option,
and did not have a default compiler (gettext) present.