### PR TITLE
Return mutated connection

### DIFF
--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -90,7 +90,7 @@ defmodule Phoenix.Transports.WebSocket do
           {:ok, socket} ->
             {:ok, conn, {__MODULE__, {socket, opts}}}
           :error ->
-            send_resp(conn, 403, "")
+            conn = send_resp(conn, 403, "")
             {:error, conn}
         end
       %{halted: true} = conn ->
@@ -99,7 +99,7 @@ defmodule Phoenix.Transports.WebSocket do
   end
 
   def init(conn, _) do
-    send_resp(conn, :bad_request, "")
+    conn = send_resp(conn, :bad_request, "")
     {:error, conn}
   end
 


### PR DESCRIPTION
Fixes #2601

By not returning the connection returned by send_resp, cowboy is unable to determine whether a response was allready sent, and send another 204 over the tcp connection.