### PR TITLE
Fix nested context module name (#2240)

### DIFF
--- a/lib/mix/phoenix/context.ex
+++ b/lib/mix/phoenix/context.ex
@@ -25,12 +25,12 @@ defmodule Mix.Phoenix.Context do
     ctx_app   = opts[:context_app] || Mix.Phoenix.context_app()
     base      = Module.concat([Mix.Phoenix.context_base(ctx_app)])
     module    = Module.concat(base, context_name)
-    alias     = module |> Module.split() |> tl() |> Module.concat()
-    basename  = Phoenix.Naming.underscore(context_name)
-    dir       = Mix.Phoenix.context_lib_path(ctx_app, basename)
+    alias     = module |> Module.split() |> List.last() |> Module.concat(nil)
+    basename  = context_name |> String.split(".") |> List.last |> Phoenix.Naming.underscore
+    dir       = Mix.Phoenix.context_lib_path(ctx_app, Phoenix.Naming.underscore(context_name))
     test_dir  = Mix.Phoenix.context_app_path(ctx_app, "test")
     file      = Path.join([dir, basename <> ".ex"])
-    test_file = Path.join([test_dir, basename <> "_test.exs"])
+    test_file = Path.join([test_dir, Phoenix.Naming.underscore(context_name) <> "_test.exs"])
     generate? = Keyword.get(opts, :context, true)
 
     %Context{

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -99,7 +99,8 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     {opts, parsed, _} = parse_opts(args)
     [context_name, schema_name, plural | schema_args] = validate_args!(parsed)
 
-    table = Keyword.get(opts, :table, Phoenix.Naming.underscore(context_name) <> "_#{plural}")
+    table_name = context_name |> Phoenix.Naming.underscore |> String.replace("/", "_")
+    table = Keyword.get(opts, :table, "#{table_name}_#{plural}")
     schema_module = inspect(Module.concat(context_name, schema_name))
 
     schema = Gen.Schema.build([schema_module, plural | schema_args] ++ ["--table", table], opts, __MODULE__)

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -41,6 +41,33 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
     end
   end
 
+  test "new nested context", config do
+    in_tmp_project config.test, fn ->
+      schema = Schema.new("Site.Blog.Post", "posts", [], [])
+      context = Context.new("Site.Blog", schema, [])
+
+      assert %Context{
+        alias: Blog,
+        base_module: Phoenix,
+        basename: "blog",
+        module: Phoenix.Site.Blog,
+        web_module: Phoenix.Web,
+        schema: %Mix.Phoenix.Schema{
+          alias: Post,
+          human_plural: "Posts",
+          human_singular: "Post",
+          module: Phoenix.Site.Blog.Post,
+          plural: "posts",
+          singular: "post"
+        }} = context
+
+      assert String.ends_with?(context.dir, "lib/phoenix/site/blog")
+      assert String.ends_with?(context.file, "lib/phoenix/site/blog/blog.ex")
+      assert String.ends_with?(context.test_file, "test/site/blog_test.exs")
+      assert String.ends_with?(context.schema.file, "lib/phoenix/site/blog/post.ex")
+    end
+  end
+
   test "new existing context", config do
     in_tmp_project config.test, fn ->
       File.mkdir_p!("lib/phoenix/blog")


### PR DESCRIPTION
#2240 

1. To make the table name I made a new method (`Context.underscore/1`) that underscores the context name without `.`, to prevent the `\` character as a result of `Phoenix.Naming.underscore/1`.

```elixir
def underscore(context_name) do
  context_name
  |> String.replace(".","")
  |> Phoenix.Naming.underscore
end
```

2. The basename of the context is going to be the last word of a list split by `.` in case the module name is a nested context.
3. The directories will use `Phoenix.Naming.underscore/1` like before to take advantage of the `\` character.