### PR TITLE
Replace 'umbrella application(s)' with 'umbrella project(s)'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 See these [`1.2.x` to `1.3.x` upgrade instructions](https://gist.github.com/chrismccord/71ab10d433c98b714b75c886eff17357) to bring your existing apps up to speed.
 
 * Enhancements
-  * [Generator] Add new `phx.new`, `phx.new.web`, `phx.new.ecto` project generators with improved application structure and support for umbrella applications
+  * [Generator] Add new `phx.new`, `phx.new.web`, `phx.new.ecto` project generators with improved application structure and support for umbrella projects
   * [Generator] Add new `phx.gen.html` and `phx.gen.json` resource generators with improved isolation of API boundaries
   * [Controller] Add `current_path` and `current_url` to generate a connection's path and url
   * [Controller] Introduce `action_fallback` to registers a plug to call as a fallback to the controller action

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -12,7 +12,7 @@ defmodule Mix.Tasks.Phx.New do
 
   ## Options
 
-    * `--umbrella` - generate an umbrella application,
+    * `--umbrella` - generate an umbrella project,
       with one application for your domain, and
       a second application for the web interface.
 

--- a/installer/lib/mix/tasks/phx.new.web.ex
+++ b/installer/lib/mix/tasks/phx.new.web.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Phx.New.Web do
   Creates a new Phoenix web project within an umbrella project.
 
   It expects the name of the otp app as the first argument and
-  for the command to be run inside your umbrella application's
+  for the command to be run inside your umbrella project
   apps directory:
 
       $ cd my_umbrella/apps
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.Phx.New.Web do
 
   This task is inteded to create a bare Phoenix project without
   database integration, which interfaces with your greater
-  umbrella application(s).
+  umbrella project(s).
 
   ## Examples
 

--- a/installer/test/phx_new_ecto_test.exs
+++ b/installer/test/phx_new_ecto_test.exs
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Phx.New.EctoTest do
   test "new without args" do
     in_tmp_umbrella_project "new without args", fn ->
       assert capture_io(fn -> Mix.Tasks.Phx.New.Ecto.run([]) end) =~
-             "Creates a new Ecto project within an umbrella application."
+             "Creates a new Ecto project within an umbrella project."
     end
   end
 

--- a/installer/test/phx_new_web_test.exs
+++ b/installer/test/phx_new_web_test.exs
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Phx.New.WebTest do
   test "new without args" do
     in_tmp_umbrella_project "new without args", fn ->
       assert capture_io(fn -> Mix.Tasks.Phx.New.Web.run([]) end) =~
-             "Creates a new Phoenix web project within an umbrella application."
+             "Creates a new Phoenix web project within an umbrella project."
     end
   end
 

--- a/lib/mix/tasks/phx.gen.channel.ex
+++ b/lib/mix/tasks/phx.gen.channel.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
     * a channel in lib/my_app/web/channels
     * a channel_test in test/my_app/web/channels
 
-  For an umbrella application:
+  For an umbrella project:
 
     * a channel in lib/my_app/channels
     * a channel_test in test/my_app/channels

--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   controller features will also be generated.
 
   The location of the web files (controllers, views, templates, etc) in an
-  umbrella application will vary based on the `:context_app` config located
+  umbrella project will vary based on the `:context_app` config located
   in your applications `:generators` configuration. When set, the Phoenix
   generators will generate web files directly in your lib and test folders
   since the application is assumed to be isolated to web specific functionality.

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
   controller features will also be generated.
 
   The location of the web files (controllers, views, templates, etc) in an
-  umbrella application will vary based on the `:context_app` config located
+  umbrella project will vary based on the `:context_app` config located
   in your applications `:generators` configuration. When set, the Phoenix
   generators will generate web files directly in your lib and test folders
   since the application is assumed to be isolated to web specific functionality.

--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Phx.Routes do
 
   defp router(nil, base) do
     if Mix.Project.umbrella?() do
-      Mix.raise "umbrella applications require an explicit router to be given to phx.routes"
+      Mix.raise "umbrella projects require an explicit router to be given to phx.routes"
     end
     web_router = app_mod(base, "Web.Router")
     old_router = app_mod(base, "Router")


### PR DESCRIPTION
Sometimes it's called `umbrella application`, sometimes `umbrella project`.

IMHO, it doesn't really matter how its called, but it also makes sense to call umbrellas as projects, cause it feels natural for a project to have multiple apps, docs, marketing department other sub-projects.

However, the main purpose of this PR is to avoid such fails ;)

https://travis-ci.org/phoenixframework/phoenix/jobs/237944489#L344
