### PR TITLE
guides/contexts: fix path to accounts/user.ex

### DIFF
--- a/guides/docs/contexts.md
+++ b/guides/docs/contexts.md
@@ -308,7 +308,7 @@ Generated hello app
 [info]  == Migrated in 0.0s
 ```
 
-Before we integrate credentials in the web layer, we need to let our context know how to associate users and credentials. First, open up `lib/accounts/user.ex` and add the following association:
+Before we integrate credentials in the web layer, we need to let our context know how to associate users and credentials. First, open up `lib/hello/accounts/user.ex` and add the following association:
 
 
 ```elixir


### PR DESCRIPTION
The `hello` path component is missing, yet the path was being referenced relative to `lib/`.

---

Files in other paragraphs are relative to `accounts/`; I'd be happy to change this that way instead, but it isn't consistent through the entire file, so I kept it as is.