### PR TITLE
Add missing .gitignore in umbrella app

### DIFF
--- a/installer/lib/phx_new/umbrella.ex
+++ b/installer/lib/phx_new/umbrella.ex
@@ -7,6 +7,7 @@ defmodule Phx.New.Umbrella do
   template :new, [
     {:eex,  "phx_umbrella/config/config.exs", :project, "config/config.exs"},
     {:eex,  "phx_umbrella/mix.exs",           :project, "mix.exs"},
+    {:eex,  "phx_umbrella/gitignore",         :project, ".gitignore"},
     {:eex,  "phx_umbrella/README.md",         :project, "README.md"},
   ]
 

--- a/installer/templates/phx_umbrella/gitignore
+++ b/installer/templates/phx_umbrella/gitignore
@@ -3,4 +3,3 @@
 /deps
 erl_crash.dump
 *.ez
-node_modules

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -35,6 +35,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       Mix.Tasks.Phx.New.run([@app, "--umbrella"])
 
       assert_file root_path(@app, "README.md")
+      assert_file root_path(@app, ".gitignore")
       assert_file app_path(@app, "README.md")
       assert_file web_path(@app, "README.md")
       assert_file root_path(@app, "mix.exs"), fn file ->


### PR DESCRIPTION
`mix phx.new app_name --umbrella` creates a new umbrella app without `.gitignore` file in the root directory. This PR adds a test and fixes the same.