### PR TITLE
Adds documentation to Phoenix.Router about nested resources in the router

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -538,6 +538,28 @@ defmodule Phoenix.Router do
 
       resources "/account", AccountController, only: [:show], singleton: true
 
+  ## Nested Resources
+
+  The `controller` param can be passed as a block. This is helpful for nesting
+  children resources within their parents to generate nested routes.
+
+  The given definition:
+
+      resources "/users", UserController do
+        resources "/posts", PostController
+      end
+
+  will include the following routes:
+
+      user_post_path  GET     /users/:user_id/posts           PostController :index
+      user_post_path  GET     /users/:user_id/posts/:id/edit  PostController :edit
+      user_post_path  GET     /users/:user_id/posts/new       PostController :new
+      user_post_path  GET     /users/:user_id/posts/:id       PostController :show
+      user_post_path  POST    /users/:user_id/posts           PostController :create
+      user_post_path  PATCH   /users/:user_id/posts/:id       PostController :update
+                      PUT     /users/:user_id/posts/:id       PostController :update
+      user_post_path  DELETE  /users/:user_id/posts/:id       PostController :delete
+
   """
   defmacro resources(path, controller, opts, do: nested_context) do
     add_resources path, controller, opts, do: nested_context


### PR DESCRIPTION
## Details
This PR adds an example of nested resources in the router and what routes are generated from such nesting.

## Screenshot
<img width="888" alt="screen shot 2017-05-11 at 7 45 25 am" src="https://cloud.githubusercontent.com/assets/6050768/25947646/55eb4e2e-361e-11e7-98e8-bf587086305e.png">
