### PR TITLE
Revert "use new elixir "not in" syntax in docs"

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -91,7 +91,7 @@ defmodule Phoenix.Controller do
   a plug to only run in some particular action:
 
       plug :authenticate, [usernames: ["jose", "eric", "sonny"]] when action in [:show, :edit]
-      plug :authenticate, [usernames: ["admin"]] when action not in [:index]
+      plug :authenticate, [usernames: ["admin"]] when not action in [:index]
 
   The first plug will run only when action is show or edit. The second plug will
   always run, except for the index action.


### PR DESCRIPTION
Reverts phoenixframework/phoenix#2555

The syntax is exclusive to Elixir v1.5 so we are not quite ready for it yet.