### PR TITLE
Use describe for generated controller tests

### DIFF
--- a/priv/templates/phx.gen.html/controller_test.exs
+++ b/priv/templates/phx.gen.html/controller_test.exs
@@ -12,59 +12,78 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     <%= schema.singular %>
   end
 
-  test "lists all entries on index", %{conn: conn} do
-    conn = get conn, <%= schema.route_helper %>_path(conn, :index)
-    assert html_response(conn, 200) =~ "Listing <%= schema.human_plural %>"
-  end
-
-  test "renders form for new <%= schema.plural %>", %{conn: conn} do
-    conn = get conn, <%= schema.route_helper %>_path(conn, :new)
-    assert html_response(conn, 200) =~ "New <%= schema.human_singular %>"
-  end
-
-  test "creates <%= schema.singular %> and redirects to show when data is valid", %{conn: conn} do
-    conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @create_attrs
-
-    assert %{id: id} = redirected_params(conn)
-    assert redirected_to(conn) == <%= schema.route_helper %>_path(conn, :show, id)
-
-    conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
-    assert html_response(conn, 200) =~ "Show <%= schema.human_singular %>"
-  end
-
-  test "does not create <%= schema.singular %> and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @invalid_attrs
-    assert html_response(conn, 200) =~ "New <%= schema.human_singular %>"
-  end
-
-  test "renders form for editing chosen <%= schema.singular %>", %{conn: conn} do
-    <%= schema.singular %> = fixture(:<%= schema.singular %>)
-    conn = get conn, <%= schema.route_helper %>_path(conn, :edit, <%= schema.singular %>)
-    assert html_response(conn, 200) =~ "Edit <%= schema.human_singular %>"
-  end
-
-  test "updates chosen <%= schema.singular %> and redirects when data is valid", %{conn: conn} do
-    <%= schema.singular %> = fixture(:<%= schema.singular %>)
-    conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @update_attrs
-    assert redirected_to(conn) == <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)
-
-    conn = get conn, <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)<%= if schema.string_attr do %>
-    assert html_response(conn, 200) =~ <%= inspect Mix.Phoenix.Schema.default_param(schema, :update) %><% else %>
-    assert html_response(conn, 200)<% end %>
-  end
-
-  test "does not update chosen <%= schema.singular %> and renders errors when data is invalid", %{conn: conn} do
-    <%= schema.singular %> = fixture(:<%= schema.singular %>)
-    conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @invalid_attrs
-    assert html_response(conn, 200) =~ "Edit <%= schema.human_singular %>"
-  end
-
-  test "deletes chosen <%= schema.singular %>", %{conn: conn} do
-    <%= schema.singular %> = fixture(:<%= schema.singular %>)
-    conn = delete conn, <%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>)
-    assert redirected_to(conn) == <%= schema.route_helper %>_path(conn, :index)
-    assert_error_sent 404, fn ->
-      get conn, <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)
+  describe "index" do
+    test "lists all <%= schema.plural %>", %{conn: conn} do
+      conn = get conn, <%= schema.route_helper %>_path(conn, :index)
+      assert html_response(conn, 200) =~ "Listing <%= schema.human_plural %>"
     end
+  end
+
+  describe "new <%= schema.singular %>" do
+    test "renders form", %{conn: conn} do
+      conn = get conn, <%= schema.route_helper %>_path(conn, :new)
+      assert html_response(conn, 200) =~ "New <%= schema.human_singular %>"
+    end
+  end
+
+  describe "create <%= schema.singular %>" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @create_attrs
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == <%= schema.route_helper %>_path(conn, :show, id)
+
+      conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
+      assert html_response(conn, 200) =~ "Show <%= schema.human_singular %>"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @invalid_attrs
+      assert html_response(conn, 200) =~ "New <%= schema.human_singular %>"
+    end
+  end
+
+  describe "edit <%= schema.singular %>" do
+    setup [:create_<%= schema.singular %>]
+
+    test "renders form for editing chosen <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      conn = get conn, <%= schema.route_helper %>_path(conn, :edit, <%= schema.singular %>)
+      assert html_response(conn, 200) =~ "Edit <%= schema.human_singular %>"
+    end
+  end
+
+  describe "update <%= schema.singular %>" do
+    setup [:create_<%= schema.singular %>]
+
+    test "redirects when data is valid", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @update_attrs
+      assert redirected_to(conn) == <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)
+
+      conn = get conn, <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)<%= if schema.string_attr do %>
+      assert html_response(conn, 200) =~ <%= inspect Mix.Phoenix.Schema.default_param(schema, :update) %><% else %>
+      assert html_response(conn, 200)<% end %>
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @invalid_attrs
+      assert html_response(conn, 200) =~ "Edit <%= schema.human_singular %>"
+    end
+  end
+
+  describe "delete <%= schema.singular %>" do
+    setup [:create_<%= schema.singular %>]
+
+    test "deletes chosen <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      conn = delete conn, <%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>)
+      assert redirected_to(conn) == <%= schema.route_helper %>_path(conn, :index)
+      assert_error_sent 404, fn ->
+        get conn, <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)
+      end
+    end
+  end
+
+  defp create_<%= schema.singular %>(_) do
+    <%= schema.singular %> = fixture(:<%= schema.singular %>)
+    {:ok, <%= schema.singular %>: <%= schema.singular %>}
   end
 end

