### PR TITLE
Generate multiple_select input in form for array fields.

### DIFF
--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -182,8 +182,6 @@ defmodule Mix.Tasks.Phx.Gen.Html do
 
   defp inputs(%Schema{} = schema) do
     Enum.map(schema.attrs, fn
-      {_, {:array, _}} ->
-        {nil, nil, nil}
       {_, {:references, _}} ->
         {nil, nil, nil}
       {key, :integer} ->
@@ -204,6 +202,10 @@ defmodule Mix.Tasks.Phx.Gen.Html do
         {label(key), ~s(<%= datetime_select f, #{inspect(key)}, class: "form-control" %>), error(key)}
       {key, :naive_datetime} ->
         {label(key), ~s(<%= datetime_select f, #{inspect(key)}, class: "form-control" %>), error(key)}
+      {key, {:array, :integer}} ->
+        {label(key), ~s(<%= multiple_select f, #{inspect(key)}, ["1": 1, "2": 2], class: "form-control" %>), error(key)}
+      {key, {:array, _}} ->
+        {label(key), ~s(<%= multiple_select f, #{inspect(key)}, ["Option 1": "option1", "Option 2": "option2"], class: "form-control" %>), error(key)}
       {key, _}  ->
         {label(key), ~s(<%= text_input f, #{inspect(key)}, class: "form-control" %>), error(key)}
     end)

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -108,6 +108,7 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
         assert file =~ ~s(<%= text_input f, :title, class: "form-control" %>)
         assert file =~ ~s(<%= number_input f, :votes, class: "form-control" %>)
         assert file =~ ~s(<%= number_input f, :cost, step: "any", class: "form-control" %>)
+        assert file =~ ~s(<%= multiple_select f, :tags, ["Option 1": "option1", "Option 2": "option2"], class: "form-control" %>)
         assert file =~ ~s(<%= checkbox f, :popular, class: "checkbox" %>)
         assert file =~ ~s(<%= datetime_select f, :drafted_at, class: "form-control" %>)
         assert file =~ ~s(<%= datetime_select f, :published_at, class: "form-control" %>)
@@ -119,6 +120,7 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
         assert file =~ ~s(<%= label f, :title, class: "control-label" %>)
         assert file =~ ~s(<%= label f, :votes, class: "control-label" %>)
         assert file =~ ~s(<%= label f, :cost, class: "control-label" %>)
+        assert file =~ ~s(<%= label f, :tags, class: "control-label" %>)
         assert file =~ ~s(<%= label f, :popular, class: "control-label" %>)
         assert file =~ ~s(<%= label f, :drafted_at, class: "control-label" %>)
         assert file =~ ~s(<%= label f, :published_at, class: "control-label" %>)
@@ -127,7 +129,6 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
         assert file =~ ~s(<%= label f, :alarm, class: "control-label" %>)
         assert file =~ ~s(<%= label f, :secret, class: "control-label" %>)
 
-        refute file =~ ":tags"
         refute file =~ ~s(<%= label f, :user_id)
         refute file =~ ~s(<%= number_input f, :user_id)
       end


### PR DESCRIPTION
This PR resolves #2381 

However, I'm not sure if just generate integer values for `array:integer`, and string values for other typs is sufficient, or I should generate different type for those possible arguments like `array:time` things. Please advise, thanks!