### PR TITLE
Fix the typo in phx.router (should be phx.routes)

### DIFF
--- a/lib/mix/tasks/phoenix.routes.ex
+++ b/lib/mix/tasks/phoenix.routes.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Phoenix.Routes do
   """
 
   def run(args, base \\ Mix.Phoenix.base()) do
-    IO.puts :stderr, "mix phoenix.router is deprecated. Use phx.router instead."
+    IO.puts :stderr, "mix phoenix.routes is deprecated. Use phx.routes instead."
     Mix.Tasks.Phx.Routes.run(args, base)
   end
 end


### PR DESCRIPTION
This fixes the warning message that says:

"mix phoenix.router is deprecated. Use phx.router instead."

The mix task is called `phx.routes`.