--- a/priv/templates/phx.gen.json/controller_test.exs
+++ b/priv/templates/phx.gen.json/controller_test.exs
@@ -17,49 +17,63 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
-  test "lists all entries on index", %{conn: conn} do
-    conn = get conn, <%= schema.route_helper %>_path(conn, :index)
-    assert json_response(conn, 200)["data"] == []
-  end
-
-  test "creates <%= schema.singular %> and renders <%= schema.singular %> when data is valid", %{conn: conn} do
-    conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @create_attrs
-    assert %{"id" => id} = json_response(conn, 201)["data"]
-
-    conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
-    assert json_response(conn, 200)["data"] == %{
-      "id" => id<%= for {key, val} <- schema.params.create do %>,
-      "<%= key %>" => <%= inspect val %><% end %>}
-  end
-
-  test "does not create <%= schema.singular %> and renders errors when data is invalid", %{conn: conn} do
-    conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @invalid_attrs
-    assert json_response(conn, 422)["errors"] != %{}
-  end
-
-  test "updates chosen <%= schema.singular %> and renders <%= schema.singular %> when data is valid", %{conn: conn} do
-    %<%= inspect schema.alias %>{id: id} = <%= schema.singular %> = fixture(:<%= schema.singular %>)
-    conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @update_attrs
-    assert %{"id" => ^id} = json_response(conn, 200)["data"]
-
-    conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
-    assert json_response(conn, 200)["data"] == %{
-      "id" => id<%= for {key, val} <- schema.params.update do %>,
-      "<%= key %>" => <%= inspect val %><% end %>}
-  end
-
-  test "does not update chosen <%= schema.singular %> and renders errors when data is invalid", %{conn: conn} do
-    <%= schema.singular %> = fixture(:<%= schema.singular %>)
-    conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @invalid_attrs
-    assert json_response(conn, 422)["errors"] != %{}
-  end
-
-  test "deletes chosen <%= schema.singular %>", %{conn: conn} do
-    <%= schema.singular %> = fixture(:<%= schema.singular %>)
-    conn = delete conn, <%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>)
-    assert response(conn, 204)
-    assert_error_sent 404, fn ->
-      get conn, <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)
+  describe "index" do
+    test "lists all <%= schema.plural %>", %{conn: conn} do
+      conn = get conn, <%= schema.route_helper %>_path(conn, :index)
+      assert json_response(conn, 200)["data"] == []
     end
+  end
+
+  describe "create <%= schema.singular %>" do
+    test "renders <%= schema.singular %> when data is valid", %{conn: conn} do
+      conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @create_attrs
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
+      assert json_response(conn, 200)["data"] == %{
+        "id" => id<%= for {key, val} <- schema.params.create do %>,
+        "<%= key %>" => <%= inspect val %><% end %>}
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @invalid_attrs
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update <%= schema.singular %>" do
+    setup [:create_<%= schema.singular %>]
+
+    test "renders <%= schema.singular %> when data is valid", %{conn: conn, <%= schema.singular %>: %<%= inspect schema.alias %>{id: id} = <%= schema.singular %>} do
+      conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @update_attrs
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
+      assert json_response(conn, 200)["data"] == %{
+        "id" => id<%= for {key, val} <- schema.params.update do %>,
+        "<%= key %>" => <%= inspect val %><% end %>}
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @invalid_attrs
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete <%= schema.singular %>" do
+    setup [:create_<%= schema.singular %>]
+
+    test "deletes chosen <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      conn = delete conn, <%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>)
+      assert response(conn, 204)
+      assert_error_sent 404, fn ->
+        get conn, <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)
+      end
+    end
+  end
+
+  defp create_<%= schema.singular %>(_) do
+    <%= schema.singular %> = fixture(:<%= schema.singular %>)
+    {:ok, <%= schema.singular %>: <%= schema.singular %>}
   end
 end


### PR DESCRIPTION
Opening for discussion as suggested by @chrismccord 

Here is an example gist containing the new and old generated controller tests:

new: https://gist.github.com/Gazler/aa4b6dfcd92cbe86e58e4ad22918b4fe#file-new_controller_test-exs
old: https://gist.github.com/Gazler/aa4b6dfcd92cbe86e58e4ad22918b4fe#file-old_controller_test-exs

If we want to continue with this, I'll update the rest of the generators.