### PR TITLE
phx.gen.*: Remove dependency on installer code

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -243,6 +243,7 @@ defmodule Phx.New.Generator do
         """
     end
   end
+
   defp phoenix_path(path, true) do
     absolute = Path.expand(path)
     relative = Path.relative_to(absolute, @phoenix)
@@ -256,7 +257,6 @@ defmodule Phx.New.Generator do
     |> Enum.map(fn _ -> ".." end)
     |> Path.join()
   end
-
   defp phoenix_path(_path, false) do
     "deps/phoenix"
   end

--- a/lib/mix/phx.ex
+++ b/lib/mix/phx.ex
@@ -1,0 +1,23 @@
+defmodule Mix.Phx do
+  @moduledoc false
+
+  def in_single?(path) do
+    mixfile = Path.join(path, "mix.exs")
+    apps_path = Path.join(path, "apps")
+
+    File.exists?(mixfile) and not File.exists?(apps_path)
+  end
+
+  def in_umbrella?(app_path) do
+    try do
+      umbrella = Path.expand(Path.join [app_path, "..", ".."])
+      File.exists?(Path.join(umbrella, "mix.exs")) &&
+        Mix.Project.in_project(:umbrella_check, umbrella, fn _ ->
+          path = Mix.Project.config[:apps_path]
+          path && Path.expand(path) == Path.join(umbrella, "apps")
+        end)
+    catch
+      _, _ -> false
+    end
+  end
+end

--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -1,5 +1,3 @@
-Code.require_file("../../../installer/lib/phx_new/generator.ex", __DIR__)
-
 defmodule Mix.Tasks.Phx.Gen.Html do
   @shortdoc "Generates controller, views, and bounded context for an HTML resource"
 
@@ -49,7 +47,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   end
 
   def build(args) do
-    unless Phx.New.Generator.in_single?(File.cwd!()) do
+    unless Mix.Phx.in_single?(File.cwd!()) do
       Mix.raise "mix phx.gen.html and phx.gen.json can only be run inside an application directory"
     end
     switches = [binary_id: :boolean, model: :boolean, table: :string]
@@ -121,7 +119,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   end
 
   def web_prefix do
-    if Phx.New.Generator.in_umbrella?(File.cwd!()) do
+    if Mix.Phx.in_umbrella?(File.cwd!()) do
       "lib"
     else
       "lib/web"
@@ -129,7 +127,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   end
 
   def test_prefix do
-    if Phx.New.Generator.in_umbrella?(File.cwd!()) do
+    if Mix.Phx.in_umbrella?(File.cwd!()) do
       "test"
     else
       "test/web"

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -1,5 +1,3 @@
-Code.require_file("../../../installer/lib/phx_new/generator.ex", __DIR__)
-
 defmodule Mix.Tasks.Phx.Gen.Json do
   @shortdoc "Generates controller, views, and bounded context for a JSON resource"
 

--- a/lib/mix/tasks/phx.gen.schema.ex
+++ b/lib/mix/tasks/phx.gen.schema.ex
@@ -1,5 +1,3 @@
-Code.require_file("../../../installer/lib/phx_new/generator.ex", __DIR__)
-
 defmodule Mix.Tasks.Phx.Gen.Schema do
   @shortdoc "Generates an Ecto Schema"
 
@@ -99,7 +97,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   end
 
   def build(args, help \\ __MODULE__) do
-    unless Phx.New.Generator.in_single?(File.cwd!()) do
+    unless Mix.Phx.in_single?(File.cwd!()) do
       Mix.raise "mix phx.gen.schema can only be run inside an application directory"
     end
     {opts, parsed, _} = OptionParser.parse(args, switches: @switches)


### PR DESCRIPTION
This fixes compilation issues (https://github.com/phoenixframework/phoenix/pull/1927/files#diff-7a2d67c8d1b6c38fd3498e4e09e8d9e2R1)

The code has been copied from `Phx.New.Generator`.