### PR TITLE
Fix: Typo

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -378,7 +378,7 @@ defmodule Phoenix.Endpoint do
   @callback path(path :: String.t) :: String.t
 
   @doc """
-  Geerates the static URL without any path information.
+  Generates the static URL without any path information.
   """
   @callback static_url() :: String.t
 


### PR DESCRIPTION
Documentation for `Phoenix.Endpoint.static_path/1` callback had a typo