### PR TITLE
Add moduledoc to application file

### DIFF
--- a/installer/templates/phx_single/lib/app_name/application.ex
+++ b/installer/templates/phx_single/lib/app_name/application.ex
@@ -1,4 +1,12 @@
 defmodule <%= app_module %>.Application do
+  @moduledoc """
+  The <%= app_module %> Application Service.
+  
+  The <%= app_name %> system business domain lives in this application.
+  
+  Exposes API to clients such as the `<%= app_module %>.Web` application
+  for use in channels, controllers, and elsewhere.
+  """
   use Application
 
   # See https://hexdocs.pm/elixir/Application.html

--- a/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name/application.ex
@@ -1,4 +1,12 @@
 defmodule <%= web_namespace %>.Application do
+  @moduledoc """
+  The <%= web_namespace %> Application Service.
+  
+  The <%= app_name %> system business domain lives in this application.
+  
+  Exposes API to clients such as the `<%= web_namespace %>.Web` application
+  for use in channels, controllers, and elsewhere.
+  """
   use Application
 
   def start(_type, _args) do


### PR DESCRIPTION
It was added [in the general umbrella app template](https://github.com/phoenixframework/phoenix/blob/master/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex) but was never added to the other application file templates. Credo will fail with a default Phoenix app and since it was already in 1 file, seemed harmless to add to the other template files and will get Credo to pass with a stock `phx.new` install.