### PR TITLE
Remove all functions from mix tasks from docs

### DIFF
--- a/lib/mix/tasks/phoenix.digest.ex
+++ b/lib/mix/tasks/phoenix.digest.ex
@@ -32,6 +32,7 @@ defmodule Mix.Tasks.Phoenix.Digest do
     * cache_manifest.json
   """
 
+  @doc false
   def run(args) do
     IO.puts :stderr, "mix phoenix.digest is deprecated. Use phx.digest instead."
     Mix.Tasks.Phx.Digest.run(args)

--- a/lib/mix/tasks/phoenix.gen.channel.ex
+++ b/lib/mix/tasks/phoenix.gen.channel.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Channel do
   """
   use Mix.Task
 
+  @doc false
   def run(args) do
     IO.puts :stderr, "mix phoenix.gen.channel is deprecated. Use phx.gen.channel instead."
 
@@ -37,6 +38,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Channel do
     """
   end
 
+  @doc false
   @spec raise_with_help() :: no_return()
   defp raise_with_help do
     Mix.raise """

--- a/lib/mix/tasks/phoenix.gen.html.ex
+++ b/lib/mix/tasks/phoenix.gen.html.ex
@@ -24,6 +24,8 @@ defmodule Mix.Tasks.Phoenix.Gen.Html do
   Read the documentation for `phoenix.gen.model` for more
   information on attributes and namespaced resources.
   """
+
+  @doc false
   def run(args) do
     IO.puts :stderr, "mix phoenix.gen.html is deprecated. Use phx.gen.html instead."
     switches = [binary_id: :boolean, model: :boolean]

--- a/lib/mix/tasks/phoenix.gen.json.ex
+++ b/lib/mix/tasks/phoenix.gen.json.ex
@@ -21,6 +21,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Json do
   """
   use Mix.Task
 
+  @doc false
   def run(args) do
     IO.puts :stderr, "mix phoenix.gen.json is deprecated. Use phx.gen.json instead."
     switches = [binary_id: :boolean, model: :boolean]

--- a/lib/mix/tasks/phoenix.gen.model.ex
+++ b/lib/mix/tasks/phoenix.gen.model.ex
@@ -80,6 +80,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Model do
   """
   use Mix.Task
 
+  @doc false
   def run(args) do
     IO.puts :stderr, "mix phoenix.gen.model is deprecated. Use phx.gen.schema instead."
     switches = [migration: :boolean, binary_id: :boolean, instructions: :string]

--- a/lib/mix/tasks/phoenix.gen.presence.ex
+++ b/lib/mix/tasks/phoenix.gen.presence.ex
@@ -17,6 +17,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Presence do
   """
   use Mix.Task
 
+  @doc false
   def run([]) do
     run(["Presence"])
   end

--- a/lib/mix/tasks/phoenix.gen.secret.ex
+++ b/lib/mix/tasks/phoenix.gen.secret.ex
@@ -10,6 +10,7 @@ defmodule Mix.Tasks.Phoenix.Gen.Secret do
   """
   use Mix.Task
 
+  @doc false
   def run(args) do
     IO.puts :stderr, "mix phoenix.gen.secret is deprecated. Use phx.gen.secret instead."
     Mix.Tasks.Phx.Gen.Secret.run(args)

--- a/lib/mix/tasks/phoenix.routes.ex
+++ b/lib/mix/tasks/phoenix.routes.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Phoenix.Routes do
   therefore always expect a router to be given.
   """
 
+  @doc false
   def run(args, base \\ Mix.Phoenix.base()) do
     IO.puts :stderr, "mix phoenix.routes is deprecated. Use phx.routes instead."
     Mix.Tasks.Phx.Routes.run(args, base)

--- a/lib/mix/tasks/phoenix.server.ex
+++ b/lib/mix/tasks/phoenix.server.ex
@@ -18,6 +18,8 @@ defmodule Mix.Tasks.Phoenix.Server do
 
   The `--no-halt` flag is automatically added.
   """
+
+  @doc false
   def run(args) do
     IO.puts :stderr, "mix phoenix.server is deprecated. Use phx.server instead."
     Mix.Tasks.Phx.Server.run(args)

--- a/lib/mix/tasks/phx.digest.clean.ex
+++ b/lib/mix/tasks/phx.digest.clean.ex
@@ -31,6 +31,8 @@ defmodule Mix.Tasks.Phx.Digest.Clean do
       Defaults to 2 previous version.
 
   """
+
+  @doc false
   def run(args) do
     switches = [output: :string, age: :integer, keep: :integer]
     {opts, _, _} = OptionParser.parse(args, switches: switches, aliases: [o: :output])

