### PR TITLE
Feat/log on invalid cowboy version

### DIFF
--- a/lib/phoenix/endpoint/handler.ex
+++ b/lib/phoenix/endpoint/handler.ex
@@ -78,15 +78,17 @@ defmodule Phoenix.Endpoint.Handler do
 
     If you wish to use Cowboy 1, please update mix.exs to point to the \
     correct Cowboy version:
-    
+
         {:cowboy, "~> 1.0"}
-    
+
     If you want to use Cowboy 2, then please remove the :handler option \
     in your config.exs file or set it to:
 
         handler: Phoenix.Endpoint.Cowboy2Handler
 
     """)
+
+    raise "aborting due to handler mismatch"
   end
   defp warn_on_different_handler_version(_user, _autodetected, _endpoint), do: nil
 end

--- a/lib/phoenix/endpoint/handler.ex
+++ b/lib/phoenix/endpoint/handler.ex
@@ -16,6 +16,8 @@ defmodule Phoenix.Endpoint.Handler do
   """
   @callback child_spec(scheme :: atom, endpoint :: module, config :: Keyword.t) :: Supervisor.Spec.spec
 
+  alias Phoenix.Endpoint.{CowboyHandler, Cowboy2Handler}
+
   use Supervisor
   require Logger
 
@@ -26,7 +28,11 @@ defmodule Phoenix.Endpoint.Handler do
 
   @doc false
   def init({otp_app, endpoint}) do
-    handler  = endpoint.config(:handler)
+    user_handler  = endpoint.config(:handler)
+    autodetected_handler = cowboy_version_handler()
+    warn_on_different_handler_version(user_handler, autodetected_handler, endpoint)
+    handler = user_handler || autodetected_handler
+
     children =
       for {scheme, port} <- [http: 4000, https: 4040],
           config = endpoint.config(scheme) do
@@ -56,4 +62,27 @@ defmodule Phoenix.Endpoint.Handler do
   defp to_port(binary)  when is_binary(binary), do: String.to_integer(binary)
   defp to_port(integer) when is_integer(integer), do: integer
   defp to_port({:system, env_var}), do: to_port(System.get_env(env_var))
+
+  defp cowboy_version_handler() do
+    case Application.spec(:cowboy, :vsn) do
+      [?1 | _] -> CowboyHandler
+      _ -> Cowboy2Handler
+    end
+  end
+
+  defp warn_on_different_handler_version(CowboyHandler, Cowboy2Handler, endpoint) do
+    Logger.warn("""
+    You have specified #{inspect CowboyHandler} for cowboy v1.x
+    in the :handler configuration of your Phoenix endpoint #{inspect endpoint}
+    but your mix.exs has fetched cowboy v2.x.
+
+    If you wish to use Cowboy 1.x, please update mix.exs to point to the
+    correct Cowboy version. If you want to use Cowboy 2, then please set:
+
+        handler: Phoenix.Endpoint.Cowboy2Handler,
+
+    In your config.exs file.
+    """)
+  end
+  defp warn_on_different_handler_version(_user, _autodetected, _endpoint), do: nil
 end

--- a/lib/phoenix/endpoint/handler.ex
+++ b/lib/phoenix/endpoint/handler.ex
@@ -76,7 +76,7 @@ defmodule Phoenix.Endpoint.Handler do
     in the :handler configuration of your Phoenix endpoint #{inspect endpoint} \
     but your mix.exs has fetched Cowboy v2.x.
 
-    If you wish to use Cowboy 1.x, please update mix.exs to point to the \
+    If you wish to use Cowboy 1, please update mix.exs to point to the \
     correct Cowboy version:
     
         {:cowboy, "~> 1.0"}

--- a/lib/phoenix/endpoint/handler.ex
+++ b/lib/phoenix/endpoint/handler.ex
@@ -28,7 +28,7 @@ defmodule Phoenix.Endpoint.Handler do
 
   @doc false
   def init({otp_app, endpoint}) do
-    user_handler  = endpoint.config(:handler)
+    user_handler = endpoint.config(:handler)
     autodetected_handler = cowboy_version_handler()
     warn_on_different_handler_version(user_handler, autodetected_handler, endpoint)
     handler = user_handler || autodetected_handler
