### PR TITLE
Improve websocket check_origin documentation to be more explicit

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -412,7 +412,9 @@ defmodule Phoenix.Socket.Transport do
     case URI.parse(origin) do
       %{host: nil} ->
         raise ArgumentError,
-          "invalid check_origin: #{inspect origin} (expected an origin with a host)"
+          "invalid check_origin: #{inspect origin}. Expected an origin with a
+          host that is parsable by URI.parse/1. For example:
+          [\"https://example.com\", \"//another.com:888\", \"//other.com\"]"
       %{scheme: scheme, port: port, host: host} ->
         {scheme, host, port}
     end

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -27,8 +27,8 @@ defmodule Phoenix.Transports.WebSocket do
       check_origin: ["https://example.com",
                      "//another.com:888", "//other.com"]
 
-      Note: it is necessary to set `check_origin: false` to support native
-      mobile apps.
+      Note: To connect from a native app be sure to either have the native app
+      set an origin or allow any origin via `check_origin: false`
 
     * `:code_reloader` - optionally override the default `:code_reloader` value
       from the socket's endpoint

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -22,7 +22,13 @@ defmodule Phoenix.Transports.WebSocket do
       origin header is present. It defaults to true and, in such cases,
       it will check against the host value in `YourApp.Endpoint.config(:url)[:host]`.
       It may be set to `false` (not recommended) or to a list of explicitly
-      allowed origins
+      allowed origins.
+
+      check_origin: ["https://example.com",
+                     "//another.com:888", "//other.com"]
+
+      Note: it is necessary to set `check_origin: false` to support native
+      mobile apps.
 
     * `:code_reloader` - optionally override the default `:code_reloader` value
       from the socket's endpoint


### PR DESCRIPTION
Since I spent 20 minutes tracking down why check_origin wasn't working
as expected I'm submitting this as a PR to improve the documentation
(since I never encountered the (very nice!) error defined in
transport.ex)

I'm not sure if the formatting would come out 100% but wanted to at least get the conversation about the content started.