### PR TITLE
Bug fix channel join with timeout behavior

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -256,7 +256,7 @@ class Push {
     this.timeoutTimer = null
   }
 
-  startTimeout(){ if(this.timeoutTimer){ return }
+  startTimeout(){ if(this.timeoutTimer){ this.cancelTimeout() }
     this.ref      = this.channel.socket.makeRef()
     this.refEvent = this.channel.replyEventName(this.ref)
 

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -132,6 +132,43 @@ describe("join", () => {
       assert.equal(spy.callCount, 1)
     })
 
+    it("retries with backoff after timeout", () => {
+      const spy = sinon.spy(socket, "push")
+      const timeout = joinPush.timeout
+      let callCount = 1
+
+      socket.connect()
+      helpers.receiveSocketOpen()
+
+      channel.join()
+      assert.equal(spy.callCount, callCount)
+
+      clock.tick(timeout-100)
+      assert.equal(spy.callCount, callCount)
+
+      clock.tick(100)
+      assert.equal(spy.callCount, callCount)
+
+      clock.tick(1000)
+      assert.equal(spy.callCount, ++callCount)
+
+      clock.tick(2000)
+      assert.equal(spy.callCount, ++callCount)
+
+      clock.tick(5000)
+      assert.equal(spy.callCount, ++callCount)
+
+      clock.tick(10000)
+      assert.equal(spy.callCount, ++callCount)
+
+      joinPush.trigger("ok", {})
+      assert.equal(channel.state, "joined")
+
+      clock.tick(10000)
+      assert.equal(channel.state, "joined")
+      assert.equal(spy.callCount, callCount)
+    })
+
     it("with socket and join delay", () => {
       const spy = sinon.spy(socket, "push")
       const clock = sinon.useFakeTimers()

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -131,6 +131,50 @@ describe("join", () => {
       clock.tick(timeout)
       assert.equal(spy.callCount, 1)
     })
+
+    it("with socket and join delay", () => {
+      const spy = sinon.spy(socket, "push")
+      const clock = sinon.useFakeTimers()
+      const joinPush = channel.joinPush
+
+      socket.connect()
+
+      channel.join()
+      assert.equal(spy.callCount, 1)
+
+      // open socket after delay
+      clock.tick(6000)
+      sinon.stub(socket, "isConnected", () => true)
+      socket.onConnOpen()
+
+      assert.equal(spy.callCount, 1)
+
+      // join request succeeds after delay
+      clock.tick(11000)
+      joinPush.trigger("ok", {})
+
+      assert.equal(channel.state, "joined")
+      assert.equal(spy.callCount, 1)
+    })
+
+    it("with socket delay only", () => {
+      const spy = sinon.spy(socket, "push")
+      const clock = sinon.useFakeTimers()
+      const joinPush = channel.joinPush
+
+      socket.connect()
+      // open socket after delay
+      clock.tick(12000)
+      sinon.stub(socket, "isConnected", () => true)
+      socket.onConnOpen()
+
+      assert.equal(spy.callCount, 1)
+
+      // join request succeeds
+      joinPush.trigger("ok", {})
+
+      assert.equal(channel.state, "joined")
+    })
   })
 })
 

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -113,7 +113,7 @@ describe("join", () => {
     })
 
     it("succeeds before timeout", () => {
-      const spy = sinon.spy(socket, "push")
+      const spy = sinon.stub(socket, "push")
       const timeout = joinPush.timeout
 
       socket.connect()
@@ -133,7 +133,7 @@ describe("join", () => {
     })
 
     it("retries with backoff after timeout", () => {
-      const spy = sinon.spy(socket, "push")
+      const spy = sinon.stub(socket, "push")
       const timeout = joinPush.timeout
       let callCount = 1
 
@@ -143,10 +143,7 @@ describe("join", () => {
       channel.join()
       assert.equal(spy.callCount, callCount)
 
-      clock.tick(timeout-100)
-      assert.equal(spy.callCount, callCount)
-
-      clock.tick(100)
+      clock.tick(timeout)
       assert.equal(spy.callCount, callCount)
 
       clock.tick(1000)
@@ -161,55 +158,67 @@ describe("join", () => {
       clock.tick(10000)
       assert.equal(spy.callCount, ++callCount)
 
+      console.log("test: joinPush.trigger ok")
       joinPush.trigger("ok", {})
       assert.equal(channel.state, "joined")
 
       clock.tick(10000)
-      assert.equal(channel.state, "joined")
       assert.equal(spy.callCount, callCount)
+      assert.equal(channel.state, "joined")
     })
 
     it("with socket and join delay", () => {
-      const spy = sinon.spy(socket, "push")
+      const spy = sinon.stub(socket, "push")
       const clock = sinon.useFakeTimers()
       const joinPush = channel.joinPush
-
-      socket.connect()
 
       channel.join()
       assert.equal(spy.callCount, 1)
 
       // open socket after delay
-      clock.tick(6000)
-      sinon.stub(socket, "isConnected", () => true)
-      socket.onConnOpen()
+      clock.tick(9000)
 
       assert.equal(spy.callCount, 1)
 
+      // join request returns between timeouts
+      clock.tick(1000)
+      socket.connect()
+      helpers.receiveSocketOpen()
+      joinPush.trigger("ok", {})
+
+      assert.equal(channel.state, "errored")
+
       // join request succeeds after delay
-      clock.tick(11000)
+      clock.tick(1000)
+
+      assert.equal(channel.state, "joining")
+
       joinPush.trigger("ok", {})
 
       assert.equal(channel.state, "joined")
-      assert.equal(spy.callCount, 1)
+      assert.equal(spy.callCount, 2)
     })
 
     it("with socket delay only", () => {
-      const spy = sinon.spy(socket, "push")
+      const spy = sinon.stub(socket, "push")
       const clock = sinon.useFakeTimers()
       const joinPush = channel.joinPush
 
+      channel.join()
+
+      // connect socket after delay
+      clock.tick(6000)
       socket.connect()
+
       // open socket after delay
-      clock.tick(12000)
-      sinon.stub(socket, "isConnected", () => true)
-      socket.onConnOpen()
-
-      assert.equal(spy.callCount, 1)
-
-      // join request succeeds
+      clock.tick(5000)
+      helpers.receiveSocketOpen()
       joinPush.trigger("ok", {})
 
+      clock.tick(2000)
+      assert.equal(channel.state, "joining")
+
+      joinPush.trigger("ok", {})
       assert.equal(channel.state, "joined")
     })
   })


### PR DESCRIPTION
Fixes #2035 

- [x] - Test for joining after socket and channel delay
- [x] - Test for joining after socket delay only
- [x] - Test for retries with backoff
- [x] - Implement fix without introducing API change (i.e., without adding callbacks/promises, etc.)

