### PR TITLE
Adds clarification to what term means for flash

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -276,7 +276,9 @@ defmodule Phoenix.ConnTest do
   defdelegate get_flash(conn, key), to: Phoenix.Controller
 
   @doc """
-  Puts the given value under key in the flash storage.
+  Puts the given value under key in the flash storage. The value
+  can be any term so if you need more than one message under a
+  key a list may be used.
   """
   @spec put_flash(Conn.t, term, term) :: Conn.t
   defdelegate put_flash(conn, key, value), to: Phoenix.Controller


### PR DESCRIPTION
A few times I have seen people ask how to put more than one
message under the same flash key. Adding the idea of a what
a term in here may further what a term means in the specs and
keep people from needing to search as far.

Amos King @adkron <amos@binarynoggin.com>