### PR TITLE
Add graceful exit contract to transports

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -62,6 +62,7 @@ defmodule Phoenix.Socket do
     * `handler` - The socket module where this socket originated, for example: `MyApp.UserSocket`
     * `joined` - If the socket has effectively joined the channel
     * `pubsub_server` - The registered name of the socket's pubsub server
+    * `join_ref` - The ref sent by the client when joining
     * `ref` - The latest ref sent by the client
     * `topic` - The string topic, for example `"room:123"`
     * `transport` - The socket's transport, for example: `Phoenix.Transports.WebSocket`
@@ -145,6 +146,7 @@ defmodule Phoenix.Socket do
             joined: false,
             pubsub_server: nil,
             ref: nil,
+            join_ref: nil,
             topic: nil,
             transport: nil,
             transport_pid: nil,

--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -325,7 +325,9 @@ defmodule Phoenix.ChannelTest do
   """
   def join(%Socket{} = socket, channel, topic, payload \\ %{})
       when is_atom(channel) and is_binary(topic) and is_map(payload) do
-    socket = Transport.build_channel_socket(socket, channel, topic)
+
+    ref = System.unique_integer([:positive])
+    socket = Transport.build_channel_socket(socket, channel, topic, ref)
 
     case Server.join(socket, payload) do
       {:ok, reply, pid} ->

--- a/lib/phoenix/transports/long_poll_server.ex
+++ b/lib/phoenix/transports/long_poll_server.ex
@@ -112,6 +112,11 @@ defmodule Phoenix.Transports.LongPoll.Server do
     end
   end
 
+  def handle_info({:graceful_exit, channel_pid, %Phoenix.Socket.Message{} = msg}, state) do
+    new_state = delete(state, msg.topic, channel_pid)
+    publish_reply(msg, new_state)
+  end
+
   def handle_info({:subscribe, client_ref, ref}, state) do
     broadcast_from!(state, client_ref, {:subscribe, ref})
     {:noreply, state}

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -132,8 +132,13 @@ defmodule Phoenix.Transports.WebSocket do
       nil   -> {:ok, state}
       {topic, join_ref} ->
         new_state = delete(state, topic, channel_pid)
-        encode_reply Transport.on_exit_message(topic, join_ref, reason), new_state
+        encode_reply(Transport.on_exit_message(topic, join_ref, reason), new_state)
     end
+  end
+
+  def ws_info({:graceful_exit, channel_pid, %Phoenix.Socket.Message{} = msg}, state) do
+    new_state = delete(state, msg.topic, channel_pid)
+    encode_reply(msg, new_state)
   end
 
   @doc false

--- a/test/phoenix/integration/long_poll_test.exs
+++ b/test/phoenix/integration/long_poll_test.exs
@@ -346,7 +346,7 @@ defmodule Phoenix.Integration.LongPollTest do
 
     resp = poll(:get, "/ws", session)
 
-    [_phx_reply, _joined, _user_entered, _leave_reply, _you_left_msg, phx_close] = resp.body["messages"]
+    [_phx_reply, _joined, _user_entered, _leave_reply, phx_close, _you_left_msg] = resp.body["messages"]
 
     assert phx_close ==
       %{"event" => "phx_close", "payload" => %{}, "ref" => "123", "topic" => "room:lobby"}

--- a/test/phoenix/transports/transport_test.exs
+++ b/test/phoenix/transports/transport_test.exs
@@ -28,12 +28,6 @@ defmodule Phoenix.Transports.TransportTest do
   ## on_exit_message
 
   test "on_exit_message/3" do
-    assert Transport.on_exit_message("foo", "1", :normal) ==
-           %Message{ref: "1", event: "phx_close", payload: %{}, topic: "foo"}
-    assert Transport.on_exit_message("foo", "1", :shutdown) ==
-           %Message{ref: "1", event: "phx_close", payload: %{}, topic: "foo"}
-    assert Transport.on_exit_message("foo", "1", {:shutdown, :whatever}) ==
-           %Message{ref: "1", event: "phx_close", payload: %{}, topic: "foo"}
     assert Transport.on_exit_message("foo", "1", :oops) ==
            %Message{ref: "1", event: "phx_error", payload: %{}, topic: "foo"}
   end


### PR DESCRIPTION
ref: https://github.com/phoenixframework/phoenix_pubsub/issues/68

Previously a channel could gracefully terminate
using the stop semantics of a regular genserver;
however when restarting an application for deploys
the shutdown of the transport and channel processes
would be indistinguisable from an intentional channel
shutdown and would cause clients to incorrectly not
reconnect after server restart. This commit adds a
{:graceful_exit, channel_pid, %Phoenix.Socket.Message{}}
contract to distinguish an intentional channel exit from
what should be regarded as an error condition on the client.

cc @josevalim . Longer term, Saša's design will be a better solution so we can avoid more duplication across transports, but in the interest of shipping 1.3, the `{:graceful_exit, ...` can be handled inline.