### PR TITLE
Adds mix.phoenix task to provide list of phoenix tasks

### DIFF
--- a/lib/mix/tasks/phoenix.ex
+++ b/lib/mix/tasks/phoenix.ex
@@ -6,26 +6,17 @@ defmodule Mix.Tasks.Phoenix do
   @moduledoc """
   Prints Phoenix tasks and their information.
 
-    mix phoenix
+      mix phoenix
 
   """
 
   @doc false
-  def run(args) do
-    {_opts, args, _} = OptionParser.parse(args)
-
-    case args do
-      [] -> help()
-      _  ->
-        Mix.raise "Invalid arguments, expected: mix phoenix"
-    end
-  end
-
-  defp help() do
+  def run(_args) do
     Application.ensure_all_started(:phoenix)
     Mix.shell.info "Phoenix v#{Application.spec(:phoenix, :vsn)}"
     Mix.shell.info "A productive web framework that does not compromise speed and maintainability."
     Mix.shell.info "\nAvailable tasks:\n"
     Mix.Tasks.Help.run(["--search", "phoenix."])
   end
+
 end

--- a/lib/mix/tasks/phoenix.ex
+++ b/lib/mix/tasks/phoenix.ex
@@ -1,0 +1,31 @@
+defmodule Mix.Tasks.Phoenix do
+  use Mix.Task
+
+  @shortdoc "Prints Phoenix help information"
+
+  @moduledoc """
+  Prints Phoenix tasks and their information.
+
+    mix phoenix
+
+  """
+
+  @doc false
+  def run(args) do
+    {_opts, args, _} = OptionParser.parse(args)
+
+    case args do
+      [] -> help()
+      _  ->
+        Mix.raise "Invalid arguments, expected: mix phoenix"
+    end
+  end
+
+  defp help() do
+    Application.ensure_all_started(:phoenix)
+    Mix.shell.info "Phoenix v#{Application.spec(:phoenix, :vsn)}"
+    Mix.shell.info "A productive web framework that does not compromise speed and maintainability."
+    Mix.shell.info "\nAvailable tasks:\n"
+    Mix.Tasks.Help.run(["--search", "phoenix."])
+  end
+end

--- a/test/mix/tasks/phoenix_test.exs
+++ b/test/mix/tasks/phoenix_test.exs
@@ -10,21 +10,9 @@ defmodule Mix.Tasks.PhoenixTest do
     Mix.Tasks.Phoenix.run []
 
     assert_received {:mix_shell, :info, ["mix phoenix.digest " <> _]}
-    assert_received {:mix_shell, :info, ["mix phoenix.digest.clean " <> _]}
-    assert_received {:mix_shell, :info, ["mix phoenix.gen.channel" <> _]}
-    assert_received {:mix_shell, :info, ["mix phoenix.gen.html" <> _]}
-    assert_received {:mix_shell, :info, ["mix phoenix.gen.json" <> _]}
-    assert_received {:mix_shell, :info, ["mix phoenix.gen.model" <> _]}
-    assert_received {:mix_shell, :info, ["mix phoenix.gen.presence" <> _]}
     assert_received {:mix_shell, :info, ["mix phoenix.gen.secret" <> _]}
     assert_received {:mix_shell, :info, ["mix phoenix.routes" <> _]}
     assert_received {:mix_shell, :info, ["mix phoenix.server" <> _]}
-  end
-
-  test "expects no arguments" do
-    assert_raise Mix.Error, fn ->
-      Mix.Tasks.Phoenix.run ["invalid"]
-    end
   end
 
 end

--- a/test/mix/tasks/phoenix_test.exs
+++ b/test/mix/tasks/phoenix_test.exs
@@ -3,22 +3,22 @@ defmodule Mix.Tasks.PhoenixTest do
 
   test "prints version" do
     Mix.Tasks.Phoenix.run []
-    assert_received { :mix_shell, :info, ["Phoenix v" <> _]}
+    assert_received {:mix_shell, :info, ["Phoenix v" <> _]}
   end
 
   test "provide a list of available phoenix mix tasks" do
     Mix.Tasks.Phoenix.run []
 
