### PR TITLE
Make application.ex match upgrade instructions

### DIFF
--- a/installer/templates/phx_single/lib/app_name/application.ex
+++ b/installer/templates/phx_single/lib/app_name/application.ex
@@ -21,11 +21,4 @@ defmodule <%= app_module %>.Application do
     opts = [strategy: :one_for_one, name: <%= app_module %>.Supervisor]
     Supervisor.start_link(children, opts)
   end
-
-  # Tell Phoenix to update the endpoint configuration
-  # whenever the application is updated.
-  def config_change(changed, _new, removed) do
-    <%= endpoint_module %>.config_change(changed, removed)
-    :ok
-  end
 end


### PR DESCRIPTION
The [Phoenix 1.2 -> 1.3 upgrade instructions](https://gist.github.com/chrismccord/71ab10d433c98b714b75c886eff17357) tell you to "remove the config_change callback", but the codegen incorrectly creates this callback.

Let me know if I should have created a topic branch per the contributing guidelines; this seemed too trivial for that.

(Additionally, for Elixir 1.5 users application.ex is using a deprecated module (Supervisor.Spec).  Can/should the codegen target different Elixir versions?)