### PR TITLE
Remove mentions of "ecto models" from mix tasks documentation

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ecto.ex
+++ b/installer/lib/mix/tasks/phx.new.ecto.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Phx.New.Ecto do
       `mongodb`. Defaults to `postgres`
 
     * `--binary-id` - use `binary_id` as primary key type
-      in ecto models
+      in Ecto schemas
 
   ## Examples
 

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Phx.New do
     * `--no-html` - do not generate HTML views.
 
     * `--binary-id` - use `binary_id` as primary key type
-      in ecto models
+      in Ecto schemas
 
   ## Examples
 


### PR DESCRIPTION
I believe (newbie alert!), that these two mentions of "ecto models" in the new `phx` mix tasks documentation were overlooked in #1927.

This PR fixes that.
