### PR TITLE
Fix tiny typo in guides/docs/views.md

### DIFF
--- a/guides/docs/views.md
+++ b/guides/docs/views.md
@@ -60,7 +60,7 @@ defmodule HelloWeb.PageView do
 end
 ```
 
-Now if you fire up the server with `mix phx.server` and visit `http://locahost:4000`, you should see the following text below your layout header instead of the main template page:
+Now if you fire up the server with `mix phx.server` and visit `http://localhost:4000`, you should see the following text below your layout header instead of the main template page:
 ```
 rendering with assigns [:conn, :view_module, :view_template]
 ```


### PR DESCRIPTION
Change http://locahost:4000 to http://localhost:4000.