### PR TITLE
Add a forceDisconnect function to Socket that also resets reconnectTimer in addition to disconnecting

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -750,6 +750,17 @@ export class Socket {
   }
 
   /**
+   * Cancels pending reconnect attempts and then disconnects
+   * @param {Function} callback
+   * @param {integer} code
+   * @param {string} reason
+   */
+  forceDisconnect(callback, code, reason){
+    this.reconnectTimer.reset()
+    this.disconnect(callback, code, reason)
+  }
+
+  /**
    *
    * @param {Object} params - The params to send when connecting, for example `{user_id: userToken}`
    */


### PR DESCRIPTION
I think I might still be experiencing the issue described in #2187 in v1.3.0, and I can't find anything that was changed with `disconnect` or `reconnectTimer` to resolve this issue.

The line highlighted in that issue is probably not the one causing this problem, as the noop function that `this.conn.onclose` is set to gets overwritten by `connect` to point back to `this.onConnClose()` in the next reconnection attempt.

This line seems to be intended to stop `reconnectTimer` from being scheduled in the first place, so it seems that a good way to resolve this problem would be to reset the timer if it has already been scheduled.

---

I initially tried to fix this by resetting `reconnectTimer` inside of `disconnect`. This was a problem because `reconnectTimer` uses `disconnect` as part of its callback function, and trying to reset `reconnectTimer` inside of `disconnect` would cause `reconnectTimer` to reset itself.

Instead, I think it might be a good idea to implement a new function that resets `reconnectTimer` before calling `disconnect`, and have this one be documented so that people can find it more easily.