### PR TITLE
Do not encode  in v1 websocket messages (#2582)

### DIFF
--- a/lib/phoenix/transports/websocket_serializer.ex
+++ b/lib/phoenix/transports/websocket_serializer.ex
@@ -11,31 +11,26 @@ defmodule Phoenix.Transports.WebSocketSerializer do
   Translates a `Phoenix.Socket.Broadcast` into a `Phoenix.Socket.Message`.
   """
   def fastlane!(%Broadcast{} = msg) do
-    {:socket_push, :text, Poison.encode_to_iodata!(%Message{
-      topic: msg.topic,
-      event: msg.event,
-      payload: msg.payload
-    })}
+    msg = %Message{topic: msg.topic, event: msg.event, payload: msg.payload}
+
+    {:socket_push, :text, encode_v1_fields_only(msg)}
   end
 
   @doc """
   Encodes a `Phoenix.Socket.Message` struct to JSON string.
   """
   def encode!(%Reply{} = reply) do
-    {:socket_push, :text, Poison.encode_to_iodata!(%Message{
+    msg = %Message{
       topic: reply.topic,
       event: "phx_reply",
       ref: reply.ref,
       payload: %{status: reply.status, response: reply.payload}
-    })}
+    }
+
+    {:socket_push, :text, encode_v1_fields_only(msg)}
   end
   def encode!(%Message{} = msg) do
-    encoded_msg =
-      msg
-      |> Map.take([:topic, :event, :payload, :ref])
-      |> Poison.encode_to_iodata!()
-
-    {:socket_push, :text, encoded_msg}
+    {:socket_push, :text, encode_v1_fields_only(msg)}
   end
 
   @doc """
@@ -45,5 +40,11 @@ defmodule Phoenix.Transports.WebSocketSerializer do
     message
     |> Poison.decode!()
     |> Phoenix.Socket.Message.from_map!()
+  end
+
+  defp encode_v1_fields_only(%Message{} = msg) do
+    msg
+    |> Map.take([:topic, :event, :payload, :ref])
+    |> Poison.encode_to_iodata!()
   end
 end

--- a/test/phoenix/transports/websocket_serializer_test.exs
+++ b/test/phoenix/transports/websocket_serializer_test.exs
@@ -2,33 +2,45 @@ defmodule Phoenix.Tranports.WebSocketSerializerTest do
   use ExUnit.Case, async: true
 
   alias Phoenix.Transports.{V2, WebSocketSerializer}
-  alias Phoenix.Socket.Message
+  alias Phoenix.Socket.{Broadcast, Message, Reply}
 
-  @msg_json [123, [[34, ["topic"], 34], 58, [34, ["t"], 34], 44, [34, ["ref"], 34], 58, "null", 44, [34, ["payload"], 34], 58, [34, ["m"], 34], 44, [34, ["event"], 34], 58, [34, ["e"], 34]], 125]
-  @msg_json_2 [91, ["null", 44, "null", 44, [34, ["t"], 34], 44, [34, ["e"], 34], 44, [34, ["m"], 34]], 93]
-
+  # v1 responses must not contain join_ref
+  @v1_msg_json [123, [[34, ["topic"], 34], 58, [34, ["t"], 34], 44, [34, ["ref"], 34], 58, "null", 44, [34, ["payload"], 34], 58, [34, ["m"], 34], 44, [34, ["event"], 34], 58, [34, ["e"], 34]], 125]
+  @v1_reply_json [123, [[34, ["topic"], 34], 58, [34, ["t"], 34], 44, [34, ["ref"], 34], 58, [34, ["null"], 34], 44, [34, ["payload"], 34], 58, [123, [[34, ["status"], 34], 58, "null", 44, [34, ["response"], 34], 58, "null"], 125], 44, [34, ["event"], 34], 58, [34, ["phx_reply"], 34]], 125]
+  @v1_fastlane_json [123, [[34, ["topic"], 34], 58, [34, ["t"], 34], 44, [34, ["ref"], 34], 58, "null", 44, [34, ["payload"], 34], 58, [34, ["m"], 34], 44, [34, ["event"], 34], 58, [34, ["e"], 34]], 125]
+  @v2_msg_json [91, ["null", 44, "null", 44, [34, ["t"], 34], 44, [34, ["e"], 34], 44, [34, ["m"], 34]], 93]
 
   describe "version 1.0.0" do
     test "encode!/1 encodes `Phoenix.Socket.Message` as JSON" do
       msg = %Message{topic: "t", event: "e", payload: "m"}
-      assert WebSocketSerializer.encode!(msg) == {:socket_push, :text, @msg_json}
+      assert WebSocketSerializer.encode!(msg) == {:socket_push, :text, @v1_msg_json}
+    end
+
+    test "encode!/1 encodes `Phoenix.Socket.Reply` as JSON" do
+      msg = %Reply{topic: "t", ref: "null"}
+      assert WebSocketSerializer.encode!(msg) == {:socket_push, :text, @v1_reply_json}
     end
 
     test "decode!/2 decodes `Phoenix.Socket.Message` from JSON" do
       assert %Message{topic: "t", event: "e", payload: "m"} ==
-        WebSocketSerializer.decode!(@msg_json, opcode: :text)
+        WebSocketSerializer.decode!(@v1_msg_json, opcode: :text)
+    end
+
+    test "fastlane!/1 encodes a broadcast into a message as JSON" do
+      msg = %Broadcast{topic: "t", event: "e", payload: "m"}
+      assert WebSocketSerializer.fastlane!(msg) == {:socket_push, :text, @v1_fastlane_json}
     end
   end
 
   describe "version 2.0.0" do
     test "encode!/1 encodes `Phoenix.Socket.Message` as JSON" do
       msg = %Message{topic: "t", event: "e", payload: "m"}
-      assert V2.WebSocketSerializer.encode!(msg) == {:socket_push, :text, @msg_json_2}
+      assert V2.WebSocketSerializer.encode!(msg) == {:socket_push, :text, @v2_msg_json}
     end
 
     test "decode!/2 decodes `Phoenix.Socket.Message` from JSON" do
       assert %Message{topic: "t", event: "e", payload: "m"} ==
-        V2.WebSocketSerializer.decode!(@msg_json_2, opcode: :text)
+        V2.WebSocketSerializer.decode!(@v2_msg_json, opcode: :text)
     end
   end
 end


### PR DESCRIPTION
`:join_ref` was not filtered out from all v1 websocket JSON responses (replies and broadcasts) which was crashing our Java library.