### PR TITLE
Allows atom statuses in `redirected_to`

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -436,6 +436,10 @@ defmodule Phoenix.ConnTest do
     raise "expected connection to have redirected but no response was set/sent"
   end
 
+  def redirected_to(conn, status) when is_atom(status) do
+    redirected_to(conn, Plug.Conn.Status.code(status))
+  end
+
   def redirected_to(%Conn{status: status} = conn, status) do
     location = Conn.get_resp_header(conn, "location") |> List.first
     location || raise "no location header was set on redirected_to"

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -310,6 +310,15 @@ defmodule Phoenix.Test.ConnTest do
     end
   end
 
+  test "redirected_to/2 with status atom" do
+    conn =
+      build_conn(:get, "/")
+      |> put_resp_header("location", "new location")
+      |> send_resp(301, "foo")
+
+    assert redirected_to(conn, :moved_permanently) == "new location"
+  end
+
   test "redirected_to/2 without header" do
     assert_raise RuntimeError,
                  "no location header was set on redirected_to", fn ->


### PR DESCRIPTION
Fixes `redirected_to` when passed an atom instead of an integer for the status. The docs for `redirected_to/2` give the following example, which doesn't currently work. This PR fixes it.

```elixir
      assert redirected_to(conn, :moved_permanently) =~ "/foo/bar"
```