### PR TITLE
Reuse common lines in controller tests via test case

### DIFF
--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -1,14 +1,6 @@
 defmodule Phoenix.Controller.ControllerTest do
-  use ExUnit.Case, async: true
-  use RouterHelper
-
-  import Phoenix.Controller
+  use Phoenix.Controller.ConnCase
   alias Plug.Conn
-
-  setup do
-    Logger.disable(self())
-    :ok
-  end
 
   defp get_resp_content_type(conn) do
     [header]  = get_resp_header(conn, "content-type")

--- a/test/phoenix/controller/flash_test.exs
+++ b/test/phoenix/controller/flash_test.exs
@@ -1,13 +1,5 @@
 defmodule Phoenix.Controller.FlashTest do
-  use ExUnit.Case, async: true
-  use RouterHelper
-
-  import Phoenix.Controller
-
-  setup do
-    Logger.disable(self())
-    :ok
-  end
+  use Phoenix.Controller.ConnCase
 
   test "flash is persisted when status is a redirect" do
     for status <- 300..308 do

--- a/test/phoenix/controller/pipeline_test.exs
+++ b/test/phoenix/controller/pipeline_test.exs
@@ -1,8 +1,5 @@
 defmodule Phoenix.Controller.PipelineTest do
-  use ExUnit.Case, async: true
-  use RouterHelper
-
-  import Phoenix.Controller
+  use Phoenix.Controller.ConnCase
 
   defmodule MyController do
     use Phoenix.Controller
@@ -94,11 +91,6 @@ defmodule Phoenix.Controller.PipelineTest do
   def init(opts), do: opts
   def call(conn, :not_a_conn), do: Plug.Conn.send_resp(conn, 200, "fallback")
   def call(_conn, :bad_fallback), do: :bad_fallback
-
-  setup do
-    Logger.disable(self())
-    :ok
-  end
 
   test "invokes the plug stack" do
     conn = stack_conn()

--- a/test/phoenix/controller/render_test.exs
+++ b/test/phoenix/controller/render_test.exs
@@ -1,10 +1,7 @@
 Code.require_file "../../fixtures/views.exs", __DIR__
 
 defmodule Phoenix.Controller.RenderTest do
-  use ExUnit.Case, async: true
-
-  use RouterHelper
-  import Phoenix.Controller
+  use Phoenix.Controller.ConnCase
 
   defp conn() do
     conn(:get, "/") |> put_view(MyApp.UserView) |> fetch_query_params

--- a/test/support/controller/conn_case.exs
+++ b/test/support/controller/conn_case.exs
@@ -1,0 +1,23 @@
+defmodule Phoenix.Controller.ConnCase do
+  @moduledoc """
+  This module defines the test case that:
+
+    * Runs concurrenty with other test cases.
+    * Uses convenience methods for testing routers and controllers.
+    * Uses functions from Phoenix.Controller, and
+    * Disables logger.
+  """
+
+  defmacro __using__(_) do
+    quote do
+      use ExUnit.Case, async: true
+      use RouterHelper
+      import Phoenix.Controller
+
+      setup do
+        Logger.disable(self())
+        :ok
+      end
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 Code.require_file("support/router_helper.exs", __DIR__)
+Code.require_file("support/controller/conn_case.exs", __DIR__)
 
 # Starts web server applications
 Application.ensure_all_started(:cowboy)


### PR DESCRIPTION
This PR extracted:
- 2 `use` lines
- 1 `import` line
- and a `setup` block 

which are common in `test/phoenix/controller` tests. Extracted file is placed inside `test/support` as `Phoenix.Controller.ConnCase` test case. The `test/phoenix/controller` tests then can just do

```elixir
use Phoenix.Controller.ConnCase
```

instead of the repetitive common lines.

@chrismccord @josevalim What do you think?