### PR TITLE
Fix phx.gen.html templates and shell instructions with --web

### DIFF
--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -161,7 +161,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
 
       Add the resource to your #{schema.web_namespace} :browser scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
 
-          scope "/#{schema.web_path}", #{inspect Module.concat(context.web_module, schema.web_namespace)} do
+          scope "/#{schema.web_path}", #{inspect Module.concat(context.web_module, schema.web_namespace)}, as: :#{schema.web_path} do
             pipe_through :browser
             ...
             resources "/#{schema.plural}", #{inspect schema.alias}Controller

--- a/priv/templates/phx.gen.html/edit.html.eex
+++ b/priv/templates/phx.gen.html/edit.html.eex
@@ -1,6 +1,6 @@
 <h2>Edit <%= schema.human_singular %></h2>
 
 <%%= render "form.html", changeset: @changeset,
-                        action: <%= schema.singular %>_path(@conn, :update, @<%= schema.singular %>) %>
+                        action: <%= schema.route_helper %>_path(@conn, :update, @<%= schema.singular %>) %>
 
-<span><%%= link "Back", to: <%= schema.singular %>_path(@conn, :index) %></span>
+<span><%%= link "Back", to: <%= schema.route_helper %>_path(@conn, :index) %></span>

--- a/priv/templates/phx.gen.html/index.html.eex
+++ b/priv/templates/phx.gen.html/index.html.eex
@@ -14,13 +14,13 @@
 <%= for {k, _} <- schema.attrs do %>      <td><%%= <%= schema.singular %>.<%= k %> %></td>
 <% end %>
       <td class="text-right">
-        <span><%%= link "Show", to: <%= schema.singular %>_path(@conn, :show, <%= schema.singular %>), class: "btn btn-default btn-xs" %></span>
-        <span><%%= link "Edit", to: <%= schema.singular %>_path(@conn, :edit, <%= schema.singular %>), class: "btn btn-default btn-xs" %></span>
-        <span><%%= link "Delete", to: <%= schema.singular %>_path(@conn, :delete, <%= schema.singular %>), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %></span>
+        <span><%%= link "Show", to: <%= schema.route_helper %>_path(@conn, :show, <%= schema.singular %>), class: "btn btn-default btn-xs" %></span>
+        <span><%%= link "Edit", to: <%= schema.route_helper %>_path(@conn, :edit, <%= schema.singular %>), class: "btn btn-default btn-xs" %></span>
+        <span><%%= link "Delete", to: <%= schema.route_helper %>_path(@conn, :delete, <%= schema.singular %>), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %></span>
       </td>
     </tr>
 <%% end %>
   </tbody>
 </table>
 
-<span><%%= link "New <%= schema.human_singular %>", to: <%= schema.singular %>_path(@conn, :new) %></span>
+<span><%%= link "New <%= schema.human_singular %>", to: <%= schema.route_helper %>_path(@conn, :new) %></span>

--- a/priv/templates/phx.gen.html/new.html.eex
+++ b/priv/templates/phx.gen.html/new.html.eex
@@ -1,6 +1,6 @@
 <h2>New <%= schema.human_singular %></h2>
 
 <%%= render "form.html", changeset: @changeset,
-                        action: <%= schema.singular %>_path(@conn, :create) %>
+                        action: <%= schema.route_helper %>_path(@conn, :create) %>
 
-<span><%%= link "Back", to: <%= schema.singular %>_path(@conn, :index) %></span>
+<span><%%= link "Back", to: <%= schema.route_helper %>_path(@conn, :index) %></span>

--- a/priv/templates/phx.gen.html/show.html.eex
+++ b/priv/templates/phx.gen.html/show.html.eex
@@ -9,5 +9,5 @@
 <% end %>
 </ul>
 
-<span><%%= link "Edit", to: <%= schema.singular %>_path(@conn, :edit, @<%= schema.singular %>) %></span>
-<span><%%= link "Back", to: <%= schema.singular %>_path(@conn, :index) %></span>
+<span><%%= link "Edit", to: <%= schema.route_helper %>_path(@conn, :edit, @<%= schema.singular %>) %></span>
+<span><%%= link "Back", to: <%= schema.route_helper %>_path(@conn, :index) %></span>

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -166,6 +166,18 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
       end
 
       assert_file "lib/phoenix/web/templates/blog/post/form.html.eex"
+      assert_file "lib/phoenix/web/templates/blog/post/edit.html.eex", fn file ->
+        assert file =~ " blog_post_path(@conn"
+      end
+      assert_file "lib/phoenix/web/templates/blog/post/index.html.eex", fn file ->
+        assert file =~ " blog_post_path(@conn"
+      end
+      assert_file "lib/phoenix/web/templates/blog/post/new.html.eex", fn file ->
+        assert file =~ " blog_post_path(@conn"
+      end
+      assert_file "lib/phoenix/web/templates/blog/post/show.html.eex", fn file ->
+        assert file =~ " blog_post_path(@conn"
+      end
       assert_file "lib/phoenix/web/views/blog/post_view.ex", fn file ->
         assert file =~ "defmodule Phoenix.Web.Blog.PostView"
       end
@@ -174,7 +186,7 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
 
       Add the resource to your Blog :browser scope in lib/phoenix/web/router.ex:
 
-          scope "/blog", Phoenix.Web.Blog do
+          scope "/blog", Phoenix.Web.Blog, as: :blog do
             pipe_through :browser
             ...
             resources "/posts", PostController


### PR DESCRIPTION
Currently, when the `--web` option is used, the templates generated are inconsistent with the controller code regarding namespaced path helpers. While the controller correctly follows the convention of `<namespace>_<resource>_path(conn, ...)`, the templates are always generated with `<resource>_path(conn, ...)`, regardless of `--web`.

As an example, when we run the generator as follows:

```
mix phx.gen.html Blog Post posts title:string --web Admin
```

We expect all path helpers to be generated as `admin_post_path(@conn)`. The same goes for the router scope, to be compatible it should include an `as` directive – like `scope "/admin", App.Web.Admin, as: :admin` – otherwise both controller and templates will not compile.

Now the templates follow the same convention, as well as the shell instructions. So, when the instructions are followed, the generated code compiles correctly.