### PR TITLE
Fix model mix task deprecation warning

### DIFF
--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -81,7 +81,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
   use Mix.Task
 
   def run(args) do
-    IO.puts :stderr, "mix phoenix.gen.json is deprecated. Use phx.gen.schema instead."
+    IO.puts :stderr, "mix phoenix.gen.model is deprecated. Use phx.gen.schema instead."
     switches = [migration: :boolean, binary_id: :boolean, instructions: :string]
 
     {opts, parsed, _} = OptionParser.parse(args, switches: switches)


### PR DESCRIPTION
Fixes a small typo in the `phoenix.gen.model` task. It named `phoenix.gen.json` instead of phoenix.gen.model` as the current mix task.