@@ -72,16 +72,20 @@ defmodule Phoenix.Endpoint.Handler do
 
   defp warn_on_different_handler_version(CowboyHandler, Cowboy2Handler, endpoint) do
     Logger.warn("""
-    You have specified #{inspect CowboyHandler} for cowboy v1.x
-    in the :handler configuration of your Phoenix endpoint #{inspect endpoint}
-    but your mix.exs has fetched cowboy v2.x.
+    You have specified #{inspect CowboyHandler} for Cowboy v1.x \
+    in the :handler configuration of your Phoenix endpoint #{inspect endpoint} \
+    but your mix.exs has fetched Cowboy v2.x.
 
-    If you wish to use Cowboy 1.x, please update mix.exs to point to the
-    correct Cowboy version. If you want to use Cowboy 2, then please set:
+    If you wish to use Cowboy 1.x, please update mix.exs to point to the \
+    correct Cowboy version:
+    
+        {:cowboy, "~> 1.0"}
+    
+    If you want to use Cowboy 2, then please remove the :handler option \
+    in your config.exs file or set it to:
 
-        handler: Phoenix.Endpoint.Cowboy2Handler,
+        handler: Phoenix.Endpoint.Cowboy2Handler
 
-    In your config.exs file.
     """)
   end
   defp warn_on_different_handler_version(_user, _autodetected, _endpoint), do: nil

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -114,7 +114,6 @@ defmodule Phoenix.Endpoint.Supervisor do
 
   defp defaults(otp_app, module) do
     [otp_app: otp_app,
-     handler: Phoenix.Endpoint.CowboyHandler,
 
      # Compile-time config
      code_reloader: false,

--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -183,21 +183,6 @@ defmodule Phoenix.Integration.EndpointTest do
     end
   end
 
-  if List.starts_with?(Application.spec(:cowboy, :vsn), '2.') do
-    test "adapters warns if the handler doesn't match the cowboy version" do
-      log =
-        capture_log fn ->
-          # Has server: true
-          {:ok, _} = InvalidHandlerEndpoint.start_link()
-
-          Supervisor.stop(InvalidHandlerEndpoint)
-        end
-
-      assert log =~ "You have specified Phoenix.Endpoint.CowboyHandler for cowboy v1.x"
-      assert log =~ "endpoint Phoenix.Integration.AdapterTest.InvalidHandlerEndpoint"
-    end
-  end
-
   defp serve_endpoints(bool) do
     Application.put_env(:phoenix, :serve_endpoints, bool)
   end

--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -8,20 +8,18 @@ defmodule Phoenix.Integration.EndpointTest do
   alias Phoenix.Integration.AdapterTest.ProdEndpoint
   alias Phoenix.Integration.AdapterTest.DevEndpoint
   alias Phoenix.Integration.AdapterTest.ProdInet6Endpoint
-
-  handler =
-    case Application.spec(:cowboy, :vsn) do
-      [?2 | _] -> Phoenix.Endpoint.Cowboy2Handler
-      _ -> Phoenix.Endpoint.CowboyHandler
-    end
+  alias Phoenix.Integration.AdapterTest.InvalidHandlerEndpoint
 
   Application.put_env(:endpoint_int, ProdEndpoint,
     http: [port: "4807"], url: [host: "example.com"], server: true,
-    handler: handler, render_errors: [accepts: ~w(html json)])
+    render_errors: [accepts: ~w(html json)])
   Application.put_env(:endpoint_int, DevEndpoint,
-      http: [port: "4808"], handler: handler, debug_errors: true)
+      http: [port: "4808"], debug_errors: true)
   Application.put_env(:endpoint_int, ProdInet6Endpoint,
-    http: [{:port, "4809"}, :inet6], handler: handler,
+    http: [{:port, "4809"}, :inet6],
+    url: [host: "example.com"], server: true)
+  Application.put_env(:endpoint_int, InvalidHandlerEndpoint,
+    http: [{:port, "4810"}, :inet6], handler: Phoenix.Endpoint.CowboyHandler,
     url: [host: "example.com"], server: true)
 
   defmodule Router do
@@ -80,7 +78,7 @@ defmodule Phoenix.Integration.EndpointTest do
     end
   end
 
-  for mod <- [ProdEndpoint, DevEndpoint, ProdInet6Endpoint] do
+  for mod <- [ProdEndpoint, DevEndpoint, ProdInet6Endpoint, InvalidHandlerEndpoint] do
     defmodule mod do
       use Phoenix.Endpoint, otp_app: :endpoint_int
       @before_compile Wrapper
@@ -182,6 +180,21 @@ defmodule Phoenix.Integration.EndpointTest do
       {:ok, _} = ProdInet6Endpoint.start_link()
 
       Supervisor.stop(ProdInet6Endpoint)
+    end
+  end
+
+  if List.starts_with?(Application.spec(:cowboy, :vsn), '2.') do
+    test "adapters warns if the handler doesn't match the cowboy version" do
+      log =
+        capture_log fn ->
+          # Has server: true
+          {:ok, _} = InvalidHandlerEndpoint.start_link()
+
+          Supervisor.stop(InvalidHandlerEndpoint)
+        end
+
+      assert log =~ "You have specified Phoenix.Endpoint.CowboyHandler for cowboy v1.x"
+      assert log =~ "endpoint Phoenix.Integration.AdapterTest.InvalidHandlerEndpoint"
     end
   end
 


### PR DESCRIPTION
This relies on the Cowboy 2 PR, so that should be merged first. I discovered this could happen quite easily when upgrading an app using the gr-cowboy2 branch.

If a user updates their cowboy dependency without updating the relevant
hander in their config then the warning will be displayed. This should
help minimize issues when users simply update the Cowboy version without
also updating the config.