### PR TITLE
Corrected commands to reset changes made in Ecto guide

### DIFF
--- a/guides/docs/contexts.md
+++ b/guides/docs/contexts.md
@@ -28,8 +28,8 @@ In order to run the context generators, we need to come up with a module name th
 Before we use the generators, we need to undo the changes we made in the Ecto guide, so we can give our user schema a proper home. Run these commands to undo our previous work:
 
 ```console
-$ rm lib/hello/user.ex
-$ rm priv/repo/migrations/*_create_user.exs
+$ rm lib/hello/accounts/user.ex
+$ rm priv/repo/migrations/*_create_users.exs
 ```
 
 Next, let's reset our database so we also discard the table we have just removed:


### PR DESCRIPTION
The Ecto guide command generates the user.ex in an accounts directory and migration with *_created_users.exs (plural users).