### PR TITLE
Fix outdated links: from elixir-lang.org to hexdocs.pm

### DIFF
--- a/installer/templates/new/lib/app_name.ex
+++ b/installer/templates/new/lib/app_name.ex
@@ -1,7 +1,7 @@
 defmodule <%= app_module %> do
   use Application
 
-  # See http://elixir-lang.org/docs/stable/elixir/Application.html
+  # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
     import Supervisor.Spec
@@ -16,7 +16,7 @@ defmodule <%= app_module %> do
       # worker(<%= app_module %>.Worker, [arg1, arg2, arg3]),
     ]
 
-    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: <%= app_module %>.Supervisor]
     Supervisor.start_link(children, opts)

--- a/installer/templates/phx_single/lib/app_name/application.ex
+++ b/installer/templates/phx_single/lib/app_name/application.ex
@@ -1,7 +1,7 @@
 defmodule <%= app_module %>.Application do
   use Application
 
-  # See http://elixir-lang.org/docs/stable/elixir/Application.html
+  # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
     import Supervisor.Spec
@@ -16,7 +16,7 @@ defmodule <%= app_module %>.Application do
       # worker(<%= app_module %>.Worker, [arg1, arg2, arg3]),
     ]
 
-    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: <%= app_module %>.Supervisor]
     Supervisor.start_link(children, opts)

--- a/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name/application.ex
@@ -12,7 +12,7 @@ defmodule <%= web_namespace %>.Application do
       # worker(<%= web_namespace %>.Worker, [arg1, arg2, arg3]),
     ]
 
-    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: <%= web_namespace %>.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -72,7 +72,7 @@ defmodule Phoenix.Router do
 
   The URL generated in the named URL helpers is based on the configuration for
   `:url`, `:http` and `:https`. However, if for some reason you need to manually
-  control the URL generation, the url helpers also allow you to pass in a [`URI`](https://hexdocs.pm/elixir/URI.html)
+  control the URL generation, the url helpers also allow you to pass in a `URI`
   struct:
 
       uri = %URI{scheme: "https", host: "other.example.com"}

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -72,7 +72,7 @@ defmodule Phoenix.Router do
 
   The URL generated in the named URL helpers is based on the configuration for
   `:url`, `:http` and `:https`. However, if for some reason you need to manually
-  control the URL generation, the url helpers also allow you to pass in a [`URI`](http://elixir-lang.org/docs/stable/elixir/URI.html)
+  control the URL generation, the url helpers also allow you to pass in a [`URI`](https://hexdocs.pm/elixir/URI.html)
   struct:
 
       uri = %URI{scheme: "https", host: "other.example.com"}


### PR DESCRIPTION
There are a number of links pointing to elixir-lang.org that
are redirected to hexdocs.pm currently. Simply replace the old ones
to the new targets.

e.g.
http://elixir-lang.org/docs/stable/elixir/Application.html
=>
https://hexdocs.pm/elixir/Application.html