### PR TITLE
Hide precheck in issue template from appearing in issues

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--
 ### Precheck
 
 * For help and support, use Stack Overflow or the Phoenix Talk mailing list
@@ -5,6 +6,7 @@
 * For bugs, do a quick search and make sure the bug has not yet been reported
 * Ensure that this issue is related to the Phoenix library and not one of the dependencies listed in mix.exs (Ecto, Plug, etc.)
 * All checked? Be nice and have fun!
+-->
 
 ### Environment
 


### PR DESCRIPTION
Html comments allow the precheck part of the issue template to remain visible for the issue creator, but it's not going to be visible as part of the issue when rendered by github.