### PR TITLE
fix init return type in Presence.init/1

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -108,7 +108,7 @@ defmodule Phoenix.Presence do
   @type topic :: String.t
 
   @callback start_link(Keyword.t) :: {:ok, pid()} | {:error, reason :: term()} :: :ignore
-  @callback init(Keyword.t) :: {:ok, map()} | {:error, reason :: term}
+  @callback init(Keyword.t) :: {:ok, state :: term} | {:error, reason :: term}
   @callback track(Phoenix.Socket.t, key :: String.t, meta :: map()) :: {:ok, binary()} | {:error, reason :: term()}
   @callback track(pid, topic, key :: String.t, meta :: map()) :: {:ok, binary()} | {:error, reason :: term()}
   @callback untrack(Phoenix.Socket.t, key :: String.t) :: :ok

--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -108,7 +108,7 @@ defmodule Phoenix.Presence do
   @type topic :: String.t
 
   @callback start_link(Keyword.t) :: {:ok, pid()} | {:error, reason :: term()} :: :ignore
-  @callback init(Keyword.t) :: {:ok, pid()} | {:error, reason :: term}
+  @callback init(Keyword.t) :: {:ok, map()} | {:error, reason :: term}
   @callback track(Phoenix.Socket.t, key :: String.t, meta :: map()) :: {:ok, binary()} | {:error, reason :: term()}
   @callback track(pid, topic, key :: String.t, meta :: map()) :: {:ok, binary()} | {:error, reason :: term()}
   @callback untrack(Phoenix.Socket.t, key :: String.t) :: :ok


### PR DESCRIPTION
The phoenix presence init/1 return type does not match the one declared in the callback declaration, causing an error when dialyzer is used.

This small PR should fix it.