### PR TITLE
Shortening phoenix.js example so it renders correctly.

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -667,7 +667,9 @@ const Serializer = {
  * ```
  * @param {Function} opts.logger - The optional function for specialized logging, ie:
  * ```javascript
- * logger: (kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }
+ * function(kind, msg, data) { 
+ *   console.log(`${kind}: ${msg}`, data) 
+ * }
  * ```
  *
  * @param {number}  opts.longpollerTimeout - The maximum timeout of a long poll AJAX request.


### PR DESCRIPTION
When the examples go too long it makes the table render off the side and it looks bad.

Also in our examples we used 3 different ways of showing js functions, this reduces that a bit.

Before:
<img width="1231" alt="screen shot 2017-09-06 at 12 23 08 pm" src="https://user-images.githubusercontent.com/100886/30130497-3bbd302a-92fe-11e7-9146-79b5c4e22f9f.png">

After:
<img width="1144" alt="screen shot 2017-09-06 at 12 23 15 pm" src="https://user-images.githubusercontent.com/100886/30130502-3f6d08e4-92fe-11e7-8d81-9d1eb7f51459.png">
