### PR TITLE
Deprecate global format encoders and move config per app

### DIFF
--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -33,8 +33,7 @@ defmodule Phoenix do
   @doc false
   def start(_type, _args) do
     # Warm up caches
-    _ = Phoenix.Template.engines
-    _ = Phoenix.Template.format_encoder("index.html")
+    _ = Phoenix.Template.engines()
 
     # Configure proper system flags from Phoenix only
     if stacktrace_depth = Application.get_env(:phoenix, :stacktrace_depth) do

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -406,6 +406,7 @@ defmodule Phoenix.Endpoint do
 
       # Avoid unused variable warnings
       _ = var!(code_reloading?)
+      def __otp_app__(), do: @otp_app
     end
   end
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -280,6 +280,7 @@ defmodule Phoenix.Endpoint.Supervisor do
   Invoked to warm up caches on start and config change.
   """
   def warmup(endpoint) do
+    _ = Phoenix.Template.format_encoder(endpoint.__otp_app__(), "index.html")
     endpoint.host
     endpoint.path("/")
     endpoint.script_name
@@ -287,8 +288,7 @@ defmodule Phoenix.Endpoint.Supervisor do
     warmup_static(endpoint)
     :ok
   rescue
-    _ ->
-      :ok
+    _ -> :ok
   end
 
   defp warmup_url(endpoint) do

--- a/lib/phoenix/template/eex_engine.ex
+++ b/lib/phoenix/template/eex_engine.ex
@@ -10,7 +10,7 @@ defmodule Phoenix.Template.EExEngine do
   end
 
   defp engine_for(name) do
-    case Phoenix.Template.format_encoder(name) do
+    case Phoenix.Template.format_encoder(Mix.Phoenix.otp_app(), name) do
       Phoenix.Template.HTML ->
         unless Code.ensure_loaded?(Phoenix.HTML.Engine) do
           raise "Could not load Phoenix.HTML.Engine to use with .html.eex templates. " <>

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -254,9 +254,10 @@ defmodule Phoenix.Transports.LongPoll do
   defp status_json(conn, data) do
     status = Plug.Conn.Status.code(conn.status || 200)
     data   = Map.put(data, :status, status)
+
     conn
-    |> put_status(200)
-    |> Phoenix.Controller.json(data)
+    |> put_resp_header("content-type", "application/json")
+    |> send_resp(200, Poison.encode_to_iodata!(data))
   end
 
   defp code_reload(conn, opts, endpoint) do

--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -132,6 +132,7 @@ defmodule Phoenix.View do
 
       @doc "The resource name, as an atom, for this view"
       def __resource__, do: @view_resource
+      def __otp_app__, do: unquote(Mix.Phoenix.otp_app())
     end
   end
 
@@ -329,7 +330,7 @@ defmodule Phoenix.View do
   Renders the template and returns iodata.
   """
   def render_to_iodata(module, template, assign) do
