### PR TITLE
Use new generator commands in the README template files

### DIFF
--- a/installer/templates/phx_single/README.md
+++ b/installer/templates/phx_single/README.md
@@ -5,7 +5,7 @@ To start your Phoenix server:
   * Install dependencies with `mix deps.get`<%= if ecto do %>
   * Create and migrate your database with `mix ecto.create && mix ecto.migrate`<% end %><%= if brunch do %>
   * Install Node.js dependencies with `cd assets && npm install`<% end %>
-  * Start Phoenix endpoint with `mix phoenix.server`
+  * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 

--- a/installer/templates/phx_umbrella/apps/app_name_web/README.md
+++ b/installer/templates/phx_umbrella/apps/app_name_web/README.md
@@ -5,7 +5,7 @@ To start your Phoenix server:
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.create && mix ecto.migrate`
   * Install Node.js dependencies with `cd assets && npm install`
-  * Start Phoenix endpoint with `mix phoenix.server`
+  * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 


### PR DESCRIPTION
When creating a new Phoenix application, it generates README files that include the old deprecated `mix phoenix.server` command.