### PR TITLE
Add .eot and .ttf to gzippable_exts

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule Phoenix.Mixfile do
         format_encoders: [],
         filter_parameters: ["password"],
         serve_endpoints: false,
-        gzippable_exts: ~w(.js .css .txt .text .html .json .svg)
+        gzippable_exts: ~w(.js .css .txt .text .html .json .svg .eot .ttf)
       ]
     ]
   end


### PR DESCRIPTION
This change makes `mix phx.digest` compress font files by default.
`.woff` files are still ignored since they're already compressed.