### PR TITLE
Revert new template (rc1) mix.exs to working version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We appreciate any contribution to Phoenix. Check our [CODE_OF_CONDUCT.md](CODE_O
 
 You can create a new project using the latest Phoenix source installer (the `phx.new` Mix task) with the following steps:
 
-1. Remove any previously installed `phx_new` archives so that Mix will pick up the local source code. This can be done with `mix archive.uninstall phx_new.ez` or by simply deleting the file, which is usually in `~/.mix/archives/`.
+1. Remove any previously installed `phx_new` archives so that Mix will pick up the local source code. This can be done with `mix archive.uninstall phx_new` or by simply deleting the file, which is usually in `~/.mix/archives/`.
 2. Copy this repo via `git clone https://github.com/phoenixframework/phoenix` or by downloading it
 3. Run the `phx.new` mix task from within the `installer` directory, for example:
 

--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -21,7 +21,9 @@ defmodule <%= app_module %>.Mixfile do
   # Type `mix help compile.app` for more information.
   def application do
     [mod: {<%= app_module %>, []},
-     extra_applications: [:logger]]
+    applications: [:phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :gettext,
+                    :phoenix_ecto, :postgrex, :runtime_tools],
+    extra_applications: [:logger]]
   end
 
   # Specifies which paths to compile per environment.

--- a/installer/templates/new/mix.exs
+++ b/installer/templates/new/mix.exs
@@ -21,9 +21,8 @@ defmodule <%= app_module %>.Mixfile do
   # Type `mix help compile.app` for more information.
   def application do
     [mod: {<%= app_module %>, []},
-    applications: [:phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :gettext,
-                    :phoenix_ecto, :postgrex, :runtime_tools],
-    extra_applications: [:logger]]
+     applications: [:phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :logger :gettext,
+                    :phoenix_ecto, :postgrex, :runtime_tools]]
   end
 
   # Specifies which paths to compile per environment.


### PR DESCRIPTION
There was a "extra_applications" in `def application do` in Mix.exs but the core applications were missing.
Closes #2225 