### PR TITLE
Fix the generated code of the ecto repo 

### DIFF
--- a/installer/templates/phx_ecto/repo.ex
+++ b/installer/templates/phx_ecto/repo.ex
@@ -6,6 +6,10 @@ defmodule <%= app_module %>.Repo do
   DATABASE_URL environment variable.
   """
   def init(_, opts) do
-    {:ok, Keyword.put(opts, :url, System.get_env("DATABASE_URL"))}
+	  if url = System.get_env("DATABASE_URL") do
+	    {:ok, Keyword.put(opts, :url, url)}
+	  else
+	    {:ok, opts}
+	  end
   end
 end

--- a/installer/templates/phx_ecto/repo.ex
+++ b/installer/templates/phx_ecto/repo.ex
@@ -6,10 +6,10 @@ defmodule <%= app_module %>.Repo do
   DATABASE_URL environment variable.
   """
   def init(_, opts) do
-	  if url = System.get_env("DATABASE_URL") do
-	    {:ok, Keyword.put(opts, :url, url)}
-	  else
-	    {:ok, opts}
-	  end
+    if url = System.get_env("DATABASE_URL") do
+      {:ok, Keyword.put(opts, :url, url)}
+    else
+      {:ok, opts}
+    end
   end
 end


### PR DESCRIPTION
So that the `url:` param in the config file is being properly picked up if we want to hard code the config. in the dev. env.

With the previous code, even if we were populating the `url:` param in the dev.exs file we would have errors being thrown as the `DATABASE_URL` would be empty and would also empty the param for ecto thus creating an error.

This new code simply checks if the env. variable exists, if it does then it uses it to populate the config. otherwise it ignores it.