### PR TITLE
Update docs to use groups_for_extras for guide grouping

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,8 @@ defmodule Phoenix.Mixfile do
         extra_section: "GUIDES",
         assets: "guides/docs/assets",
         formatters: ["html", "epub"],
-        extras: extras()
+        extras: extras(),
+        groups_for_extras: groups_for_extras()
       ],
       aliases: aliases(),
       source_url: "https://github.com/phoenixframework/phoenix",
@@ -62,7 +63,7 @@ defmodule Phoenix.Mixfile do
       {:gettext, "~> 0.8", only: :test},
 
       # Docs dependencies
-      {:ex_doc, "~> 0.16.4", only: :docs},
+      {:ex_doc, "~> 0.17.0", only: :docs},
       {:inch_ex, "~> 0.2", only: :docs},
 
       # Test dependencies
@@ -86,34 +87,42 @@ defmodule Phoenix.Mixfile do
 
   defp extras do
     [
-      "introduction/overview.md": [group: "Introduction"],
-      "introduction/installation.md": [group: "Introduction"],
-      "introduction/learning.md": [group: "Introduction"],
-      "introduction/community.md": [group: "Introduction"],
+      "guides/docs/introduction/overview.md",
+      "guides/docs/introduction/installation.md",
+      "guides/docs/introduction/learning.md",
+      "guides/docs/introduction/community.md",
 
-      "up_and_running.md": [group: "Guides"],
-      "adding_pages.md": [group: "Guides"],
-      "routing.md": [group: "Guides"],
-      "plug.md": [group: "Guides"],
-      "endpoint.md": [group: "Guides"],
-      "controllers.md": [group: "Guides"],
-      "views.md": [group: "Guides"],
-      "templates.md": [group: "Guides"],
-      "channels.md": [group: "Guides"],
-      "ecto.md": [group: "Guides"],
-      "contexts.md": [group: "Guides"],
-      "phoenix_mix_tasks.md": [group: "Guides"],
-      "errors.md": [group: "Guides"],
+      "guides/docs/up_and_running.md",
+      "guides/docs/adding_pages.md",
+      "guides/docs/routing.md",
+      "guides/docs/plug.md",
+      "guides/docs/endpoint.md",
+      "guides/docs/controllers.md",
+      "guides/docs/views.md",
+      "guides/docs/templates.md",
+      "guides/docs/channels.md",
+      "guides/docs/ecto.md",
+      "guides/docs/contexts.md",
+      "guides/docs/phoenix_mix_tasks.md",
+      "guides/docs/errors.md",
 
-      "testing/testing.md": [group: "Testing"],
-      "testing/testing_schemas.md": [group: "Testing"],
-      "testing/testing_controllers.md": [group: "Testing"],
-      "testing/testing_channels.md": [group: "Testing"],
+      "guides/docs/testing/testing.md",
+      "guides/docs/testing/testing_schemas.md",
+      "guides/docs/testing/testing_controllers.md",
+      "guides/docs/testing/testing_channels.md",
 
-      "deployment/deployment.md": [group: "Deployment"],
-      "deployment/heroku.md": [group: "Deployment"]
+      "guides/docs/deployment/deployment.md",
+      "guides/docs/deployment/heroku.md"
+      ]
+  end
+
+  defp groups_for_extras do
+    [
+      "Introduction": ~r/guides\/docs\/introduction\/.?/,
+      "Guides": ~r/guides\/docs\/[^\/]+\.md/,
+      "Testing": ~r/guides\/docs\/testing\/.?/,
+      "Deployment": ~r/guides\/docs\/deployment\/.?/
     ]
-    |> Enum.map(fn {file, opts} -> {:"guides/docs/#{file}", opts} end)
   end
 
   defp aliases do

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.16.4", "4bf6b82d4f0a643b500366ed7134896e8cccdbab4d1a7a35524951b25b1ec9f0", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.17.0", "fdf3dc9c6cd1945afb583488de1bf8c12bd8b2ab80f2e7a0e2476a60b9e3bd8f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], []},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},


### PR DESCRIPTION
Please don't merge until ExDoc 0.17 is released