### PR TITLE
Fix documentation on format encoders

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -93,7 +93,7 @@ defmodule Phoenix.Template do
   New encoders can be added via the format encoder option:
 
       config :phoenix, :format_encoders,
-        html: Phoenix.HTML.Engine,
+        html: Phoenix.Template.HTML,
         json: Poison
 
   """


### PR DESCRIPTION
`:format_encoders` example shows `Phoenix.HTML.Engine` set as the encoder for HTML.

However, `Phoenix.Template.HTML` is the module that implements `encode_to_iodata!/1`, not `Phoenix.HTML.Engine`.