### PR TITLE
Make the default page responsive

### DIFF
--- a/installer/templates/static/phoenix.css
+++ b/installer/templates/static/phoenix.css
@@ -34,6 +34,7 @@ form.link, form.button {
   height: 27px;
   background-size: 100%;
   display: inline-block;
+  margin-top: 0.5em;
   margin-bottom: 1em;
   background-image: url("/images/phoenix.png");
 }
@@ -77,6 +78,7 @@ form.link, form.button {
   .logo {
     width: 519px;
     height: 71px;
+    margin-top: 0;
     background-size: 519px 71px;
   }
   /* Space out the masthead */

--- a/installer/templates/static/phoenix.css
+++ b/installer/templates/static/phoenix.css
@@ -26,13 +26,16 @@ form.link, form.button {
 .header {
   border-bottom: 1px solid #e5e5e5;
 }
+.header ul {
+  margin-top: 0;
+}
 .logo {
-  width: 519px;
-  height: 71px;
+  width: 200px;
+  height: 27px;
+  background-size: 100%;
   display: inline-block;
   margin-bottom: 1em;
   background-image: url("/images/phoenix.png");
-  background-size: 519px 71px;
 }
 
 /* Everything but the jumbotron gets side spacing for mobile first views */
@@ -71,9 +74,17 @@ form.link, form.button {
     padding-right: 0;
     padding-left: 0;
   }
+  .logo {
+    width: 519px;
+    height: 71px;
+    background-size: 519px 71px;
+  }
   /* Space out the masthead */
   .header {
     margin-bottom: 30px;
+  }
+  .header ul {
+    margin-top: 1em;
   }
   /* Remove the bottom border on the jumbotron for visual effect */
   .jumbotron {


### PR DESCRIPTION
This was made in response to #2103. Please excuse any mistakes as this is my first PR to Phoenix.

This tweaks the default CSS as little as possible so that the framework logo is scaled on mobile devices. The page looks as it already does on larger devices.

I'm more than happy to pop in standard Bootstrap navigation which would collapse by default if it's something you'd be interested in. Thanks!