### PR TITLE
Fixed newline in migration template

### DIFF
--- a/priv/templates/phoenix.gen.model/migration.exs
+++ b/priv/templates/phoenix.gen.model/migration.exs
@@ -8,9 +8,8 @@ defmodule <%= base %>.Repo.Migrations.Create<%= scoped %> do
 <% end %><%= for {_, i, _, s} <- assocs do %>      add <%= if(String.ends_with?(inspect(i), "_id"), do: inspect(i), else: inspect(i) <> "_id") %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if binary_id do %>, type: :binary_id<% end %>)
 <% end %>
       timestamps()
-    end
-<%= for index <- indexes do %>
-    <%= index %><% end %>
+    end<%= if length(indexes) > 0 do %>
+
+    <%= Enum.join(indexes, "\n    ") %><% end %>
   end
 end
-


### PR DESCRIPTION
Fixed code style in migration template: extra newline before `end` removed, and only one newline at the end of file left.

Was before:

```elixir
defmodule YahtzeePhoenix.Repo.Migrations.CreateThing do
  use Ecto.Migration

  def change do
    create table(:things) do
      add :name, :string

      timestamps()
    end

  end
end
# Two newlines at the end of file
```
Is now:

```elixir
defmodule YahtzeePhoenix.Repo.Migrations.CreateThing do
  use Ecto.Migration

  def change do
    create table(:things) do
      add :name, :string

      timestamps()
    end
  end
end # Single newline at then end of file
```