### PR TITLE
Fixed errors in the documentation in the presence.ex template and gen.presence file

### DIFF
--- a/lib/mix/tasks/phx.gen.presence.ex
+++ b/lib/mix/tasks/phx.gen.presence.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Phx.Gen.Presence do
 
     * lib/my_app_web/channels/presence.ex
 
-  Where `presence.ex` is the snake cased version of the module name provided.
+  Where `my_app_web` is the snake cased version of the module name provided.
   """
   use Mix.Task
 

--- a/priv/templates/phx.gen.presence/presence.ex
+++ b/priv/templates/phx.gen.presence/presence.ex
@@ -11,10 +11,10 @@ defmodule <%= module %> do
 
       defmodule <%= base %>.MyChannel do
         use <%= base %>Web, :channel
-        alias <%= base %>.Presence
+        alias <%= base %>Web.Presence
 
         def join("some:topic", _params, socket) do
-          send(self, :after_join)
+          send(self(), :after_join)
           {:ok, assign(socket, :user_id, ...)}
         end
 


### PR DESCRIPTION
The main changes are in the template where the Presence module should have a `Web` suffix and there should be parentheses after `self`.