### PR TITLE
Change the order of text when creating new phoenix application

### DIFF
--- a/installer/lib/mix/tasks/phoenix.new.ex
+++ b/installer/lib/mix/tasks/phoenix.new.ex
@@ -248,11 +248,11 @@ defmodule Mix.Tasks.Phoenix.New do
       brunch? = install_brunch(install?)
       extra   = if mix?, do: [], else: ["$ mix deps.get"]
 
-      print_mix_info(path, extra)
-
       if binding[:ecto] do
         print_ecto_info()
       end
+
+      print_mix_info(path, extra)
 
       if not brunch? do
         print_brunch_info()


### PR DESCRIPTION
In the console the following text "We are all set! Run your Phoenix application mix phoenix.server"
comes before "Before moving on, configure your database in config/dev.exs and run mix ecto.create"

Since mix ecto.create needs to run first, I changed the order of when they display in the console.
