### PR TITLE
not-web app secret config generated with phx.new --umbrella is not ignored

### DIFF
--- a/installer/lib/phx_new/ecto.ex
+++ b/installer/lib/phx_new/ecto.ex
@@ -6,15 +6,16 @@ defmodule Phx.New.Ecto do
   @pre "phx_umbrella/apps/app_name"
 
   template :new, [
-    {:eex, "#{@pre}/config/config.exs",           :app, "config/config.exs"},
-    {:eex, "#{@pre}/config/dev.exs",              :app, "config/dev.exs"},
-    {:eex, "#{@pre}/config/prod.exs",             :app, "config/prod.exs"},
-    {:eex, "#{@pre}/config/prod.secret.exs",      :app, "config/prod.secret.exs"},
-    {:eex, "#{@pre}/config/test.exs",             :app, "config/test.exs"},
-    {:eex, "#{@pre}/lib/app_name/application.ex", :app, "lib/:app/application.ex"},
-    {:eex, "#{@pre}/test/test_helper.exs",        :app, "test/test_helper.exs"},
-    {:eex, "#{@pre}/README.md",                   :app, "README.md"},
-    {:eex, "#{@pre}/mix.exs",                     :app, "mix.exs"},
+    {:eex,  "#{@pre}/config/config.exs",           :app, "config/config.exs"},
+    {:eex,  "#{@pre}/config/dev.exs",              :app, "config/dev.exs"},
+    {:eex,  "#{@pre}/config/prod.exs",             :app, "config/prod.exs"},
+    {:eex,  "#{@pre}/config/prod.secret.exs",      :app, "config/prod.secret.exs"},
+    {:eex,  "#{@pre}/config/test.exs",             :app, "config/test.exs"},
+    {:eex,  "#{@pre}/lib/app_name/application.ex", :app, "lib/:app/application.ex"},
+    {:eex,  "#{@pre}/test/test_helper.exs",        :app, "test/test_helper.exs"},
+    {:eex,  "#{@pre}/README.md",                   :app, "README.md"},
+    {:eex,  "#{@pre}/mix.exs",                     :app, "mix.exs"},
+    {:text, "#{@pre}/gitignore",                   :app, ".gitignore"},
   ]
 
   template :ecto, [

--- a/installer/lib/phx_new/ecto.ex
+++ b/installer/lib/phx_new/ecto.ex
@@ -15,7 +15,7 @@ defmodule Phx.New.Ecto do
     {:eex,  "#{@pre}/test/test_helper.exs",        :app, "test/test_helper.exs"},
     {:eex,  "#{@pre}/README.md",                   :app, "README.md"},
     {:eex,  "#{@pre}/mix.exs",                     :app, "mix.exs"},
-    {:text, "#{@pre}/gitignore",                   :app, ".gitignore"},
+    {:text, "phx_assets/bare/gitignore",           :app, ".gitignore"},
   ]
 
   template :ecto, [

--- a/installer/templates/phx_umbrella/apps/app_name/gitignore
+++ b/installer/templates/phx_umbrella/apps/app_name/gitignore
@@ -3,3 +3,5 @@
 /deps
 erl_crash.dump
 *.ez
+
+/config/*.secret.exs

--- a/installer/templates/phx_umbrella/apps/app_name/gitignore
+++ b/installer/templates/phx_umbrella/apps/app_name/gitignore
@@ -1,7 +1,0 @@
-/_build
-/cover
-/deps
-erl_crash.dump
-*.ez
-
-/config/*.secret.exs

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -36,6 +36,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file root_path(@app, "README.md")
       assert_file root_path(@app, ".gitignore")
       assert_file app_path(@app, "README.md")
+      assert_file app_path(@app, ".gitignore")
       assert_file web_path(@app, "README.md")
       assert_file root_path(@app, "mix.exs"), fn file ->
         assert file =~ "apps_path: \"apps\""


### PR DESCRIPTION
`mix phx.new --umbrella` creates two application in an umbrella project, say `my_app` and `my_app_web`. I found that `prod.secret.exs` in `apps/my_app/config` is not listed in `gitignore`. So the file possibly accidentally be under version controlled. I guess this is not intended.

In this pull request, I add a line simply ignoring `config/*.secret.exs`. Would you let me know If there is any other good solution or some reasons that it is not ignored.

Thanks.