### PR TITLE
HTML options for generated error_tag

### DIFF
--- a/installer/templates/phx_web/views/error_helpers.ex
+++ b/installer/templates/phx_web/views/error_helpers.ex
@@ -10,7 +10,7 @@ defmodule <%= web_namespace %>.ErrorHelpers do
   """
   def error_tag(form, field, html_opts \\ []) do
     html_tag = Keyword.get(html_opts, :tag, :span)
-    class = Keyword.get(html_opts, :class, "help-block")
+    class    = Keyword.get(html_opts, :class, "help-block")
     Enum.map(Keyword.get_values(form.errors, field), fn (error) ->
       content_tag html_tag, translate_error(error), class: class
     end)

--- a/installer/templates/phx_web/views/error_helpers.ex
+++ b/installer/templates/phx_web/views/error_helpers.ex
@@ -8,9 +8,11 @@ defmodule <%= web_namespace %>.ErrorHelpers do
   @doc """
   Generates tag for inlined form input errors.
   """
-  def error_tag(form, field) do
+  def error_tag(form, field, html_opts \\ []) do
+    html_tag = Keyword.get(html_opts, :tag, :span)
+    class = Keyword.get(html_opts, :class, "help-block")
     Enum.map(Keyword.get_values(form.errors, field), fn (error) ->
-      content_tag :span, translate_error(error), class: "help-block"
+      content_tag html_tag, translate_error(error), class: class
     end)
   end
 <% end %>


### PR DESCRIPTION
I found it helpful to be able to customize error_tag similar to other html tag helpers.