### PR TITLE
Arity typo on list_<schema> context test name?

### DIFF
--- a/priv/templates/phx.gen.context/test_cases.exs
+++ b/priv/templates/phx.gen.context/test_cases.exs
@@ -15,7 +15,7 @@
       <%= schema.singular %>
     end
 
-    test "list_<%= schema.plural %>/1 returns all <%= schema.plural %>" do
+    test "list_<%= schema.plural %>/0 returns all <%= schema.plural %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
       assert <%= inspect context.alias %>.list_<%= schema.plural %>() == [<%= schema.singular %>]
     end


### PR DESCRIPTION
The generated context test is named "list_xxx/1 returns all xxxs", but list_xxx takes no arguments.

/0, right?