### PR TITLE
Remove unnecessary Phoenix.Param.Any.deriving/3 public function

### DIFF
--- a/lib/phoenix/param.ex
+++ b/lib/phoenix/param.ex
@@ -81,10 +81,6 @@ end
 
 defimpl Phoenix.Param, for: Any do
   defmacro __deriving__(module, struct, options) do
-    deriving(module, struct, options)
-  end
-
-  def deriving(module, struct, options) do
     key = Keyword.get(options, :key, :id)
 
     unless Map.has_key?(struct, key) do


### PR DESCRIPTION
It was in use before in Phoenix.Param.Map, but is not anymore
after the dropping of Elixir v1.1 support.