### PR TITLE
Mention conn.path_params in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ See these [`1.2.x` to `1.3.x` upgrade instructions](https://gist.github.com/chri
   * [Channel] Add ability to configure channel event logging with `:log_join` and `:log_handle_in` options
   * [Channel] Warn on unhandled `handle_info/2` messages
   * [Channel] Channels now distinguish from graceful exits and application restarts, allowing clients to enter error mode and reconnected after cold deploys.
-  * [Router] document `match` support for matching on any http method with the special `:*` argument
+  * [Router] Document `match` support for matching on any HTTP method with the special `:*` argument
   * [Router] Populate `conn.path_params` with path parameters for the route
   * [ConnTest] Add `redirected_params/1` to return the named params matched in the router for the redirected URL
   * [Digester] Add `mix phx.digest.clean` to remove old versions of compiled assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See these [`1.2.x` to `1.3.x` upgrade instructions](https://gist.github.com/chri
   * [Channel] Warn on unhandled `handle_info/2` messages
   * [Channel] Channels now distinguish from graceful exits and application restarts, allowing clients to enter error mode and reconnected after cold deploys.
   * [Router] document `match` support for matching on any http method with the special `:*` argument
+  * [Router] Populate `conn.path_params` with path parameters for the route
   * [ConnTest] Add `redirected_params/1` to return the named params matched in the router for the redirected URL
   * [Digester] Add `mix phx.digest.clean` to remove old versions of compiled assets
 


### PR DESCRIPTION
I have seen at least [one question](https://elixirforum.com/t/access-conn-path-params-in-phoenix-app/3902) asking why `conn.path_params` doesn't work in Phoenix 1.2 even with Plug 1.3.

Now that support was added in dad413f, we might as well document it, at least in the CHANGELOG. :)

This PR also fixes capitalization of the previous line to match the rest of them.