### PR TITLE
Align and bump npm package versions.

### DIFF
--- a/installer/templates/assets/brunch/package.json
+++ b/installer/templates/assets/brunch/package.json
@@ -11,9 +11,9 @@
   },
   "devDependencies": {
     "babel-brunch": "6.0.6",
-    "brunch": "2.10.5",
-    "clean-css-brunch": "2.0.0",
-    "css-brunch": "2.6.1",
-    "uglify-js-brunch": "2.0.1"
+    "brunch": "2.10.7",
+    "clean-css-brunch": "2.10.0",
+    "css-brunch": "2.10.0",
+    "uglify-js-brunch": "2.1.1"
   }
 }

--- a/installer/templates/static/brunch/package.json
+++ b/installer/templates/static/brunch/package.json
@@ -11,10 +11,9 @@
   },
   "devDependencies": {
     "babel-brunch": "6.0.6",
-    "brunch": "2.9.1",
-    "clean-css-brunch": "2.0.0",
-    "css-brunch": "2.6.1",
-    "javascript-brunch": "2.0.0",
-    "uglify-js-brunch": "2.0.1"
+    "brunch": "2.10.7",
+    "clean-css-brunch": "2.10.0",
+    "css-brunch": "2.10.0",
+    "uglify-js-brunch": "2.1.1"
   }
 }


### PR DESCRIPTION
In https://github.com/phoenixframework/phoenix/pull/2082 we forgot to remove deprecated `javascript-brunch` package and align the versions in both installer templates. 

Shall we add a comment to both files that there are two of them to mitigate the reduce the likelihood of doing the same mistake again?