### PR TITLE
Support signed_at option for Token.sign

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -101,13 +101,16 @@ defmodule Phoenix.Token do
       when generating the encryption and signing keys. Defaults to 32;
     * `:key_digest` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to `:sha256`;
+    * `:signed_at` - set the timestamp of the token. Defaults to `System.system_time(:milliseconds)`;
   """
   def sign(context, salt, data, opts \\ []) when is_binary(salt) do
-    secret = get_key_base(context) |> get_secret(salt, opts)
+    {signed_at_seconds, key_opts} = Keyword.pop(opts, :signed_at)
+    signed_at_ms = if signed_at_seconds, do: trunc(signed_at_seconds * 1000), else: now_ms()
+    secret = get_key_base(context) |> get_secret(salt, key_opts)
 
     message = %{
       data: data,
-      signed: now_ms(),
+      signed: signed_at_ms,
     } |> :erlang.term_to_binary()
     MessageVerifier.sign(message, secret)
   end

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -101,7 +101,7 @@ defmodule Phoenix.Token do
       when generating the encryption and signing keys. Defaults to 32;
     * `:key_digest` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to `:sha256`;
-    * `:signed_at` - set the timestamp of the token. Defaults to `System.system_time(:milliseconds)`;
+    * `:signed_at` - set the timestamp of the token in seconds. Defaults to `System.system_time(:seconds)`;
   """
   def sign(context, salt, data, opts \\ []) when is_binary(salt) do
     {signed_at_seconds, key_opts} = Keyword.pop(opts, :signed_at)

--- a/test/phoenix/token_test.exs
+++ b/test/phoenix/token_test.exs
@@ -51,6 +51,38 @@ defmodule Phoenix.TokenTest do
     assert Token.verify(conn(), "id", token, max_age: 0.1) == {:error, :expired}
   end
 
+  test "supports signed_at in seconds" do
+    seconds_in_day = 24*60*60
+    day_ago_seconds = System.system_time(:seconds) - seconds_in_day
+    token = Token.sign(conn(), "id", 1, signed_at: day_ago_seconds)
+    assert Token.verify(conn(), "id", token, max_age: seconds_in_day + 1) == {:ok, 1}
+    assert Token.verify(conn(), "id", token, max_age: seconds_in_day - 1) == {:error, :expired}
+  end
+
+  test "passes key_iterations options to key generator" do
+    signed1 = Token.sign(conn(), "id", 1, signed_at: 0, key_iterations: 1)
+    signed2 = Token.sign(conn(), "id", 1, signed_at: 0, key_iterations: 2)
+    assert signed1 != signed2
+  end
+
+  test "passes key_digest options to key generator" do
+    signed1 = Token.sign(conn(), "id", 1, signed_at: 0, key_digest: :sha256)
+    signed2 = Token.sign(conn(), "id", 1, signed_at: 0, key_digest: :sha512)
+    assert signed1 != signed2
+  end
+
+  test "passes key_length options to key generator" do
+    signed1 = Token.sign(conn(), "id", 1, signed_at: 0, key_length: 16)
+    signed2 = Token.sign(conn(), "id", 1, signed_at: 0, key_length: 32)
+    assert signed1 != signed2
+  end
+
+  test "key defaults" do
+    signed1 = Token.sign(conn(), "id", 1, signed_at: 0)
+    signed2 = Token.sign(conn(), "id", 1, signed_at: 0, key_length: 32, key_digest: :sha256, key_iterations: 1000)
+    assert signed1 == signed2
+  end
+
   defp socket() do
     %Phoenix.Socket{endpoint: TokenEndpoint}
   end


### PR DESCRIPTION
This parameter can be useful for integration testing or to deal with edge cases such as day light savings when using short-lived tokens.

I can imagine some might prefer ```System.monotonic_time``` over ```System.system_time```. With this change it would be possible to make that choice. Might make sense to implement a complementary parameter to verify. At the moment we can use max_age to adjust time on ```verify```.

I also added some tests for key options, It might be redundant but better err on the side of too many tests when dealing with security related matters. These test make sure we are at least sending the parameters with correct spelling and provide reasonably secure defaults.