### PR TITLE
Update instructions for token authentication in comments

### DIFF
--- a/installer/templates/static/brunch/socket.js
+++ b/installer/templates/static/brunch/socket.js
@@ -48,8 +48,9 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 //       end
 //     end
 //
-// Finally, pass the token on connect as below. Or remove it
-// from connect if you don't care about authentication.
+// Finally, pass the token to the Socket constructor as above.
+// Or, remove it from the constructor if you don't care about
+// authentication.
 
 socket.connect()
 


### PR DESCRIPTION
The instructions currently refer to the old way to passing passing
parameters on `socket.connect`. If followed, this results in a
warning message in the JS console that "passing params to connect is
deprecated. Instead pass :params to the Socket constructor", see
[`phoenix.js L533`](https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js#L533).

This confused me as I was reading through this, so I've created an
update that points to the correct location for passing the token.