### PR TITLE
Include documentation bug reports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,9 @@ making it easier for developers to [contribute to Phoenix](#pull-requests).
 
 ## Bug reports
 
-A bug is a _demonstrable problem_ that is caused by the code in the repository.
-Good bug reports are extremely helpful - thank you!
+A bug is either a _demonstrable problem_ that is caused by the code in the repository,
+or indicate missing, unclear, or misleading documentation. Good bug reports are extremely 
+helpful - thank you!
 
 Guidelines for bug reports:
 


### PR DESCRIPTION
I found a passage in the routing documentation that I thought needs improvement and came here to check how to report and possibly contribute a patch, once the answer was researched.

Then the guidelines seems to rule out non-code issues being opened. I brought up the question where to raise doc issues on #elixir-lang. The view was offered that documentation was as important as code and needs to be handled similarly wrt issues. 

This is an attempt to reflect that in the contrib guide. Please consider this suggestion.