### PR TITLE
Fix create function example in context generator template

### DIFF
--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -35,10 +35,10 @@
 
   ## Examples
 
-      iex> create_<%= schema.singular %>(<%= schema.singular %>, %{field: value})
+      iex> create_<%= schema.singular %>(%{field: value})
       {:ok, %<%= inspect schema.alias %>{}}
 
-      iex> create_<%= schema.singular %>(<%= schema.singular %>, %{field: bad_value})
+      iex> create_<%= schema.singular %>(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """


### PR DESCRIPTION
Create function has one param while the produced examples have two.

Current produced examples:

```elixir
iex> create_letter(letter, %{field: value})
{:ok, %Letter{}}

iex> create_letter(letter, %{field: bad_value})
{:error, %Ecto.Changeset{}}
```