### PR TITLE
fix code order. follows code from web module order

### DIFF
--- a/installer/templates/phx_umbrella/apps/app_name/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/mix.exs
@@ -20,8 +20,8 @@ defmodule <%= app_module %>.Mixfile do
   #
   # Type `mix help compile.app` for more information.
   def application do
-    [applications: [:logger<%= if ecto do %>, :<%= adapter_app %>, :ecto<% end %>],
-     mod: {<%= app_module %>.Application, []}]
+    [mod: {<%= app_module %>.Application, []},
+     applications: [:logger<%= if ecto do %>, :<%= adapter_app %>, :ecto<% end %>]]
   end
 
   # Specifies which paths to compile per environment.


### PR DESCRIPTION
This follows the order from here https://github.com/phoenixframework/phoenix/blob/cm-phx-gen-next/installer/templates/phx_umbrella/apps/app_name_web/mix.exs#L23