### PR TITLE
[WIP] Persist resp_headers and other conn data on NoRouteError

### DIFF
--- a/lib/phoenix/endpoint/render_errors.ex
+++ b/lib/phoenix/endpoint/render_errors.ex
@@ -51,6 +51,11 @@ defmodule Phoenix.Endpoint.RenderErrors do
     __catch__(conn, kind, reason, System.stacktrace, opts)
   end
 
+  defp __catch__(_conn, :error, %Phoenix.Router.NoRouteError{} = reason, stack, opts) do
+    maybe_render(reason.conn, :error, reason, stack, opts)
+    :erlang.raise(:error, reason, stack)
+  end
+
   defp __catch__(conn, kind, reason, stack, opts) do
     maybe_render(conn, kind, reason, stack, opts)
     :erlang.raise(kind, reason, stack)

--- a/test/phoenix/endpoint/render_errors_test.exs
+++ b/test/phoenix/endpoint/render_errors_test.exs
@@ -230,4 +230,13 @@ defmodule Phoenix.Endpoint.RenderErrorsTest do
       |> render([], fn -> throw :hello end)
     end) == ""
   end
+
+  test "exception page for NoRouteError with plug_status 404" do
+    conn = render(conn(:get, "/"), [], fn ->
+      raise Phoenix.Router.NoRouteError, conn: conn(:get, "/"), router: nil, plug_status: 404
+    end)
+
+    assert conn.status == 404
+    assert conn.resp_body == "Got 404 from error with GET"
+  end
 end


### PR DESCRIPTION
Related to #2198.