### PR TITLE
Deprecate render/3 and render/4 in favor of put_view/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   * [Logger] Add whitelist support to `filter_parameters` logger configuration, via new `:keep` tuple format
   * [Router] Raise on duplicate plugs in pipe_through scopes
 
+* Deprecations
+  * [Controller] Passing a view in `render/3` and `render/4` is deprecated in favor of `put_view/2`
+
 ## 1.3.0 (2017-07-28)
 
 See these [`1.2.x` to `1.3.x` upgrade instructions](https://gist.github.com/chrismccord/71ab10d433c98b714b75c886eff17357) to bring your existing apps up to speed.

--- a/guides/docs/controllers.md
+++ b/guides/docs/controllers.md
@@ -452,7 +452,8 @@ The correct way to render the 404 page from `HelloWeb.PageController` is:
 def index(conn, _params) do
   conn
   |> put_status(:not_found)
-  |> render(HelloWeb.ErrorView, "404.html")
+  |> put_view(HelloWeb.ErrorView)
+  |> render("404.html")
 end
 ```
 
@@ -558,11 +559,13 @@ defmodule HelloWeb.MyController do
       {:error, :not_found} ->
         conn
         |> put_status(:not_found)
-        |> render(ErrorView, :"404")
+        |> put_view(ErrorView)
+        |> render(:"404")
       {:error, :unauthorized} ->
         conn
         |> put_status(403)
-        |> render(ErrorView, :"403")
+        |> put_view(ErrorView)
+        |> render(:"403")
     end
   end
 end
@@ -578,13 +581,15 @@ defmodule HelloWeb.MyFallbackController do
   def call(conn, {:error, :not_found}) do
     conn
     |> put_status(:not_found)
-    |> render(ErrorView, :"404")
+    |> put_view(ErrorView)
+    |> render(:"404")
   end
 
   def call(conn, {:error, :unauthorized}) do
     conn
     |> put_status(403)
-    |> render(ErrorView, :"403")
+    |> put_view(ErrorView)
+    |> render(:"403")
   end
 end
 ```

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -635,12 +635,8 @@ defmodule Phoenix.Controller do
 
   By default, Controllers render templates in a view with a similar name to the
   controller. For example, `MyApp.UserController` will render templates inside
-  the `MyApp.UserView`. This information can be changed any time by using
-  `render/3`, `render/4` or the `put_view/2` function:
-
-      def show(conn, _params) do
-        render(conn, MyApp.SpecialView, :show, message: "Hello")
-      end
+  the `MyApp.UserView`. This information can be changed any time by using the
+  `put_view/2` function:
 
       def show(conn, _params) do
         conn
@@ -704,10 +700,13 @@ defmodule Phoenix.Controller do
 
   def render(conn, view, template)
       when is_atom(view) and (is_binary(template) or is_atom(template)) do
+    IO.warn "#{__MODULE__}.render/3 with a view is deprecated, see the documentation for render/3 for an alternative"
     render(conn, view, template, [])
   end
 
   @doc """
+  WARNING: This function is deprecated in favor of `render/3` + `put_view/2`.
+
   A shortcut that renders the given template in the given view.
 
   Equivalent to:
@@ -720,6 +719,7 @@ defmodule Phoenix.Controller do
   @spec render(Plug.Conn.t, atom, atom | binary, Keyword.t | map) :: Plug.Conn.t
   def render(conn, view, template, assigns)
       when is_atom(view) and (is_binary(template) or is_atom(template)) do
+    IO.warn "#{__MODULE__}.render/4 with a view is deprecated, see the documentation for render/3 for an alternative"
     conn
     |> put_view(view)
     |> render(template, assigns)

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -214,13 +214,15 @@ defmodule Phoenix.Controller do
         def call(conn, {:error, :not_found}) do
           conn
           |> put_status(:not_found)
-          |> render(MyErrorView, :"404")
+          |> put_view(MyErrorView)
+          |> render(:"404")
         end
 
         def call(conn, {:error, :unauthorized}) do
           conn
           |> put_status(403)
-          |> render(MyErrorView, :"403")
+          |> put_view(MyErrorView)
+          |> render(:"403")
         end
       end
   """

--- a/priv/templates/phx.gen.json/fallback_controller.ex
+++ b/priv/templates/phx.gen.json/fallback_controller.ex
@@ -9,12 +9,14 @@ defmodule <%= inspect context.web_module %>.FallbackController do
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)
-    |> render(<%= inspect context.web_module %>.ChangesetView, "error.json", changeset: changeset)
+    |> put_view(<%= inspect context.web_module %>.ChangesetView)
+    |> render("error.json", changeset: changeset)
   end
 
   def call(conn, {:error, :not_found}) do
     conn
     |> put_status(:not_found)
-    |> render(<%= inspect context.web_module %>.ErrorView, :"404")
+    |> put_view(<%= inspect context.web_module %>.ErrorView)
+    |> render(:"404")
   end
 end


### PR DESCRIPTION
Encourage the use of `put_view/2` and `plug :put_view, View` instead.

See #2469.