### PR TITLE
Add controller and view generators

### DIFF
--- a/lib/mix/tasks/phx.gen.controller.ex
+++ b/lib/mix/tasks/phx.gen.controller.ex
@@ -1,0 +1,64 @@
+defmodule Mix.Tasks.Phx.Gen.Controller do
+  @shortdoc "Generates a Phoenix controller"
+
+  @moduledoc """
+  Generates a Phoenix controller.
+
+      mix phx.gen.controller Posts
+
+  Accepts the module name for the controller
+
+  The generated files will contain:
+
+  For a regular application:
+
+    * a controller in lib/my_app_web/controllers
+    * a controller_test in test/my_app_web/controllers
+
+  For an umbrella application:
+
+    * a controller in apps/my_app_web/lib/app_name_web/controllers
+    * a controller_test in apps/my_app_web/test/my_app_web/controllers
+  """
+  use Mix.Task
+
+  @doc false
+  def run(args) do
+    if Mix.Project.umbrella?() do
+      Mix.raise "mix phx.gen.controller can only be run inside an application directory"
+    end
+    [controller_name] = validate_args!(args)
+    context_app = Mix.Phoenix.context_app()
+    web_prefix = Mix.Phoenix.web_path(context_app)
+    test_prefix = Mix.Phoenix.web_test_path(context_app)
+    binding = Mix.Phoenix.inflect(controller_name)
+    binding = Keyword.put(binding, :module, "#{binding[:web_module]}.#{binding[:scoped]}")
+
+    Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Controller")
+
+    Mix.Phoenix.copy_from paths(), "priv/templates/phx.gen.controller", binding, [
+      {:eex, "controller.ex",       Path.join(web_prefix, "controllers/#{binding[:path]}_controller.ex")},
+      {:eex, "controller_test.exs", Path.join(test_prefix, "controllers/#{binding[:path]}_controller_test.exs")},
+    ]
+  end
+
+  @spec raise_with_help() :: no_return()
+  defp raise_with_help do
+    Mix.raise """
+    mix phx.gen.controller expects just the module name:
+
+        mix phx.gen.controller Posts
+    """
+  end
+
+  defp validate_args!(args) do
+    unless length(args) == 1 do
+      raise_with_help()
+    end
+    args
+  end
+
+  defp paths do
+    [".", :phoenix]
+  end
+end

--- a/lib/mix/tasks/phx.gen.view.ex
+++ b/lib/mix/tasks/phx.gen.view.ex
@@ -1,0 +1,60 @@
+defmodule Mix.Tasks.Phx.Gen.View do
+  @shortdoc "Generates a Phoenix view"
+
+  @moduledoc """
+  Generates a Phoenix view.
+
+      mix phx.gen.view Pages
+
+  Accepts the module name for the view
+
+  The generated files will contain:
+
+  For a regular application:
+
+    * a view in lib/my_app_web/views
+
+  For an umbrella application:
+
+    * a view in apps/my_app_web/lib/app_name_web/views
+  """
+  use Mix.Task
+
+  @doc false
+  def run(args) do
+    if Mix.Project.umbrella?() do
+      Mix.raise "mix phx.gen.view can only be run inside an application directory"
+    end
+    [view_name] = validate_args!(args)
+    context_app = Mix.Phoenix.context_app()
+    web_prefix = Mix.Phoenix.web_path(context_app)
+    binding = Mix.Phoenix.inflect(view_name)
+    binding = Keyword.put(binding, :module, "#{binding[:web_module]}.#{binding[:scoped]}")
+
+    Mix.Phoenix.check_module_name_availability!(binding[:module] <> "View")
+
+    Mix.Phoenix.copy_from paths(), "priv/templates/phx.gen.view", binding, [
+      {:eex, "view.ex",       Path.join(web_prefix, "views/#{binding[:path]}_view.ex")},
+    ]
+  end
+
+  @spec raise_with_help() :: no_return()
+  defp raise_with_help do
+    Mix.raise """
+    mix phx.gen.view expects just the module name:
+
+        mix phx.gen.view Pages
+    """
+  end
+
+  defp validate_args!(args) do
+    unless length(args) == 1 do
+      raise_with_help()
+    end
+    args
+  end
+
+  defp paths do
+    [".", :phoenix]
+  end
+end

--- a/priv/templates/phx.gen.controller/controller.ex
+++ b/priv/templates/phx.gen.controller/controller.ex
@@ -1,0 +1,3 @@
+defmodule <%= module %>Controller do
+  use <%= web_module %>, :controller
+end

--- a/priv/templates/phx.gen.controller/controller_test.exs
+++ b/priv/templates/phx.gen.controller/controller_test.exs
@@ -1,0 +1,5 @@
+defmodule <%= module %>ControllerTest do
+  use <%= web_module %>.ConnCase
+
+  alias <%= module %>Controller
+end

--- a/priv/templates/phx.gen.view/view.ex
+++ b/priv/templates/phx.gen.view/view.ex
@@ -1,0 +1,3 @@
+defmodule <%= module %>View do
+  use <%= web_module %>, :view
+end

