### PR TITLE
Update the docs for bypass_through to be more explicit.

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -495,7 +495,7 @@ defmodule Phoenix.ConnTest do
   Useful for unit testing Plugs where Endpoint and/or
   router pipeline plugs are required for proper setup.
   
-  Note the use of `get("/")` following `bypass_through` in the examples bellow. 
+  Note the use of `get("/")` following `bypass_through` in the examples below. 
   For session and flash related dependencies you will need to invoke a request. 
   If you ommit the request you may find that your tests return 
   a `flash not fetched, call fetch_flash/2` or simular error.

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -494,13 +494,16 @@ defmodule Phoenix.ConnTest do
 
   Useful for unit testing Plugs where Endpoint and/or
   router pipeline plugs are required for proper setup.
+  
+  Note the use of `get("/")` following `bypass_through` in the examples bellow. 
+  For session and flash related dependencies you will need to invoke a request. 
+  If you ommit the request you may find that your tests return 
+  a `flash not fetched, call fetch_flash/2` or simular error.
 
   ## Examples
 
   For example, imagine you are testing an authentication
-  plug in isolation, but you need to invoke the Endpoint plugs
-  and `:browser` pipeline of your Router for session and flash
-  related dependencies:
+  plug in isolation:
 
       conn =
         conn


### PR DESCRIPTION
I found it hard to understand that invoking the route/endpoint was related to the use of `get("/")` and ran into a `** (ArgumentError) flash not fetched, call fetch_flash/2` error on my tests related to the fact I had a flash dependency in my test but was not invoking the router.  That led me to write a post in the elixir forums. https://elixirforum.com/t/bypass-through-3-not-working/10070/2
 
It was later made clear that I needed to invoke the router via `get("/")`. 

I made this pr in hopes to guide people to this same solution when searching for `flash not fetched, call fetch_flash/2` since I was unable to resolve my issue by searching alone and felt the docs missed explicitly calling out why the use of `get("/")` was needed.