### PR TITLE
Start AppName.Repo as a supervisor in umbrella projects

### DIFF
--- a/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
@@ -13,7 +13,7 @@ defmodule <%= app_module %>.Application do
     import Supervisor.Spec, warn: false
 
     Supervisor.start_link([
-      <%= if ecto do %>worker(<%= app_module %>.Repo, []),<% end %>
+      <%= if ecto do %>supervisor(<%= app_module %>.Repo, []),<% end %>
     ], strategy: :one_for_one, name: <%= app_module %>.Supervisor)
   end
 end


### PR DESCRIPTION
In templates for umbrella projects, the Repo should also be started as a **supervisor**, not a worker.