### PR TITLE
Fix for dializer with `build_conn`

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -112,7 +112,7 @@ defmodule Phoenix.ConnTest do
   """
   @spec build_conn() :: Conn.t
   def build_conn() do
-    build_conn(:get, "/", nil)
+    build_conn(:get, "/", [])
   end
 
   @doc """
@@ -135,7 +135,7 @@ defmodule Phoenix.ConnTest do
   for testing a plug or a particular function.
   """
   @spec build_conn(atom | binary, binary, binary | list | map) :: Conn.t
-  def build_conn(method, path, params_or_body \\ nil) do
+  def build_conn(method, path, params_or_body \\ []) do
     Plug.Adapters.Test.Conn.conn(%Conn{}, method, path, params_or_body)
     |> Conn.put_private(:plug_skip_csrf_protection, true)
     |> Conn.put_private(:phoenix_recycled, true)


### PR DESCRIPTION
Currently the typespec for `build_conn` requires passing in the params as a binary/list/map, yet a nil is being passed in as the default and as it is not the list nil of `[]` but rather the atom `nil` it is making dialyzer very unhappy, fixed to the empty nil list of `[]` makes dialyzer happy again.