### PR TITLE
Provides a common view helpers module for user-define view helpers.

### DIFF
--- a/guides/docs/adding_pages.md
+++ b/guides/docs/adding_pages.md
@@ -31,6 +31,7 @@ Most of our work in this guide will be in the `lib/hello_web` directory, which h
 │   └── page
 │       └── index.html.eex
 └── views
+│   ├── common_helpers.ex
 │   ├── error_helpers.ex
 │   ├── error_view.ex
 │   ├── layout_view.ex

--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -13,6 +13,7 @@ defmodule Phx.New.Single do
     {:eex,  "phx_single/lib/app_name.ex",               :project, "lib/:app.ex"},
     {:eex,  "phx_web/channels/user_socket.ex",          :project, "lib/:lib_web_name/channels/user_socket.ex"},
     {:keep, "phx_web/controllers",                      :project, "lib/:lib_web_name/controllers"},
+    {:eex,  "phx_web/views/common_helpers.ex",          :project, "lib/:lib_web_name/views/common_helpers.ex"},
     {:eex,  "phx_web/views/error_helpers.ex",           :project, "lib/:lib_web_name/views/error_helpers.ex"},
     {:eex,  "phx_web/views/error_view.ex",              :project, "lib/:lib_web_name/views/error_view.ex"},
     {:eex,  "phx_web/endpoint.ex",                      :project, "lib/:lib_web_name/endpoint.ex"},

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -17,6 +17,7 @@ defmodule Phx.New.Web do
     {:keep, "phx_web/controllers",                    :web, "lib/:web_app/controllers"},
     {:eex,  "phx_web/endpoint.ex",                    :web, "lib/:web_app/endpoint.ex"},
     {:eex,  "phx_web/router.ex",                      :web, "lib/:web_app/router.ex"},
+    {:eex,  "phx_web/views/common_helpers.ex",        :web, "lib/:lib_web_name/views/common_helpers.ex"},
     {:eex,  "phx_web/views/error_helpers.ex",         :web, "lib/:web_app/views/error_helpers.ex"},
     {:eex,  "phx_web/views/error_view.ex",            :web, "lib/:web_app/views/error_view.ex"},
     {:eex,  "#{@pre}/mix.exs",                        :web, "mix.exs"},

--- a/installer/templates/phx_single/lib/app_name_web.ex
+++ b/installer/templates/phx_single/lib/app_name_web.ex
@@ -39,6 +39,7 @@ defmodule <%= web_namespace %> do
 
       import <%= web_namespace %>.Router.Helpers
       import <%= web_namespace %>.ErrorHelpers
+      import <%= web_namespace %>.CommonHelpers
       import <%= web_namespace %>.Gettext
     end
   end

--- a/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name.ex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name.ex
@@ -39,6 +39,7 @@ defmodule <%= web_namespace %> do
 
       import <%= web_namespace %>.Router.Helpers
       import <%= web_namespace %>.ErrorHelpers
+      import <%= web_namespace %>.CommonHelpers
       import <%= web_namespace %>.Gettext
     end
   end

--- a/installer/templates/phx_web/views/common_helpers.ex
+++ b/installer/templates/phx_web/views/common_helpers.ex
@@ -1,0 +1,5 @@
+defmodule <%= web_namespace %>.CommonHelpers do
+  @moduledoc """
+  Place for common view helpers.
+  """
+end


### PR DESCRIPTION
On developing with Phoenix, I found that there needs a place to define own view helpers callable inside my app. And this user-defined methods are essential for most of the web dev works as well; like full_title(), render_shared(), and more. (I use many partial chunks and they're embedded with render_shared() often.)

Though I named this module as "CommonHelpers", please open a discuss and find the best one instead.
Suffix with '**Helpers**' doesn't seem look nice since they're in "/view" folder. It's also weird to take '**View**' because this module is not intended to work for some specific templates nor it use Phoenix.View inside. Even more this '**Common**' thing should not be generated while View things are generated on task '**phx.gen.***'.

#### Here are some examples :

- GeneralHelpers
- GlobalHelpers
- CommonView
- GeneralView
- GlobalView