### PR TITLE
Fix spacing in generated embedded schemas

### DIFF
--- a/priv/templates/phx.gen.embedded/embedded_schema.ex
+++ b/priv/templates/phx.gen.embedded/embedded_schema.ex
@@ -4,8 +4,8 @@ defmodule <%= inspect schema.module %> do
   alias <%= inspect schema.module %>
 
   embedded_schema do
-<%= for {k, v} <- schema.types do %>    field <%= inspect k %>, <%= inspect v %><%= schema.defaults[k] %><% end %>
-  end
+<%= for {k, v} <- schema.types do %>    field <%= inspect k %>, <%= inspect v %><%= schema.defaults[k] %>
+<% end %>  end
 
   @doc false
   def changeset(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do


### PR DESCRIPTION
The current template generates inlined fields, which is invalid Elixir. Now we have one line per field.

```
$ mix phx.gen.embedded Blog.Postr title:string body:text views:integer
```

Before:

```elixir
  embedded_schema do
    field :body, :string    field :title, :string    field :views, :integer
  end
```

After:

```elixir
  embedded_schema do
    field :body, :string
    field :title, :string
    field :views, :integer
  end
```