### PR TITLE
Add PHOENIX_SERVER=true environment variable to set `server: true`.

### DIFF
--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -48,6 +48,15 @@ defmodule <%= endpoint_module %> do
   """
   def init(_key, config) do
     if config[:load_from_system_env] do
+      config = case Keyword.has_key?(config, :server) do
+        true -> config
+        false ->
+          case System.get_env("PHOENIX_SERVER") do
+            "true" -> Keyword.put(config, :server, true)
+            _ -> config
+          end
+      end
+
       port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
       {:ok, Keyword.put(config, :http, [:inet6, port: port])}
     else


### PR DESCRIPTION
Hi! 

Following up on the discussion in #2499, forgetting to set `server: true` in `prod.exs` when using Distillery is an extremely common source of confusion for newcomers. 

It makes sense to default it to `false`, but I wonder if you would consider supporting a `PHOENIX_SERVER=true` environment variable to control whether the endpoint server is started or not. This could be useful for anyone using releases because Distillery can set this environment variable automatically. This would reduce the steps in getting up and running in production and eliminate a source of confusion and reduce the number of repeat questions in the Slack channels.

Even if it is not set automatically by Distillery, instructing newcomers to run

    PHOENIX_SERVER=true PORT=4000 _build/prod/rel/dev_app/bin/dev_app foreground

is much easier than explaining how to modify their `prod.exs` file. Let me know what you think! And thanks for considering this.