### PR TITLE
Remove javascript-brunch because it is deprecated

### DIFF
--- a/installer/templates/assets/brunch/package.json
+++ b/installer/templates/assets/brunch/package.json
@@ -11,10 +11,9 @@
   },
   "devDependencies": {
     "babel-brunch": "6.0.6",
-    "brunch": "2.9.1",
+    "brunch": "2.10.5",
     "clean-css-brunch": "2.0.0",
     "css-brunch": "2.6.1",
-    "javascript-brunch": "2.0.0",
     "uglify-js-brunch": "2.0.1"
   }
 }


### PR DESCRIPTION
Bump brunch to 2.10, as this is the minimum required to work without javascript-brunch