### PR TITLE
Enforce safe local urls with static_path

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -670,6 +670,7 @@ defmodule Phoenix.Endpoint do
       Generates a route to a static file in `priv/static`.
       """
       def static_path(path) do
+        Phoenix.Endpoint.validate_local_url(path)
         Phoenix.Config.cache(__MODULE__, :__phoenix_static__,
                              &Phoenix.Endpoint.Supervisor.static_path/1) <>
         Phoenix.Config.cache(__MODULE__, {:__phoenix_static__, path},
@@ -814,4 +815,22 @@ defmodule Phoenix.Endpoint do
     end
   end
   defp tear_alias(other), do: other
+
+  @invalid_local_url_chars ["\\"]
+  @doc false
+  def validate_local_url("//" <> _ = path), do: raise_invalid_url(path)
+  def validate_local_url("/" <> _ = path) do
+    if String.contains?(path, @invalid_local_url_chars) do
+      raise ArgumentError, "unsafe characters detected for path #{inspect path}"
+    else
+      path
+    end
+  end
+  def validate_local_url(path), do: raise_invalid_url(path)
+
+  @spec raise_invalid_url(term()) :: no_return()
+  defp raise_invalid_url(path) do
+    raise ArgumentError, "expected a local path but was #{inspect path}"
+  end
 end
+

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -170,4 +170,17 @@ defmodule Phoenix.Endpoint.EndpointTest do
     Application.put_env(:phoenix, endpoint, [])
     refute Phoenix.Endpoint.server?(:phoenix, endpoint)
   end
+
+  test "static_path/1 validates paths are local/safe" do
+    safe_path = "/some_safe_path"
+    assert Endpoint.static_path(safe_path) == safe_path
+
+    assert_raise ArgumentError, ~r/unsafe characters/, fn ->
+      Endpoint.static_path("/\\unsafe_path")
+    end
+
+    assert_raise ArgumentError, ~r/expected a local path/, fn ->
+      Endpoint.static_path("//invalid_path")
+    end
+  end
 end


### PR DESCRIPTION
Enforces local paths when using `static_path`.

Resolves #2516.