### PR TITLE
Simplify npm test entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "assets/js/phoenix.js"
   ],
   "scripts": {
-    "test": "./node_modules/.bin/mocha ./assets/test/**/*.js --compilers js:babel-register -r jsdom-global/register",
+    "test": "mocha ./assets/test/**/*.js --compilers js:babel-register -r jsdom-global/register",
     "docs": "documentation build assets/js/phoenix.js -f html -o doc/js",
     "watch": "brunch watch",
     "build": "brunch build"


### PR DESCRIPTION
The node_module/.bin directory will be on the PATH for executing npm scripts so there's no need to qualify this location in package.json. 

https://docs.npmjs.com/misc/scripts#path