### PR TITLE
Guides (Contexts): Fix commands for undoing Ecto Guide changes

### DIFF
--- a/guides/docs/contexts.md
+++ b/guides/docs/contexts.md
@@ -28,8 +28,8 @@ In order to run the context generators, we need to come up with a module name th
 Before we use the generators, we need to undo the changes we made in the Ecto guide, so we can give our user schema a proper home. Run these commands to undo our previous work:
 
 ```console
-$ rm lib/hello/user.ex
-$ rm priv/repo/migrations/*_create_user.exs
+$ rm -r lib/hello/accounts/
+$ rm priv/repo/migrations/*_create_users.exs
 ```
 
 Next, let's reset our database so we also discard the table we have just removed:


### PR DESCRIPTION
I'm currently working through the guides, and I noticed that the commands listed for undoing the changes from the Ecto guide in order to work with the generators in the Contexts guide are slightly off. 

The commands are meant to undo the work of this command from the Ecto Guide (`mix phx.gen.html Accounts User users name:string username:string:unique`), also shown in the screenshot here:

<a href="https://hexdocs.pm/phoenix/ecto.html#content">
<img width="1096" alt="screen shot 2017-10-24 at 2 15 39 pm" src="https://user-images.githubusercontent.com/11711662/31960449-d768e95a-b8c5-11e7-87d6-61b74f844721.png"></a>

But the commands currently given in the Context guide don't quite delete the correct files. I wonder if the Ecto guide was perhaps changed at some point, but these commands weren't updated to match. I think this PR should fix the discrepancy. 
