### PR TITLE
`error_tag` shows all errors on field, not just first

### DIFF
--- a/installer/templates/new/web/views/error_helpers.ex
+++ b/installer/templates/new/web/views/error_helpers.ex
@@ -9,9 +9,9 @@ defmodule <%= app_module %>.ErrorHelpers do
   Generates tag for inlined form input errors.
   """
   def error_tag(form, field) do
-    if error = form.errors[field] do
+    Enum.map(Keyword.get_values(form.errors, field), fn (error) ->
       content_tag :span, translate_error(error), class: "help-block"
-    end
+    end)
   end
 <% end %>
   @doc """

--- a/installer/templates/phx_web/views/error_helpers.ex
+++ b/installer/templates/phx_web/views/error_helpers.ex
@@ -9,9 +9,9 @@ defmodule <%= web_namespace %>.ErrorHelpers do
   Generates tag for inlined form input errors.
   """
   def error_tag(form, field) do
-    if error = form.errors[field] do
+    Enum.map(Keyword.get_values(form.errors, field), fn (error) ->
       content_tag :span, translate_error(error), class: "help-block"
-    end
+    end)
   end
 <% end %>
   @doc """


### PR DESCRIPTION
Previously, if a field had multiple errors, only the first would be
displayed.

With this change, each error on the field is displayed in its own tag.

Fixes https://github.com/phoenixframework/phoenix/issues/2274