### PR TITLE
Phoenix.new: Fix path for brunch invocation

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -178,7 +178,7 @@ defmodule Mix.Tasks.Phx.New do
   defp switch_to_string({name, val}), do: name <> "=" <> val
 
   defp install_brunch(install?) do
-    maybe_cmd "cd assets && npm install && node node_modules/brunch/bin/brunch build",
+    maybe_cmd "cd assets && npm install && node node_modules/brunch/.bin/brunch build",
               File.exists?("assets/brunch-config.js"), install? && System.find_executable("npm")
   end
 


### PR DESCRIPTION
## Context

Running the `mix phoenix.new` command yields an error when running brunch. The cause is that the execution path for the node module is wrong. The correct path is `node_modules/brunch/.bin/brunch`, instead of `node_modules/brunch/bin/brunch` (missing `.`).

This is a small PR to fix the path so that the `brunch` executable is found and task succeeds.