### PR TITLE
Generate Phoenix.js documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ See the official site at http://www.phoenixframework.org/
 
 API documentation is available at [https://hexdocs.pm/phoenix](https://hexdocs.pm/phoenix)
 
+Phoenix.js documentation is available at [https://hexdocs.pm/phoenix/js](https://hexdocs.pm/phoenix/js)
+
 ## Contributing
 
 We appreciate any contribution to Phoenix. Check our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and [CONTRIBUTING.md](CONTRIBUTING.md) guides for more information. We usually keep a list of features and bugs [in the issue tracker][4].

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -1,171 +1,184 @@
-// Phoenix Channels JavaScript client
-//
-// ## Socket Connection
-//
-// A single connection is established to the server and
-// channels are multiplexed over the connection.
-// Connect to the server using the `Socket` class:
-//
-//     let socket = new Socket("/socket", {params: {userToken: "123"}})
-//     socket.connect()
-//
-// The `Socket` constructor takes the mount point of the socket,
-// the authentication params, as well as options that can be found in
-// the Socket docs, such as configuring the `LongPoll` transport, and
-// heartbeat.
-//
-// ## Channels
-//
-// Channels are isolated, concurrent processes on the server that
-// subscribe to topics and broker events between the client and server.
-// To join a channel, you must provide the topic, and channel params for
-// authorization. Here's an example chat room example where `"new_msg"`
-// events are listened for, messages are pushed to the server, and
-// the channel is joined with ok/error/timeout matches:
-//
-//     let channel = socket.channel("room:123", {token: roomToken})
-//     channel.on("new_msg", msg => console.log("Got message", msg) )
-//     $input.onEnter( e => {
-//       channel.push("new_msg", {body: e.target.val}, 10000)
-//        .receive("ok", (msg) => console.log("created message", msg) )
-//        .receive("error", (reasons) => console.log("create failed", reasons) )
-//        .receive("timeout", () => console.log("Networking issue...") )
-//     })
-//     channel.join()
-//       .receive("ok", ({messages}) => console.log("catching up", messages) )
-//       .receive("error", ({reason}) => console.log("failed join", reason) )
-//       .receive("timeout", () => console.log("Networking issue. Still waiting...") )
-//
-//
-// ## Joining
-//
-// Creating a channel with `socket.channel(topic, params)`, binds the params to
-// `channel.params`, which are sent up on `channel.join()`.
-// Subsequent rejoins will send up the modified params for
-// updating authorization params, or passing up last_message_id information.
-// Successful joins receive an "ok" status, while unsuccessful joins
-// receive "error".
-//
-// ## Duplicate Join Subscriptions
-//
-// While the client may join any number of topics on any number of channels,
-// the client may only hold a single subscription for each unique topic at any
-// given time. When attempting to create a duplicate subscription,
-// the server will close the existing channel, log a warning, and
-// spawn a new channel for the topic. The client will have their
-// `channel.onClose` callbacks fired for the existing channel, and the new
-// channel join will have its receive hooks processed as normal.
-//
-// ## Pushing Messages
-//
-// From the previous example, we can see that pushing messages to the server
-// can be done with `channel.push(eventName, payload)` and we can optionally
-// receive responses from the push. Additionally, we can use
-// `receive("timeout", callback)` to abort waiting for our other `receive` hooks
-//  and take action after some period of waiting. The default timeout is 5000ms.
-//
-//
-// ## Socket Hooks
-//
-// Lifecycle events of the multiplexed connection can be hooked into via
-// `socket.onError()` and `socket.onClose()` events, ie:
-//
-//     socket.onError( () => console.log("there was an error with the connection!") )
-//     socket.onClose( () => console.log("the connection dropped") )
-//
-//
-// ## Channel Hooks
-//
-// For each joined channel, you can bind to `onError` and `onClose` events
-// to monitor the channel lifecycle, ie:
-//
-//     channel.onError( () => console.log("there was an error!") )
-//     channel.onClose( () => console.log("the channel has gone away gracefully") )
-//
-// ### onError hooks
-//
-// `onError` hooks are invoked if the socket connection drops, or the channel
-// crashes on the server. In either case, a channel rejoin is attempted
-// automatically in an exponential backoff manner.
-//
-// ### onClose hooks
-//
-// `onClose` hooks are invoked only in two cases. 1) the channel explicitly
-// closed on the server, or 2). The client explicitly closed, by calling
-// `channel.leave()`
-//
-//
-// ## Presence
-//
-// The `Presence` object provides features for syncing presence information
-// from the server with the client and handling presences joining and leaving.
-//
-// ### Syncing initial state from the server
-//
-// `Presence.syncState` is used to sync the list of presences on the server
-// with the client's state. An optional `onJoin` and `onLeave` callback can
-// be provided to react to changes in the client's local presences across
-// disconnects and reconnects with the server.
-//
-// `Presence.syncDiff` is used to sync a diff of presence join and leave
-// events from the server, as they happen. Like `syncState`, `syncDiff`
-// accepts optional `onJoin` and `onLeave` callbacks to react to a user
-// joining or leaving from a device.
-//
-// ### Listing Presences
-//
-// `Presence.list` is used to return a list of presence information
-// based on the local state of metadata. By default, all presence
-// metadata is returned, but a `listBy` function can be supplied to
-// allow the client to select which metadata to use for a given presence.
-// For example, you may have a user online from different devices with
-// a metadata status of "online", but they have set themselves to "away"
-// on another device. In this case, the app may choose to use the "away"
-// status for what appears on the UI. The example below defines a `listBy`
-// function which prioritizes the first metadata which was registered for
-// each user. This could be the first tab they opened, or the first device
-// they came online from:
-//
-//     let state = {}
-//     state = Presence.syncState(state, stateFromServer)
-//     let listBy = (id, {metas: [first, ...rest]}) => {
-//       first.count = rest.length + 1 // count of this user's presences
-//       first.id = id
-//       return first
-//     }
-//     let onlineUsers = Presence.list(state, listBy)
-//
-//
-// ### Example Usage
-//
-//     // detect if user has joined for the 1st time or from another tab/device
-//     let onJoin = (id, current, newPres) => {
-//       if(!current){
-//         console.log("user has entered for the first time", newPres)
-//       } else {
-//         console.log("user additional presence", newPres)
-//       }
-//     }
-//     // detect if user has left from all tabs/devices, or is still present
-//     let onLeave = (id, current, leftPres) => {
-//       if(current.metas.length === 0){
-//         console.log("user has left from all devices", leftPres)
-//       } else {
-//         console.log("user left from a device", leftPres)
-//       }
-//     }
-//     let presences = {} // client's initial empty presence state
-//     // receive initial presence data from server, sent after join
-//     myChannel.on("presence_state", state => {
-//       presences = Presence.syncState(presences, state, onJoin, onLeave)
-//       displayUsers(Presence.list(presences))
-//     })
-//     // receive "presence_diff" from server, containing join/leave events
-//     myChannel.on("presence_diff", diff => {
-//       presences = Presence.syncDiff(presences, diff, onJoin, onLeave)
-//       this.setState({users: Presence.list(room.presences, listBy)})
-//     })
-//
+/**
+ * Phoenix Channels JavaScript client
+ *
+ * ## Socket Connection
+ *
+ * A single connection is established to the server and
+ * channels are multiplexed over the connection.
+ * Connect to the server using the `Socket` class:
+ *
+ * ```javascript
+ *     let socket = new Socket("/socket", {params: {userToken: "123"}})
+ *     socket.connect()
+ * ```
+ *
+ * The `Socket` constructor takes the mount point of the socket,
+ * the authentication params, as well as options that can be found in
+ * the Socket docs, such as configuring the `LongPoll` transport, and
+ * heartbeat.
+ *
+ * ## Channels
+ *
+ * Channels are isolated, concurrent processes on the server that
+ * subscribe to topics and broker events between the client and server.
+ * To join a channel, you must provide the topic, and channel params for
+ * authorization. Here's an example chat room example where `"new_msg"`
+ * events are listened for, messages are pushed to the server, and
+ * the channel is joined with ok/error/timeout matches:
+ *
+ * ```javascript
+ *     let channel = socket.channel("room:123", {token: roomToken})
+ *     channel.on("new_msg", msg => console.log("Got message", msg) )
+ *     $input.onEnter( e => {
+ *       channel.push("new_msg", {body: e.target.val}, 10000)
+ *        .receive("ok", (msg) => console.log("created message", msg) )
+ *        .receive("error", (reasons) => console.log("create failed", reasons) )
+ *        .receive("timeout", () => console.log("Networking issue...") )
+ *     })
+ *     channel.join()
+ *       .receive("ok", ({messages}) => console.log("catching up", messages) )
+ *       .receive("error", ({reason}) => console.log("failed join", reason) )
+ *       .receive("timeout", () => console.log("Networking issue. Still waiting...") )
+ *```
+ *
+ * ## Joining
+ *
+ * Creating a channel with `socket.channel(topic, params)`, binds the params to
+ * `channel.params`, which are sent up on `channel.join()`.
+ * Subsequent rejoins will send up the modified params for
+ * updating authorization params, or passing up last_message_id information.
+ * Successful joins receive an "ok" status, while unsuccessful joins
+ * receive "error".
+ *
+ * ## Duplicate Join Subscriptions
+ *
+ * While the client may join any number of topics on any number of channels,
+ * the client may only hold a single subscription for each unique topic at any
+ * given time. When attempting to create a duplicate subscription,
+ * the server will close the existing channel, log a warning, and
+ * spawn a new channel for the topic. The client will have their
+ * `channel.onClose` callbacks fired for the existing channel, and the new
+ * channel join will have its receive hooks processed as normal.
+ *
+ * ## Pushing Messages
+ *
+ * From the previous example, we can see that pushing messages to the server
+ * can be done with `channel.push(eventName, payload)` and we can optionally
+ * receive responses from the push. Additionally, we can use
+ * `receive("timeout", callback)` to abort waiting for our other `receive` hooks
+ *  and take action after some period of waiting. The default timeout is 5000ms.
+ *
+ *
+ * ## Socket Hooks
+ *
+ * Lifecycle events of the multiplexed connection can be hooked into via
+ * `socket.onError()` and `socket.onClose()` events, ie:
+ *
+ * ```javascript
+ *     socket.onError( () => console.log("there was an error with the connection!") )
+ *     socket.onClose( () => console.log("the connection dropped") )
+ * ```
+ *
+ *
+ * ## Channel Hooks
+ *
+ * For each joined channel, you can bind to `onError` and `onClose` events
+ * to monitor the channel lifecycle, ie:
+ *
+ * ```javascript
+ *     channel.onError( () => console.log("there was an error!") )
+ *     channel.onClose( () => console.log("the channel has gone away gracefully") )
+ * ```
+ *
+ * ### onError hooks
+ *
+ * `onError` hooks are invoked if the socket connection drops, or the channel
+ * crashes on the server. In either case, a channel rejoin is attempted
+ * automatically in an exponential backoff manner.
+ *
+ * ### onClose hooks
+ *
+ * `onClose` hooks are invoked only in two cases. 1) the channel explicitly
+ * closed on the server, or 2). The client explicitly closed, by calling
+ * `channel.leave()`
+ *
+ *
+ * ## Presence
+ *
+ * The `Presence` object provides features for syncing presence information
+ * from the server with the client and handling presences joining and leaving.
+ *
+ * ### Syncing initial state from the server
+ *
+ * `Presence.syncState` is used to sync the list of presences on the server
+ * with the client's state. An optional `onJoin` and `onLeave` callback can
+ * be provided to react to changes in the client's local presences across
+ * disconnects and reconnects with the server.
+ *
+ * `Presence.syncDiff` is used to sync a diff of presence join and leave
+ * events from the server, as they happen. Like `syncState`, `syncDiff`
+ * accepts optional `onJoin` and `onLeave` callbacks to react to a user
+ * joining or leaving from a device.
+ *
+ * ### Listing Presences
+ *
+ * `Presence.list` is used to return a list of presence information
+ * based on the local state of metadata. By default, all presence
+ * metadata is returned, but a `listBy` function can be supplied to
+ * allow the client to select which metadata to use for a given presence.
+ * For example, you may have a user online from different devices with
+ * a metadata status of "online", but they have set themselves to "away"
+ * on another device. In this case, the app may choose to use the "away"
+ * status for what appears on the UI. The example below defines a `listBy`
+ * function which prioritizes the first metadata which was registered for
+ * each user. This could be the first tab they opened, or the first device
+ * they came online from:
+ *
+ * ```javascript
+ *     let state = {}
+ *     state = Presence.syncState(state, stateFromServer)
+ *     let listBy = (id, {metas: [first, ...rest]}) => {
+ *       first.count = rest.length + 1 // count of this user's presences
+ *       first.id = id
+ *       return first
+ *     }
+ *     let onlineUsers = Presence.list(state, listBy)
+ * ```
+ *
+ *
+ * ### Example Usage
+ *```javascript
+ *     // detect if user has joined for the 1st time or from another tab/device
+ *     let onJoin = (id, current, newPres) => {
+ *       if(!current){
+ *         console.log("user has entered for the first time", newPres)
+ *       } else {
+ *         console.log("user additional presence", newPres)
+ *       }
+ *     }
+ *     // detect if user has left from all tabs/devices, or is still present
+ *     let onLeave = (id, current, leftPres) => {
+ *       if(current.metas.length === 0){
+ *         console.log("user has left from all devices", leftPres)
+ *       } else {
+ *         console.log("user left from a device", leftPres)
+ *       }
+ *     }
+ *     let presences = {} // client's initial empty presence state
+ *     // receive initial presence data from server, sent after join
+ *     myChannel.on("presence_state", state => {
+ *       presences = Presence.syncState(presences, state, onJoin, onLeave)
+ *       displayUsers(Presence.list(presences))
+ *     })
+ *     // receive "presence_diff" from server, containing join/leave events
+ *     myChannel.on("presence_diff", diff => {
+ *       presences = Presence.syncDiff(presences, diff, onJoin, onLeave)
+ *       this.setState({users: Presence.list(room.presences, listBy)})
+ *     })
+ * ```
+ * @module phoenix
+ */
+
 const VSN = "1.0.0"
 const SOCKET_STATES = {connecting: 0, open: 1, closing: 2, closed: 3}
 const DEFAULT_TIMEOUT = 10000
@@ -189,15 +202,15 @@ const TRANSPORTS = {
   websocket: "websocket"
 }
 
+/**
+ * Initializes the Push
+ * @param {Channel} channel - The Channel
+ * @param {string} event - The event, for example `"phx_join"`
+ * @param {Object} payload - The payload, for example `{user_id: 123}`
+ * @param {number} timeout - The push timeout in milliseconds
+ */
 class Push {
 
-  // Initializes the Push
-  //
-  // channel - The Channel
-  // event - The event, for example `"phx_join"`
-  // payload - The payload, for example `{user_id: 123}`
-  // timeout - The push timeout in milliseconds
-  //
   constructor(channel, event, payload, timeout){
     this.channel      = channel
     this.event        = event
@@ -209,6 +222,10 @@ class Push {
     this.sent         = false
   }
 
+  /**
+   *
+   * @param {number} timeout
+   */
   resend(timeout){
     this.timeout = timeout
     this.cancelRefEvent()
@@ -219,6 +236,9 @@ class Push {
     this.send()
   }
 
+  /**
+   *
+   */
   send(){ if(this.hasReceived("timeout")){ return }
     this.startTimeout()
     this.sent = true
@@ -230,6 +250,11 @@ class Push {
     })
   }
 
+  /**
+   *
+   * @param {*} status
+   * @param {*} callback
+   */
   receive(status, callback){
     if(this.hasReceived(status)){
       callback(this.receivedResp.response)
@@ -281,6 +306,9 @@ class Push {
   }
 }
 
+/**
+ *
+ */
 export class Channel {
   constructor(topic, params, socket) {
     this.state       = CHANNEL_STATES.closed
@@ -367,18 +395,20 @@ export class Channel {
     return pushEvent
   }
 
-  // Leaves the channel
-  //
-  // Unsubscribes from server events, and
-  // instructs channel to terminate on server
-  //
-  // Triggers onClose() hooks
-  //
-  // To receive leave acknowledgements, use the a `receive`
-  // hook to bind to the server ack, ie:
-  //
-  //     channel.leave().receive("ok", () => alert("left!") )
-  //
+  /** Leaves the channel
+   *
+   * Unsubscribes from server events, and
+   * instructs channel to terminate on server
+   *
+   * Triggers onClose() hooks
+   *
+   * To receive leave acknowledgements, use the a `receive`
+   * hook to bind to the server ack, ie:
+   *
+   * ```javascript
+   *     channel.leave().receive("ok", () => alert("left!") )
+   * ```
+   */
   leave(timeout = this.timeout){
     this.state = CHANNEL_STATES.leaving
     let onClose = () => {
@@ -394,12 +424,14 @@ export class Channel {
     return leavePush
   }
 
-  // Overridable message hook
-  //
-  // Receives all events for specialized message handling
-  // before dispatching to the channel callbacks.
-  //
-  // Must return the payload, modified or unmodified
+  /**
+   * Overridable message hook
+   *
+   * Receives all events for specialized message handling
+   * before dispatching to the channel callbacks.
+   *
+   * Must return the payload, modified or unmodified
+   */
   onMessage(event, payload, ref){ return payload }
 
   // private
@@ -438,44 +470,62 @@ export class Channel {
   isLeaving(){ return this.state === CHANNEL_STATES.leaving }
 }
 
+  /** Initializes the Socket
+   *
+   *
+   * @param {string} endPoint - The string WebSocket endpoint, ie, `"ws://example.com/socket"`,
+   *                                               `"wss://example.com"`
+   *                                               `"/socket"` (inherited host & protocol)
+   * @param {Object} opts - Optional configuration
+   * @param {string} opts.transport - The Websocket Transport, for example WebSocket or Phoenix.LongPoll.
+   *
+   * Defaults to WebSocket with automatic LongPoll fallback.
+   * @param {Function} opts.encode - The function to encode outgoing messages.
+   *
+   * Defaults to JSON:
+   *
+   * ```javascript
+   * (payload, callback) => callback(JSON.stringify(payload))
+   * ```
+   *
+   * @param {Function} opts.decode - The function to decode incoming messages.
+   *
+   * Defaults to JSON:
+   *
+   * ```javascript
+   * (payload, callback) => callback(JSON.parse(payload))
+   * ```
+   *
+   * @param {number} opts.timeout - The default timeout in milliseconds to trigger push timeouts.
+   *
+   * Defaults `DEFAULT_TIMEOUT`
+   * @param {number} opts.heartbeatIntervalMs - The millisec interval to send a heartbeat message
+   * @param {number} opts.reconnectAfterMs - The optional function that returns the millsec reconnect interval.
+   *
+   * Defaults to stepped backoff of:
+   *
+   * ```javascript
+   *  function(tries){
+   *    return [1000, 5000, 10000][tries - 1] || 10000
+   *  }
+   * ```
+   * @param {Function} opts.logger - The optional function for specialized logging, ie:
+   * ```javascript
+   * logger: (kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }
+   * ```
+   *
+   * @param {number}  opts.longpollerTimeout - The maximum timeout of a long poll AJAX request.
+   *
+   * Defaults to 20s (double the server long poll timer).
+   *
+   * @param {Object}  opts.params - The optional params to pass when connecting
+   *
+   *
+   * For IE8 support use an ES5-shim (https://github.com/es-shims/es5-shim)
+  */
 export class Socket {
 
-  // Initializes the Socket
-  //
-  // endPoint - The string WebSocket endpoint, ie, "ws://example.com/socket",
-  //                                               "wss://example.com"
-  //                                               "/socket" (inherited host & protocol)
-  // opts - Optional configuration
-  //   transport - The Websocket Transport, for example WebSocket or Phoenix.LongPoll.
-  //               Defaults to WebSocket with automatic LongPoll fallback.
-  //   encode - The function to encode outgoing messages. Defaults to JSON:
-  //
-  //     (payload, callback) => callback(JSON.stringify(payload))
-  //
-  //   decode - The function to decode incoming messages. Defaults to JSON:
-  //
-  //     (payload, callback) => callback(JSON.parse(payload))
-  //
-  //   timeout - The default timeout in milliseconds to trigger push timeouts.
-  //             Defaults `DEFAULT_TIMEOUT`
-  //   heartbeatIntervalMs - The millisec interval to send a heartbeat message
-  //   reconnectAfterMs - The optional function that returns the millsec
-  //                      reconnect interval. Defaults to stepped backoff of:
-  //
-  //     function(tries){
-  //       return [1000, 5000, 10000][tries - 1] || 10000
-  //     }
-  //
-  //   logger - The optional function for specialized logging, ie:
-  //     `logger: (kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }
-  //
-  //   longpollerTimeout - The maximum timeout of a long poll AJAX request.
-  //                        Defaults to 20s (double the server long poll timer).
-  //
-  //   params - The optional params to pass when connecting
-  //
-  // For IE8 support use an ES5-shim (https://github.com/es-shims/es5-shim)
-  //
+
   constructor(endPoint, opts = {}){
     this.stateChangeCallbacks = {open: [], close: [], error: [], message: []}
     this.channels             = []
@@ -527,7 +577,10 @@ export class Socket {
     callback && callback()
   }
 
-  // params - The params to send when connecting, for example `{user_id: userToken}`
+  /**
+   *
+   * @param {Object} params - The params to send when connecting, for example `{user_id: userToken}`
+   */
   connect(params){
     if(params){
       console && console.log("passing params to connect is deprecated. Instead pass :params to the Socket constructor")
@@ -543,7 +596,12 @@ export class Socket {
     this.conn.onclose   = event => this.onConnClose(event)
   }
 
-  // Logs the message. Override `this.logger` for specialized logging. noops by default
+  /**
+   * Logs the message. Override `this.logger` for specialized logging. noops by default
+   * @param {*} kind
+   * @param {*} msg
+   * @param {*} data
+   */
   log(kind, msg, data){ this.logger(kind, msg, data) }
 
   // Registers callbacks for connection state change events
@@ -749,7 +807,6 @@ export class LongPoll {
   }
 }
 
-
 export class Ajax {
 
   static request(method, endPoint, accept, body, timeout, ontimeout, callback){
@@ -912,19 +969,25 @@ export var Presence = {
 }
 
 
-// Creates a timer that accepts a `timerCalc` function to perform
-// calculated timeout retries, such as exponential backoff.
-//
-// ## Examples
-//
-//    let reconnectTimer = new Timer(() => this.connect(), function(tries){
-//      return [1000, 5000, 10000][tries - 1] || 10000
-//    })
-//    reconnectTimer.scheduleTimeout() // fires after 1000
-//    reconnectTimer.scheduleTimeout() // fires after 5000
-//    reconnectTimer.reset()
-//    reconnectTimer.scheduleTimeout() // fires after 1000
-//
+/**
+ *
+ * Creates a timer that accepts a `timerCalc` function to perform
+ * calculated timeout retries, such as exponential backoff.
+ *
+ * ## Examples
+ *
+ * ```javascript
+ *    let reconnectTimer = new Timer(() => this.connect(), function(tries){
+ *      return [1000, 5000, 10000][tries - 1] || 10000
+ *    })
+ *    reconnectTimer.scheduleTimeout() // fires after 1000
+ *    reconnectTimer.scheduleTimeout() // fires after 5000
+ *    reconnectTimer.reset()
+ *    reconnectTimer.scheduleTimeout() // fires after 1000
+ * ```
+ * @param {Function} callback
+ * @param {Function} timerCalc
+ */
 class Timer {
   constructor(callback, timerCalc){
     this.callback  = callback
@@ -938,7 +1001,9 @@ class Timer {
     clearTimeout(this.timer)
   }
 
-  // Cancels any previous scheduleTimeout and schedules callback
+  /**
+   * Cancels any previous scheduleTimeout and schedules callback
+   */
   scheduleTimeout(){
     clearTimeout(this.timer)
 

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -308,6 +308,9 @@ class Push {
 
 /**
  *
+ * @param {string} topic
+ * @param {Object} params
+ * @param {Socket} socket
  */
 export class Channel {
   constructor(topic, params, socket) {
@@ -473,6 +476,8 @@ export class Channel {
   /** Initializes the Socket
    *
    *
+   * For IE8 support use an ES5-shim (https://github.com/es-shims/es5-shim)
+   *
    * @param {string} endPoint - The string WebSocket endpoint, ie, `"ws://example.com/socket"`,
    *                                               `"wss://example.com"`
    *                                               `"/socket"` (inherited host & protocol)
@@ -521,7 +526,6 @@ export class Channel {
    * @param {Object}  opts.params - The optional params to pass when connecting
    *
    *
-   * For IE8 support use an ES5-shim (https://github.com/es-shims/es5-shim)
   */
 export class Socket {
 
@@ -598,9 +602,9 @@ export class Socket {
 
   /**
    * Logs the message. Override `this.logger` for specialized logging. noops by default
-   * @param {*} kind
-   * @param {*} msg
-   * @param {*} data
+   * @param {string} kind
+   * @param {string} msg
+   * @param {Object} data
    */
   log(kind, msg, data){ this.logger(kind, msg, data) }
 
@@ -681,7 +685,9 @@ export class Socket {
     }
   }
 
-  // Return the next message ref, accounting for overflows
+  /**
+   * Return the next message ref, accounting for overflows
+   */
   makeRef(){
     let newRef = this.ref + 1
     if(newRef === this.ref){ this.ref = 0 } else { this.ref = newRef }

--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -10,7 +10,7 @@ defmodule Phoenix do
     * [Phoenix](https://hexdocs.pm/phoenix) - the Phoenix web framework
       (these docs)
 
-    * [Phoenix.js](/js) - Phoenix Channels JavaScript client
+    * [Phoenix.js](js) - Phoenix Channels JavaScript client
 
     * [Phoenix Pubsub](https://hexdocs.pm/phoenix_pubsub) - a distributed
       pubsub system with presence support

--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -10,6 +10,8 @@ defmodule Phoenix do
     * [Phoenix](https://hexdocs.pm/phoenix) - the Phoenix web framework
       (these docs)
 
+    * [Phoenix.js](/js) - Phoenix Channels JavaScript client
+
     * [Phoenix Pubsub](https://hexdocs.pm/phoenix_pubsub) - a distributed
       pubsub system with presence support
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule Phoenix.Mixfile do
             extra_section: "GUIDES",
             assets: "deps/phoenix_guides/images",
             extras: extras()],
+     aliases: aliases(),
      source_url: "https://github.com/phoenixframework/phoenix",
      homepage_url: "http://www.phoenixframework.org",
      description: """
@@ -112,5 +113,17 @@ defmodule Phoenix.Mixfile do
      "bonus_guides/learning_elixir.md": [group: "Bonus Guides"],
      "bonus_guides/seeding_data.md": [group: "Bonus Guides"]]
     |> Enum.map(fn {file, opts} -> {:"deps/phoenix_guides/docs/#{file}", opts} end)
+  end
+
+  defp aliases do
+    [
+      generate_js_docs: &generate_js_docs/1,
+      "docs": ["docs", "generate_js_docs"]
+    ]
+  end
+
+  def generate_js_docs(_) do
+    Mix.Task.run "app.start"
+    System.cmd("npm", ["run", "docs"])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -117,8 +117,7 @@ defmodule Phoenix.Mixfile do
 
   defp aliases do
     [
-      generate_js_docs: &generate_js_docs/1,
-      "docs": ["docs", "generate_js_docs"]
+      "docs": ["docs", &generate_js_docs/1]
     ]
   end
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js", "assets/js/phoenix.js"],
   "scripts": {
     "test": "./node_modules/.bin/mocha ./assets/test/**/*.js --compilers js:babel-register -r jsdom-global/register",
-    "docs": "documentation build assets/js/phoenix.js -f html -o doc/phoenix.js"
+    "docs": "documentation build assets/js/phoenix.js -f html -o doc/js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "babel-brunch": "~6.0.0",
     "brunch": "~2.6.5",
+    "documentation": "^4.0.0-rc.1",
     "jsdom": "9.8.3",
     "jsdom-global": "2.1.0",
     "mocha": "~2.4.4",
@@ -21,6 +22,7 @@
   },
   "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js", "assets/js/phoenix.js"],
   "scripts": {
-    "test": "./node_modules/.bin/mocha ./assets/test/**/*.js --compilers js:babel-register -r jsdom-global/register"
+    "test": "./node_modules/.bin/mocha ./assets/test/**/*.js --compilers js:babel-register -r jsdom-global/register",
+    "docs": "documentation build assets/js/phoenix.js -f html -o doc/phoenix.js"
   }
 }

--- a/priv/static/phoenix.js
+++ b/priv/static/phoenix.js
@@ -17,174 +17,187 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-// Phoenix Channels JavaScript client
-//
-// ## Socket Connection
-//
-// A single connection is established to the server and
-// channels are multiplexed over the connection.
-// Connect to the server using the `Socket` class:
-//
-//     let socket = new Socket("/socket", {params: {userToken: "123"}})
-//     socket.connect()
-//
-// The `Socket` constructor takes the mount point of the socket,
-// the authentication params, as well as options that can be found in
-// the Socket docs, such as configuring the `LongPoll` transport, and
-// heartbeat.
-//
-// ## Channels
-//
-// Channels are isolated, concurrent processes on the server that
-// subscribe to topics and broker events between the client and server.
-// To join a channel, you must provide the topic, and channel params for
-// authorization. Here's an example chat room example where `"new_msg"`
-// events are listened for, messages are pushed to the server, and
-// the channel is joined with ok/error/timeout matches:
-//
-//     let channel = socket.channel("room:123", {token: roomToken})
-//     channel.on("new_msg", msg => console.log("Got message", msg) )
-//     $input.onEnter( e => {
-//       channel.push("new_msg", {body: e.target.val}, 10000)
-//        .receive("ok", (msg) => console.log("created message", msg) )
-//        .receive("error", (reasons) => console.log("create failed", reasons) )
-//        .receive("timeout", () => console.log("Networking issue...") )
-//     })
-//     channel.join()
-//       .receive("ok", ({messages}) => console.log("catching up", messages) )
-//       .receive("error", ({reason}) => console.log("failed join", reason) )
-//       .receive("timeout", () => console.log("Networking issue. Still waiting...") )
-//
-//
-// ## Joining
-//
-// Creating a channel with `socket.channel(topic, params)`, binds the params to
-// `channel.params`, which are sent up on `channel.join()`.
-// Subsequent rejoins will send up the modified params for
-// updating authorization params, or passing up last_message_id information.
-// Successful joins receive an "ok" status, while unsuccessful joins
-// receive "error".
-//
-// ## Duplicate Join Subscriptions
-//
-// While the client may join any number of topics on any number of channels,
-// the client may only hold a single subscription for each unique topic at any
-// given time. When attempting to create a duplicate subscription,
-// the server will close the existing channel, log a warning, and
-// spawn a new channel for the topic. The client will have their
-// `channel.onClose` callbacks fired for the existing channel, and the new
-// channel join will have its receive hooks processed as normal.
-//
-// ## Pushing Messages
-//
-// From the previous example, we can see that pushing messages to the server
-// can be done with `channel.push(eventName, payload)` and we can optionally
-// receive responses from the push. Additionally, we can use
-// `receive("timeout", callback)` to abort waiting for our other `receive` hooks
-//  and take action after some period of waiting. The default timeout is 5000ms.
-//
-//
-// ## Socket Hooks
-//
-// Lifecycle events of the multiplexed connection can be hooked into via
-// `socket.onError()` and `socket.onClose()` events, ie:
-//
-//     socket.onError( () => console.log("there was an error with the connection!") )
-//     socket.onClose( () => console.log("the connection dropped") )
-//
-//
-// ## Channel Hooks
-//
-// For each joined channel, you can bind to `onError` and `onClose` events
-// to monitor the channel lifecycle, ie:
-//
-//     channel.onError( () => console.log("there was an error!") )
-//     channel.onClose( () => console.log("the channel has gone away gracefully") )
-//
-// ### onError hooks
-//
-// `onError` hooks are invoked if the socket connection drops, or the channel
-// crashes on the server. In either case, a channel rejoin is attempted
-// automatically in an exponential backoff manner.
-//
-// ### onClose hooks
-//
-// `onClose` hooks are invoked only in two cases. 1) the channel explicitly
-// closed on the server, or 2). The client explicitly closed, by calling
-// `channel.leave()`
-//
-//
-// ## Presence
-//
-// The `Presence` object provides features for syncing presence information
-// from the server with the client and handling presences joining and leaving.
-//
-// ### Syncing initial state from the server
-//
-// `Presence.syncState` is used to sync the list of presences on the server
-// with the client's state. An optional `onJoin` and `onLeave` callback can
-// be provided to react to changes in the client's local presences across
-// disconnects and reconnects with the server.
-//
-// `Presence.syncDiff` is used to sync a diff of presence join and leave
-// events from the server, as they happen. Like `syncState`, `syncDiff`
-// accepts optional `onJoin` and `onLeave` callbacks to react to a user
-// joining or leaving from a device.
-//
-// ### Listing Presences
-//
-// `Presence.list` is used to return a list of presence information
-// based on the local state of metadata. By default, all presence
-// metadata is returned, but a `listBy` function can be supplied to
-// allow the client to select which metadata to use for a given presence.
-// For example, you may have a user online from different devices with
-// a metadata status of "online", but they have set themselves to "away"
-// on another device. In this case, the app may choose to use the "away"
-// status for what appears on the UI. The example below defines a `listBy`
-// function which prioritizes the first metadata which was registered for
-// each user. This could be the first tab they opened, or the first device
-// they came online from:
-//
-//     let state = {}
-//     state = Presence.syncState(state, stateFromServer)
-//     let listBy = (id, {metas: [first, ...rest]}) => {
-//       first.count = rest.length + 1 // count of this user's presences
-//       first.id = id
-//       return first
-//     }
-//     let onlineUsers = Presence.list(state, listBy)
-//
-//
-// ### Example Usage
-//
-//     // detect if user has joined for the 1st time or from another tab/device
-//     let onJoin = (id, current, newPres) => {
-//       if(!current){
-//         console.log("user has entered for the first time", newPres)
-//       } else {
-//         console.log("user additional presence", newPres)
-//       }
-//     }
-//     // detect if user has left from all tabs/devices, or is still present
-//     let onLeave = (id, current, leftPres) => {
-//       if(current.metas.length === 0){
-//         console.log("user has left from all devices", leftPres)
-//       } else {
-//         console.log("user left from a device", leftPres)
-//       }
-//     }
-//     let presences = {} // client's initial empty presence state
-//     // receive initial presence data from server, sent after join
-//     myChannel.on("presence_state", state => {
-//       presences = Presence.syncState(presences, state, onJoin, onLeave)
-//       displayUsers(Presence.list(presences))
-//     })
-//     // receive "presence_diff" from server, containing join/leave events
-//     myChannel.on("presence_diff", diff => {
-//       presences = Presence.syncDiff(presences, diff, onJoin, onLeave)
-//       this.setState({users: Presence.list(room.presences, listBy)})
-//     })
-//
+/**
+ * Phoenix Channels JavaScript client
+ *
+ * ## Socket Connection
+ *
+ * A single connection is established to the server and
+ * channels are multiplexed over the connection.
+ * Connect to the server using the `Socket` class:
+ *
+ * ```javascript
+ *     let socket = new Socket("/socket", {params: {userToken: "123"}})
+ *     socket.connect()
+ * ```
+ *
+ * The `Socket` constructor takes the mount point of the socket,
+ * the authentication params, as well as options that can be found in
+ * the Socket docs, such as configuring the `LongPoll` transport, and
+ * heartbeat.
+ *
+ * ## Channels
+ *
+ * Channels are isolated, concurrent processes on the server that
+ * subscribe to topics and broker events between the client and server.
+ * To join a channel, you must provide the topic, and channel params for
+ * authorization. Here's an example chat room example where `"new_msg"`
+ * events are listened for, messages are pushed to the server, and
+ * the channel is joined with ok/error/timeout matches:
+ *
+ * ```javascript
+ *     let channel = socket.channel("room:123", {token: roomToken})
+ *     channel.on("new_msg", msg => console.log("Got message", msg) )
+ *     $input.onEnter( e => {
+ *       channel.push("new_msg", {body: e.target.val}, 10000)
+ *        .receive("ok", (msg) => console.log("created message", msg) )
+ *        .receive("error", (reasons) => console.log("create failed", reasons) )
+ *        .receive("timeout", () => console.log("Networking issue...") )
+ *     })
+ *     channel.join()
+ *       .receive("ok", ({messages}) => console.log("catching up", messages) )
+ *       .receive("error", ({reason}) => console.log("failed join", reason) )
+ *       .receive("timeout", () => console.log("Networking issue. Still waiting...") )
+ *```
+ *
+ * ## Joining
+ *
+ * Creating a channel with `socket.channel(topic, params)`, binds the params to
+ * `channel.params`, which are sent up on `channel.join()`.
+ * Subsequent rejoins will send up the modified params for
+ * updating authorization params, or passing up last_message_id information.
+ * Successful joins receive an "ok" status, while unsuccessful joins
+ * receive "error".
+ *
+ * ## Duplicate Join Subscriptions
+ *
+ * While the client may join any number of topics on any number of channels,
+ * the client may only hold a single subscription for each unique topic at any
+ * given time. When attempting to create a duplicate subscription,
+ * the server will close the existing channel, log a warning, and
+ * spawn a new channel for the topic. The client will have their
+ * `channel.onClose` callbacks fired for the existing channel, and the new
+ * channel join will have its receive hooks processed as normal.
+ *
+ * ## Pushing Messages
+ *
+ * From the previous example, we can see that pushing messages to the server
+ * can be done with `channel.push(eventName, payload)` and we can optionally
+ * receive responses from the push. Additionally, we can use
+ * `receive("timeout", callback)` to abort waiting for our other `receive` hooks
+ *  and take action after some period of waiting. The default timeout is 5000ms.
+ *
+ *
+ * ## Socket Hooks
+ *
+ * Lifecycle events of the multiplexed connection can be hooked into via
+ * `socket.onError()` and `socket.onClose()` events, ie:
+ *
+ * ```javascript
+ *     socket.onError( () => console.log("there was an error with the connection!") )
+ *     socket.onClose( () => console.log("the connection dropped") )
+ * ```
+ *
+ *
+ * ## Channel Hooks
+ *
+ * For each joined channel, you can bind to `onError` and `onClose` events
+ * to monitor the channel lifecycle, ie:
+ *
+ * ```javascript
+ *     channel.onError( () => console.log("there was an error!") )
+ *     channel.onClose( () => console.log("the channel has gone away gracefully") )
+ * ```
+ *
+ * ### onError hooks
+ *
+ * `onError` hooks are invoked if the socket connection drops, or the channel
+ * crashes on the server. In either case, a channel rejoin is attempted
+ * automatically in an exponential backoff manner.
+ *
+ * ### onClose hooks
+ *
+ * `onClose` hooks are invoked only in two cases. 1) the channel explicitly
+ * closed on the server, or 2). The client explicitly closed, by calling
+ * `channel.leave()`
+ *
+ *
+ * ## Presence
+ *
+ * The `Presence` object provides features for syncing presence information
+ * from the server with the client and handling presences joining and leaving.
+ *
+ * ### Syncing initial state from the server
+ *
+ * `Presence.syncState` is used to sync the list of presences on the server
+ * with the client's state. An optional `onJoin` and `onLeave` callback can
+ * be provided to react to changes in the client's local presences across
+ * disconnects and reconnects with the server.
+ *
+ * `Presence.syncDiff` is used to sync a diff of presence join and leave
+ * events from the server, as they happen. Like `syncState`, `syncDiff`
+ * accepts optional `onJoin` and `onLeave` callbacks to react to a user
+ * joining or leaving from a device.
+ *
+ * ### Listing Presences
+ *
+ * `Presence.list` is used to return a list of presence information
+ * based on the local state of metadata. By default, all presence
+ * metadata is returned, but a `listBy` function can be supplied to
+ * allow the client to select which metadata to use for a given presence.
+ * For example, you may have a user online from different devices with
+ * a metadata status of "online", but they have set themselves to "away"
+ * on another device. In this case, the app may choose to use the "away"
+ * status for what appears on the UI. The example below defines a `listBy`
+ * function which prioritizes the first metadata which was registered for
+ * each user. This could be the first tab they opened, or the first device
+ * they came online from:
+ *
+ * ```javascript
+ *     let state = {}
+ *     state = Presence.syncState(state, stateFromServer)
+ *     let listBy = (id, {metas: [first, ...rest]}) => {
+ *       first.count = rest.length + 1 // count of this user's presences
+ *       first.id = id
+ *       return first
+ *     }
+ *     let onlineUsers = Presence.list(state, listBy)
+ * ```
+ *
+ *
+ * ### Example Usage
+ *```javascript
+ *     // detect if user has joined for the 1st time or from another tab/device
+ *     let onJoin = (id, current, newPres) => {
+ *       if(!current){
+ *         console.log("user has entered for the first time", newPres)
+ *       } else {
+ *         console.log("user additional presence", newPres)
+ *       }
+ *     }
+ *     // detect if user has left from all tabs/devices, or is still present
+ *     let onLeave = (id, current, leftPres) => {
+ *       if(current.metas.length === 0){
+ *         console.log("user has left from all devices", leftPres)
+ *       } else {
+ *         console.log("user left from a device", leftPres)
+ *       }
+ *     }
+ *     let presences = {} // client's initial empty presence state
+ *     // receive initial presence data from server, sent after join
+ *     myChannel.on("presence_state", state => {
+ *       presences = Presence.syncState(presences, state, onJoin, onLeave)
+ *       displayUsers(Presence.list(presences))
+ *     })
+ *     // receive "presence_diff" from server, containing join/leave events
+ *     myChannel.on("presence_diff", diff => {
+ *       presences = Presence.syncDiff(presences, diff, onJoin, onLeave)
+ *       this.setState({users: Presence.list(room.presences, listBy)})
+ *     })
+ * ```
+ * @module phoenix
+ */
+
 var VSN = "1.0.0";
 var SOCKET_STATES = { connecting: 0, open: 1, closing: 2, closed: 3 };
 var DEFAULT_TIMEOUT = 10000;
@@ -208,15 +221,15 @@ var TRANSPORTS = {
   websocket: "websocket"
 };
 
-var Push = function () {
+/**
+ * Initializes the Push
+ * @param {Channel} channel - The Channel
+ * @param {string} event - The event, for example `"phx_join"`
+ * @param {Object} payload - The payload, for example `{user_id: 123}`
+ * @param {number} timeout - The push timeout in milliseconds
+ */
 
-  // Initializes the Push
-  //
-  // channel - The Channel
-  // event - The event, for example `"phx_join"`
-  // payload - The payload, for example `{user_id: 123}`
-  // timeout - The push timeout in milliseconds
-  //
+var Push = function () {
   function Push(channel, event, payload, timeout) {
     _classCallCheck(this, Push);
 
@@ -230,6 +243,12 @@ var Push = function () {
     this.sent = false;
   }
 
+  /**
+   *
+   * @param {number} timeout
+   */
+
+
   _createClass(Push, [{
     key: "resend",
     value: function resend(timeout) {
@@ -241,6 +260,11 @@ var Push = function () {
       this.sent = false;
       this.send();
     }
+
+    /**
+     *
+     */
+
   }, {
     key: "send",
     value: function send() {
@@ -256,6 +280,13 @@ var Push = function () {
         ref: this.ref
       });
     }
+
+    /**
+     *
+     * @param {*} status
+     * @param {*} callback
+     */
+
   }, {
     key: "receive",
     value: function receive(status, callback) {
@@ -332,6 +363,11 @@ var Push = function () {
 
   return Push;
 }();
+
+/**
+ *
+ */
+
 
 var Channel = exports.Channel = function () {
   function Channel(topic, params, socket) {
@@ -455,18 +491,20 @@ var Channel = exports.Channel = function () {
       return pushEvent;
     }
 
-    // Leaves the channel
-    //
-    // Unsubscribes from server events, and
-    // instructs channel to terminate on server
-    //
-    // Triggers onClose() hooks
-    //
-    // To receive leave acknowledgements, use the a `receive`
-    // hook to bind to the server ack, ie:
-    //
-    //     channel.leave().receive("ok", () => alert("left!") )
-    //
+    /** Leaves the channel
+     *
+     * Unsubscribes from server events, and
+     * instructs channel to terminate on server
+     *
+     * Triggers onClose() hooks
+     *
+     * To receive leave acknowledgements, use the a `receive`
+     * hook to bind to the server ack, ie:
+     *
+     * ```javascript
+     *     channel.leave().receive("ok", () => alert("left!") )
+     * ```
+     */
 
   }, {
     key: "leave",
@@ -494,12 +532,14 @@ var Channel = exports.Channel = function () {
       return leavePush;
     }
 
-    // Overridable message hook
-    //
-    // Receives all events for specialized message handling
-    // before dispatching to the channel callbacks.
-    //
-    // Must return the payload, modified or unmodified
+    /**
+     * Overridable message hook
+     *
+     * Receives all events for specialized message handling
+     * before dispatching to the channel callbacks.
+     *
+     * Must return the payload, modified or unmodified
+     */
 
   }, {
     key: "onMessage",
@@ -591,44 +631,62 @@ var Channel = exports.Channel = function () {
   return Channel;
 }();
 
-var Socket = exports.Socket = function () {
+/** Initializes the Socket
+ *
+ *
+ * @param {string} endPoint - The string WebSocket endpoint, ie, `"ws://example.com/socket"`,
+ *                                               `"wss://example.com"`
+ *                                               `"/socket"` (inherited host & protocol)
+ * @param {Object} opts - Optional configuration
+ * @param {string} opts.transport - The Websocket Transport, for example WebSocket or Phoenix.LongPoll.
+ *
+ * Defaults to WebSocket with automatic LongPoll fallback.
+ * @param {Function} opts.encode - The function to encode outgoing messages.
+ *
+ * Defaults to JSON:
+ *
+ * ```javascript
+ * (payload, callback) => callback(JSON.stringify(payload))
+ * ```
+ *
+ * @param {Function} opts.decode - The function to decode incoming messages.
+ *
+ * Defaults to JSON:
+ *
+ * ```javascript
+ * (payload, callback) => callback(JSON.parse(payload))
+ * ```
+ *
+ * @param {number} opts.timeout - The default timeout in milliseconds to trigger push timeouts.
+ *
+ * Defaults `DEFAULT_TIMEOUT`
+ * @param {number} opts.heartbeatIntervalMs - The millisec interval to send a heartbeat message
+ * @param {number} opts.reconnectAfterMs - The optional function that returns the millsec reconnect interval.
+ *
+ * Defaults to stepped backoff of:
+ *
+ * ```javascript
+ *  function(tries){
+ *    return [1000, 5000, 10000][tries - 1] || 10000
+ *  }
+ * ```
+ * @param {Function} opts.logger - The optional function for specialized logging, ie:
+ * ```javascript
+ * logger: (kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }
+ * ```
+ *
+ * @param {number}  opts.longpollerTimeout - The maximum timeout of a long poll AJAX request.
+ *
+ * Defaults to 20s (double the server long poll timer).
+ *
+ * @param {Object}  opts.params - The optional params to pass when connecting
+ *
+ *
+ * For IE8 support use an ES5-shim (https://github.com/es-shims/es5-shim)
+*/
 
-  // Initializes the Socket
-  //
-  // endPoint - The string WebSocket endpoint, ie, "ws://example.com/socket",
-  //                                               "wss://example.com"
-  //                                               "/socket" (inherited host & protocol)
-  // opts - Optional configuration
-  //   transport - The Websocket Transport, for example WebSocket or Phoenix.LongPoll.
-  //               Defaults to WebSocket with automatic LongPoll fallback.
-  //   encode - The function to encode outgoing messages. Defaults to JSON:
-  //
-  //     (payload, callback) => callback(JSON.stringify(payload))
-  //
-  //   decode - The function to decode incoming messages. Defaults to JSON:
-  //
-  //     (payload, callback) => callback(JSON.parse(payload))
-  //
-  //   timeout - The default timeout in milliseconds to trigger push timeouts.
-  //             Defaults `DEFAULT_TIMEOUT`
-  //   heartbeatIntervalMs - The millisec interval to send a heartbeat message
-  //   reconnectAfterMs - The optional function that returns the millsec
-  //                      reconnect interval. Defaults to stepped backoff of:
-  //
-  //     function(tries){
-  //       return [1000, 5000, 10000][tries - 1] || 10000
-  //     }
-  //
-  //   logger - The optional function for specialized logging, ie:
-  //     `logger: (kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }
-  //
-  //   longpollerTimeout - The maximum timeout of a long poll AJAX request.
-  //                        Defaults to 20s (double the server long poll timer).
-  //
-  //   params - The optional params to pass when connecting
-  //
-  // For IE8 support use an ES5-shim (https://github.com/es-shims/es5-shim)
-  //
+
+var Socket = exports.Socket = function () {
   function Socket(endPoint) {
     var _this4 = this;
 
@@ -705,7 +763,10 @@ var Socket = exports.Socket = function () {
       callback && callback();
     }
 
-    // params - The params to send when connecting, for example `{user_id: userToken}`
+    /**
+     *
+     * @param {Object} params - The params to send when connecting, for example `{user_id: userToken}`
+     */
 
   }, {
     key: "connect",
@@ -736,7 +797,12 @@ var Socket = exports.Socket = function () {
       };
     }
 
-    // Logs the message. Override `this.logger` for specialized logging. noops by default
+    /**
+     * Logs the message. Override `this.logger` for specialized logging. noops by default
+     * @param {*} kind
+     * @param {*} msg
+     * @param {*} data
+     */
 
   }, {
     key: "log",
@@ -1267,19 +1333,25 @@ var Presence = exports.Presence = {
   }
 };
 
-// Creates a timer that accepts a `timerCalc` function to perform
-// calculated timeout retries, such as exponential backoff.
-//
-// ## Examples
-//
-//    let reconnectTimer = new Timer(() => this.connect(), function(tries){
-//      return [1000, 5000, 10000][tries - 1] || 10000
-//    })
-//    reconnectTimer.scheduleTimeout() // fires after 1000
-//    reconnectTimer.scheduleTimeout() // fires after 5000
-//    reconnectTimer.reset()
-//    reconnectTimer.scheduleTimeout() // fires after 1000
-//
+/**
+ *
+ * Creates a timer that accepts a `timerCalc` function to perform
+ * calculated timeout retries, such as exponential backoff.
+ *
+ * ## Examples
+ *
+ * ```javascript
+ *    let reconnectTimer = new Timer(() => this.connect(), function(tries){
+ *      return [1000, 5000, 10000][tries - 1] || 10000
+ *    })
+ *    reconnectTimer.scheduleTimeout() // fires after 1000
+ *    reconnectTimer.scheduleTimeout() // fires after 5000
+ *    reconnectTimer.reset()
+ *    reconnectTimer.scheduleTimeout() // fires after 1000
+ * ```
+ * @param {Function} callback
+ * @param {Function} timerCalc
+ */
 
 var Timer = function () {
   function Timer(callback, timerCalc) {
@@ -1298,7 +1370,9 @@ var Timer = function () {
       clearTimeout(this.timer);
     }
 
-    // Cancels any previous scheduleTimeout and schedules callback
+    /**
+     * Cancels any previous scheduleTimeout and schedules callback
+     */
 
   }, {
     key: "scheduleTimeout",


### PR DESCRIPTION
connects to #2331  

This PR does the following:

* Updates the comments in `assets/js/phoenix.js` to JSDoc format
* Adds `documentation` as a dev dependency in package.json
* Adds  an npm script `docs` to generate docs into the `doc/phoenix.js` folder

When generated, the docs look like below
<img width="1119" alt="screen shot 2017-05-30 at 6 00 14 pm" src="https://cloud.githubusercontent.com/assets/1257573/26608887/95c66dc2-4563-11e7-8f37-75ec3ee434b9.png">


I did also try outputting the docs as markdown and including them as an extra for Phoenix's docs and while it did work, it was a bit jumbled I think. Here is a screen shot of that

<img width="877" alt="screen shot 2017-05-30 at 5 59 53 pm" src="https://cloud.githubusercontent.com/assets/1257573/26608922/ca63fba8-4563-11e7-800f-575f4f935af0.png">

