### PR TITLE
Update documentation for Phoenix.Presence

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -38,7 +38,7 @@ defmodule Phoenix.Presence do
         alias MyApp.Presence
 
         def join("some:topic", _params, socket) do
-          send(self, :after_join)
+          send(self(), :after_join)
           {:ok, assign(socket, :user_id, ...)}
         end
 


### PR DESCRIPTION
Edit documentation to remain consistent with the new convention for calling zero arity functions with parentheses in the latest versions of Elixir.