### PR TITLE
Show context module file creation when using phx.gen

### DIFF
--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -100,10 +100,9 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     context
   end
 
-  defp inject_schema_access(%Context{dir: dir, file: file} = context, paths, binding) do
+  defp inject_schema_access(%Context{file: file} = context, paths, binding) do
     unless context.pre_existing? do
-      File.mkdir_p!(dir)
-      File.write!(file, Mix.Phoenix.eval_from(paths, "priv/templates/phx.gen.context/context.ex", binding))
+      Mix.Generator.create_file(file, Mix.Phoenix.eval_from(paths, "priv/templates/phx.gen.context/context.ex", binding))
     end
 
     schema_content = Mix.Phoenix.eval_from(paths, "priv/templates/phx.gen.context/schema_access.ex", binding)


### PR DESCRIPTION
Fixes #2173.

The context module generator was creating the file with `File.write!/3` instead of the `Mix.Generator` convenience function `create_file/3`.