### PR TITLE
Group modules using ExUnit 0.17 groupings

### DIFF
--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -11,18 +11,7 @@ defmodule Phoenix.Digester do
     :calendar.datetime_to_gregorian_seconds(:calendar.universal_time)
   end
 
-  @moduledoc """
-  Digests and compresses static files.
-
-  For each file under the given input path, Phoenix will generate a digest
-  and also compress in `.gz` format. The filename and its digest will be
-  used to generate the cache manifest file. It also avoids duplication, checking
-  for already digested files.
-
-  For stylesheet files found under the given path, Phoenix will replace
-  asset references with the digested paths, as long as the asset exists
-  in the generated cache manifest.
-  """
+  @moduledoc false
 
   @doc """
   Digests and compresses the static files and saves them in the given output path.

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule Phoenix.Mixfile do
         extra_section: "GUIDES",
         assets: "guides/docs/assets",
         formatters: ["html", "epub"],
+        groups_for_modules: groups_for_modules(),
         extras: extras(),
         groups_for_extras: groups_for_extras()
       ],
@@ -122,6 +123,54 @@ defmodule Phoenix.Mixfile do
       "Guides": ~r/guides\/docs\/[^\/]+\.md/,
       "Testing": ~r/guides\/docs\/testing\/.?/,
       "Deployment": ~r/guides\/docs\/deployment\/.?/
+    ]
+  end
+
+  defp groups_for_modules do
+    # Ungrouped Modules:
+    #
+    # Phoenix
+    # Phoenix.Channel
+    # Phoenix.Controller
+    # Phoenix.Naming
+    # Phoenix.Param
+    # Phoenix.Presence
+    # Phoenix.Router
+    # Phoenix.Token
+    # Phoenix.View
+
+    [
+      "Endpoint And Plugs": [
+        Phoenix.CodeReloader,
+        Phoenix.Endpoint,
+        Phoenix.Endpoint.CowboyHandler,
+        Phoenix.Endpoint.Handler,
+        Phoenix.Logger,
+      ],
+
+      "Socket And Transport": [
+        Phoenix.Socket,
+        Phoenix.Socket.Broadcast,
+        Phoenix.Socket.Message,
+        Phoenix.Socket.Reply,
+        Phoenix.Socket.Transport,
+        Phoenix.Transports.LongPoll,
+        Phoenix.Transports.Serializer,
+        Phoenix.Transports.WebSocket,
+      ],
+
+      "Templating": [
+        Phoenix.Template,
+        Phoenix.Template.EExEngine,
+        Phoenix.Template.Engine,
+        Phoenix.Template.ExsEngine,
+        Phoenix.Template.HTML,
+      ],
+
+      "Testing": [
+        Phoenix.ChannelTest,
+        Phoenix.ConnTest,
+      ],
     ]
   end
 


### PR DESCRIPTION
Please see this issue:
https://github.com/elixir-lang/ex_doc/issues/779
and this PR:
https://github.com/elixir-lang/elixir/pull/6621

This groups the modules in the following way:

    (not in a group)
    Phoenix
    Phoenix.Digester
    Phoenix.Logger
    Phoenix.Naming
    Phoenix.Token

    CHANNELS AND TRANSPORTS
    Phoenix.Channel
    Phoenix.Presence
    Phoenix.Socket
    Phoenix.Socket.Broadcast
    Phoenix.Socket.Message
    Phoenix.Socket.Reply
    Phoenix.Socket.Transport
    Phoenix.Transports.LongPoll
    Phoenix.Transports.Serializer
    Phoenix.Transports.WebSocket

    DEVELOPMENT & TESTING
    Phoenix.ChannelTest
    Phoenix.CodeReloader
    Phoenix.ConnTest

    ENDPOINT & REQUESTS
    Phoenix.Controller
    Phoenix.Endpoint
    Phoenix.Endpoint.CowboyHandler
    Phoenix.Endpoint.Handler
    Phoenix.Router

    PROTOCOLS
    Phoenix.Param

    VIEWS AND TEMPLATING
    Phoenix.Template
    Phoenix.Template.EExEngine
    Phoenix.Template.Engine
    Phoenix.Template.ExsEngine
    Phoenix.Template.HTML
    Phoenix.View