### PR TITLE
Remove flash function inconsistency

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1224,8 +1224,7 @@ defmodule Phoenix.Controller do
 
   """
   def get_flash(conn) do
-    Map.get(conn.private, :phoenix_flash) ||
-      raise ArgumentError, message: "flash not fetched, call fetch_flash/2"
+    Map.get(conn.private, :phoenix_flash, %{})
   end
 
   @doc """


### PR DESCRIPTION
`Phoenix.Controller.clear_flash/1` resets the flash messages to en empty map.

Raising an error via `Phoenix.Controller.get_flash/1` when there are no flash messages is therefore inconsistent. Better set the default value to an empty map and save a needless exception.