### PR TITLE
Use log_join flag in Phoenix.Socket.Transport

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -268,11 +268,11 @@ defmodule Phoenix.Socket.Transport do
 
         case Phoenix.Channel.Server.join(socket, msg.payload) do
           {:ok, response, pid} ->
-            log_info topic, fn -> "Replied #{topic} :ok" end
+            log socket, topic, fn -> "Replied #{topic} :ok" end
             {:joined, pid, %Reply{join_ref: socket.join_ref, ref: msg.ref, topic: topic, status: :ok, payload: response}}
 
           {:error, reason} ->
-            log_info topic, fn -> "Replied #{topic} :error" end
+            log socket, topic, fn -> "Replied #{topic} :error" end
             {:error, reason, %Reply{join_ref: socket.join_ref, ref: msg.ref, topic: topic, status: :error, payload: reason}}
         end
 
@@ -296,8 +296,10 @@ defmodule Phoenix.Socket.Transport do
     :noreply
   end
 
-  defp log_info("phoenix" <> _, _func), do: :noop
-  defp log_info(_topic, func), do: Logger.info(func)
+  defp log(_, "phoenix" <> _, _func), do: :noop
+  defp log(%{ private: %{ log_join: false } }, _topic, _func), do: :noop
+  defp log(%{ private: %{ log_join: level } }, _topic, func), do: Logger.log(level, func)
+  defp log(_, _topic, func), do: Logger.info(func)
 
   defp reply_ignore(msg, socket) do
     Logger.warn fn -> "Ignoring unmatched topic \"#{msg.topic}\" in #{inspect(socket.handler)}" end

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -299,7 +299,6 @@ defmodule Phoenix.Socket.Transport do
   defp log(_, "phoenix" <> _, _func), do: :noop
   defp log(%{ private: %{ log_join: false } }, _topic, _func), do: :noop
   defp log(%{ private: %{ log_join: level } }, _topic, func), do: Logger.log(level, func)
-  defp log(_, _topic, func), do: Logger.info(func)
 
   defp reply_ignore(msg, socket) do
     Logger.warn fn -> "Ignoring unmatched topic \"#{msg.topic}\" in #{inspect(socket.handler)}" end


### PR DESCRIPTION
As mentioned in #2365 `Phoenix.Socket.Transport` doesn't use the flag for configuring logging. This is pretty spammy since it logs every time a channel is joined :-)

This PR changes this so the flag is checked whenever `Phoenix.Socket.Transport` would previously log as info.