### PR TITLE
Update faulty @doc for Phoenix.Controller.get_flash/1

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1050,9 +1050,12 @@ defmodule Phoenix.Controller do
   end
 
   @doc """
-  Returns a previously set flash message or nil.
+  Returns a map of previously set flash messages or an empty map.
 
   ## Examples
+
+      iex> get_flash(conn)
+      %{}
 
       iex> conn = put_flash(conn, :info, "Welcome Back!")
       iex> get_flash(conn)


### PR DESCRIPTION
Fix the documentation that wrongly states the function `Phoenix.Controller.get_flash/1` would return `nil` if no flash messages are set, even though `conn.private.phoenix_flash` is an empty map by default.