### PR TITLE
Fix ecto generator config path for umbrella apps

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -131,7 +131,7 @@ defmodule Mix.Tasks.Phx.New do
         Task.await(compile, :infinity)
 
         print_mix_info(project.project_path, extra)
-        if Project.ecto?(project), do: print_ecto_info()
+        if Project.ecto?(project), do: print_ecto_info(project)
         if not brunch?, do: print_brunch_info(project, starting_dir)
       end)
     end)
@@ -181,9 +181,15 @@ defmodule Mix.Tasks.Phx.New do
     nil
   end
 
-  defp print_ecto_info do
+  defp print_ecto_info(%Project{app_path: nil}), do: nil
+  defp print_ecto_info(%Project{app_path: app_path} = project) do
+    config_path =
+      app_path
+      |> Path.join("config/dev.exs")
+      |> Path.relative_to(project.project_path)
+
     Mix.shell.info """
-    Before moving on, configure your database in config/dev.exs and run:
+    Before moving on, configure your database in #{config_path} and run:
 
         $ mix ecto.create
     """

--- a/installer/test/phoenix_new_test.exs
+++ b/installer/test/phoenix_new_test.exs
@@ -112,7 +112,7 @@ defmodule Mix.Tasks.Phoenix.NewTest do
       assert msg =~ "$ cd photo_blog"
       assert msg =~ "$ mix phoenix.server"
 
-      assert_received {:mix_shell, :info, ["Before moving on," <> _ = msg]}
+      assert_received {:mix_shell, :info, ["Before moving on, configure your database in config/dev.exs" <> _ = msg]}
       assert msg =~ "$ mix ecto.create"
 
       # Channels

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -163,7 +163,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert msg =~ "$ cd phx_umb"
       assert msg =~ "$ mix phx.server"
 
-      assert_received {:mix_shell, :info, ["Before moving on," <> _ = msg]}
+      assert_received {:mix_shell, :info, ["Before moving on, configure your database in apps/#{@app}/config/dev.exs" <> _ = msg]}
       assert msg =~ "$ mix ecto.create"
 
       # Channels
@@ -508,6 +508,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         assert_received {:mix_shell, :info, ["\nWe are all set!" <> _ = msg]}
         assert msg =~ "$ cd another"
         assert msg =~ "$ mix phx.server"
+
+        refute_received {:mix_shell, :info, ["Before moving on, configure your database" <> _]}
 
         # Channels
         assert File.exists?("another/lib/another/channels")


### PR DESCRIPTION
When running the new phoenix 1.3 umbrella generator, the path to the database config
file is incorrect.  Eg.

$ mix phx.new /tmp/hello --umbrella

before:

```
Before moving on, configure your database in config/dev.exs and run:

    $ mix ecto.create
```

after:

```
Before moving on, configure your database in apps/hello/config/dev.exs and run:

    $ mix ecto.create
```

A side-effect of this fix is that when you run the phx.new.web generator
the configuration message is no longer displayed (because there is no app_path)
which is correct since the web-only app doesn't have any database config.
