### PR TITLE
Ignore all files matching /config/*.secret.exs pattern by default.

### DIFF
--- a/installer/templates/assets/bare/gitignore
+++ b/installer/templates/assets/bare/gitignore
@@ -7,10 +7,10 @@
 # Generated on crash by the VM
 erl_crash.dump
 
-# The config/prod.secret.exs file by default contains sensitive
-# data and you should not commit it into version control.
+# Files matching config/*.secret.exs pattern contain sensitive
+# data and you should not commit them into version control.
 #
 # Alternatively, you may comment the line below and commit the
-# secrets file as long as you replace its contents by environment
+# secrets files as long as you replace their contents by environment
 # variables.
-/config/prod.secret.exs
+/config/*.secret.exs

--- a/installer/templates/assets/brunch/gitignore
+++ b/installer/templates/assets/brunch/gitignore
@@ -18,10 +18,10 @@ npm-debug.log
 # this depending on your deployment strategy.
 /priv/static/
 
-# The config/prod.secret.exs file by default contains sensitive
-# data and you should not commit it into version control.
+# Files matching config/*.secret.exs pattern contain sensitive
+# data and you should not commit them into version control.
 #
 # Alternatively, you may comment the line below and commit the
-# secrets file as long as you replace its contents by environment
+# secrets files as long as you replace their contents by environment
 # variables.
-/config/prod.secret.exs
+/config/*.secret.exs

--- a/installer/templates/phx_umbrella/apps/app_name_web/gitignore
+++ b/installer/templates/phx_umbrella/apps/app_name_web/gitignore
@@ -15,10 +15,10 @@ erl_crash.dump
 # this depending on your deployment strategy.
 /priv/static/
 
-# The config/prod.secret.exs file by default contains sensitive
-# data and you should not commit it into version control.
+# Files matching config/*.secret.exs pattern contain sensitive
+# data and you should not commit them into version control.
 #
 # Alternatively, you may comment the line below and commit the
-# secrets file as long as you replace its contents by environment
+# secrets files as long as you replace their contents by environment
 # variables.
-/config/prod.secret.exs
+/config/*.secret.exs

--- a/installer/templates/static/bare/gitignore
+++ b/installer/templates/static/bare/gitignore
@@ -7,10 +7,10 @@
 # Generated on crash by the VM
 erl_crash.dump
 
-# The config/prod.secret.exs file by default contains sensitive
-# data and you should not commit it into version control.
+# Files matching config/*.secret.exs pattern contain sensitive
+# data and you should not commit them into version control.
 #
 # Alternatively, you may comment the line below and commit the
-# secrets file as long as you replace its contents by environment
+# secrets files as long as you replace their contents by environment
 # variables.
-/config/prod.secret.exs
+/config/*.secret.exs


### PR DESCRIPTION
Hey Guys,

**TL;DR:** In this PR I propose to ignore all secret files in the config folder.

I read through the “Programming Phoenix” book the other day. In this book I came across a chapter where I had to create `dev.secret.exs` in the config folder.

In order to protect it I had to put it into `.gitignore`. So I thought we should ignore all secret files matching the pattern by default.