### PR TITLE
Use const for immutable bindings.

### DIFF
--- a/installer/templates/assets/brunch/socket.js
+++ b/installer/templates/assets/brunch/socket.js
@@ -5,7 +5,7 @@
 // and connect at the socket path in "lib/my_app/endpoint.ex":
 import {Socket} from "phoenix"
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+const socket = new Socket("/socket", {params: {token: window.userToken}})
 
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,
@@ -54,7 +54,7 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
+const channel = socket.channel("topic:subtopic", {})
 channel.join()
   .receive("ok", resp => { console.log("Joined successfully", resp) })
   .receive("error", resp => { console.log("Unable to join", resp) })

--- a/installer/templates/static/brunch/socket.js
+++ b/installer/templates/static/brunch/socket.js
@@ -5,7 +5,7 @@
 // and connect at the socket path in "lib/my_app/endpoint.ex":
 import {Socket} from "phoenix"
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+const socket = new Socket("/socket", {params: {token: window.userToken}})
 
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,
@@ -54,7 +54,7 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
+const channel = socket.channel("topic:subtopic", {})
 channel.join()
   .receive("ok", resp => { console.log("Joined successfully", resp) })
   .receive("error", resp => { console.log("Unable to join", resp) })


### PR DESCRIPTION
It is a common misconception that ES2015 `const` keyword creates constants or immutable vars but that is not true. The following code is perfectly valid:

```js
const foo = {};
foo.bar = false;

const baz = [];
baz.push('item')
```

The truth is that `const` creates **an immutable binding** which means the following code would throw:

```js
const foo = {}
foo = [] // throws “Assignment to constant variable.”
```

Some eslint configs use [import/no-mutable-exports](https://github.com/benmosher/eslint-plugin-import/blob/24e2c9d27110c04a31323c8cee1c9509a4c8a969/docs/rules/no-mutable-exports.md) rule which causes a linting error in the socket.js file.

Hence I propose to change `let` to `const`.