### PR TITLE
Adds eslint for phoenix.js and js tests

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,312 @@
+{
+    "env": {
+        "browser": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "sourceType": "module"
+    },
+    "globals": {
+      "after": true,
+      "before": true,
+      "beforeEach": true,
+      "it": true,
+      "describe": true,
+      "afterEach": true,
+      "ActiveXObject": true
+    },
+    "rules": {
+        "accessor-pairs": "error",
+        "array-bracket-newline": "off",
+        "array-bracket-spacing": [
+            "error",
+            "never"
+        ],
+        "array-callback-return": "error",
+        "array-element-newline": "off",
+        "arrow-body-style": "off",
+        "arrow-parens": "off",
+        "arrow-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": true
+            }
+        ],
+        "block-scoped-var": "off",
+        "block-spacing": [
+            "error",
+            "always"
+        ],
+        "brace-style": "off",
+        "callback-return": "off",
+        "camelcase": "off",
+        "capitalized-comments": "off",
+        "class-methods-use-this": "off",
+        "comma-dangle": "off",
+        "comma-spacing": "off",
+        "comma-style": [
+            "error",
+            "last"
+        ],
+        "complexity": "error",
+        "computed-property-spacing": [
+            "error",
+            "never"
+        ],
+        "consistent-return": "error",
+        "consistent-this": "error",
+        "curly": "error",
+        "default-case": "error",
+        "dot-location": [
+            "error",
+            "property"
+        ],
+        "dot-notation": [
+            "error",
+            {
+                "allowKeywords": true
+            }
+        ],
+        "eol-last": "off",
+        "eqeqeq": "error",
+        "for-direction": "error",
+        "func-call-spacing": "error",
+        "func-name-matching": "off",
+        "func-names": "off",
+        "func-style": [
+            "error",
+            "expression"
+        ],
+        "function-paren-newline": "off",
+        "generator-star-spacing": "error",
+        "getter-return": "error",
+        "global-require": "error",
+        "guard-for-in": "error",
+        "handle-callback-err": "error",
+        "id-blacklist": "error",
+        "id-length": "off",
+        "id-match": "error",
+        "indent": "off",
+        "indent-legacy": "off",
+        "init-declarations": "off",
+        "jsx-quotes": "error",
+        "key-spacing": "off",
+        "keyword-spacing": "off",
+        "line-comment-position": "off",
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "lines-around-comment": "error",
+        "lines-around-directive": "error",
+        "lines-between-class-members": "off",
+        "max-depth": "error",
+        "max-len": "off",
+        "max-lines": "off",
+        "max-nested-callbacks": "error",
+        "max-params": "off",
+        "max-statements": "off",
+        "max-statements-per-line": "off",
+        "multiline-comment-style": "off",
+        "multiline-ternary": [
+            "error",
+            "always-multiline"
+        ],
+        "new-parens": "error",
+        "newline-after-var": "off",
+        "newline-before-return": "off",
+        "newline-per-chained-call": "error",
+        "no-alert": "error",
+        "no-array-constructor": "error",
+        "no-await-in-loop": "error",
+        "no-bitwise": "error",
+        "no-buffer-constructor": "error",
+        "no-caller": "error",
+        "no-catch-shadow": "error",
+        "no-confusing-arrow": "error",
+        "no-continue": "off",
+        "no-div-regex": "error",
+        "no-duplicate-imports": "error",
+        "no-else-return": "off",
+        "no-empty-function": "off",
+        "no-eq-null": "error",
+        "no-eval": "error",
+        "no-extend-native": "error",
+        "no-extra-bind": "error",
+        "no-extra-label": "error",
+        "no-extra-parens": "off",
+        "no-floating-decimal": "error",
+        "no-implicit-coercion": "error",
+        "no-implicit-globals": "error",
+        "no-implied-eval": "error",
+        "no-inline-comments": "off",
+        "no-inner-declarations": [
+            "error",
+            "functions"
+        ],
+        "no-invalid-this": "error",
+        "no-iterator": "error",
+        "no-label-var": "error",
+        "no-labels": "error",
+        "no-lone-blocks": "error",
+        "no-lonely-if": "error",
+        "no-loop-func": "error",
+        "no-magic-numbers": "off",
+        "no-mixed-operators": "off",
+        "no-mixed-requires": "error",
+        "no-multi-assign": "error",
+        "no-multi-spaces": "off",
+        "no-multi-str": "error",
+        "no-multiple-empty-lines": "off",
+        "no-native-reassign": "error",
+        "no-negated-condition": "off",
+        "no-negated-in-lhs": "error",
+        "no-nested-ternary": "error",
+        "no-new": "error",
+        "no-new-func": "error",
+        "no-new-object": "error",
+        "no-new-require": "error",
+        "no-new-wrappers": "error",
+        "no-octal-escape": "error",
+        "no-param-reassign": "off",
+        "no-path-concat": "error",
+        "no-plusplus": "off",
+        "no-process-env": "error",
+        "no-process-exit": "error",
+        "no-proto": "error",
+        "no-prototype-builtins": "off",
+        "no-restricted-globals": "error",
+        "no-restricted-imports": "error",
+        "no-restricted-modules": "error",
+        "no-restricted-properties": "error",
+        "no-restricted-syntax": "error",
+        "no-return-assign": "off",
+        "no-return-await": "error",
+        "no-script-url": "error",
+        "no-self-compare": "error",
+        "no-sequences": "error",
+        "no-shadow": "off",
+        "no-shadow-restricted-names": "error",
+        "no-spaced-func": "error",
+        "no-sync": "error",
+        "no-tabs": "error",
+        "no-template-curly-in-string": "error",
+        "no-ternary": "off",
+        "no-throw-literal": "off",
+        "no-trailing-spaces": "off",
+        "no-undef-init": "error",
+        "no-undefined": "error",
+        "no-underscore-dangle": "error",
+        "no-unmodified-loop-condition": "error",
+        "no-unneeded-ternary": "error",
+        "no-unused-vars": ["error", {
+            "argsIgnorePattern": "^_"
+          }
+        ],
+        "no-use-before-define": "off",
+        "no-useless-call": "error",
+        "no-useless-computed-key": "error",
+        "no-useless-concat": "error",
+        "no-useless-constructor": "error",
+        "no-useless-rename": "error",
+        "no-useless-return": "error",
+        "no-var": "off",
+        "no-void": "error",
+        "no-warning-comments": "off",
+        "no-whitespace-before-property": "error",
+        "no-with": "error",
+        "nonblock-statement-body-position": "error",
+        "object-curly-newline": "off",
+        "object-curly-spacing": "off",
+        "object-property-newline": [
+            "error",
+            {
+                "allowMultiplePropertiesPerLine": true
+            }
+        ],
+        "object-shorthand": "off",
+        "one-var": "off",
+        "one-var-declaration-per-line": [
+            "error",
+            "initializations"
+        ],
+        "operator-assignment": "error",
+        "operator-linebreak": [
+            "error",
+            "after"
+        ],
+        "padded-blocks": "off",
+        "padding-line-between-statements": "error",
+        "prefer-arrow-callback": "error",
+        "prefer-const": "off",
+        "prefer-destructuring": "off",
+        "prefer-numeric-literals": "error",
+        "prefer-promise-reject-errors": "error",
+        "prefer-reflect": "off",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error",
+        "prefer-template": "off",
+        "quote-props": "off",
+        "quotes": "off",
+        "radix": "error",
+        "require-await": "error",
+        "require-jsdoc": "error",
+        "rest-spread-spacing": [
+            "error",
+            "never"
+        ],
+        "semi": "off",
+        "semi-spacing": "error",
+        "semi-style": [
+            "error",
+            "last"
+        ],
+        "sort-imports": "off",
+        "sort-keys": "off",
+        "sort-vars": "off",
+        "space-before-blocks": "off",
+        "space-before-function-paren": "off",
+        "space-in-parens": "off",
+        "space-infix-ops": "error",
+        "space-unary-ops": [
+            "error",
+            {
+                "nonwords": false,
+                "words": false
+            }
+        ],
+        "spaced-comment": [
+            "error",
+            "always"
+        ],
+        "strict": "error",
+        "switch-colon-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": false
+            }
+        ],
+        "symbol-description": "error",
+        "template-curly-spacing": [
+            "error",
+            "never"
+        ],
+        "template-tag-spacing": "error",
+        "unicode-bom": [
+            "error",
+            "never"
+        ],
+        "valid-jsdoc": "off",
+        "vars-on-top": "off",
+        "wrap-iife": "error",
+        "wrap-regex": "error",
+        "yield-star-spacing": "error",
+        "yoda": [
+            "error",
+            "never"
+        ]
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
 script:
   - mix test
   - cd installer && mix test
