### PR TITLE
Fix direct link to endpoint API docs

### DIFF
--- a/guides/docs/endpoint.md
+++ b/guides/docs/endpoint.md
@@ -100,7 +100,7 @@ end
 
 Faults in the different parts of the supervision tree, such as the Ecto Repo, will not immediately impact the main application. The supervisor is therefore able to restart those processes separately after unexpected faults. It is also possible for an application to have multiple endpoints, each with its own supervision tree.
 
-There are many functions defined in the endpoint module for path helpers, channel subscriptions and broadcasts, instrumentation, and endpoint configuration. These are all covered in the [Endpoint API of the `Phoenix.Endpoint` docs](Phoenix.Endpoint.html#module-endpoints-api).
+There are many functions defined in the endpoint module for path helpers, channel subscriptions and broadcasts, instrumentation, and endpoint configuration. These are all covered in the [Endpoint API docs](Phoenix.Endpoint.html#module-endpoint-api) for `Phoenix.Endpoint`.
 
 
 ## Using SSL


### PR DESCRIPTION
Autolinking of the text inside ticks within link was causing markdown to be output to text of link (image). Also fixes the url fragment to the Endpoint API section.

![endpoint_ _phoenix_v1_3_0](https://user-images.githubusercontent.com/11673/33078000-5d6e4a1a-ce9f-11e7-8d3d-2a1dcd6d2035.jpg)
