### PR TITLE
Remove plural name arg from phx.gen.embedded

### DIFF
--- a/lib/mix/tasks/phx.gen.schema.ex
+++ b/lib/mix/tasks/phx.gen.schema.ex
@@ -178,8 +178,8 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
     Mix.raise """
     #{msg}
 
-    mix phx.gen.schema and phx.gen.embedded expect both a module
-    name and the plural of the generated resource followed by
+    mix phx.gen.schema expects both a module name and
+    the plural of the generated resource followed by
     any number of attributes:
 
         mix phx.gen.schema Blog.Post blog_posts title:string

--- a/test/mix/tasks/phx.gen.embedded_test.exs
+++ b/test/mix/tasks/phx.gen.embedded_test.exs
@@ -13,17 +13,17 @@ defmodule Mix.Tasks.Phx.Gen.EmbeddedTest do
 
   test "build" do
     in_tmp_project "embedded build", fn ->
-      schema = Gen.Embedded.build(~w(Blog.Post posts title:string), [])
+      schema = Gen.Embedded.build(~w(Blog.Post title:string))
 
       assert %Schema{
         alias: Post,
         module: Phoenix.Blog.Post,
         repo: Phoenix.Repo,
-        migration?: true,
+        migration?: false,
         migration_defaults: %{title: ""},
-        plural: "posts",
+        plural: nil,
         singular: "post",
-        human_plural: "Posts",
+        human_plural: "Nil",
         human_singular: "Post",
         attrs: [title: :string],
         types: %{title: :string},
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Phx.Gen.EmbeddedTest do
 
   test "generates embedded schema", config do
     in_tmp_project config.test, fn ->
-      Gen.Embedded.run(~w(Blog.Post blog_posts title:string))
+      Gen.Embedded.run(~w(Blog.Post title:string))
       assert_file "lib/phoenix/blog/post.ex", fn file ->
         assert file =~ "embedded_schema do"
       end
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Phx.Gen.EmbeddedTest do
 
   test "generates nested embedded schema", config do
     in_tmp_project config.test, fn ->
-      Gen.Embedded.run(~w(Blog.Admin.User users name:string))
+      Gen.Embedded.run(~w(Blog.Admin.User name:string))
 
       assert_file "lib/phoenix/blog/admin/user.ex", fn file ->
         assert file =~ "defmodule Phoenix.Blog.Admin.User do"
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Phx.Gen.EmbeddedTest do
 
   test "generates embedded schema with proper datetime types", config do
     in_tmp_project config.test, fn ->
-      Gen.Embedded.run(~w(Blog.Comment comments title:string drafted_at:datetime published_at:naive_datetime edited_at:utc_datetime))
+      Gen.Embedded.run(~w(Blog.Comment title:string drafted_at:datetime published_at:naive_datetime edited_at:utc_datetime))
 
       assert_file "lib/phoenix/blog/comment.ex", fn file ->
         assert file =~ "field :drafted_at, :naive_datetime"


### PR DESCRIPTION
I was surprised reading the docs for `mix phx.gen.embedded` saying that it required a plural name which is used for the 'table name'.

Embedded schemas aren't linked to a table, and may be used to validate data coming from other sources (request params, message queues, etc.)

This PR removes the required plural name argument from `phx.gen.embedded` and de-couples `phx.gen.embedded` from `phx.gen.schema`.

So the interface is just:

```
mix phx.gen.embedded Blog.Post title:string views:integer
```