### PR TITLE
Fix syntax errors in controller plug examples

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -90,8 +90,8 @@ defmodule Phoenix.Controller do
   `plug/2` in controllers supports guards, allowing a developer to configure
   a plug to only run in some particular action:
 
-      plug :authenticate, usernames: ["jose", "eric", "sonny"] when action in [:show, :edit]
-      plug :authenticate, usernames: ["admin"] when not action in [:index]
+      plug :authenticate, [usernames: ["jose", "eric", "sonny"]] when action in [:show, :edit]
+      plug :authenticate, [usernames: ["admin"]] when not action in [:index]
 
   The first plug will run only when action is show or edit. The second plug will
   always run, except for the index action.


### PR DESCRIPTION
I'm not sure if there is a more preferred syntax here, but these example didn't work for me unless I wrapped the parameters in brackets. I'm told that `when` is not a function.