### PR TITLE
Update docs for action_fallback

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -189,7 +189,7 @@ defmodule Phoenix.Controller do
         action_fallback MyFallbackController
 
         def show(conn, %{"id" => id}, current_user) do
-          with {:ok, post} <- Blog.fetch_post(post),
+          with {:ok, post} <- Blog.fetch_post(id),
                :ok <- Authorizer.authorize(current_user, :view, post) do
 
             render(conn, "show.json", post: post)

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -200,7 +200,7 @@ defmodule Phoenix.Controller do
   In the above example, `with` is used to match only a successful
   post fetch, followed by valid authorization for the current user.
   In the event either of those fail to match, `with` will not invoke
-  the render block and instead returned the unmatched value. In this case,
+  the render block and instead return the unmatched value. In this case,
   imagine `Blog.fetch_post/2` returned `{:error, :not_found}` or
   `Authorizer.authorize/3` returned `{:error, :unauthorized}`. For cases
   where these datastructures serve as return values across multiple


### PR DESCRIPTION
Correct the doc example for `action_fallback`, by fetching the post with the correct param, id.