### PR TITLE
Delete typo

### DIFF
--- a/guides/docs/plug.md
+++ b/guides/docs/plug.md
@@ -82,7 +82,6 @@ defmodule HelloWeb.MessageController do
     end
   end
 
-  defp find_message(id), do: ...
   defp find_message(conn, _) do
     case find_message(conn.params["id"]) do
       nil ->


### PR DESCRIPTION
This line looks like typo and it has two bugs anyway.

1. the comma shouldn't be there
2. if it's a function plug, the first argument should be `` conn `` instead of `` id ``

So I guess it's a typo. Feel free to close it if it's not a typo. Or let me know how to fix that line so I can help fix it.

Thanks!