### PR TITLE
fix doc of errors_on function

### DIFF
--- a/installer/templates/phx_ecto/data_case.ex
+++ b/installer/templates/phx_ecto/data_case.ex
@@ -38,7 +38,7 @@ defmodule <%= app_module %>.DataCase do
   @doc """
   A helper that transform changeset errors to a map of messages.
 
-      changeset = Accounts.create_user(%{password: "short"})
+      assert {:error, changeset} = Accounts.create_user(%{password: "short"})
       assert "password is too short" in errors_on(changeset).password
       assert %{password: ["password is too short"]} = errors_on(changeset)
 


### PR DESCRIPTION
This is code of the generated `Accounts.create_user`:

```
  @doc """
  Creates a user.

  ## Examples

      iex> create_user(%{field: value})
      {:ok, %User{}}

      iex> create_user(%{field: bad_value})
      {:error, %Ecto.Changeset{}}

  """
  def create_user(attrs \\ %{}) do
    %User{}
    |> user_changeset(attrs)
    |> Repo.insert()
  end
```
It will return `{:error, changeset}` when errors happen, not `changeset`.