### PR TITLE
Removed reasigned conn's in phx.gen.json controller test [Proposal]

### DIFF
--- a/priv/templates/phx.gen.json/controller_test.exs
+++ b/priv/templates/phx.gen.json/controller_test.exs
@@ -19,25 +19,25 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   describe "index" do
     test "lists all <%= schema.plural %>", %{conn: conn} do
-      conn = get conn, <%= schema.route_helper %>_path(conn, :index)
-      assert json_response(conn, 200)["data"] == []
+      list = get conn, <%= schema.route_helper %>_path(conn, :index)
+      assert json_response(list, 200)["data"] == []
     end
   end
 
   describe "create <%= schema.singular %>" do
     test "renders <%= schema.singular %> when data is valid", %{conn: conn} do
-      conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @create_attrs
-      assert %{"id" => id} = json_response(conn, 201)["data"]
+      create_result = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @create_attrs
+      assert %{"id" => id} = json_response(create_result, 201)["data"]
 
-      conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
-      assert json_response(conn, 200)["data"] == %{
+      get_result = get conn, <%= schema.route_helper %>_path(conn, :show, id)
+      assert json_response(get_result, 200)["data"] == %{
         "id" => id<%= for {key, val} <- schema.params.create do %>,
         "<%= key %>" => <%= inspect val %><% end %>}
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @invalid_attrs
-      assert json_response(conn, 422)["errors"] != %{}
+      expected_error = post conn, <%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @invalid_attrs
+      assert json_response(expected_error, 422)["errors"] != %{}
     end
   end
 
@@ -45,18 +45,18 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     setup [:create_<%= schema.singular %>]
 
     test "renders <%= schema.singular %> when data is valid", %{conn: conn, <%= schema.singular %>: %<%= inspect schema.alias %>{id: id} = <%= schema.singular %>} do
-      conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @update_attrs
-      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+      update_result = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @update_attrs
+      assert %{"id" => ^id} = json_response(update_result, 200)["data"]
 
-      conn = get conn, <%= schema.route_helper %>_path(conn, :show, id)
-      assert json_response(conn, 200)["data"] == %{
+      get_result = get conn, <%= schema.route_helper %>_path(conn, :show, id)
+      assert json_response(get_result, 200)["data"] == %{
         "id" => id<%= for {key, val} <- schema.params.update do %>,
         "<%= key %>" => <%= inspect val %><% end %>}
     end
 
     test "renders errors when data is invalid", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @invalid_attrs
-      assert json_response(conn, 422)["errors"] != %{}
+      expected_error = put conn, <%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @invalid_attrs
+      assert json_response(expected_error, 422)["errors"] != %{}
     end
   end
 
@@ -64,8 +64,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     setup [:create_<%= schema.singular %>]
 
     test "deletes chosen <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = delete conn, <%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>)
-      assert response(conn, 204)
+      delete_result = delete conn, <%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>)
+      assert response(delete_result, 204)
       assert_error_sent 404, fn ->
         get conn, <%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)
       end


### PR DESCRIPTION
Since I am probably abusing generators I often encountered a problem when generated test would fail because conn was overwritten.

I often use Guardian or other similar library to handle user authentication. Most of the time needed data is carried somewhere in `conn` struct. In current form conn is overwritten which often means that mandatory data is lost when conn is being reused. (`Guardian`'s case)

That's why I often have to change their names to not collide and to always blank conn is being used. I also do think overwriting params is bad practice so this change would carry over some good practices.

If you think this change could be beneficial conducting similar operation on `gen.html` would also make sense.

This is not a huge deal but it would make life easier (at least for me).