### PR TITLE
Fix dialyzer error when on Phoenix.Controller.render/3

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -681,7 +681,7 @@ defmodule Phoenix.Controller do
   `layout_formats/1` and `put_layout_formats/2` can be used to configure
   which formats support/require layout rendering (defaults to "html" only).
   """
-  @spec render(Plug.Conn.t, binary | atom, Keyword.t | map) :: Plug.Conn.t
+  @spec render(Plug.Conn.t, binary | atom, Keyword.t | map | binary | atom) :: Plug.Conn.t
   def render(conn, template, assigns)
       when is_atom(template) and (is_map(assigns) or is_list(assigns)) do
     format =


### PR DESCRIPTION
`mix phx.gen.json ...` generates FallbackController with line
`|> render(MyAppWeb.ErrorView, :"404")`

This causes dialyzer to fail with:
`The call 'Elixir.Phoenix.Controller':render(#{'__struct__':='Elixir.Plug.Conn'...},'Elixir.MyAppWeb.ErrorView','404') breaks the contract ('Elixir.Plug.Conn':t(),binary() | atom(),'Elixir.Keyword':t() | map()) -> 'Elixir.Plug.Conn':t()`

This PR relaxes type spec on Phoenix.Controller.render/3 to allow calling
`def render(conn, view, template)
      when is_atom(view) and (is_binary(template) or is_atom(template))` override