### PR TITLE
fix docs: phx does not prepend context name to table names anymore.

### DIFF
--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   Overall, this generator will add the following files to `lib/`:
 
     * a context module in lib/app/accounts/accounts.ex for the accounts API
-    * a schema in lib/app/accounts/user.ex, with an `accounts_users` table
+    * a schema in lib/app/accounts/user.ex, with an `users` table
     * a view in lib/app_web/views/user_view.ex
     * a controller in lib/app_web/controllers/user_controller.ex
     * default CRUD templates in lib/app_web/templates/user

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
   Overall, this generator will add the following files to `lib/`:
 
     * a context module in lib/app/accounts/accounts.ex for the accounts API
-    * a schema in lib/app/accounts/user.ex, with an `accounts_users` table
+    * a schema in lib/app/accounts/user.ex, with an `users` table
     * a view in lib/app_web/views/user_view.ex
     * a controller in lib/app_web/controllers/user_controller.ex
 


### PR DESCRIPTION
Phoenix used to generate tables like `<context_name>_<table_name>` but not anymore.
The docs for `phx.gen.context` state that the generator will generate normal table names without prepending the context name, which is the actual behavior.
This PR is just to fix the docs for `phx.gen.html` and `phx.gen.json`.