### PR TITLE
Prevent non-atoms being used as plugs

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -462,6 +462,11 @@ defmodule Phoenix.Router do
   See `pipeline/2` for more information.
   """
   defmacro plug(plug, opts \\ []) do
+    if not is_atom(plug) do
+      raise ArgumentError, "the plug must expects an atom (for example `:fetch_session`) " <>
+        "or a module (for example `Plug.Logger`). Got #{Macro.to_string(plug)}"
+    end
+
     quote do
       if pipeline = @phoenix_pipeline do
         @phoenix_pipeline [{unquote(plug), unquote(opts), true}|pipeline]

--- a/test/phoenix/router/pipeline_test.exs
+++ b/test/phoenix/router/pipeline_test.exs
@@ -134,4 +134,18 @@ defmodule Phoenix.Router.PipelineTest do
     conn = call(Router, :get, "/browser/hello")
     assert conn.assigns[:params] == %{"id" => "hello"}
   end
+
+  test "pipeline with a non-atom plug raises" do
+    assert_raise(ArgumentError, fn ->
+      Code.eval_string("""
+        defmodule Phoenix.Router.PipelineTest.RouterWithException do
+          use Phoenix.Router
+          pipeline :browser do
+            plug SampleController.noop_plug
+          end
+        end
+      """)
+    end)
+  end
+
 end


### PR DESCRIPTION
When a non-atom is passed to the `plug` macro, an error is raised at
compile time.

This is base on https://github.com/phoenixframework/phoenix_guides/issues/696#issuecomment-309361956

This does however, eliminate a valid use case:

```elixir
defmodule TestPlug do
  defmacro foo, do: :fetch_session
end
```

Is there a way to determine if an AST is a macro? @josevalim If you want this, I can also port it to `Plug.Builder`
