### PR TITLE
Use Parantheses for render calls

### DIFF
--- a/installer/templates/new/web/controllers/page_controller.ex
+++ b/installer/templates/new/web/controllers/page_controller.ex
@@ -2,6 +2,6 @@ defmodule <%= app_module %>.PageController do
   use <%= app_module %>.Web, :controller
 
   def index(conn, _params) do
-    render conn, "index.html"
+    render(conn, "index.html")
   end
 end

--- a/installer/templates/new/web/views/error_view.ex
+++ b/installer/templates/new/web/views/error_view.ex
@@ -12,7 +12,7 @@ defmodule <%= app_module %>.ErrorView do
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do
-    render "500.html", assigns
+    render("500.html", assigns)
   end<% else %>def render("404.json", _assigns) do
     %{errors: %{detail: "Page not found"}}
   end
@@ -24,6 +24,6 @@ defmodule <%= app_module %>.ErrorView do
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do
-    render "500.json", assigns
+    render("500.json", assigns)
   end<% end %>
 end

--- a/installer/templates/phx_web/controllers/page_controller.ex
+++ b/installer/templates/phx_web/controllers/page_controller.ex
@@ -2,6 +2,6 @@ defmodule <%= web_namespace %>.PageController do
   use <%= web_namespace %>, :controller
 
   def index(conn, _params) do
-    render conn, "index.html"
+    render(conn, "index.html")
   end
 end

--- a/installer/templates/phx_web/views/error_view.ex
+++ b/installer/templates/phx_web/views/error_view.ex
@@ -12,7 +12,7 @@ defmodule <%= web_namespace %>.ErrorView do
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do
-    render "500.html", assigns
+    render("500.html", assigns)
   end<% else %>def render("404.json", _assigns) do
     %{errors: %{detail: "Page not found"}}
   end
@@ -24,6 +24,6 @@ defmodule <%= web_namespace %>.ErrorView do
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do
-    render "500.json", assigns
+    render("500.json", assigns)
   end<% end %>
 end

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -22,7 +22,7 @@ defmodule Phoenix.Controller do
 
         def show(conn, %{"id" => id}) do
           user = Repo.get(User, id)
-          render conn, "show.html", user: user
+          render(conn, "show.html", user: user)
         end
       end
 
@@ -614,7 +614,7 @@ defmodule Phoenix.Controller do
         use Phoenix.Controller
 
         def show(conn, _params) do
-          render conn, "show.html", message: "Hello"
+          render(conn, "show.html", message: "Hello")
         end
       end
 
@@ -626,7 +626,7 @@ defmodule Phoenix.Controller do
   the extension):
 
       def show(conn, _params) do
-        render conn, :show, message: "Hello"
+        render(conn, :show, message: "Hello")
       end
 
   In order for the example above to work, we need to do content negotiation with
@@ -660,7 +660,7 @@ defmodule Phoenix.Controller do
         plug :put_view, MyApp.SpecialView
 
         def show(conn, _params) do
-          render conn, :show, message: "Hello"
+          render(conn, :show, message: "Hello")
         end
       end
 
@@ -673,7 +673,7 @@ defmodule Phoenix.Controller do
         use Phoenix.Controller
 
         def show(conn, _params) do
-          render conn, "show.html", message: "Hello"
+          render(conn, "show.html", message: "Hello")
         end
       end
 

--- a/lib/phoenix/endpoint/instrument.ex
+++ b/lib/phoenix/endpoint/instrument.ex
@@ -23,7 +23,7 @@ defmodule Phoenix.Endpoint.Instrument do
       ## Examples
 
           instrument :render_view, %{view: "index.html"}, fn ->
-            render conn, "index.html"
+            render(conn, "index.html")
           end
 
       """

--- a/lib/phoenix/endpoint/render_errors.ex
+++ b/lib/phoenix/endpoint/render_errors.ex
@@ -87,7 +87,7 @@ defmodule Phoenix.Endpoint.RenderErrors do
         %{conn | state: :sent}
     after
       0 ->
-        render conn, kind, reason, stack, opts
+        render(conn, kind, reason, stack, opts)
     end
   end
 

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -56,8 +56,8 @@ defmodule Phoenix.ConnTest do
   For such cases, a connection can be created using the
   `conn/3` helper:
 
-      MyApp.UserView.render "hello.html",
-                             conn: conn(:get, "/")
+      MyApp.UserView.render("hello.html",
+                             conn: conn(:get, "/"))
 
   ## Recycling
 

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -57,8 +57,8 @@ defmodule Phoenix.Token do
 
       def create(conn, params) do
         user = User.create(params)
-        render(conn, "user.json",)
-               %{token: Phoenix.Token.sign(conn, "user salt", user.id), user: user}
+        render(conn, "user.json",
+               %{token: Phoenix.Token.sign(conn, "user salt", user.id), user: user})
       end
 
   Once the token is sent, the client may now send it back to the server

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -57,7 +57,7 @@ defmodule Phoenix.Token do
 
       def create(conn, params) do
         user = User.create(params)
-        render conn, "user.json",
+        render(conn, "user.json",)
                %{token: Phoenix.Token.sign(conn, "user salt", user.id), user: user}
       end
 

--- a/test/phoenix/template_test.exs
+++ b/test/phoenix/template_test.exs
@@ -113,7 +113,7 @@ defmodule Phoenix.TemplateTest do
       use Phoenix.Template, root: Path.join(__DIR__, "not-exists")
 
       def template_not_found(_template, assigns) do
-        render "this-does-not-exist.html", assigns
+        render("this-does-not-exist.html", assigns)
       end
     end
 


### PR DESCRIPTION
Use parentheses when calling `render` to keep it consistent.

* EEX templates don't use parentheses
* EX(S) files use parentheses for function calls