### PR TITLE
Extract Phoenix.Socket.Transport.dispatch to separate module

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -120,8 +120,7 @@ defmodule Phoenix.Socket.Transport do
 
   require Logger
   alias Phoenix.Socket
-  alias Phoenix.Socket.Message
-  alias Phoenix.Socket.Reply
+  alias Phoenix.Socket.TransportDispatcher
 
   @protocol_version "2.0.0"
 
@@ -239,78 +238,15 @@ defmodule Phoenix.Socket.Transport do
   Phoenix's default is `["password"]`.
 
   """
-  def dispatch(msg, channels, socket)
-
-  def dispatch(%{ref: ref, topic: "phoenix", event: "heartbeat"}, _channels, socket) do
-    {:reply, %Reply{join_ref: socket.join_ref, ref: ref, topic: "phoenix", status: :ok, payload: %{}}}
-  end
-
-  def dispatch(%Message{} = msg, channels, socket) do
-    channels
-    |> Map.get(msg.topic)
-    |> do_dispatch(msg, socket)
-  end
-
-  @doc false
-  def build_channel_socket(%Socket{} = socket, channel, topic, join_ref, opts) do
-    %Socket{socket |
-            topic: topic,
-            channel: channel,
-            join_ref: join_ref,
-            assigns: Map.merge(socket.assigns, opts[:assigns] || %{}),
-            private: channel.__socket__(:private)}
-  end
-
-  defp do_dispatch(nil, %{event: "phx_join", topic: topic} = msg, base_socket) do
-    case base_socket.handler.__channel__(topic, base_socket.transport_name) do
-      {channel, opts} ->
-        socket = build_channel_socket(base_socket, channel, topic, msg.ref, opts)
-
-        case Phoenix.Channel.Server.join(socket, msg.payload) do
-          {:ok, response, pid} ->
-            log socket, topic, fn -> "Replied #{topic} :ok" end
-            {:joined, pid, %Reply{join_ref: socket.join_ref, ref: msg.ref, topic: topic, status: :ok, payload: response}}
-
-          {:error, reason} ->
-            log socket, topic, fn -> "Replied #{topic} :error" end
-            {:error, reason, %Reply{join_ref: socket.join_ref, ref: msg.ref, topic: topic, status: :error, payload: reason}}
-        end
-
-      nil -> reply_ignore(msg, base_socket)
-    end
-  end
-
-  defp do_dispatch(pid, %{event: "phx_join"} = msg, socket) when is_pid(pid) do
-    Logger.debug "Duplicate channel join for topic \"#{msg.topic}\" in #{inspect(socket.handler)}. " <>
-                 "Closing existing channel for new join."
-    :ok = Phoenix.Channel.Server.close(pid)
-    do_dispatch(nil, msg, socket)
-  end
-
-  defp do_dispatch(nil, msg, socket) do
-    reply_ignore(msg, socket)
-  end
-
-  defp do_dispatch(channel_pid, msg, _socket) do
-    send(channel_pid, msg)
-    :noreply
-  end
-
-  defp log(_, "phoenix" <> _, _func), do: :noop
-  defp log(%{ private: %{ log_join: false } }, _topic, _func), do: :noop
-  defp log(%{ private: %{ log_join: level } }, _topic, func), do: Logger.log(level, func)
-
-  defp reply_ignore(msg, socket) do
-    Logger.warn fn -> "Ignoring unmatched topic \"#{msg.topic}\" in #{inspect(socket.handler)}" end
-    {:error, :unmatched_topic, %Reply{join_ref: socket.join_ref, ref: msg.ref, topic: msg.topic, status: :error,
-                                      payload: %{reason: "unmatched topic"}}}
+  def dispatch(msg, channels, socket) do
+    TransportDispatcher.dispatch(msg, channels, socket)
   end
 
   @doc """
   Returns the message to be relayed when a channel exits.
   """
   def on_exit_message(topic, join_ref, _reason) do
-    %Message{join_ref: join_ref, ref: join_ref, topic: topic, event: "phx_error", payload: %{}}
+    TransportDispatcher.on_exit_message(topic, join_ref)
   end
 
   # TODO v2: Remove 2-arity
@@ -322,7 +258,7 @@ defmodule Phoenix.Socket.Transport do
 
   @doc false
   def notify_graceful_exit(%Socket{topic: topic, join_ref: ref} = socket) do
-    close_msg = %Message{join_ref: ref, ref: ref, topic: topic, event: "phx_close", payload: %{}}
+    close_msg = TransportDispatcher.on_graceful_exit_message(topic, ref)
     send(socket.transport_pid, {:graceful_exit, self(), close_msg})
   end
 

--- a/lib/phoenix/socket/transport_dispatcher.ex
+++ b/lib/phoenix/socket/transport_dispatcher.ex
@@ -1,0 +1,93 @@
+defmodule Phoenix.Socket.TransportDispatcher do
+  @moduledoc """
+  Callback module for dispatching `Phoenix.Socket.Message` to a channel.
+
+  This module handles incoming events:
+
+    * "hearteat" events in the "phoenix" topic - emits OK reploy
+    * "phx_join" on any topic - joins socket to topic
+    * any event with topic matching joined channels - sends event to channel
+    * any other topics - replies with `unmatched_topic` error
+  """
+  alias Phoenix.Socket
+  alias Phoenix.Socket.{Reply, Message}
+
+  require Logger
+
+  @doc false
+  def dispatch(%{ref: ref, topic: "phoenix", event: "heartbeat"}, _channels, socket) do
+    {:reply, %Reply{join_ref: socket.join_ref, ref: ref, topic: "phoenix", status: :ok, payload: %{}}}
+  end
+
+  @doc false
+  def dispatch(%Message{} = msg, channels, socket) do
+    channels
+    |> Map.get(msg.topic)
+    |> do_dispatch(msg, socket)
+  end
+
+  @doc false
+  def build_channel_socket(%Socket{} = socket, channel, topic, join_ref, opts) do
+    %Socket{socket |
+            topic: topic,
+            channel: channel,
+            join_ref: join_ref,
+            assigns: Map.merge(socket.assigns, opts[:assigns] || %{}),
+            private: channel.__socket__(:private)}
+  end
+
+  @doc false
+  def on_exit_message(topic, join_ref) do
+    %Message{join_ref: join_ref, ref: join_ref, topic: topic, event: "phx_error", payload: %{}}
+  end
+
+  @doc false
+  def on_graceful_exit_message(topic, ref) do
+    %Message{join_ref: ref, ref: ref, topic: topic, event: "phx_close", payload: %{}}
+  end
+
+  defp do_dispatch(nil, %{event: "phx_join", topic: topic} = msg, base_socket) do
+    case base_socket.handler.__channel__(topic, base_socket.transport_name) do
+      {channel, opts} ->
+        socket = build_channel_socket(base_socket, channel, topic, msg.ref, opts)
+
+        case Phoenix.Channel.Server.join(socket, msg.payload) do
+          {:ok, response, pid} ->
+            log socket, topic, fn -> "Replied #{topic} :ok" end
+            {:joined, pid, %Reply{join_ref: socket.join_ref, ref: msg.ref, topic: topic, status: :ok, payload: response}}
+
+          {:error, reason} ->
+            log socket, topic, fn -> "Replied #{topic} :error" end
+            {:error, reason, %Reply{join_ref: socket.join_ref, ref: msg.ref, topic: topic, status: :error, payload: reason}}
+        end
+
+      nil -> reply_ignore(msg, base_socket)
+    end
+  end
+
+  defp do_dispatch(pid, %{event: "phx_join"} = msg, socket) when is_pid(pid) do
+    Logger.debug "Duplicate channel join for topic \"#{msg.topic}\" in #{inspect(socket.handler)}. " <>
+                 "Closing existing channel for new join."
+    :ok = Phoenix.Channel.Server.close(pid)
+    do_dispatch(nil, msg, socket)
+  end
+
+  defp do_dispatch(nil, msg, socket) do
+    reply_ignore(msg, socket)
+  end
+
+  defp do_dispatch(channel_pid, msg, _socket) do
+    send(channel_pid, msg)
+    :noreply
+  end
+
+  defp log(_, "phoenix" <> _, _func), do: :noop
+  defp log(%{ private: %{ log_join: false } }, _topic, _func), do: :noop
+  defp log(%{ private: %{ log_join: level } }, _topic, func), do: Logger.log(level, func)
+
+  defp reply_ignore(msg, socket) do
+    Logger.warn fn -> "Ignoring unmatched topic \"#{msg.topic}\" in #{inspect(socket.handler)}" end
+    {:error, :unmatched_topic, %Reply{join_ref: socket.join_ref, ref: msg.ref, topic: msg.topic, status: :error,
+                                      payload: %{reason: "unmatched topic"}}}
+  end
+end

--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -156,6 +156,7 @@ defmodule Phoenix.ChannelTest do
   alias Phoenix.Socket.Broadcast
   alias Phoenix.Socket.Reply
   alias Phoenix.Socket.Transport
+  alias Phoenix.Socket.TransportDispatcher
   alias Phoenix.Channel.Server
 
   defmodule NoopSerializer do
@@ -353,7 +354,7 @@ defmodule Phoenix.ChannelTest do
       when is_atom(channel) and is_binary(topic) and is_map(payload) do
 
     ref = System.unique_integer([:positive])
-    socket = Transport.build_channel_socket(socket, channel, topic, ref, [])
+    socket = TransportDispatcher.build_channel_socket(socket, channel, topic, ref, [])
 
     case Server.join(socket, payload) do
       {:ok, reply, pid} ->


### PR DESCRIPTION
Hi,
I think what extracting of phoenix transport protocol to separate module would give some benefits - e.g. If you mind you could have your own realisation of it and make some custom logic on top of it later. So I extracted responsibility of Phoenix.Transport.dispatch to separate module. And also this extraction separates logic of handling transport itself from handling events and channels logic.