### PR TITLE
Docs on deploying to DigitalOcean

### DIFF
--- a/guides/docs/deployment/deployment.md
+++ b/guides/docs/deployment/deployment.md
@@ -8,7 +8,7 @@ When preparing an application for deployment, there are three main steps:
   * Compiling your application assets
   * Starting your server in production
 
-How those are exactly handled depends on your deployment infrastructure. We have included a guide specific to [Heroku](heroku.html), and for anyone not using Heroku, we recommend using  [Distillery](https://github.com/bitwalker/distillery).
+How those are exactly handled depends on your deployment infrastructure. We have included a guide specific to [Heroku](heroku.html) and [DigitalOcean](digital_ocean.html). For anyone not using these services, we recommend using [Distillery](https://github.com/bitwalker/distillery).
 
 In any case, this chapter provides a general overview of the deployment steps, which will be useful regardless of your infrastructure or if you want to run in production locally.
 

--- a/guides/docs/deployment/digital_ocean.md
+++ b/guides/docs/deployment/digital_ocean.md
@@ -1,0 +1,47 @@
+# Deploying Phoenix to DigitalOcean
+
+- [Part 1](https://medium.com/@zek/deploy-early-and-often-deploying-phoenix-with-edeliver-and-distillery-part-one-5e91cac8d4bd)
+- [Part 2](https://medium.com/@zek/deploy-early-and-often-deploying-phoenix-with-edeliver-and-distillery-part-two-f361ef36aa10)
+
+# Gotchas for Phoenix v1.3
+
+_Credits to [this comment](https://medium.com/@ian_32298/thanks-for-the-blog-post-i-had-to-change-the-following-to-get-it-to-work-with-phoenix-v1-3-64ef20c6d6eb)_
+
+#### Don't add the `http: [port: 8888]` config in `config/prod.exs`
+
+Instead, you'll need to add `export PORT=8888` to `~/.profile` on your DigitalOcean droplet.
+
+#### Read this when you get to the step for creating a `.deliver/config` file.
+
+Replace the function below in `.deliver/config`
+
+```
+pre_erlang_clean_compile() {
+  status "Running phx.digest" # log output prepended with "----->"
+  __sync_remote " # runs the commands on the build host
+    # [ -f ~/.profile ] && source ~/.profile # load profile (optional)
+    source ~/.profile
+
+    # echo \$PATH # check if rbenv is in the path
+    set -e # fail if any command fails (recommended)
+    cd '$BUILD_AT' # enter the build directory on the build host (required)
+
+    # prepare something
+    mkdir -p priv/static # required by the phoenix.digest task
+    ( cd assets && npm install && ./node_modules/brunch/bin/brunch build --production )
+
+    # run your custom task
+    APP='$APP' MIX_ENV='$TARGET_MIX_ENV' $MIX_CMD phx.digest $SILENCE
+  "
+}
+```
+
+#### `mix edeliver start production`
+
+The `response` for this command should be `response: ok`.
+
+# Other useful resources
+
+- [Securing your app with SSL](https://medium.com/@zek/secure-your-phoenix-app-with-free-ssl-48ac749c17d7)
+
+- [Automated Backups with the Ruby Backup Gem and Amazon S3](https://medium.com/@zek/automated-backups-with-the-ruby-backup-gem-and-amazon-s3-f0f2f986876e)

--- a/mix.exs
+++ b/mix.exs
@@ -113,7 +113,8 @@ defmodule Phoenix.Mixfile do
       "guides/docs/testing/testing_channels.md",
 
       "guides/docs/deployment/deployment.md",
-      "guides/docs/deployment/heroku.md"
+      "guides/docs/deployment/heroku.md",
+      "guides/docs/deployment/digital_ocean.md"
       ]
   end
 


### PR DESCRIPTION
I've started playing with Elixir/Phoenix 2 days ago and was following the guides in https://hexdocs.pm/phoenix and got stuck on deployment.

Spent a ton of time researching on how to deploy to DO, attempting pieces of possible solutions from different places, it was frustrating.

If I had seen this section in there, it'd have been much easier for me to get started.

I believe having a this doc would make Phoenix's initial experience smoother for newbies like myself.

It may not be the ideal doc, but I believe it's good enough to start with. 