### PR TITLE
Implement phxrc

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -47,6 +47,9 @@ defmodule Mix.Tasks.Phx.New do
   `phx.gen.html` will no longer work, as important HTML components
   will be missing.
 
+  When no options passed. And there's a file `.phxrc` in the home directory
+  then Phoenix will load the options from there. Each option separated by a newline.
+
   ## Examples
 
       mix phx.new hello_world

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -168,6 +168,12 @@ defmodule Mix.Tasks.Phx.New do
   defp maybe_cd(path, func), do: path && File.cd!(path, func)
 
   defp parse_opts(argv) do
+    if phxrc_exist?() and Enum.count(argv) < 2 do
+      {:ok, phxrc} = File.read(Path.expand("~/.phxrc"))
+      opts = phxrc |> String.trim |> String.split("\n")
+      argv = argv ++ opts
+      IO.puts("Using #{phxrc} from #{Path.expand("~/.phxrc")}")
+    end
     case OptionParser.parse(argv, strict: @switches) do
       {opts, argv, []} ->
         {opts, argv}
@@ -177,6 +183,7 @@ defmodule Mix.Tasks.Phx.New do
   end
   defp switch_to_string({name, nil}), do: name
   defp switch_to_string({name, val}), do: name <> "=" <> val
+  defp phxrc_exist?(), do: File.exists?(Path.expand("~/.phxrc"))
 
   defp install_brunch(install?) do
     maybe_cmd "cd assets && npm install && node node_modules/.bin/brunch build",


### PR DESCRIPTION
Implement `~/.phxrc` as options when create new phoenix app.

So what this PR do is: when create a new phoenix app. And no options has been passed, and there's a file `.phxrc` in the home directory. Then the options will be load from `.phxrc`

I think it's quite handy to have this feature. 