### PR TITLE
Fixed generate typo in phx.gen.html and phx.gen.json docs

### DIFF
--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
 
   ## Generating without a schema or context file
 
-  In some cases, you may wish to boostrap HTML templates, controllers, and
+  In some cases, you may wish to bootstrap HTML templates, controllers, and
   controller tests, but leave internal implementation of the context or schema
   to yourself. You can use the `--no-context` and `--no-schema` flags for
   file generation control.

--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
 
       mix phx.gen.html Sales User users --web Sales
 
-  Which would geneate a `lib/app_web/controllers/sales/user_controller.ex` and
+  Which would generate a `lib/app_web/controllers/sales/user_controller.ex` and
   `lib/app_web/views/sales/user_view.ex`.
 
   ## Generating without a schema or context file

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
 
       mix phx.gen.html Sales User users --web Sales
 
-  Which would geneate a `lib/app_web/controllers/sales/user_controller.ex` and
+  Which would generate a `lib/app_web/controllers/sales/user_controller.ex` and
   `lib/app_web/views/sales/user_view.ex`.
 
   ## Generating without a schema or context file


### PR DESCRIPTION
I noticed a very small typo getting re-acquainted with mix tasks under the `Web namespace` section (https://hexdocs.pm/phoenix/1.3.0/Mix.Tasks.Phx.Gen.Json.html#module-web-namespace) that appears to affect both `phx.gen.html` and `phx.gen.json`. I looked for similar PR's to see if this was addressed recently and noticed #2406 also didn't cover both files, so I included that as well.