### PR TITLE
Remove the use of Repo in the generated presence docs

### DIFF
--- a/priv/templates/phx.gen.presence/presence.ex
+++ b/priv/templates/phx.gen.presence/presence.ex
@@ -54,12 +54,8 @@ defmodule <%= module %> do
   to include any additional information. For example:
 
       def fetch(_topic, entries) do
-        query =
-          from u in User,
-            where: u.id in ^Map.keys(entries),
-            select: {u.id, u}
-
-        users = query |> Repo.all |> Enum.into(%{})
+        users = entries |> Map.keys() |> Accounts.get_users_map(entries)
+        # => %{"123" => %{name: "User 123"}, "456" => %{name: nil}}
 
         for {key, %{metas: metas}} <- entries, into: %{} do
           {key, %{metas: metas, user: users[key]}}


### PR DESCRIPTION
Since we want to discourage the use of Repo outside of contexts in 1.3,
we should probably use a context (Accounts) when fetching the user map.

A comment has been left on the format of the `users` so that the code
example is still obvious.