--- a/lib/mix/tasks/phx.digest.ex
+++ b/lib/mix/tasks/phx.digest.ex
@@ -34,6 +34,7 @@ defmodule Mix.Tasks.Phx.Digest do
     * cache_manifest.json
   """
 
+  @doc false
   def run(args) do
     {opts, args, _} = OptionParser.parse(args, aliases: [o: :output])
     input_path  = List.first(args) || @default_input_path

--- a/lib/mix/tasks/phx.gen.channel.ex
+++ b/lib/mix/tasks/phx.gen.channel.ex
@@ -23,6 +23,7 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
   """
   use Mix.Task
 
+  @doc false
   def run(args) do
     [channel_name] = validate_args!(args)
     otp_app = Mix.Phoenix.otp_app()

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -73,6 +73,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
 
   @default_opts [schema: true, context: true]
 
+  @doc false
   def run(args) do
     if Mix.Project.umbrella? do
       Mix.raise "mix phx.gen.context can only be run inside an application directory"
@@ -95,6 +96,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     |> Mix.Phoenix.prompt_for_conflicts()
   end
 
+  @doc false
   def build(args) do
     {opts, parsed, _} = parse_opts(args)
     [context_name, schema_name, plural | schema_args] = validate_args!(parsed)
@@ -122,6 +124,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     Keyword.put(opts, :context_app, String.to_atom(string))
   end
 
+  @doc false
   def files_to_be_generated(%Context{schema: schema}) do
     if schema.generate? do
       Gen.Schema.files_to_be_generated(schema)
@@ -130,6 +133,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     end
   end
 
+  @doc false
   def copy_new_files(%Context{schema: schema} = context, paths, binding) do
     if schema.generate?, do: Gen.Schema.copy_new_files(schema, paths, binding)
     inject_schema_access(context, paths, binding)
@@ -180,6 +184,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     end
   end
 
+  @doc false
   def print_shell_instructions(%Context{schema: schema}) do
     if schema.generate? do
       Gen.Schema.print_shell_instructions(schema)
@@ -213,6 +218,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     raise_with_help "Invalid arguments"
   end
 
+  @doc false
   @spec raise_with_help(String.t) :: no_return()
   def raise_with_help(msg) do
     Mix.raise """

--- a/lib/mix/tasks/phx.gen.embedded.ex
+++ b/lib/mix/tasks/phx.gen.embedded.ex
@@ -31,6 +31,7 @@ defmodule Mix.Tasks.Phx.Gen.Embedded do
   alias Mix.Tasks.Phx.Gen
   alias Mix.Phoenix.Schema
 
+  @doc false
   def run(args) do
     if Mix.Project.umbrella?() do
       Mix.raise "mix phx.gen.embedded can only be run inside an application directory"
@@ -45,6 +46,7 @@ defmodule Mix.Tasks.Phx.Gen.Embedded do
     copy_new_files(schema, paths, schema: schema)
   end
 
+  @doc false
   def build(args, _opts), do: Gen.Schema.build(args, [embedded: true], Gen.Schema)
 
   defp prompt_for_conflicts(schema) do
@@ -53,10 +55,12 @@ defmodule Mix.Tasks.Phx.Gen.Embedded do
     |> Mix.Phoenix.prompt_for_conflicts()
   end
 
+  @doc false
   def files_to_be_generated(%Schema{} = schema) do
     [{:eex, "embedded_schema.ex", schema.file}]
   end
 
+  @doc false
   def copy_new_files(%Schema{} = schema, paths, binding) do
     files = files_to_be_generated(schema)
     Mix.Phoenix.copy_from(paths,"priv/templates/phx.gen.embedded", "", binding, files)

--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -99,6 +99,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   alias Mix.Phoenix.{Context, Schema}
   alias Mix.Tasks.Phx.Gen
 
+  @doc false
   def run(args) do
     if Mix.Project.umbrella? do
       Mix.raise "mix phx.gen.html can only be run inside an application directory"
@@ -127,6 +128,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
     []
   end
 
+  @doc false
   def files_to_be_generated(%Context{schema: schema, context_app: context_app}) do
     web_prefix = Mix.Phoenix.web_path(context_app)
     test_prefix = Mix.Phoenix.web_test_path(context_app)
@@ -144,7 +146,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
     ]
   end
 
-
+  @doc false
   def copy_new_files(%Context{} = context, paths, binding) do
     files = files_to_be_generated(context)
     Mix.Phoenix.copy_from(paths, "priv/templates/phx.gen.html", "", binding, files)
@@ -152,6 +154,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
     context
   end
 
+  @doc false
   def print_shell_instructions(%Context{schema: schema, context_app: ctx_app} = context) do
     if schema.web_namespace do
       Mix.shell.info """

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -98,6 +98,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
   alias Mix.Phoenix.Context
   alias Mix.Tasks.Phx.Gen
 
