### PR TITLE
Add security headers

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -969,6 +969,12 @@ defmodule Phoenix.Controller do
         script and style tags to be sent with proper content type
       * x-xss-protection - set to "1; mode=block" to improve XSS
         protection on both Chrome and IE
+      * x-download-options - set to noopen to instruct the browser
+        not to open a download directly in the browser, to avoid
+        HTML files rendering inline and accessing the security
+        context of the application (like critical domain cookies)
+      * x-permitted-cross-domain-policies - set to none to restrict
+        Adobe Flash Player’s access to data
 
   A custom headers map may also be given to be merged with defaults.
   """
@@ -985,7 +991,9 @@ defmodule Phoenix.Controller do
     merge_resp_headers(conn, [
       {"x-frame-options", "SAMEORIGIN"},
       {"x-xss-protection", "1; mode=block"},
-      {"x-content-type-options", "nosniff"}
+      {"x-content-type-options", "nosniff"},
+      {"x-download-options", "noopen"},
+      {"x-permitted-cross-domain-policies", "none"}
     ])
   end
 

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -525,11 +525,15 @@ defmodule Phoenix.Controller.ControllerTest do
     assert get_resp_header(conn, "x-frame-options") == ["SAMEORIGIN"]
     assert get_resp_header(conn, "x-xss-protection") == ["1; mode=block"]
     assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+    assert get_resp_header(conn, "x-download-options") == ["noopen"]
+    assert get_resp_header(conn, "x-permitted-cross-domain-policies") == ["none"]
 
     custom_headers = %{"x-frame-options" => "custom", "foo" => "bar"}
     conn = conn(:get, "/") |> put_secure_browser_headers(custom_headers)
     assert get_resp_header(conn, "x-frame-options") == ["custom"]
     assert get_resp_header(conn, "x-xss-protection") == ["1; mode=block"]
+    assert get_resp_header(conn, "x-download-options") == ["noopen"]
+    assert get_resp_header(conn, "x-permitted-cross-domain-policies") == ["none"]
     assert get_resp_header(conn, "foo") == ["bar"]
   end
 


### PR DESCRIPTION
This PR adds two additional security headers. [This was first discussed in the Phoenix-core mailing list](https://groups.google.com/forum/#!topic/phoenix-core/VtDUm21wSnc).

## X-Download-Options

The `X-Download-Options` HTTP header has only one option: `X-Download-Options: noopen`. This is for Internet Explorer from version 8 on to instruct the browser not to open a download directly in the browser, but instead to provide only the ‘Save’ option. The user has to first save it and then open it in an application. The reason for this is that when HTML files download from the application, the browser will render it directly inline. That means that the file renders as part of the application and has direct access to the security context of it, meaning it may run phishing attacks or maybe access critical domain cookies.

## X-Permitted-Cross-Domain-Policies

The `X-Permitted-Cross-Domain-Policies` HTTP header restricts Adobe Flash player’s access to data. The Adobe products PDF and Flash use a same-origin concept that sometimes allow cross-domain access. Flash on a.com will be able to access data on b.com if there is a Cross Domain Policy File at b.com/crossdomain.xml that allows data to be accessed from a.com (or from all sources).