-    render(module, template, assign) |> encode(template)
+    render(module, template, assign) |> encode(module, template)
   end
 
   @doc """
@@ -339,8 +340,8 @@ defmodule Phoenix.View do
     render_to_iodata(module, template, assign) |> IO.iodata_to_binary
   end
 
-  defp encode(content, template) do
-    if encoder = Template.format_encoder(template) do
+  defp encode(content, view, template) do
+    if encoder = Template.format_encoder(view.__otp_app__(), template) do
       encoder.encode_to_iodata!(content)
     else
       content

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -10,6 +10,13 @@ defmodule Phoenix.Controller.ControllerTest do
     :ok
   end
 
+  defp endpoint_conn(method, path) do
+    method
+    |> conn(path)
+    |> put_private(:phoenix_endpoint, __MODULE__)
+  end
+  def __otp_app__(), do: :phoenix
+
   defp get_resp_content_type(conn) do
     [header]  = get_resp_header(conn, "content-type")
     header |> String.split(";") |> Enum.fetch!(0)
@@ -112,21 +119,21 @@ defmodule Phoenix.Controller.ControllerTest do
 
   describe "json/2" do
     test "encodes content to json" do
-      conn = json(conn(:get, "/"), %{foo: :bar})
+      conn = json(endpoint_conn(:get, "/"), %{foo: :bar})
       assert conn.resp_body == "{\"foo\":\"bar\"}"
       assert get_resp_content_type(conn) == "application/json"
       refute conn.halted
     end
 
     test "allows status injection on connection" do
-      conn = conn(:get, "/") |> put_status(400)
+      conn = endpoint_conn(:get, "/") |> put_status(400)
       conn = json(conn, %{foo: :bar})
       assert conn.resp_body == "{\"foo\":\"bar\"}"
       assert conn.status == 400
     end
 
     test "allows content-type injection on connection" do
-      conn = conn(:get, "/") |> put_resp_content_type("application/vnd.api+json")
+      conn = endpoint_conn(:get, "/") |> put_resp_content_type("application/vnd.api+json")
       conn = json(conn, %{foo: :bar})
       assert conn.resp_body == "{\"foo\":\"bar\"}"
       assert Conn.get_resp_header(conn, "content-type") ==
@@ -134,7 +141,7 @@ defmodule Phoenix.Controller.ControllerTest do
     end
 
     test "with allow_jsonp/2 returns json when no callback param is present" do
-      conn = conn(:get, "/")
+      conn = endpoint_conn(:get, "/")
              |> fetch_query_params()
              |> allow_jsonp()
              |> json(%{foo: "bar"})
@@ -144,7 +151,7 @@ defmodule Phoenix.Controller.ControllerTest do
     end
 
     test "with allow_jsonp/2 returns json when callback name is left empty" do
-      conn = conn(:get, "/?callback=")
+      conn = endpoint_conn(:get, "/?callback=")
              |> fetch_query_params()
              |> allow_jsonp()
              |> json(%{foo: "bar"})
@@ -154,7 +161,7 @@ defmodule Phoenix.Controller.ControllerTest do
     end
 
     test "with allow_jsonp/2 returns javascript when callback param is present" do
-      conn = conn(:get, "/?callback=cb")
+      conn = endpoint_conn(:get, "/?callback=cb")
              |> fetch_query_params
              |> allow_jsonp
              |> json(%{foo: "bar"})
@@ -164,7 +171,7 @@ defmodule Phoenix.Controller.ControllerTest do
     end
 
     test "with allow_jsonp/2 allows to override the callback param" do
-      conn = conn(:get, "/?cb=cb")
+      conn = endpoint_conn(:get, "/?cb=cb")
              |> fetch_query_params
              |> allow_jsonp(callback: "cb")
              |> json(%{foo: "bar"})
@@ -181,7 +188,7 @@ defmodule Phoenix.Controller.ControllerTest do
     end
 
     test "with allow_jsonp/2 escapes invalid javascript characters" do
-      conn = conn(:get, "/?cb=cb")
+      conn = endpoint_conn(:get, "/?cb=cb")
              |> fetch_query_params
              |> allow_jsonp(callback: "cb")
              |> json(%{foo: <<0x2028::utf8, 0x2029::utf8>>})

--- a/test/phoenix/endpoint/render_errors_test.exs
+++ b/test/phoenix/endpoint/render_errors_test.exs
@@ -5,6 +5,8 @@ defmodule Phoenix.Endpoint.RenderErrorsTest do
 
   view = __MODULE__
 
+  def __otp_app__(), do: :phoenix
+
   def render("app.html", %{view_template: view_template} = assigns) do
     "Layout: " <> render(view_template, assigns)
   end

--- a/test/phoenix/template_test.exs
+++ b/test/phoenix/template_test.exs
@@ -44,10 +44,10 @@ defmodule Phoenix.TemplateTest do
     assert is_binary Template.hash(@templates)
   end
 
-  test "format_encoder/1 returns the formatter for a given template" do
-    assert Template.format_encoder("hello.html") == Phoenix.Template.HTML
-    assert Template.format_encoder("hello.js") == Phoenix.Template.HTML
-    assert Template.format_encoder("hello.unknown") == nil
+  test "format_encoder/2 returns the formatter for a given template" do
+    assert Template.format_encoder(:phoenix, "hello.html") == Phoenix.Template.HTML
+    assert Template.format_encoder(:phoenix, "hello.js") == Phoenix.Template.HTML
+    assert Template.format_encoder(:phoenix, "hello.unknown") == nil
   end
 
   ## On use

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,6 +11,8 @@ end
 # Used whenever a router fails. We default to simply
 # rendering a short string.
 defmodule Phoenix.ErrorView do
+  def __otp_app__(), do: :phoenix
+
   def render("404.json", %{kind: kind, reason: _reason, stack: _stack, conn: conn}) do
     %{error: "Got 404 from #{kind} with #{conn.method}"}
   end


### PR DESCRIPTION
@josevalim I will need a second set of eyes on this one as it's a bit complex to support since we relied on the global config in a couple places. I'm not thrilled about having to inject `__otp_app__` into both the endpoints and views, but I couldn't come up with a better option. Thoughts?

P.S. What we decide here will also be applied to the global template_engines config, since it has the same issues.