### PR TITLE
Use 0.1.0 for the initial version in templates

### DIFF
--- a/guides/docs/phoenix_mix_tasks.md
+++ b/guides/docs/phoenix_mix_tasks.md
@@ -121,7 +121,7 @@ defmodule Hello.Mixfile do
 
   def project do
     [app: :hello,
-     version: "0.0.1",
+     version: "0.1.0",
 . . .
 ```
 

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -4,7 +4,7 @@ defmodule <%= app_module %>.Mixfile do
   def project do
     [
       app: :<%= app_name %>,
-      version: "0.0.1",<%= if in_umbrella do %>
+      version: "0.1.0",<%= if in_umbrella do %>
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/installer/templates/phx_umbrella/apps/app_name/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/mix.exs
@@ -4,7 +4,7 @@ defmodule <%= app_module %>.Mixfile do
   def project do
     [
       app: :<%= app_name %>,
-      version: "0.0.1",
+      version: "0.1.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
@@ -4,7 +4,7 @@ defmodule <%= web_namespace %>.Mixfile do
   def project do
     [
       app: :<%= web_app_name %>,
-      version: "0.0.1",
+      version: "0.1.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",


### PR DESCRIPTION
Semantic versioning starts at 0.1.0.

Also has been fixed in Elixir some time ago: https://github.com/elixir-lang/elixir/pull/4788.