### PR TITLE
Explicit js api for updating Channel reconnect join params

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -270,6 +270,16 @@ class Push {
   }
 
   /**
+   * Updates the Push payload for subsequent resends
+   *
+   * @param {Object} payload
+   * @returns {Push}
+   */
+  updatePayload(payload) {
+    this.payload = payload;
+  }
+
+  /**
    * @private
    */
   reset(){
@@ -412,6 +422,17 @@ export class Channel {
       this.rejoin(timeout)
       return this.joinPush
     }
+  }
+
+  /**
+   * Updates the params passed as the second argument to `new Channel("topic", params, socket)`
+   * Any subsequent reconnects on the channel will send the updated params to the `join` callback on the sever
+   *
+   * @param {Object} params
+   */
+  updateJoinParams(params = {}) {
+    this.params = params;
+    this.joinPush.updatePayload(params);
   }
 
   /**

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -40,6 +40,31 @@ describe("constructor", () => {
   })
 })
 
+describe("updateJoinParams", () => {
+  beforeEach(() => {
+    socket = { timeout: 1234 }
+  })
+
+  it("can update the join params", () => {
+    channel = new Channel("topic", { one: "two" }, socket)
+    const joinPush = channel.joinPush
+
+    assert.deepEqual(joinPush.channel, channel)
+    assert.deepEqual(joinPush.payload, { one: "two" })
+    assert.equal(joinPush.event, "phx_join")
+    assert.equal(joinPush.timeout, 1234)
+
+    channel.updateJoinParams({ three: "four" })
+
+    assert.deepEqual(joinPush.channel, channel)
+    assert.deepEqual(joinPush.payload, { three: "four" })
+    assert.deepEqual(channel.params, { three: "four" })
+    assert.equal(joinPush.event, "phx_join")
+    assert.equal(joinPush.timeout, 1234)
+
+  });
+});
+
 describe("join", () => {
   beforeEach(() => {
     socket = new Socket("/socket", { timeout: defaultTimeout })


### PR DESCRIPTION
By default, Phoenix channels send up exactly the same join payload up to the server on a reconnect. This is fine for simple cases, but in more complex scenarios, you might have additional data to send to `join` in the case of reconnect.

This PR aims to provide an explicit API for updating the join params. The closest discussion that I could about this problem was [here](https://groups.google.com/forum/#!topic/phoenix-core/YrfjvctJW_0), but was referring to the socket payload.

Happy to add additional tests, or change function names if there are better alternatives. 🍍 🍍 🍍 