### PR TITLE
Add @shortdoc for phx.new.web and phx.new.ecto

### DIFF
--- a/installer/lib/phx_new/ecto.ex
+++ b/installer/lib/phx_new/ecto.ex
@@ -42,6 +42,8 @@ defmodule Mix.Tasks.Phx.New.Ecto do
   use Mix.Task
   import Phx.New.Generator
 
+  @shortdoc "Creates a new Ecto project within an umbrella application."
+
   def run([path | _] = args) do
     unless in_umbrella?(path) do
       Mix.raise "the ecto task can only be run within an umbrella's apps directory"

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -28,6 +28,10 @@ defmodule Mix.Tasks.Phx.New.Web do
   use Phx.New.Generator
   alias Phx.New.{Project}
 
+  @version Mix.Project.config[:version]
+  @shortdoc "Creates a new Phoenix v#{@version} application inside an umbrella application"
+
+
   @pre "phx_umbrella/apps/app_name_web"
 
   template :new, [


### PR DESCRIPTION
Without the `@shortdoc` in both these tasks, they don't show up in `mix help`. This PR fixes it.