### PR TITLE
Improved Endpoint.subscribe/1 Error Message

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -478,46 +478,69 @@ defmodule Phoenix.Endpoint do
 
       def __pubsub_server__, do: @pubsub_server
 
+      defp __pubsub_server__! do
+        if @pubsub_server do
+          @pubsub_server
+        else
+          app_module =
+            __MODULE__
+            |> Module.split
+            |> List.first
+
+          raise ArgumentError, """
+          No pubsub server configured, please setup pubsub in your config.
+
+          By default this looks like
+          ```
+          config #{inspect @otp_app}, #{__MODULE__},
+            # other config ...
+            pubsub: [name: #{app_module}.PubSub,
+               adapter: Phoenix.PubSub.PG2]
+          ```\
+          """
+        end
+      end
+
       # TODO v2: Remove pid version
       @doc false
       def subscribe(pid, topic) when is_pid(pid) and is_binary(topic) do
         IO.warn "#{__MODULE__}.subscribe/2 is deprecated, please use subscribe/1"
-        Phoenix.PubSub.subscribe(@pubsub_server, pid, topic, [])
+        Phoenix.PubSub.subscribe(__pubsub_server__!(), pid, topic, [])
       end
       def subscribe(pid, topic, opts) when is_pid(pid) and is_binary(topic) and is_list(opts) do
-        Phoenix.PubSub.subscribe(@pubsub_server, pid, topic, opts)
+        Phoenix.PubSub.subscribe(__pubsub_server__!(), pid, topic, opts)
       end
       def subscribe(topic) when is_binary(topic) do
-        Phoenix.PubSub.subscribe(@pubsub_server, topic, [])
+        Phoenix.PubSub.subscribe(__pubsub_server__!(), topic, [])
       end
       def subscribe(topic, opts) when is_binary(topic) and is_list(opts) do
-        Phoenix.PubSub.subscribe(@pubsub_server, topic, opts)
+        Phoenix.PubSub.subscribe(__pubsub_server__!(), topic, opts)
       end
 
       # TODO v2: Remove pid version
       @doc false
       def unsubscribe(pid, topic) do
         IO.warn "#{__MODULE__}.unsubscribe/2 is deprecated, please use unsubscribe/1"
-        Phoenix.PubSub.unsubscribe(@pubsub_server, topic)
+        Phoenix.PubSub.unsubscribe(__pubsub_server__!(), topic)
       end
       def unsubscribe(topic) do
-        Phoenix.PubSub.unsubscribe(@pubsub_server, topic)
+        Phoenix.PubSub.unsubscribe(__pubsub_server__!(), topic)
       end
 
       def broadcast_from(from, topic, event, msg) do
-        Phoenix.Channel.Server.broadcast_from(@pubsub_server, from, topic, event, msg)
+        Phoenix.Channel.Server.broadcast_from(__pubsub_server__!(), from, topic, event, msg)
       end
 
       def broadcast_from!(from, topic, event, msg) do
-        Phoenix.Channel.Server.broadcast_from!(@pubsub_server, from, topic, event, msg)
+        Phoenix.Channel.Server.broadcast_from!(__pubsub_server__!(), from, topic, event, msg)
       end
 
       def broadcast(topic, event, msg) do
-        Phoenix.Channel.Server.broadcast(@pubsub_server, topic, event, msg)
+        Phoenix.Channel.Server.broadcast(__pubsub_server__!(), topic, event, msg)
       end
 
       def broadcast!(topic, event, msg) do
-        Phoenix.Channel.Server.broadcast!(@pubsub_server, topic, event, msg)
+        Phoenix.Channel.Server.broadcast!(__pubsub_server__!(), topic, event, msg)
       end
     end
   end


### PR DESCRIPTION
Right now if you don't have pubsub configured at at all and attempt to use `Endpoint.subscribe` or similar, you get an error that looks like:

```
** (ArgumentError) argument error
    (stdlib) :ets.lookup(nil, :subscribe)
    (phoenix_pubsub) lib/phoenix/pubsub.ex:288: Phoenix.PubSub.call/3
    (absinthe) lib/absinthe/subscription/proxy.ex:19: Absinthe.Subscription.Proxy.init/1
    (stdlib) gen_server.erl:365: :gen_server.init_it/2
    (stdlib) gen_server.erl:333: :gen_server.init_it/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```

Separately I plan on adding a PR to Phoenix.PubSub to make that a little better, but the advantage of handling this error in Phoenix itself is that we can provide very detailed suggestions for how to recover from the error.

Note: I'm a bit unclear on the best way to test this.