### PR TITLE
change getting started url in the default layout

### DIFF
--- a/installer/templates/phx_web/templates/layout/app.html.eex
+++ b/installer/templates/phx_web/templates/layout/app.html.eex
@@ -16,7 +16,7 @@
       <header class="header">
         <nav role="navigation">
           <ul class="nav nav-pills pull-right">
-            <li><a href="https://hexdocs.pm/phoenix/adding_pages.html">Get Started</a></li>
+            <li><a href="https://hexdocs.pm/phoenix">Get Started</a></li>
           </ul>
         </nav>
         <span class="logo"></span>

--- a/installer/templates/phx_web/templates/layout/app.html.eex
+++ b/installer/templates/phx_web/templates/layout/app.html.eex
@@ -16,7 +16,7 @@
       <header class="header">
         <nav role="navigation">
           <ul class="nav nav-pills pull-right">
-            <li><a href="http://www.phoenixframework.org/docs">Get Started</a></li>
+            <li><a href="https://hexdocs.pm/phoenix/adding_pages.html">Get Started</a></li>
           </ul>
         </nav>
         <span class="logo"></span>


### PR DESCRIPTION
**Reason for change:**
I did this because http://www.phoenixframework.org/docs url seems to have moved and returns a 404 currently. 

How change solved the issue:
I changed it to http://hexdocs.pm/phoenix/adding_pages.html which was the most appropriate link I found in the docs. I'd be happy to change it to something more useful if the community has a better suggestion.