### PR TITLE
Remove model switch from phx.gen.html.ex

### DIFF
--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
   use Mix.Task
 
   def run(args) do
-    IO.puts :stderr, "mix phoenix.gen.json is deprecated. Use phx.gen.html instead."
+    IO.puts :stderr, "mix phoenix.gen.json is deprecated. Use phx.gen.json instead."
     switches = [binary_id: :boolean, model: :boolean]
 
     {opts, parsed, _} = OptionParser.parse(args, switches: switches)

--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -50,7 +50,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
     if Mix.Project.umbrella? do
       Mix.raise "mix phx.gen.html and phx.gen.json can only be run inside an application directory"
     end
-    switches = [binary_id: :boolean, model: :boolean, table: :string]
+    switches = [binary_id: :boolean, table: :string]
     {opts, parsed, _} = OptionParser.parse(args, switches: switches)
     [context_name, schema_name, plural | schema_args] = validate_args!(parsed)
 


### PR DESCRIPTION
Does it make sense to add a “-no-schema” option to phx.gen.html/json? May be useful in umbrella apps where schema goes in another app/folder.