### PR TITLE
simple tests to check that generated .gitignore end with newline

### DIFF
--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -70,6 +70,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       # Brunch
       assert_file "phx_blog/.gitignore", "/node_modules"
+      assert_file "phx_blog/.gitignore", ~r/\n$/
       assert_file "phx_blog/assets/brunch-config.js", ~s("js/app.js": ["js/app"])
       assert_file "phx_blog/config/dev.exs", fn file ->
         assert file =~ "watchers: [node:"
@@ -141,6 +142,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       # No Brunch
       refute File.read!("phx_blog/.gitignore") |> String.contains?("/node_modules")
+      assert_file "phx_blog/.gitignore", ~r/\n$/
       assert_file "phx_blog/config/dev.exs", ~r/watchers: \[\]/
 
       # No Brunch & No Html
@@ -197,6 +199,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       Mix.Tasks.Phx.New.run([@app_name, "--no-brunch"])
 
       assert_file "phx_blog/.gitignore"
+      assert_file "phx_blog/.gitignore", ~r/\n$/
       assert_file "phx_blog/priv/static/css/app.css"
       assert_file "phx_blog/priv/static/favicon.ico"
       assert_file "phx_blog/priv/static/images/phoenix.png"
@@ -235,6 +238,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       Mix.Tasks.Phx.New.run([project_path, "--app", @app_name, "--module", "PhoteuxBlog"])
 
       assert_file "custom_path/.gitignore"
+      assert_file "custom_path/.gitignore", ~r/\n$/
       assert_file "custom_path/mix.exs", ~r/app: :phx_blog/
       assert_file "custom_path/lib/phx_blog_web/endpoint.ex", ~r/app: :phx_blog/
       assert_file "custom_path/config/config.exs", ~r/namespace: PhoteuxBlog/

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -35,8 +35,11 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file root_path(@app, "README.md")
       assert_file root_path(@app, ".gitignore")
+      assert_file( root_path(@app, ".gitignore"), ~r/\n$/)
+
       assert_file app_path(@app, "README.md")
       assert_file app_path(@app, ".gitignore")
+      assert_file( app_path(@app, ".gitignore"), ~r/\n$/)
       assert_file web_path(@app, "README.md")
       assert_file root_path(@app, "mix.exs"), fn file ->
         assert file =~ "apps_path: \"apps\""
@@ -103,6 +106,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       # Brunch
       assert_file web_path(@app, ".gitignore"), "/node_modules"
+      assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
       assert_file web_path(@app, "assets/brunch-config.js"), ~s("js/app.js": ["js/app"])
       assert_file web_path(@app, "config/dev.exs"), fn file ->
         assert file =~ "watchers: [node:"
@@ -186,6 +190,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       # No Brunch
       refute File.read!(web_path(@app, ".gitignore")) |> String.contains?("/node_modules")
+      assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
       assert_file web_path(@app, "config/dev.exs"), ~r/watchers: \[\]/
 
       # No Brunch & No Html
@@ -242,6 +247,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       Mix.Tasks.Phx.New.run([@app, "--umbrella", "--no-brunch"])
 
       assert_file web_path(@app, ".gitignore")
+      assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
       assert_file web_path(@app, "priv/static/css/app.css")
       assert_file web_path(@app, "priv/static/favicon.ico")
       assert_file web_path(@app, "priv/static/images/phoenix.png")
@@ -472,6 +478,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
         # Brunch
         assert_file "another/.gitignore", "/node_modules"
+        assert_file "another/.gitignore",  ~r/\n$/
         assert_file "another/assets/brunch-config.js", ~s("js/app.js": ["js/app"])
         assert_file "another/config/dev.exs", "watchers: [node:"
         assert_file "another/assets/static/favicon.ico"


### PR DESCRIPTION
Just went through and added something like:

assert_file "phx_blog/.gitignore", ~r/\n$/

every time I found .gitignore in the installer tests.

passes if and only if the new phx installer is installed locally.  Not
sure how to trigger tests to use the repo's version of the installer.