--- a/test/mix/tasks/phx.gen.controller_test.exs
+++ b/test/mix/tasks/phx.gen.controller_test.exs
@@ -1,0 +1,84 @@
+Code.require_file "../../../installer/test/mix_helper.exs", __DIR__
+
+defmodule PhoenixWeb.DupController do
+end
+
+defmodule Mix.Tasks.Phx.Gen.ControllerTest do
+  use ExUnit.Case
+  import MixHelper
+  alias Mix.Tasks.Phx.Gen
+
+  setup do
+    Mix.Task.clear()
+    :ok
+  end
+
+  test "generates controller" do
+    in_tmp_project "generates controller", fn ->
+      Gen.Controller.run ["Posts"]
+
+      assert_file "lib/phoenix_web/controllers/posts_controller.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.PostsController do|
+        assert file =~ ~S|use PhoenixWeb, :controller|
+      end
+
+      assert_file "test/phoenix_web/controllers/posts_controller_test.exs", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.PostsControllerTest|
+        assert file =~ ~S|use PhoenixWeb.ConnCase|
+        assert file =~ ~S|alias PhoenixWeb.PostsController|
+      end
+    end
+  end
+
+  test "in an umbrella with a context_app, generates the files" do
+    in_tmp_umbrella_project "generates controllers", fn ->
+      Application.put_env(:phoenix, :generators, context_app: {:another_app, "another_app"})
+      Gen.Controller.run ["posts"]
+      assert_file "lib/phoenix/controllers/posts_controller.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.PostsController do|
+        assert file =~ ~S|use PhoenixWeb, :controller|
+      end
+
+      assert_file "test/phoenix/controllers/posts_controller_test.exs", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.PostsControllerTest|
+        assert file =~ ~S|use PhoenixWeb.ConnCase|
+        assert file =~ ~S|alias PhoenixWeb.PostsController|
+      end
+    end
+  end
+
+  test "generates nested controller" do
+    in_tmp_project "generates nested controller", fn ->
+      Gen.Controller.run ["Admin.Posts"]
+
+      assert_file "lib/phoenix_web/controllers/admin/posts_controller.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.Admin.PostsController do|
+        assert file =~ ~S|use PhoenixWeb, :controller|
+      end
+
+      assert_file "test/phoenix_web/controllers/admin/posts_controller_test.exs", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.Admin.PostsControllerTest|
+        assert file =~ ~S|use PhoenixWeb.ConnCase|
+        assert file =~ ~S|alias PhoenixWeb.Admin.PostsController|
+      end
+    end
+  end
+
+  test "passing no args raises error" do
+    assert_raise Mix.Error, fn ->
+      Gen.Controller.run []
+    end
+  end
+
+  test "passing extra args raises error" do
+    assert_raise Mix.Error, fn ->
+      Gen.Controller.run ["Admin.Posts", "new_message"]
+    end
+  end
+
+  test "name is already defined" do
+    assert_raise Mix.Error, ~r/DupController is already taken/, fn ->
+      Gen.Controller.run ["Dup"]
+    end
+  end
+end

--- a/test/mix/tasks/phx.gen.view_test.exs
+++ b/test/mix/tasks/phx.gen.view_test.exs
@@ -1,0 +1,66 @@
+Code.require_file "../../../installer/test/mix_helper.exs", __DIR__
+
+defmodule PhoenixWeb.DupView do
+end
+
+defmodule Mix.Tasks.Phx.Gen.ViewTest do
+  use ExUnit.Case
+  import MixHelper
+  alias Mix.Tasks.Phx.Gen
+
+  setup do
+    Mix.Task.clear()
+    :ok
+  end
+
+  test "generates view" do
+    in_tmp_project "generates view", fn ->
+      Gen.View.run ["Posts"]
+
+      assert_file "lib/phoenix_web/views/posts_view.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.PostsView do|
+        assert file =~ ~S|use PhoenixWeb, :view|
+      end
+    end
+  end
+
+  test "in an umbrella with a context_app, generates the files" do
+    in_tmp_umbrella_project "generates views", fn ->
+      Application.put_env(:phoenix, :generators, context_app: {:another_app, "another_app"})
+      Gen.View.run ["posts"]
+      assert_file "lib/phoenix/views/posts_view.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.PostsView do|
+        assert file =~ ~S|use PhoenixWeb, :view|
+      end
+    end
+  end
+
+  test "generates nested view" do
+    in_tmp_project "generates nested view", fn ->
+      Gen.View.run ["Admin.Posts"]
+
+      assert_file "lib/phoenix_web/views/admin/posts_view.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.Admin.PostsView do|
+        assert file =~ ~S|use PhoenixWeb, :view|
+      end
+    end
+  end
+
+  test "passing no args raises error" do
+    assert_raise Mix.Error, fn ->
+      Gen.View.run []
+    end
+  end
+
+  test "passing extra args raises error" do
+    assert_raise Mix.Error, fn ->
+      Gen.View.run ["Admin.Posts", "new_message"]
+    end
+  end
+
+  test "name is already defined" do
+    assert_raise Mix.Error, ~r/DupView is already taken/, fn ->
+      Gen.View.run ["Dup"]
+    end
+  end
+end


### PR DESCRIPTION
I often want to quickly create a controller or view, not necessarily tied to an entire context/model.

Right now I copy an existing controller/view, and strip it down to a new one. These generators look pretty small, but imo it would be a great workflow improvement to be able to generate these from the command line.

If there's no interest in maintaining this in core, I'll probably move these to an `extra_generators` package or something.

If this gets merged, I'll whip up a docs PR too :)