### PR TITLE
Fix CHANGELOG version typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.3.0-rc.2 (2017-07-24)
+## 1.3.0-rc.3 (2017-07-24)
 
 * Enhancements
   * [ChannelTest] Subscribe `connect` to `UserSocket.id` to support testing forceful disconnects


### PR DESCRIPTION
Looks like @chrismccord  typed rc.2 by mistake instead of rc.3.