### PR TITLE
use Mix.Dep.Umbrella.cached/0 instead of loaded/0

### DIFF
--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -106,9 +106,18 @@ defmodule Phoenix.CodeReloader.Server do
     end
   end
 
+  # TODO: Remove the function_exported call after 1.3 support is removed
+  # and just use loaded. apply/3 is used to prevent a compilation
+  # warning.
   defp mix_compile({:module, Mix.Task}, compilers) do
     if Mix.Project.umbrella? do
-      Enum.each Mix.Dep.Umbrella.loaded, fn dep ->
+      deps =
+        if function_exported?(Mix.Dep.Umbrella, :cached, 0) do
+          apply(Mix.Dep.Umbrella, :cached, 0)
+        else
+          Mix.Dep.Umbrella.loaded
+        end
+      Enum.each deps, fn dep ->
         Mix.Dep.in_dependency(dep, fn _ ->
           mix_compile_unless_stale_config(compilers)
         end)


### PR DESCRIPTION
This fixes the issues mentioned in [1] where the code reloaded would be
in the wrong directory. `cached/0` works but is Elixir 1.4 exclusive, so
the deps are retrieved conditionally depending on if the function exist.

[1] https://github.com/elixir-lang/elixir/issues/6104