### PR TITLE
remove suggestion that triggers warning

### DIFF
--- a/guides/docs/routing.md
+++ b/guides/docs/routing.md
@@ -376,8 +376,6 @@ scope "/admin" do
 end
 ```
 
-Note that Phoenix will assume that the path we set ought to begin with a slash, so `scope "/admin" do` and `scope "admin" do` will both produce the same results.
-
 Note also, that the way this scope is currently defined, we need to fully qualify our controller name, `HelloWeb.Admin.ReviewController`. We'll fix that in a minute.
 
 Running `$ mix phx.routes` again, in addition to the previous set of routes we get the following:


### PR DESCRIPTION
`scope "admin" do` triggers the following warning:

```elixir
warning: router paths should begin with a forward slash, got: "admin"
    (phoenix) lib/phoenix/router/scope.ex:77: Phoenix.Router.Scope.push/2
    lib/hello_web/router.ex:27: (module)
    (elixir) src/elixir_compiler.erl:85: :elixir_compiler.dispatch/6
    (elixir) src/elixir_module.erl:238: :elixir_module.eval_form/6
    (elixir) src/elixir_module.erl:80: :elixir_module.compile/5
    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
    (elixir) src/elixir.erl:239: :elixir.eval_forms/4
    (elixir) src/elixir_compiler.erl:61: :elixir_compiler.eval_forms/3
    (elixir) src/elixir_lexical.erl:17: :elixir_lexical.run/3
    (elixir) src/elixir_compiler.erl:27: :elixir_compiler.quoted/3
    (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
```
So I don't think the alternative should be encouraged anymore.