-    assert_received { :mix_shell, :info, ["mix phoenix.digest " <> _]}
-    assert_received { :mix_shell, :info, ["mix phoenix.digest.clean " <> _]}
-    assert_received { :mix_shell, :info, ["mix phoenix.gen.channel" <> _]}
-    assert_received { :mix_shell, :info, ["mix phoenix.gen.html" <> _]}
-    assert_received { :mix_shell, :info, ["mix phoenix.gen.json" <> _]}
-    assert_received { :mix_shell, :info, ["mix phoenix.gen.model" <> _]}
-    assert_received { :mix_shell, :info, ["mix phoenix.gen.presence" <> _]}
-    assert_received { :mix_shell, :info, ["mix phoenix.gen.secret" <> _]}
-    assert_received { :mix_shell, :info, ["mix phoenix.routes" <> _]}
-    assert_received { :mix_shell, :info, ["mix phoenix.server" <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.digest " <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.digest.clean " <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.gen.channel" <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.gen.html" <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.gen.json" <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.gen.model" <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.gen.presence" <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.gen.secret" <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.routes" <> _]}
+    assert_received {:mix_shell, :info, ["mix phoenix.server" <> _]}
   end
 
   test "expects no arguments" do

--- a/test/mix/tasks/phoenix_test.exs
+++ b/test/mix/tasks/phoenix_test.exs
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.PhoenixTest do
+  use ExUnit.Case, async: true
+
+  test "prints version" do
+    Mix.Tasks.Phoenix.run []
+    assert_received { :mix_shell, :info, ["Phoenix v" <> _]}
+  end
+
+  test "provide a list of available phoenix mix tasks" do
+    Mix.Tasks.Phoenix.run []
+
+    assert_received { :mix_shell, :info, ["mix phoenix.digest " <> _]}
+    assert_received { :mix_shell, :info, ["mix phoenix.digest.clean " <> _]}
+    assert_received { :mix_shell, :info, ["mix phoenix.gen.channel" <> _]}
+    assert_received { :mix_shell, :info, ["mix phoenix.gen.html" <> _]}
+    assert_received { :mix_shell, :info, ["mix phoenix.gen.json" <> _]}
+    assert_received { :mix_shell, :info, ["mix phoenix.gen.model" <> _]}
+    assert_received { :mix_shell, :info, ["mix phoenix.gen.presence" <> _]}
+    assert_received { :mix_shell, :info, ["mix phoenix.gen.secret" <> _]}
+    assert_received { :mix_shell, :info, ["mix phoenix.routes" <> _]}
+    assert_received { :mix_shell, :info, ["mix phoenix.server" <> _]}
+  end
+
+  test "expects no arguments" do
+    assert_raise Mix.Error, fn ->
+      Mix.Tasks.Phoenix.run ["invalid"]
+    end
+  end
+
+end


### PR DESCRIPTION
Hey :wave: 

I noticed that there was no `mix phoenix` task to list the phoenix specific mix tasks. Ecto has the `mix ecto` that I've found super useful to remind myself what the tasks are called again.

This PR adds a "base" mix task called phoenix which prints out the version of phoenix, short description and lists all the available tasks:

```
$ mix phoenix
Phoenix v1.3.0-dev
A productive web framework that does not compromise speed and maintainability.

Available tasks:

mix phoenix.digest       # Digests and compresses static files
mix phoenix.digest.clean # Removes old versions of static assets.
mix phoenix.gen.channel  # Generates a Phoenix channel
mix phoenix.gen.html     # Generates controller, model and views for an HTML based resource
mix phoenix.gen.json     # Generates a controller and model for a JSON based resource
mix phoenix.gen.model    # Generates an Ecto model
mix phoenix.gen.presence # Generates a Presence tracker
mix phoenix.gen.secret   # Generates a secret
mix phoenix.routes       # Prints all routes
mix phoenix.server       # Starts applications and their servers
```

Guess you could do the same by just doing `mix help | grep phoenix.` like I have been doing so far but thought this might make for a nice quality of life improvement :wink: 

Thanks,
Ville