### PR TITLE
Bump versions used by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: elixir
 matrix:
   include:
     - otp_release: 18.3
-      elixir: 1.3.2
+      elixir: 1.3
       script: mix test
-    - otp_release: 19.0
-      elixir: 1.3.2
+    - otp_release: 19.3
+      elixir: 1.3
       script: mix test
     - otp_release: 18.3
-      elixir: 1.4.2
-    - otp_release: 19.0
-      elixir: 1.4.2
+      elixir: 1.4
+    - otp_release: 19.3
+      elixir: 1.4
 services:
   - redis-server
 sudo: false


### PR DESCRIPTION
Hi, 

A small update to always test the latest Elixir 1.4 & 1.3 rather specify the patch level and also bump the OTP level. 

Thanks
Sam