### PR TITLE
Use brunch from node_modules/.bin

### DIFF
--- a/installer/lib/mix/tasks/phoenix.new.ex
+++ b/installer/lib/mix/tasks/phoenix.new.ex
@@ -323,7 +323,7 @@ defmodule Mix.Tasks.Phoenix.New do
   end
 
   defp install_brunch(install?) do
-    maybe_cmd "npm install && node node_modules/brunch/bin/brunch build",
+    maybe_cmd "npm install && node node_modules/.bin/brunch build",
               File.exists?("brunch-config.js"), install? && System.find_executable("npm")
   end
 

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -179,7 +179,7 @@ defmodule Mix.Tasks.Phx.New do
   defp switch_to_string({name, val}), do: name <> "=" <> val
 
   defp install_brunch(install?) do
-    maybe_cmd "cd assets && npm install && node node_modules/brunch/bin/brunch build",
+    maybe_cmd "cd assets && npm install && node node_modules/.bin/brunch build",
               File.exists?("assets/brunch-config.js"), install? && System.find_executable("npm")
   end
 

--- a/installer/templates/new/config/dev.exs
+++ b/installer/templates/new/config/dev.exs
@@ -24,7 +24,7 @@ config :<%= app_name %>, <%= app_module %>.Endpoint,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
+  watchers: <%= if brunch do %>[node: ["node_modules/.bin/brunch", "watch", "--stdin",
                     cd: Path.expand("../", __DIR__)]]<% else %>[]<% end %>
 
 

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -11,7 +11,7 @@ config :<%= app_name %>, <%= endpoint_module %>,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
+  watchers: <%= if brunch do %>[node: ["node_modules/.bin/brunch", "watch", "--stdin",
                     cd: Path.expand("../assets", __DIR__)]]<% else %>[]<% end %>
 
 # ## SSL Support

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -11,7 +11,7 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
   debug_errors: true,
   code_reloader: true,
   check_origin: false,
-  watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
+  watchers: <%= if brunch do %>[node: ["node_modules/.bin/brunch", "watch", "--stdin",
                     cd: Path.expand("../assets", __DIR__)]]<% else %>[]<% end %>
 
 # ## SSL Support

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -175,7 +175,7 @@ defmodule Phoenix.Endpoint do
       the "watch" mode of the brunch build tool when the server starts.
       You can configure it to whatever build tool or command you want:
 
-          [node: ["node_modules/brunch/bin/brunch", "watch"]]
+          [node: ["node_modules/.bin/brunch", "watch"]]
 
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of


### PR DESCRIPTION
npm links all executables from a package (as specified by the `"bin"` field in package.json) to `node_modules/.bin`.

This PR updates Phoenix to call brunch from this location so that it isn't coupled to the internal structure of the brunch package.