### PR TITLE
adding in tvOS tvml support for issue #2444

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -1032,15 +1032,21 @@ export class LongPoll {
 export class Ajax {
 
   static request(method, endPoint, accept, body, timeout, ontimeout, callback){
-    if(window.XDomainRequest){
-      let req = new XDomainRequest() // IE8, IE9
-      this.xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback)
+    if (typeof window != 'undefined') {
+      if(window.XDomainRequest){
+        let req = new XDomainRequest() // IE8, IE9
+        this.xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback)
+      } else {
+        let req = window.XMLHttpRequest ?
+                    new window.XMLHttpRequest() : // IE7+, Firefox, Chrome, Opera, Safari
+                    new ActiveXObject("Microsoft.XMLHTTP") // IE6, IE5
+        this.xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback)
+      }
     } else {
-      let req = window.XMLHttpRequest ?
-                  new window.XMLHttpRequest() : // IE7+, Firefox, Chrome, Opera, Safari
-                  new ActiveXObject("Microsoft.XMLHTTP") // IE6, IE5
+      var req = new XMLHttpRequest(); // tvOS support
       this.xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback)
     }
+
   }
 
   static xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback){

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -1032,7 +1032,7 @@ export class LongPoll {
 export class Ajax {
 
   static request(method, endPoint, accept, body, timeout, ontimeout, callback){
-    if (typeof window != 'undefined') {
+    if(typeof window !== 'undefined'){
       if(window.XDomainRequest){
         let req = new XDomainRequest() // IE8, IE9
         this.xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback)
@@ -1046,7 +1046,6 @@ export class Ajax {
       var req = new XMLHttpRequest(); // tvOS support
       this.xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback)
     }
-
   }
 
   static xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback){


### PR DESCRIPTION
#2444

This allows this configuration to work for tvOS tvml where socket.js is the file that comes by default with phoenix.

```
import {Socket,LongPoll} from "./3rd/socket.js"
let socket = new Socket("http://localhost:4000/socket", { transport: LongPoll, params: {token: "asdf"}})

  socket.connect()
  socket.onClose( e => console.log("Closed connection") )

  var channel = socket.channel("atv:lobby", {})
  channel.join()
    .receive("ok", resp => { console.log("Joined successfully", resp) })
    .receive( "error", () => console.log("Connection error") )

    channel.on( "atv:YSdjLkyEcWmkj64wW", msg => console.log(msg.body) );
```