### PR TITLE
Make sure sockets with unconfigured endpoints raise warning

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -202,7 +202,7 @@ defmodule Phoenix.Token do
   defp get_key_base(%Plug.Conn{} = conn),
     do: conn |> Phoenix.Controller.endpoint_module() |> get_endpoint_key_base()
   defp get_key_base(%Phoenix.Socket{} = socket),
-    do: socket.endpoint.config(:secret_key_base)
+    do: get_endpoint_key_base(socket.endpoint)
   defp get_key_base(endpoint) when is_atom(endpoint),
     do: get_endpoint_key_base(endpoint)
   defp get_key_base(string) when is_binary(string) and byte_size(string) >= 20,


### PR DESCRIPTION
This brings sockets in line with how connections and raw endpoints are treated by `Phoenix.Token.{sign,verify}`