### PR TITLE
Add parameter keep strategy

### DIFF
--- a/test/phoenix/logger_test.exs
+++ b/test/phoenix/logger_test.exs
@@ -72,32 +72,67 @@ defmodule Phoenix.LoggerTest do
     assert output =~ "Parameters: [UNFETCHED]"
   end
 
-  test "filter_values" do
-    assert Phoenix.Logger.filter_values(%{"foo" => "bar", "password" => "should_not_show"}, ["password"]) ==
-           %{"foo" => "bar", "password" => "[FILTERED]"}
+  describe "filter_values/2 with discard strategy" do
+    test "in top level map" do
+      values = %{"foo" => "bar", "password" => "should_not_show"}
+      assert Phoenix.Logger.filter_values(values, ["password"]) ==
+            %{"foo" => "bar", "password" => "[FILTERED]"}
+    end
+
+    test "when a map has secret key" do
+      values = %{"foo" => "bar", "map" => %{"password" => "should_not_show"}}
+      assert Phoenix.Logger.filter_values(values, ["password"]) ==
+            %{"foo" => "bar", "map" => %{"password" => "[FILTERED]"}}
+    end
+
+    test "when a list has a map with secret" do
+      values = %{"foo" => "bar", "list" => [%{"password" => "should_not_show"}]}
+      assert Phoenix.Logger.filter_values(values, ["password"]) ==
+            %{"foo" => "bar", "list" => [%{"password" => "[FILTERED]"}]}
+    end
+
+    test "does not filter structs" do
+      values = %{"foo" => "bar", "file" => %Plug.Upload{}}
+      assert Phoenix.Logger.filter_values(values, ["password"]) ==
+            %{"foo" => "bar", "file" => %Plug.Upload{}}
+
+      values = %{"foo" => "bar", "file" => %{__struct__: "s"}}
+      assert Phoenix.Logger.filter_values(values, ["password"]) ==
+            %{"foo" => "bar", "file" => %{:__struct__ => "s"}}
+    end
+
+    test "does not fail on atomic keys" do
+      values = %{:foo => "bar", "password" => "should_not_show"}
+      assert Phoenix.Logger.filter_values(values, ["password"]) ==
+            %{:foo => "bar", "password" => "[FILTERED]"}
+    end
   end
 
-  test "filter_values when a map has secret key" do
-    assert Phoenix.Logger.filter_values(%{"foo" => "bar", "map" => %{"password" => "should_not_show"}}, ["password"]) ==
-           %{"foo" => "bar", "map" => %{"password" => "[FILTERED]"}}
-  end
+  describe "filter_values/2 with keep strategy" do
+    test "discards values not specified in params" do
+      values = %{"foo" => "bar", "password" => "abc123", "file" => %Plug.Upload{}}
+      assert Phoenix.Logger.filter_values(values, {:keep, []}) ==
+            %{"foo" => "[FILTERED]", "password" => "[FILTERED]", "file" => "[FILTERED]"}
+    end
 
-  test "filter_values when a list has a map with secret" do
-    assert Phoenix.Logger.filter_values(%{"foo" => "bar", "list" => [%{"password" => "should_not_show"}]}, ["password"]) ==
-           %{"foo" => "bar", "list" => [%{"password" => "[FILTERED]"}]}
-  end
+    test "keeps values that are specified in params" do
+      values = %{"foo" => "bar", "password" => "abc123", "file" => %Plug.Upload{}}
+      assert Phoenix.Logger.filter_values(values, {:keep, ["foo", "file"]}) ==
+            %{"foo" => "bar", "password" => "[FILTERED]", "file" => %Plug.Upload{}}
+    end
 
-  test "filter_values does not filter structs" do
-    assert Phoenix.Logger.filter_values(%{"foo" => "bar", "file" => %Plug.Upload{}}, ["password"]) ==
-           %{"foo" => "bar", "file" => %Plug.Upload{}}
+    test "keeps all values under keys that are kept" do
+      values = %{"foo" => %{"bar" => 1, "baz" => 2}}
+      assert Phoenix.Logger.filter_values(values, {:keep, ["foo"]}) ==
+            %{"foo" => %{"bar" => 1, "baz" => 2}}
+    end
 
-    assert Phoenix.Logger.filter_values(%{"foo" => "bar", "file" => %{__struct__: "s"}}, ["password"]) ==
-           %{"foo" => "bar", "file" => %{:__struct__ => "s"}}
-  end
-
-  test "filter_values does not fail on atomic keys" do
-    assert Phoenix.Logger.filter_values(%{:foo => "bar", "password" => "should_not_show"}, ["password"]) ==
-           %{:foo => "bar", "password" => "[FILTERED]"}
+    test "only filters leaf values" do
+      values = %{"foo" => %{"bar" => 1, "baz" => 2}, "ids" => [1, 2]}
+      assert Phoenix.Logger.filter_values(values, {:keep, []}) ==
+            %{"foo" => %{"bar" => "[FILTERED]", "baz" => "[FILTERED]"},
+              "ids" => ["[FILTERED]", "[FILTERED]"]}
+    end
   end
 
   test "logs phoenix_channel_join as configured by the channel" do


### PR DESCRIPTION
Initial conversation here: https://groups.google.com/forum/#!topic/phoenix-core/drYwLVlnvI4

I started with `discard` and `keep` as names to get things started. I'm fine with any name you want.

There are a couple choices I made when implementing the keep strategy that are worth discussing. First, I didn't want filtering to discard the structure of the data. For example, if there is a deeply nested structure, I didn't want to specify every key in the path to the leaf data. This will make it easier to look at a log and see which key you want to add.

``` elixir
# I implemented this
filter_values(%{"foo" => %{"bar" => 1}}, ["bar"])
#=> %{"foo" => %{"bar" => 1}}

filter_values(%{"foo" => %{"bar" => 1}}, [])
#=> %{"foo" => %{"bar" => "[FILTERED]"}

# Not this
filter_values(%{"foo" => %{"bar" => 1}}, ["bar"])
#=> %{"foo" => "[FILTERED]}"

filter_values(%{"foo" => %{"bar" => 1}}, ["foo", "bar"])
#=> %{"foo" => %{"bar" => 1}}
```

Second, I used `in` to check that the exact value was in the list of params. I did this because, I didn't want keeping something like `"confirm"`, to also keep `"password_confirmation"`. This differs from the discard strategy.