### PR TITLE
Learning guide link now talks about Phoenix + other projects

### DIFF
--- a/guides/docs/introduction/overview.md
+++ b/guides/docs/introduction/overview.md
@@ -4,7 +4,7 @@ Phoenix is a web development framework written in Elixir which implements the se
 
 Phoenix provides the best of both worlds - high developer productivity _and_ high application performance. It also has some interesting new twists like channels for implementing realtime features and pre-compiled templates for blazing speed.
 
-If you are already familiar with Elixir, great! If not, there are a number of places to learn. The [Elixir guides](https://elixir-lang.org/getting-started/introduction.html) are a great place to start. We also have a list of helpful resources in the [Learning Elixir and Erlang Guide](learning.html).
+If you are already familiar with Elixir, great! If not, there are a number of places to learn. The [Elixir guides](https://elixir-lang.org/getting-started/introduction.html) are a great place to start. We also have a list of helpful resources to [learn more about Phoenix and some of the projects it depends on](learning.html).
 
 The aim of this introductory guide is to present a brief, high-level overview of Phoenix, the parts that make it up, and the layers underneath that support it.
 

--- a/guides/docs/introduction/overview.md
+++ b/guides/docs/introduction/overview.md
@@ -4,7 +4,7 @@ Phoenix is a web development framework written in Elixir which implements the se
 
 Phoenix provides the best of both worlds - high developer productivity _and_ high application performance. It also has some interesting new twists like channels for implementing realtime features and pre-compiled templates for blazing speed.
 
-If you are already familiar with Elixir, great! If not, there are a number of places to learn. The [Elixir guides](https://elixir-lang.org/getting-started/introduction.html) are a great place to start. We also have a list of helpful resources to [learn more about Phoenix and some of the projects it depends on](learning.html).
+If you are already familiar with Elixir, great! If not, there are a number of places to learn. The [Elixir guides](https://elixir-lang.org/getting-started/introduction.html) and the [Elixir learning resources page](https://elixir-lang.org/learning.html) are two great places to start. We also have a list of helpful resources to [learn more about Phoenix and some of the projects it depends on](learning.html).
 
 The aim of this introductory guide is to present a brief, high-level overview of Phoenix, the parts that make it up, and the layers underneath that support it.
 


### PR DESCRIPTION
The link to the learning guide from the overview page mentioned a "Learning Elixir and Erlang guide", but the `learning.html` page is neither of these things. I think the text should be updated to more accurately reflect the content of those pages.

I've also added a link to the [elixir-lang.org learning](https://elixir-lang.org/learning.html) page too, as I think that contains the information that the original learning link should've been pointing to.