### PR TITLE
Update Channel Terminate documentation

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -164,8 +164,8 @@ defmodule Phoenix.Channel do
   If any of the callbacks return a `:stop` tuple, it will also
   trigger terminate with the reason given in the tuple.
 
-  `terminate/2`, however, won't be invoked in case of errors nor in
-  case of exits. This is the same behaviour as you find in Elixir
+  `terminate/2`, however, won't be invoked in the case of a linked process
+  non-normal exit. This is the same behaviour as you find in Elixir
   abstractions like `GenServer` and others. Typically speaking, if you
   want to clean something up, it is better to monitor your channel
   process and do the clean up from another process.  Similar to GenServer,


### PR DESCRIPTION
I was a little bit confused by this statement:

> `terminate/2`, however, won't be invoked in case of errors nor in case of exits. This is the same behaviour as you find in Elixir abstractions like `GenServer` and others.

Mainly because the way I understand things, it just isn't true. Not only that, but it is [tested to be untrue][1].

I am submitting a PR because it's nice if you can be lazy and just merge a change. But I feel like there was some other warning that was trying to be conveyed.

[1]: https://github.com/phoenixframework/phoenix/blob/5ef5d112bebb1bb241e4696b03b4ce8ed77b5ec8/test/phoenix/test/channel_test.exs#L261
