### PR TITLE
Update relative path to installer directory (#2124)

### DIFF
--- a/installer/lib/mix/tasks/phoenix.new.ex
+++ b/installer/lib/mix/tasks/phoenix.new.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Phoenix.New do
   use Mix.Task
   import Mix.Generator
 
-  @phoenix Path.expand("../..", __DIR__)
+  @phoenix Path.expand("../../../..", __DIR__)
   @version Mix.Project.config[:version]
   @shortdoc "Creates a new Phoenix v#{@version} application"
 


### PR DESCRIPTION
`installer/lib/mix/tasks/phoenix.new.ex` got moved down two directory levels without updating the `@phoenix` path calculation, which uses `__DIR__`, causing `mix phoenix.new foo --dev` to fail.