### PR TITLE
Fix location for files in presence and channel generators

### DIFF
--- a/lib/mix/tasks/phx.gen.channel.ex
+++ b/lib/mix/tasks/phx.gen.channel.ex
@@ -24,11 +24,13 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
   use Mix.Task
 
   def run(args) do
+    if Mix.Project.umbrella?() do
+      Mix.raise "mix phx.gen.channel can only be run inside an application directory"
+    end
     [channel_name] = validate_args!(args)
-    otp_app = Mix.Phoenix.otp_app()
-
-    web_prefix = Mix.Phoenix.web_path(otp_app)
-    test_prefix = Mix.Phoenix.web_test_path(otp_app)
+    context_app = Mix.Phoenix.context_app()
+    web_prefix = Mix.Phoenix.web_path(context_app)
+    test_prefix = Mix.Phoenix.web_test_path(context_app)
     binding = Mix.Phoenix.inflect(channel_name)
     binding = Keyword.put(binding, :module, "#{binding[:web_module]}.#{binding[:scoped]}")
 
@@ -41,7 +43,7 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
 
     Mix.shell.info """
 
-    Add the channel to your `#{Mix.Phoenix.web_path(otp_app, "channels/user_socket.ex")}` handler, for example:
+    Add the channel to your `#{Mix.Phoenix.web_path(context_app, "channels/user_socket.ex")}` handler, for example:
 
         channel "#{binding[:singular]}:lobby", #{binding[:module]}Channel
     """

--- a/lib/mix/tasks/phx.gen.presence.ex
+++ b/lib/mix/tasks/phx.gen.presence.ex
@@ -23,12 +23,17 @@ defmodule Mix.Tasks.Phx.Gen.Presence do
     run(["Presence"])
   end
   def run([alias_name]) do
-    web_prefix = Mix.Phoenix.web_path(Mix.Phoenix.otp_app())
+    if Mix.Project.umbrella?() do
+      Mix.raise "mix phx.gen.presence can only be run inside an application directory"
+    end
+    context_app = Mix.Phoenix.context_app()
+    otp_app = Mix.Phoenix.context_app()
+    web_prefix = Mix.Phoenix.web_path(context_app)
     inflections = Mix.Phoenix.inflect(alias_name)
     inflections = Keyword.put(inflections, :module, "#{inflections[:web_module]}.#{inflections[:scoped]}")
 
     binding = inflections ++ [
-      otp_app: Mix.Phoenix.otp_app(),
+      otp_app: otp_app,
       pubsub_server: Module.concat(inflections[:base], PubSub)
     ]
     files = [
@@ -39,7 +44,7 @@ defmodule Mix.Tasks.Phx.Gen.Presence do
     Mix.shell.info """
 
     Add your new module to your supervision tree,
-    in lib/#{Mix.Phoenix.otp_app()}/application.ex:
+    in lib/#{otp_app}/application.ex:
 
         children = [
           ...

--- a/test/mix/tasks/phx.gen.channel_test.exs
+++ b/test/mix/tasks/phx.gen.channel_test.exs
@@ -51,6 +51,22 @@ defmodule Mix.Tasks.Phx.Gen.ChannelTest do
     end
   end
 
+  test "in an umbrella with a context_app, generates the files", config do
+    in_tmp_umbrella_project "generates presences", fn ->
+      Application.put_env(:phoenix, :generators, context_app: {:another_app, "another_app"})
+      Gen.Channel.run ["room"]
+      assert_file "lib/phoenix/channels/room_channel.ex", fn file ->
+        assert file =~ ~S|defmodule Phoenix.Web.RoomChannel do|
+        assert file =~ ~S|use Phoenix.Web, :channel|
+      end
+
+      assert_file "test/phoenix/channels/room_channel_test.exs", fn file ->
+        assert file =~ ~S|defmodule Phoenix.Web.RoomChannelTest|
+        assert file =~ ~S|alias Phoenix.Web.RoomChannel|
+      end
+    end
+  end
+
   test "generates nested channel" do
     in_tmp_project "generates nested channel", fn ->
       Gen.Channel.run ["Admin.Room"]

--- a/test/mix/tasks/phx.gen.presence_test.exs
+++ b/test/mix/tasks/phx.gen.presence_test.exs
@@ -30,4 +30,12 @@ defmodule Mix.Tasks.Phx.Gen.PresenceTest do
       end
     end
   end
+
+  test "in an umbrella with a context_app, the file goes in lib/app/channels", config do
+    in_tmp_umbrella_project "generates presences", fn ->
+      Application.put_env(:phoenix, :generators, context_app: {:another_app, "another_app"})
+      Mix.Tasks.Phx.Gen.Presence.run([])
+      assert_file "lib/phoenix/channels/presence.ex"
+    end
+  end
 end


### PR DESCRIPTION
When in an umbrella and the `context_app` config is set, the files
should go in directories without the web prefix.

In the channels test, the test_prefix is specified directly so that the
files ends up in:

`/test/channels/foo_test.exs` instead of
`test/phoenix_web/channels/foo_test.exs`