### PR TITLE
Update command in contexts.md docs.

### DIFF
--- a/guides/docs/contexts.md
+++ b/guides/docs/contexts.md
@@ -28,7 +28,7 @@ In order to run the context generators, we need to come up with a module name th
 Before we use the generators, we need to undo the changes we made in the Ecto guide, so we can give our user schema a proper home. Run these commands to undo our previous work:
 
 ```console
-$ rm lib/hello/user.ex
+$ rm -R lib/hello/accounts
 $ rm priv/repo/migrations/*_create_user.exs
 ```
 


### PR DESCRIPTION
The `user.ex` file created from the previous Ecto guide is inside `lib/hello/account/` folder instead of `lib/hello/`.

This PR change it to delete the `accounts` directory instead.