### PR TITLE
Updated a bad link and fixed a typo in the guides

### DIFF
--- a/guides/docs/contexts.md
+++ b/guides/docs/contexts.md
@@ -100,7 +100,7 @@ $ mix ecto.migrate
 [info]  == Migrated in 0.0s
 ```
 
-Before jump into the generated code, let's start the server with `mix phx.server` and visit [http://localhost:4000/users](http://localhost:4000/users). Let's follow the "New User" link and click the "Submit" button without providing any input. We should be greeted with the following output:
+Before we jump into the generated code, let's start the server with `mix phx.server` and visit [http://localhost:4000/users](http://localhost:4000/users). Let's follow the "New User" link and click the "Submit" button without providing any input. We should be greeted with the following output:
 
 ```
 Oops, something went wrong! Please check the errors below.

--- a/guides/docs/introduction/overview.md
+++ b/guides/docs/introduction/overview.md
@@ -81,4 +81,4 @@ Ecto is built around four main abstractions:
 A new Phoenix application will use Ecto with PostgreSQL storage by default.
 
 ## A Note about these guides
-If you find an issue with the guides or would like to help improve these guides please checkout the [Phoenix Guides](https://github.com/phoenixframework/phoenix_guides/) github. Issues and Pull Requests are happily accepted!
+If you find an issue with the guides or would like to help improve these guides please checkout the [Phoenix Guides](https://github.com/phoenixframework/phoenix/tree/master/guides/) on github. Issues and Pull Requests are happily accepted!


### PR DESCRIPTION
* changed the link for the guides repo from the old `https://github.com/phoenixframework/phoenix_guides/` to the current location of the guides at `https://github.com/phoenixframework/phoenix/tree/master/guides`
* fixed a small typo in the contexts guides


While going through the guides I discovered two other dead links, but I did not touch them as I didn't know what the desired change would be.

* The first was [in the overview](https://github.com/phoenixframework/phoenix/blob/master/guides/docs/introduction/overview.md#overview) the link to the `Learning Elixir and Erlang Guide` does not appear to work.

* The second was [in the channels section that links to the presence guide](https://github.com/phoenixframework/phoenix/blob/master/guides/docs/channels.md#presence). This one I was particularly uncertain of as in issue [2493](https://github.com/phoenixframework/phoenix/issues/2493) there is mention that a presence section was being created.