### PR TITLE
Fix mix phx.routes router module hint

### DIFF
--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Phx.Routes do
     if Mix.Project.umbrella?() do
       Mix.raise "umbrella applications require an explicit router to be given to phx.routes"
     end
-    web_router = app_mod(base, "Web.Router")
+    web_router = web_mod(base, "Router")
     old_router = app_mod(base, "Router")
 
     loaded(web_router) || loaded(old_router) || Mix.raise """
@@ -56,4 +56,6 @@ defmodule Mix.Tasks.Phx.Routes do
   defp loaded(module), do: Code.ensure_loaded?(module) && module
 
   defp app_mod(base, name), do: Module.concat([base, name])
+
+  defp web_mod(base, name), do: Module.concat(["#{base}Web", name])
 end

--- a/test/mix/tasks/phx.routes_test.exs
+++ b/test/mix/tasks/phx.routes_test.exs
@@ -1,6 +1,6 @@
 Code.require_file "../../../installer/test/mix_helper.exs", __DIR__
 
-defmodule PhoenixTest.Web.Router do
+defmodule PhoenixTestWeb.Router do
   use Phoenix.Router
   get "/", PageController, :index, as: :page
 end
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Phx.RoutesTest do
   use ExUnit.Case, async: true
 
   test "format routes for specific router" do
-    Mix.Tasks.Phx.Routes.run(["PhoenixTest.Web.Router"])
+    Mix.Tasks.Phx.Routes.run(["PhoenixTestWeb.Router"])
     assert_received {:mix_shell, :info, [routes]}
     assert routes =~ "page_path  GET  /  PageController :index"
   end
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Phx.RoutesTest do
   end
 
   test "prints error when implicit router cannot be found" do
-    assert_raise Mix.Error, ~r/no router found at Foo.Web.Router or Foo.Router/, fn ->
+    assert_raise Mix.Error, ~r/no router found at FooWeb.Router or Foo.Router/, fn ->
       Mix.Tasks.Phx.Routes.run([], Foo)
     end
   end


### PR DESCRIPTION
Update `mix phx.routes` hint to match generated router module with the move to isolated web directory in #2393.