### PR TITLE
fix phx.new generated generators config with --binary-id

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -204,7 +204,7 @@ defmodule Phx.New.Generator do
         """
 
         # Configure generators for this app
-        config #{inspect web_app}, :generators#{kw_to_config(conf)}
+        config :#{web_app}, :generators#{kw_to_config(conf)}
         """
     end
   end

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -207,6 +207,7 @@ defmodule Mix.Tasks.Phx.NewTest do
   test "new with binary_id" do
     in_tmp "new with binary_id", fn ->
       Mix.Tasks.Phx.New.run([@app_name, "--binary-id"])
+      assert_file "phx_blog/config/config.exs", ~r/config :phx_blog, :generators/
       assert_file "phx_blog/config/config.exs", ~r/binary_id: true/
     end
   end


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2957936/23584582/6721511e-01a0-11e7-881f-0c1009527d59.png)

web_app's type is string

fix #2155