### PR TITLE
Ref generation for channel even handlers

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -387,10 +387,12 @@ export class Channel {
     }
   }
 
-  onClose(callback){ this.on(CHANNEL_EVENTS.close, callback) }
+  onClose(callback){
+    return this.on(CHANNEL_EVENTS.close, callback)
+  }
 
   onError(callback){
-    this.on(CHANNEL_EVENTS.error, reason => callback(reason) )
+    return this.on(CHANNEL_EVENTS.error, reason => callback(reason))
   }
 
  /** Subscribes on channel events

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -734,6 +734,12 @@ describe("on", () => {
 
     assert.ok(!ignoredSpy.called)
   })
+  
+  it("generates unique refs for callbacks", () => {
+    const ref1 = channel.on("event1", () => 0)
+    const ref2 = channel.on("event2", () => 0)
+    assert.equal(ref1 + 1, ref2)
+  })
 })
 
 describe("off", () => {
@@ -761,6 +767,20 @@ describe("off", () => {
     assert.ok(!spy1.called)
     assert.ok(!spy2.called)
     assert.ok(spy3.called)
+  })
+  
+  it("removes callback by its ref", () => {
+    const spy1 = sinon.spy()
+    const spy2 = sinon.spy()
+    
+    const ref1 = channel.on("event", spy1)
+    const ref2 = channel.on("event", spy2)
+
+    channel.off("event", ref1)
+    channel.trigger("event", {}, defaultRef)
+
+    assert.ok(!spy1.called)
+    assert.ok(spy2.called)    
   })
 })
 


### PR DESCRIPTION
Following this discussion: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/phoenix-core/vHq964tYMqI/Sw_5t4tQAAAJ

This PR introduces ref counter in the channel. Now `channel.on(...)` returns a unique integer, which can be used to remove one exact even handler and not all handlers matching the event as it was before.

```javascript
     ref1 = channel.on("event", do_stuff)
     ref2 = channel.on("event", do_other_stuff)
     channel.off("event", ref1)
     // Since unsubscription, do_stuff won't fire,
     // while do_other_stuff will keep firing on the "event" 
```