### PR TITLE
Update docs for mix tasks containing full phoenix name

### DIFF
--- a/guides/docs/phoenix_mix_tasks.md
+++ b/guides/docs/phoenix_mix_tasks.md
@@ -31,7 +31,7 @@ Note that there are still other tasks under the full phoenix name:
 ➜  mix help | grep -i phoenix
 mix local.phoenix      # Updates Phoenix locally
 mix phoenix.gen.html   # Generates controller, model and views for an HTML based resource
-mix phoenix.new        # Creates a new Phoenix v1.2.1 application
+mix phoenix.new        # Creates a new Phoenix v1.3.0 application
 mix phoenix.server     # Starts applications and their servers
 ```
 


### PR DESCRIPTION
Remove `mix phoenix.gen.html` and `mix phoenix.server`, and change `mix
phoenix.new` to say "Creates a new Phoenix v1.3.0 application".

Freshly installed Phoenix on two machines to confirm that `mix phoenix.gen.html` and `mix phoenix.server` no longer come up as mix tasks, and `mix phoenix.new` lists 1.3.0 as the version instead of 1.2.1. Confirmed that running `mix phoenix.new` creates a v1.3.0-rc project.