### PR TITLE
Phoenix.ConnTest.recycle/1 resets Plug.Conn.host

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -465,6 +465,7 @@ defmodule Phoenix.ConnTest do
   @spec recycle(Conn.t) :: Conn.t
   def recycle(conn) do
     build_conn()
+    |> Map.put(:host, conn.host)
     |> Plug.Test.recycle_cookies(conn)
     |> copy_headers(conn.req_headers, ~w(accept))
   end

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -160,6 +160,11 @@ defmodule Phoenix.Test.ConnTest do
     assert conn.cookies == %{"req_cookie"  => "req_cookie",
                              "over_cookie" => "pos_cookie",
                              "resp_cookie" => "resp_cookie"}
+
+    conn =
+      build_conn(:get, "http://localhost/", nil)
+      |> recycle()
+    assert conn.host == "localhost"
   end
 
   test "ensure_recycled/1" do


### PR DESCRIPTION
In the current implementation:

`build_conn/0` defaults to generating a conn where the host is set to `"www.example.com"` because it passes `"/"` which `URI.parse` will return `nil`. You can trace that to here

https://github.com/elixir-plug/plug/blob/master/lib/plug/adapters/test/conn.ex#L21

You can override this by using `build_conn/3` and pass 
`build_conn(:get, "http://localhost/", nil)`

This causes the conn to set `host` to `"localhost"`. The problem is when using `build_conn/3` in conjunction with `recycle/1`. Currently, `recycle/1` starts off by calling `build_conn/0`. 

https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/test/conn_test.ex#L467

This PR adds `build_conn/1` which takes a conn and derive the method and host to call `build_conn/3`

I am unsure if this is the right way of handling the situation, but I believe that its a bug if recycle does not derive off the initial conn.

Example of usage:
```elixir 
  defp active_login(admin) do
    build_conn(:get, "http://localhost/", nil)
      # do stuff...
      |> recycle()
  end
```
Expected: `%Conn{host: "localhost"}`
Received: `%Conn{host: "www.example.com"}`

This needs a test or two, but I wanted to get the ball rolling to see if this is how you guys wanted to handle this.