### PR TITLE
correct table relationship

### DIFF
--- a/guides/docs/routing.md
+++ b/guides/docs/routing.md
@@ -306,7 +306,7 @@ Whenever possible prefer to pass a `conn` in place of an `Endpoint`.
 
 ## Nested Resources
 
-It is also possible to nest resources in a Phoenix router. Let's say we also have a `posts` resource which has a one to many relationship with `users`. That is to say, a user can create many posts, and an individual post belongs to only one user. We can represent that by adding a nested route in `lib/hello_web/router.ex` like this:
+It is also possible to nest resources in a Phoenix router. Let's say we also have a `posts` resource which has a many-to-one relationship with `users`. That is to say, a user can create many posts, and an individual post belongs to only one user. We can represent that by adding a nested route in `lib/hello_web/router.ex` like this:
 
 ```elixir
 resources "/users", UserController do


### PR DESCRIPTION
The relationship between posts and users should be many to one, not one to many.