### PR TITLE
fix path to router.ex in generators for an umbrella application

### DIFF
--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   def print_shell_instructions(%Context{schema: schema} = context) do
     Mix.shell.info """
 
-    Add the resource to your browser scope in lib/#{Mix.Phoenix.otp_app()}/web/router.ex:
+    Add the resource to your browser scope in #{Mix.Phoenix.web_prefix()}/router.ex:
 
         resources "/#{schema.plural}", #{inspect schema.alias}Controller
     """

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -97,7 +97,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
   def print_shell_instructions(%Context{schema: schema} = context) do
     Mix.shell.info """
 
-    Add the resource to your api scope in lib/#{Mix.Phoenix.otp_app()}/web/router.ex:
+    Add the resource to your api scope in #{Mix.Phoenix.web_prefix()}/router.ex:
 
         resources "/#{schema.plural}", #{inspect schema.alias}Controller, except: [:new, :edit]
     """


### PR DESCRIPTION
When running the `phx.gen.html` or `phx.gen.json` generators, the path to the router.ex file is displayed as:

```
lib/dev_app_web/web/router.ex
```
where it is now located in

```
lib/dev_app_web/router.ex
```

This makes use of the `Mix.Phoenix.web_prefix()` function to point to the correct directory for the `router.ex` file whether in an umbrella project or not.