-  - cd ../ && npm install && npm test
+  - cd ../ && npm install && npm lint && npm test
 after_script:
   - cd $TRAVIS_BUILD_DIR
   - MIX_ENV=docs mix inch.report

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -211,7 +211,7 @@ const TRANSPORTS = {
   websocket: "websocket"
 }
 const log = (...args) => {
-  console && console.log('[phoenix.js]', ...args);
+  console && console.log('[phoenix.js]', ...args); // eslint-disable-line no-console
 }
 
 /**
@@ -286,7 +286,7 @@ class Push {
   /**
    * @private
    */
-  matchReceive({status, response, ref}){
+  matchReceive({status, response, _ref}){
     this.recHooks.filter( h => h.status === status )
                  .forEach( h => h.callback(response) )
   }
@@ -535,7 +535,7 @@ export class Channel {
    * @param {integer} ref
    * @returns {Object}
    */
-  onMessage(event, payload, ref){ return payload }
+  onMessage(event, payload, _ref){ return payload }
 
   /**
    * @private
@@ -970,7 +970,7 @@ export class LongPoll {
     return(endPoint
       .replace("ws://", "http://")
       .replace("wss://", "https://")
-      .replace(new RegExp("(.*)\/" + TRANSPORTS.websocket), "$1/" + TRANSPORTS.longpoll))
+      .replace(new RegExp("(.*)/" + TRANSPORTS.websocket), "$1/" + TRANSPORTS.longpoll))
   }
 
   endpointURL(){
@@ -992,10 +992,10 @@ export class LongPoll {
 
     Ajax.request("GET", this.endpointURL(), "application/json", null, this.timeout, this.ontimeout.bind(this), (resp) => {
       if(resp){
-        var {status, token, messages} = resp
+        var {status, token, messages} = resp // eslint-disable-line no-redeclare
         this.token = token
       } else{
-        var status = 0
+        var status = 0 // eslint-disable-line no-redeclare
       }
 
       switch(status){
@@ -1030,7 +1030,7 @@ export class LongPoll {
     })
   }
 
-  close(code, reason){
+  close(_code, _reason){
     this.readyState = SOCKET_STATES.closed
     this.onclose()
   }

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -210,6 +210,9 @@ const TRANSPORTS = {
   longpoll: "longpoll",
   websocket: "websocket"
 }
+const log = (...args) => {
+  console && console.log('[phoenix.js]', ...args);
+}
 
 /**
  * Initializes the Push
@@ -756,7 +759,7 @@ export class Socket {
    */
   connect(params){
     if(params){
-      console && console.log("passing params to connect is deprecated. Instead pass :params to the Socket constructor")
+      log("passing params to connect is deprecated. Instead pass :params to the Socket constructor")
       this.params = params
     }
     if(this.conn){ return }
@@ -1084,7 +1087,7 @@ export class Ajax {
     try {
       return JSON.parse(resp)
     } catch(e) {
-      console && console.log("failed to parse JSON response", resp)
+      log("failed to parse JSON response", resp)
       return null
     }
   }

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -1,9 +1,7 @@
 import assert from "assert"
 
-import jsdom from "jsdom"
+import "jsdom"
 import sinon from "sinon"
-import {WebSocket, Server as WebSocketServer} from "mock-socket"
-import {encode, decode} from "./serializer"
 import {Channel, Socket} from "../js/phoenix"
 
 let channel, socket
@@ -159,7 +157,6 @@ describe("join", () => {
       clock.tick(10000)
       assert.equal(spy.callCount, ++callCount)
 
-      console.log("test: joinPush.trigger ok")
       joinPush.trigger("ok", {})
       assert.equal(channel.state, "joined")
 
@@ -201,7 +198,7 @@ describe("join", () => {
     })
 
     it("with socket delay only", () => {
-      const spy = sinon.stub(socket, "push")
+      sinon.stub(socket, "push")
       const clock = sinon.useFakeTimers()
       const joinPush = channel.joinPush
 
@@ -774,13 +771,13 @@ describe("off", () => {
     const spy2 = sinon.spy()
     
     const ref1 = channel.on("event", spy1)
-    const ref2 = channel.on("event", spy2)
+    channel.on("event", spy2)
 
     channel.off("event", ref1)
     channel.trigger("event", {}, defaultRef)
 
     assert.ok(!spy1.called)
-    assert.ok(spy2.called)    
+    assert.ok(spy2.called)
   })
 })
 
@@ -893,7 +890,7 @@ describe("push", () => {
 })
 
 describe("leave", () => {
-  let clock, joinPush
+  let clock
   let socketSpy
 
   beforeEach(() => {

--- a/assets/test/presence_test.js
+++ b/assets/test/presence_test.js
@@ -133,7 +133,7 @@ describe("list", () => {
       {id: 1, phx_ref: "1.second"}]
     }}
 
-    let listBy = (key, {metas: [first, ...rest]}) => {
+    let listBy = (key, {metas: [first]}) => {
       return first
     }
 

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -3,7 +3,7 @@ import assert from "assert"
 import jsdom from "jsdom"
 import sinon from "sinon"
 import {WebSocket, Server as WebSocketServer} from "mock-socket"
-import {encode, decode} from "./serializer"
+import {encode} from "./serializer"
 import {Socket, LongPoll} from "../js/phoenix"
 
 let socket

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-brunch": "~6.0.0",
     "brunch": "~2.6.5",
     "documentation": "^4.0.0-rc.1",
+    "eslint": "^4.11.0",
     "jsdom": "9.8.3",
     "jsdom-global": "2.1.0",
     "mocha": "~2.4.4",
@@ -28,6 +29,7 @@
     "assets/js/phoenix.js"
   ],
   "scripts": {
+    "lint": "eslint assets/**/*.js",
     "test": "./node_modules/.bin/mocha ./assets/test/**/*.js --compilers js:babel-register -r jsdom-global/register",
     "docs": "documentation build assets/js/phoenix.js -f html -o doc/js",
     "watch": "brunch watch",


### PR DESCRIPTION
This PR adds [eslint](https://eslint.org) to help enforce the project's implicit JS style guide. 

* Adds `.eslintrc.json` config file, based off the project source files
* Adds `npm run lint` script to `package.json`
* Edits `phoenix.js` and tests to fix eslint errors based off the eslint config
* Lints on each travis build
