### PR TITLE
Fixed spec to match name of compile_stop_callbacks/2.

### DIFF
--- a/lib/phoenix/endpoint/instrument.ex
+++ b/lib/phoenix/endpoint/instrument.ex
@@ -156,7 +156,7 @@ defmodule Phoenix.Endpoint.Instrument do
   #     Instr0.my_event(:stop, diff, res0)
   #
   @doc false
-  @spec compile_start_callbacks(term, [module]) :: Macro.t
+  @spec compile_stop_callbacks(term, [module]) :: Macro.t
   def compile_stop_callbacks(event, instrumenters) do
     Enum.map Enum.with_index(instrumenters), fn {inst, index} ->
       error_prefix = "Instrumenter #{inspect inst}.#{event}/3 failed.\n"


### PR DESCRIPTION
In reference to issue #2163 #