### PR TITLE
Add multi flash message support

### DIFF
--- a/installer/templates/new/web/templates/layout/app.html.eex
+++ b/installer/templates/new/web/templates/layout/app.html.eex
@@ -22,8 +22,9 @@
         <span class="logo"></span>
       </header>
 
-      <p class="alert alert-info" role="alert"><%%= get_flash(@conn, :info) %></p>
-      <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
+			<%= for {type, text} <- get_flash(@conn) do %>
+				<p class="alert alert-<%= "#{type}" %>" role="alert"><%= text %></p>
+			<% end %>
 
       <main role="main">
         <%%= render @view_module, @view_template, assigns %>

--- a/installer/templates/new/web/web.ex
+++ b/installer/templates/new/web/web.ex
@@ -53,7 +53,7 @@ defmodule <%= app_module %>.Web do
       use Phoenix.View, root: "web/templates"<%= if namespaced? do %>, namespace: <%= app_module %><% end %>
 
       # Import convenience functions from controllers
-      import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, view_module: 1]<%= if html do %>
+      import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, get_flash: 1, view_module: 1]<%= if html do %>
 
       # Use all HTML functionality (forms, tags, etc)
       use Phoenix.HTML<% end %>


### PR DESCRIPTION
When generating a new project some hard coded `get_flash` calls get inserted into the layout template. This results is some manual labor for the developer to add missing flash messages.

Adding `get_flash/1` inside the the view module and looping inside the template can generate multiple alerts without hardcoding.

```
       # controller
	def contact(conn, _params) do
		conn
		|> put_flash(:success, "Hello Phoenix!")
		|> put_flash(:info, "Hello Phoenix!")
		|> render("contact.html")
	end
```

<img width="1440" alt="screen shot 2017-06-22 at 8 46 07 am" src="https://user-images.githubusercontent.com/6651506/27420681-51918b8e-5727-11e7-9bf0-9c19b04b7116.png">

Note: I'm having issues finding the failing test. If anyone could point me into the right direction

