### PR TITLE
Update channels.md typo for endpoint.ex

### DIFF
--- a/guides/docs/channels.md
+++ b/guides/docs/channels.md
@@ -76,7 +76,7 @@ The default transport mechanism is via WebSockets which will fall back to LongPo
   - [dn-phoenix](https://github.com/jfis/dn-phoenix)
 
 ## Tying it all together
-Let's tie all these ideas together by building a simple chat application. After [generating a new Phoenix application](http://www.phoenixframework.org/docs/up-and-running) we'll see that the endpoint is already set up for us in `lib/hello/endpoint.ex`:
+Let's tie all these ideas together by building a simple chat application. After [generating a new Phoenix application](http://www.phoenixframework.org/docs/up-and-running) we'll see that the endpoint is already set up for us in `lib/hello_web/endpoint.ex`:
 
 ```elixir
 defmodule Hello.Endpoint do


### PR DESCRIPTION
In the channels [Tying it all together section](https://hexdocs.pm/phoenix/channels.html#tying-it-all-together).

User is referred to
```
 lib/hello/endpoint.ex
```
but in phoenix 1.3 , path project generator makes is:
```
lib/hello_web/endpoint.ex
```