### PR TITLE
Fix digest clean

### DIFF
--- a/lib/mix/tasks/phoenix.digest.clean.ex
+++ b/lib/mix/tasks/phoenix.digest.clean.ex
@@ -42,6 +42,11 @@ defmodule Mix.Tasks.Phoenix.Digest.Clean do
 
     case Phoenix.Digester.clean(output_path, age, keep) do
       :ok ->
+        # We need to call build structure so everything we have cleaned from
+        # priv is removed from _build in case we have build_embedded set to
+        # true. In case it's not true, build structure is mostly a no-op, so we
+        # are fine.
+        Mix.Project.build_structure()
         Mix.shell.info [:green, "Clean complete for #{inspect output_path}"]
       {:error, :invalid_path} ->
         Mix.shell.error "The output path #{inspect output_path} does not exist"

--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -273,7 +273,7 @@ defmodule Phoenix.Digester do
   Digests and compresses the static files and saves them in the given output path.
 
     * `output_path` - The path where the compiled/compressed files will be saved
-    * `age` - The max age of assets to keep
+    * `age` - The max age of assets to keep in seconds
     * `keep` - The number of old versions to keep
   """
   @spec clean(String.t, integer, integer, integer) :: :ok | {:error, :invalid_path}

--- a/test/fixtures/digest/cleaner/latest_not_most_recent_manifest.json
+++ b/test/fixtures/digest/cleaner/latest_not_most_recent_manifest.json
@@ -1,0 +1,26 @@
+{
+  "digests": {
+    "app-1.css": {
+      "logical_path": "app.css",
+      "mtime": 32132171,
+      "size": 369053,
+      "digest": "1"
+    },
+    "app-2.css": {
+      "logical_path": "app.css",
+      "mtime": 32132172,
+      "size": 369053,
+      "digest": "2"
+    },
+    "app-3.css": {
+      "logical_path": "app.css",
+      "mtime": 32132170,
+      "size": 369053,
+      "digest": "3"
+    }
+  },
+  "latest": {
+    "app.css": "app-3.css"
+  },
+  "version": 1
+}

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -15,6 +15,28 @@ defmodule Phoenix.DigesterTest do
       assert {:error, :invalid_path} = Phoenix.Digester.compile("nonexistent path", "/ ?? /path")
     end
 
+    test "upgrade old manifest" do
+      source_path = "test/fixtures/digest/priv/static/"
+      input_path = "tmp/digest/static"
+      File.rm_rf!(input_path)
+      :ok = File.mkdir_p!(@output_path)
+      :ok = File.mkdir_p!(input_path)
+      :ok = File.cp(Path.join(source_path, "foo.css"), Path.join(@output_path, "foo-d978852bea6530fcd197b5445ed008fd.css"))
+      :ok = File.cp("test/fixtures/old_manifest.json", Path.join(@output_path, "manifest.json"))
+      File.write!(Path.join(input_path, "foo.css"), ".foo { background-color: blue }")
+
+      assert :ok = Phoenix.Digester.compile(input_path, @output_path)
+
+      json =
+        Path.join(@output_path, "manifest.json")
+        |> File.read!()
+        |> Poison.decode!()
+
+      assert_in_delta json["digests"]["foo-d978852bea6530fcd197b5445ed008fd.css"]["mtime"], now(), 2
+      assert_in_delta json["digests"]["foo-1198fd3c7ecf0e8f4a33a6e4fc5ae168.css"]["mtime"], now(), 2
+      assert json["latest"]["foo.css"] == "foo-1198fd3c7ecf0e8f4a33a6e4fc5ae168.css"
+    end
+
     test "digests and compress files" do
       input_path = "test/fixtures/digest/priv/static/"
       assert :ok = Phoenix.Digester.compile(input_path, @output_path)

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -344,6 +344,29 @@ defmodule Phoenix.DigesterTest do
       refute "app-1.css" in output_files
       refute "app-1.css.gz" in output_files
     end
+
+    test "cleaning updates manifest to remove cleaned files" do
+      manifest_path = "test/fixtures/digest/cleaner/manifest.json"
+      File.mkdir_p!(@output_path)
+      File.cp(manifest_path, "#{@output_path}/manifest.json")
+      File.touch("#{@output_path}/app.css")
+      File.touch("#{@output_path}/app-1.css")
+      File.touch("#{@output_path}/app-1.css.gz")
+      File.touch("#{@output_path}/app-2.css")
+      File.touch("#{@output_path}/app-2.css.gz")
+      File.touch("#{@output_path}/app-3.css")
+      File.touch("#{@output_path}/app-3.css.gz")
+      File.touch("#{@output_path}/app.css")
+
+      assert :ok = Phoenix.Digester.clean(@output_path, 3600, 1, @fake_now)
+
+      json =
+        Path.join(@output_path, "manifest.json")
+        |> File.read!()
+        |> Poison.decode!()
+
+      refute json["digests"]["app-1.css"]
+    end
   end
 
   defp assets_files(path) do

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -297,6 +297,31 @@ defmodule Phoenix.DigesterTest do
       refute "app-1.css" in output_files
       refute "app-1.css.gz" in output_files
     end
+
+    test "cleaning doesn't delete the latest even if the mtime is wrong" do
+      manifest_path = "test/fixtures/digest/cleaner/latest_not_most_recent_manifest.json"
+      File.mkdir_p!(@output_path)
+      File.cp(manifest_path, "#{@output_path}/manifest.json")
+      File.touch("#{@output_path}/app.css")
+      File.touch("#{@output_path}/app-1.css")
+      File.touch("#{@output_path}/app-1.css.gz")
+      File.touch("#{@output_path}/app-2.css")
+      File.touch("#{@output_path}/app-2.css.gz")
+      File.touch("#{@output_path}/app-3.css")
+      File.touch("#{@output_path}/app-3.css.gz")
+      File.touch("#{@output_path}/app.css")
+
+      assert :ok = Phoenix.Digester.clean(@output_path, 3600, 1, @fake_now)
+      output_files = assets_files(@output_path)
+
+      assert "app.css" in output_files
+      assert "app-3.css" in output_files
+      assert "app-3.css.gz" in output_files
+      assert "app-2.css" in output_files
+      assert "app-2.css.gz" in output_files
+      refute "app-1.css" in output_files
+      refute "app-1.css.gz" in output_files
+    end
   end
 
   defp assets_files(path) do

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -42,9 +42,11 @@ defmodule Phoenix.DigesterTest do
     test "includes existing digests in new manifest" do
       source_path = "test/fixtures/digest/priv/static/"
       input_path = "tmp/digest/static"
+      File.rm_rf!(input_path)
       :ok = File.mkdir_p!(@output_path)
       :ok = File.mkdir_p!(input_path)
       {:ok, _} = File.cp_r(source_path, input_path)
+      :ok = File.cp(Path.join(source_path, "foo.css"), Path.join(@output_path, "foo-d978852bea6530fcd197b5445ed008fd.css"))
       :ok = File.cp("test/fixtures/manifest.json", Path.join(@output_path, "manifest.json"))
 
       assert :ok = Phoenix.Digester.compile(input_path, @output_path)
@@ -56,6 +58,8 @@ defmodule Phoenix.DigesterTest do
 
       # Keep old entries
       assert json["digests"]["foo-d978852bea6530fcd197b5445ed008fd.css"]["logical_path"] == "foo.css"
+      # Update mtime
+      assert_in_delta json["digests"]["foo-d978852bea6530fcd197b5445ed008fd.css"]["mtime"], now(), 2
 
       # Add new entries
       key = Enum.find(Map.keys(json["digests"]), &(&1 =~ ~r"phoenix-#{@hash_regex}.png"))
@@ -64,6 +68,43 @@ defmodule Phoenix.DigesterTest do
       assert json["digests"][key]["size"] == 13900
       assert json["digests"][key]["digest"] =~ ~r"#{@hash_regex}"
       assert json["version"] == 1
+    end
+
+    test "old versions maintain their mtime" do
+      source_path = "test/fixtures/digest/priv/static/"
+      input_path = "tmp/digest/static"
+      File.rm_rf!(input_path)
+      :ok = File.mkdir_p!(@output_path)
+      :ok = File.mkdir_p!(input_path)
+      :ok = File.cp(Path.join(source_path, "foo.css"), Path.join(@output_path, "foo-d978852bea6530fcd197b5445ed008fd.css"))
+      :ok = File.cp("test/fixtures/manifest.json", Path.join(@output_path, "manifest.json"))
+      File.write!(Path.join(input_path, "foo.css"), ".foo { background-color: blue }")
+
+      assert :ok = Phoenix.Digester.compile(input_path, @output_path)
+
+      json =
+        Path.join(@output_path, "manifest.json")
+        |> File.read!()
+        |> Poison.decode!()
+
+      assert json["digests"]["foo-d978852bea6530fcd197b5445ed008fd.css"]["mtime"] == 32132171
+      assert_in_delta json["digests"]["foo-1198fd3c7ecf0e8f4a33a6e4fc5ae168.css"]["mtime"], now(), 2
+    end
+
+    test "excludes files that no longer exist from manifest" do
+      input_path = "tmp/digest/static"
+      File.rm_rf! input_path
+      :ok = File.mkdir_p!(input_path)
+      :ok = File.cp("test/fixtures/manifest.json", Path.join(input_path, "manifest.json"))
+
+      assert :ok = Phoenix.Digester.compile(input_path, input_path)
+
+      json =
+        Path.join(input_path, "manifest.json")
+        |> File.read!()
+        |> Poison.decode!()
+
+      assert json["digests"] == %{}
     end
 
     test "digests and compress nested files" do
@@ -83,6 +124,28 @@ defmodule Phoenix.DigesterTest do
         |> File.read!()
         |> Poison.decode!()
       assert json["latest"]["static/phoenix.png"] =~ ~r"static/phoenix-#{@hash_regex}\.png"
+    end
+
+    test "keeps old version in manifest when digesting twice" do
+      input_path = Path.join("tmp", "phoenix_digest_twice")
+      input_file = Path.join(input_path, "file.js")
+
+      File.rm_rf!(input_path)
+      File.mkdir_p!(input_path)
+      File.mkdir_p!(@output_path)
+
+      File.write!(input_file, "console.log('test');")
+      assert :ok = Phoenix.Digester.compile(input_path, @output_path)
+
+      File.write!(input_file, "console.log('test2');")
+      assert :ok = Phoenix.Digester.compile(input_path, @output_path)
+
+      json =
+        Path.join(@output_path, "manifest.json")
+        |> File.read!()
+        |> Poison.decode!()
+
+      assert Enum.count(json["digests"]) == 2
     end
 
     test "doesn't duplicate files when digesting and compressing twice" do
@@ -242,5 +305,9 @@ defmodule Phoenix.DigesterTest do
     |> Path.wildcard
     |> Enum.filter(&(!File.dir?(&1)))
     |> Enum.map(&(Path.relative_to(&1, path)))
+  end
+
+  defp now do
+    :calendar.datetime_to_gregorian_seconds(:calendar.universal_time)
   end
 end


### PR DESCRIPTION
This addresses #2074 and fixes several other bugs with the new digest/digest.clean.

Previously:

1. `mtime` was updated to the current time for all assets, including those that were not digested this time around.
2. If a file was deleted manually, it would not be removed from the manifest the next time digest was run.
3. In manifests affected by some of the other bugs this pull fixes, it was possible that clean would delete the latest version of an asset.
4. Cleaned assets were not removed from the manifest.
5. Cleaned assets were not also removed from the `_build` directory when `build_embedded` was true (#2074)
6. The documentation for `digest.clean` was incorrect.

I added test cases to cover these and some other edge cases that were exposed while I was refactoring. Please let me know if there's any changes you'd like me to make.

Thanks!