### PR TITLE
Default `server: true` in `prod.exs`

### DIFF
--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -15,6 +15,7 @@ use Mix.Config
 # which you typically run after static files are built.
 config :<%= web_app_name %>, <%= endpoint_module %>,
   load_from_system_env: true,
+  server: true,
   url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json"
 


### PR DESCRIPTION
Hi! This pull request is really more of a question than a proposal. I'm not sure why `server: true` is not set here in the `prod.exs` template. Was this a conscious decision?

Lots of newcomers run into this issue when using Distillery/releases and I answer a lot of questions about this in the elixir-lang.slack.com #deployment channel. I can understand maybe why it isn't set for development, but for production I'm not sure.

Anyway, thanks for your consideration! If you like this pull request, I can do it for the other `prod.exs` templates too.