### PR TITLE
Don't generate trailing whitespace in context tests

### DIFF
--- a/priv/templates/phx.gen.context/context_test.exs
+++ b/priv/templates/phx.gen.context/context_test.exs
@@ -24,8 +24,7 @@ defmodule <%= inspect context.module %>Test do
   end
 
   test "create_<%= schema.singular %>/1 with valid data creates a <%= schema.singular %>" do
-    assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(@create_attrs)
-    <%= for {field, value} <- schema.params.create do %>
+    assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(@create_attrs)<%= for {field, value} <- schema.params.create do %>
     assert <%= schema.singular %>.<%= field %> == <%= inspect value %><% end %>
   end
 
@@ -36,8 +35,7 @@ defmodule <%= inspect context.module %>Test do
   test "update_<%= schema.singular %>/2 with valid data updates the <%= schema.singular %>" do
     <%= schema.singular %> = fixture(:<%= schema.singular %>)
     assert {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, @update_attrs)
-    assert %<%= inspect schema.alias %>{} = <%= schema.singular %>
-    <%= for {field, value} <- schema.params.update do %>
+    assert %<%= inspect schema.alias %>{} = <%= schema.singular %><%= for {field, value} <- schema.params.update do %>
     assert <%= schema.singular %>.<%= field %> == <%= inspect value %><% end %>
   end
 


### PR DESCRIPTION
The template for context tests currently generates trailing spaces, and if the generator was called with no resource attributes, also an empty line. This fixes that behaviour.

### before/after with resource attributes
![accounts_test_exs_bak_ _phoenix_and_event_controller_test_exs_ _phestiment](https://cloud.githubusercontent.com/assets/3882931/23589899/6f4e99b0-01d6-11e7-9f72-8c5898e9fbd2.png)

### before/after without resource attributes
![accounts_test_exs_bak_ _phoenix_and_dev_app_ _-bash](https://cloud.githubusercontent.com/assets/3882931/23589898/6f4b319e-01d6-11e7-8299-aff27710b631.png)