+  @doc false
   def run(args) do
     if Mix.Project.umbrella? do
       Mix.raise "mix phx.gen.json can only be run inside an application directory"
@@ -127,6 +128,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
     []
   end
 
+  @doc false
   def files_to_be_generated(%Context{schema: schema, context_app: context_app}) do
     web_prefix = Mix.Phoenix.web_path(context_app)
     test_prefix = Mix.Phoenix.web_test_path(context_app)
@@ -141,6 +143,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
     ]
   end
 
+  @doc false
   def copy_new_files(%Context{} = context, paths, binding) do
     files = files_to_be_generated(context)
     Mix.Phoenix.copy_from paths, "priv/templates/phx.gen.json", "", binding, files
@@ -149,6 +152,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
     context
   end
 
+  @doc false
   def print_shell_instructions(%Context{schema: schema, context_app: ctx_app} = context) do
     if schema.web_namespace do
       Mix.shell.info """

--- a/lib/mix/tasks/phx.gen.presence.ex
+++ b/lib/mix/tasks/phx.gen.presence.ex
@@ -19,6 +19,7 @@ defmodule Mix.Tasks.Phx.Gen.Presence do
   """
   use Mix.Task
 
+  @doc false
   def run([]) do
     run(["Presence"])
   end

--- a/lib/mix/tasks/phx.gen.schema.ex
+++ b/lib/mix/tasks/phx.gen.schema.ex
@@ -84,6 +84,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   @switches [migration: :boolean, binary_id: :boolean, table: :string,
              web: :string]
 
+  @doc false
   def run(args) do
     if Mix.Project.umbrella?() do
       Mix.raise "mix phx.gen.schema can only be run inside an application directory"
@@ -105,6 +106,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
     |> Mix.Phoenix.prompt_for_conflicts()
   end
 
+  @doc false
   def build(args, parent_opts, help \\ __MODULE__) do
     {schema_opts, parsed, _} = OptionParser.parse(args, switches: @switches)
     [schema_name, plural | attrs] = validate_args!(parsed, help)
@@ -114,10 +116,12 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
     schema
   end
 
+  @doc false
   def files_to_be_generated(%Schema{} = schema) do
     [{:eex, "schema.ex", schema.file}]
   end
 
+  @doc false
   def copy_new_files(%Schema{context_app: ctx_app} = schema, paths, binding) do
     migration =
       schema.module
@@ -141,6 +145,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
     schema
   end
 
+  @doc false
   def print_shell_instructions(%Schema{} = schema) do
     if schema.migration? do
       Mix.shell.info """
@@ -152,6 +157,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
     end
   end
 
+  @doc false
   def validate_args!([schema, plural | _] = args, help) do
     cond do
       not Schema.valid?(schema) ->
@@ -166,6 +172,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
     help.raise_with_help "Invalid arguments"
   end
 
+  @doc false
   @spec raise_with_help(String.t) :: no_return()
   def raise_with_help(msg) do
     Mix.raise """

--- a/lib/mix/tasks/phx.gen.secret.ex
+++ b/lib/mix/tasks/phx.gen.secret.ex
@@ -12,6 +12,7 @@ defmodule Mix.Tasks.Phx.Gen.Secret do
   """
   use Mix.Task
 
+  @doc false
   def run([]),    do: run(["64"])
   def run([int]), do: int |> parse!() |> random_string() |> Mix.shell.info()
   def run([_|_]), do: invalid_args!()

--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -25,6 +25,7 @@ defmodule Mix.Tasks.Phx.Routes do
   therefore always expect a router to be given.
   """
 
+  @doc false
   def run(args, base \\ Mix.Phoenix.base()) do
     Mix.Task.run "compile", args
 

--- a/lib/mix/tasks/phx.server.ex
+++ b/lib/mix/tasks/phx.server.ex
@@ -18,6 +18,8 @@ defmodule Mix.Tasks.Phx.Server do
 
   The `--no-halt` flag is automatically added.
   """
+
+  @doc false
   def run(args) do
     Application.put_env(:phoenix, :serve_endpoints, true, persistent: true)
     Mix.Tasks.Run.run run_args() ++ args


### PR DESCRIPTION
The functions should not be called manually (only through `Mix.Task.run`).
This also makes the task docs much more concise and less cluttered.