### PR TITLE
Increase ExUnit timeout for Travis

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -26,4 +26,4 @@ end
 # For mix tests
 Mix.shell(Mix.Shell.Process)
 
-ExUnit.start(assert_receive_timeout: 200)
+ExUnit.start(assert_receive_timeout: 500)


### PR DESCRIPTION
This is should hopefully help with the failing specs in Travis.
https://travis-ci.org/phoenixframework/phoenix/jobs/213260929#L265
https://travis-ci.org/phoenixframework/phoenix/jobs/213171731#L270
https://travis-ci.org/phoenixframework/phoenix/jobs/212736626#L270
https://travis-ci.org/phoenixframework/phoenix/jobs/212665663#L277

I realize this isn't a great improvement. I'd be interested in looking at better solutions if anyone has ideas.