### PR TITLE
Start pipe chains with a raw values

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -92,9 +92,9 @@ defmodule Mix.Phoenix do
     web_module = base |> web_module() |> inspect()
     scoped     = Phoenix.Naming.camelize(singular)
     path       = Phoenix.Naming.underscore(scoped)
-    singular   = String.split(path, "/") |> List.last
-    module     = Module.concat(base, scoped) |> inspect
-    alias      = String.split(module, ".") |> List.last
+    singular   = path |> String.split("/") |> List.last
+    module     = base |> Module.concat(scoped) |> inspect
+    alias      = module |> String.split(".") |> List.last
     human      = Phoenix.Naming.humanize(singular)
 
     [alias: alias,

--- a/lib/mix/tasks/phx.gen.secret.ex
+++ b/lib/mix/tasks/phx.gen.secret.ex
@@ -25,7 +25,7 @@ defmodule Mix.Tasks.Phx.Gen.Secret do
   end
 
   defp random_string(length) when length > 31 do
-    :crypto.strong_rand_bytes(length) |> Base.encode64 |> binary_part(0, length)
+    length |> :crypto.strong_rand_bytes() |> Base.encode64 |> binary_part(0, length)
   end
   defp random_string(_), do: Mix.raise "The secret should be at least 32 characters long"
 

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -264,7 +264,8 @@ defmodule Phoenix.Controller do
   end
 
   defp get_json_encoder do
-    Application.get_env(:phoenix, :format_encoders)
+    :phoenix
+    |> Application.get_env(:format_encoders)
     |> Keyword.get(:json, Poison)
   end
 
@@ -915,7 +916,7 @@ defmodule Phoenix.Controller do
   """
   @spec scrub_params(Plug.Conn.t, String.t) :: Plug.Conn.t
   def scrub_params(conn, required_key) when is_binary(required_key) do
-    param = Map.get(conn.params, required_key) |> scrub_param()
+    param = conn.params |> Map.get(required_key) |> scrub_param()
 
     unless param do
       raise Phoenix.MissingParamError, key: required_key

--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -140,7 +140,7 @@ defmodule Phoenix.Digester do
   defp map_file(file_path, input_path) do
     {:ok, stats} = File.stat(file_path)
     %{absolute_path: file_path,
-      relative_path: Path.relative_to(file_path, input_path) |> Path.dirname(),
+      relative_path: file_path |> Path.relative_to(input_path) |> Path.dirname(),
       filename: Path.basename(file_path),
       size: stats.size,
       content: File.read!(file_path)}
@@ -153,7 +153,7 @@ defmodule Phoenix.Digester do
     digest = String.trim_leading(digest, "-")
 
     %{absolute_path: file_path,
-      relative_path: Path.relative_to(file_path, output_path) |> Path.dirname(),
+      relative_path: file_path |> Path.relative_to(output_path) |> Path.dirname(),
       digested_filename: digested_filename,
       filename: String.replace(digested_filename, @digested_file_regex, ""),
       digest: digest,

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -783,7 +783,7 @@ defmodule Phoenix.Endpoint do
 
   """
   defmacro instrument(endpoint_or_conn_or_socket, event, runtime \\ Macro.escape(%{}), fun) do
-    compile = Phoenix.Endpoint.Instrument.strip_caller(__CALLER__) |> Macro.escape()
+    compile = __CALLER__ |> Phoenix.Endpoint.Instrument.strip_caller() |> Macro.escape()
 
     quote do
       case Phoenix.Endpoint.Instrument.extract_endpoint(unquote(endpoint_or_conn_or_socket)) do

--- a/lib/phoenix/endpoint/render_errors.ex
+++ b/lib/phoenix/endpoint/render_errors.ex
@@ -105,7 +105,7 @@ defmodule Phoenix.Endpoint.RenderErrors do
     accepts(conn, Keyword.fetch!(opts, :accepts))
   rescue
     e in Phoenix.NotAcceptableError ->
-      fallback_format = Keyword.fetch!(opts, :accepts) |> List.first()
+      fallback_format = opts |> Keyword.fetch!(:accepts) |> List.first()
       Logger.warn("Could not render errors due to #{Exception.message(e)}. " <>
                   "Errors will be rendered using the first accepted format #{inspect fallback_format} as fallback. " <>
                   "Please customize the :accepts option under the :render_errors configuration " <>

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -26,7 +26,7 @@ defmodule Phoenix.Endpoint.Supervisor do
   # dependent on the module name, so we should consider enabling this
   # once we move to Firenest.
   def init({otp_app, mod}) do
-    id = :crypto.strong_rand_bytes(16) |> Base.encode64
+    id = 16 |> :crypto.strong_rand_bytes() |> Base.encode64
 
     conf =
       case mod.init(:supervisor, [endpoint_id: id] ++ config(otp_app, mod)) do
@@ -159,7 +159,7 @@ defmodule Phoenix.Endpoint.Supervisor do
   the Phoenix.Config layer knows how to cache it.
   """
   def url(endpoint) do
-    {:cache, build_url(endpoint, endpoint.config(:url)) |> String.Chars.URI.to_string()}
+    {:cache, endpoint |> build_url(endpoint.config(:url)) |> String.Chars.URI.to_string()}
   end
 
   @doc """
@@ -191,7 +191,7 @@ defmodule Phoenix.Endpoint.Supervisor do
   """
   def static_url(endpoint) do
     url = endpoint.config(:static_url) || endpoint.config(:url)
-    {:cache, build_url(endpoint, url) |> String.Chars.URI.to_string()}
+    {:cache, endpoint |> build_url(url) |> String.Chars.URI.to_string()}
   end
 
   @doc """

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -386,7 +386,7 @@ defmodule Phoenix.Socket.Transport do
 
   def check_origin(conn, handler, endpoint, opts, sender) do
     import Plug.Conn
-    origin       = get_req_header(conn, "origin") |> List.first
+    origin       = conn |> get_req_header("origin") |> List.first
     check_origin = check_origin_config(handler, endpoint, opts)
 
     cond do
@@ -415,7 +415,8 @@ defmodule Phoenix.Socket.Transport do
                 check_origin: ["https://example.com",
                                "//another.com:888", "//other.com"]
         """
-        resp(conn, :forbidden, "")
+        conn
+        |> resp(:forbidden, "")
         |> sender.()
         |> halt()
     end

--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -353,7 +353,8 @@ defmodule Phoenix.Template do
   """
   @spec hash(root, pattern :: String.t) :: binary
   def hash(root, pattern \\ @default_pattern) do
-    find_all(root, pattern)
+    root
+    |> find_all(pattern)
     |> Enum.sort()
     |> :erlang.md5()
   end
@@ -373,7 +374,7 @@ defmodule Phoenix.Template do
   defp compile(path, root) do
     name   = template_path_to_name(path, root)
     defp   = String.to_atom(name)
-    ext    = Path.extname(path) |> String.trim_leading(".") |> String.to_atom
+    ext    = path |> Path.extname() |> String.trim_leading(".") |> String.to_atom
     engine = Map.fetch!(engines(), ext)
     quoted = engine.compile(path, name)
 

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -136,7 +136,8 @@ defmodule Phoenix.ConnTest do
   """
   @spec build_conn(atom | binary, binary, binary | list | map) :: Conn.t
   def build_conn(method, path, params_or_body \\ nil) do
-    Plug.Adapters.Test.Conn.conn(%Conn{}, method, path, params_or_body)
+    %Conn{}
+    |> Plug.Adapters.Test.Conn.conn(method, path, params_or_body)
     |> Conn.put_private(:plug_skip_csrf_protection, true)
     |> Conn.put_private(:phoenix_recycled, true)
   end
@@ -441,7 +442,7 @@ defmodule Phoenix.ConnTest do
   end
 
   def redirected_to(%Conn{status: status} = conn, status) do
-    location = Conn.get_resp_header(conn, "location") |> List.first
+    location = conn |> Conn.get_resp_header("location") |> List.first
     location || raise "no location header was set on redirected_to"
   end
 

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -108,7 +108,7 @@ defmodule Phoenix.Token do
   def sign(context, salt, data, opts \\ []) when is_binary(salt) do
     {signed_at_seconds, key_opts} = Keyword.pop(opts, :signed_at)
     signed_at_ms = if signed_at_seconds, do: trunc(signed_at_seconds * 1000), else: now_ms()
-    secret = get_key_base(context) |> get_secret(salt, key_opts)
+    secret = context |> get_key_base() |> get_secret(salt, key_opts)
 
     %{data: data, signed: signed_at_ms}
     |> :erlang.term_to_binary()

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -79,7 +79,7 @@ defmodule Phoenix.Transports.LongPoll do
   # Responds to pre-flight CORS requests with Allow-Origin-* headers.
   # We allow cross-origin requests as we always validate the Origin header.
   defp dispatch(%{method: "OPTIONS"} = conn, _, _, _, _) do
-    headers = get_req_header(conn, "access-control-request-headers") |> Enum.join(", ")
+    headers = conn |> get_req_header("access-control-request-headers") |> Enum.join(", ")
 
     conn
     |> put_resp_header("access-control-allow-headers", headers)

--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -329,14 +329,14 @@ defmodule Phoenix.View do
   Renders the template and returns iodata.
   """
   def render_to_iodata(module, template, assign) do
-    render(module, template, assign) |> encode(template)
+    module |> render(template, assign) |> encode(template)
   end
 
   @doc """
   Renders the template and returns a string.
   """
   def render_to_string(module, template, assign) do
-    render_to_iodata(module, template, assign) |> IO.iodata_to_binary
+    module |> render_to_iodata(template, assign) |> IO.iodata_to_binary
   end
 
   defp encode(content, template) do


### PR DESCRIPTION
WHY IT MATTERS
┃
┃       Pipes (`|>`) can can become more readable by starting with a "raw" value.
┃
┃       So while this is easily comprehendable:
┃
┃           list
┃           |> Enum.take(5)
┃           |> Enum.shuffle
┃           |> pick_winner()
┃
┃       This might be harder to read:
┃
┃           Enum.take(list, 5)
┃           |> Enum.shuffle
┃           |> pick_winner()
┃
┃       As always: This is just a suggestion.