### PR TITLE
No need to install brunch globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ To create projects outside of the `installer/` directory, add the latest archive
 
 ```bash
 $ npm install
-$ npm install -g brunch
-$ brunch watch
+$ npm run watch
 ```
 
 ### Building docs from source

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "files": ["README.md", "LICENSE.md", "package.json", "priv/static/phoenix.js", "assets/js/phoenix.js"],
   "scripts": {
     "test": "./node_modules/.bin/mocha ./assets/test/**/*.js --compilers js:babel-register -r jsdom-global/register",
-    "docs": "documentation build assets/js/phoenix.js -f html -o doc/js"
+    "docs": "documentation build assets/js/phoenix.js -f html -o doc/js",
+    "watch": "brunch watch",
+    "build": "brunch build"
   }
 }


### PR DESCRIPTION
A global installation of brunch is not required as it can be executed using *npm scripts*. 
It also prevents any potential problems when there is a mismatch between the local version of brunch and the globally installed one.
I added two scripts for the most common tasks `watch` and `build`.

Let me know if I'm missing something.