### PR TITLE
Fix module name issue with new phx.gen.json and phx.gen.html.

### DIFF
--- a/lib/mix/phoenix/context.ex
+++ b/lib/mix/phoenix/context.ex
@@ -39,7 +39,7 @@ defmodule Mix.Phoenix.Context do
   end
   defp web_module(base) do
     case base |> Module.split() |> Enum.reverse() do
-      [Web | _] -> base
+      ["Web" | _] -> base
       _ -> Module.concat(base, "Web")
     end
   end


### PR DESCRIPTION
When I tested gen.json|html it would generate module names like `defmodule App.Web.Web.PostController do`. Now it correctly generates `defmodule App.Web.PostController do`. 

I also went ahead and made sure we weren't matching on Module.split\1 anywhere else.