### PR TITLE
Support an atom as reply in `Phoenix.Channel.reply/2` (#2704)

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -473,6 +473,9 @@ defmodule Phoenix.Channel do
 
   """
   @spec reply(socket_ref, reply) :: :ok
+  def reply(socket_ref, status) when is_atom(status) do
+    reply(socket_ref, {status, %{}})
+  end
   def reply({transport_pid, serializer, topic, ref, join_ref}, {status, payload}) do
     Server.reply(transport_pid, join_ref, ref, topic, {status, payload}, serializer)
   end

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -100,6 +100,15 @@ defmodule Phoenix.Channel.ChannelTest do
       payload: %{key: :val}, ref: "123", status: :ok, topic: "sometopic"}
   end
 
+  test "replying just status to transport" do
+    socket = %Phoenix.Socket{serializer: Phoenix.ChannelTest.NoopSerializer, ref: "123",
+                             topic: "sometopic", transport_pid: self(), joined: true,}
+    ref = socket_ref(socket)
+    reply(ref, :ok)
+    assert_receive %Phoenix.Socket.Reply{
+      payload: %{}, ref: "123", status: :ok, topic: "sometopic"}
+  end
+
   test "socket_ref raises ArgumentError when socket is not joined or has no ref" do
     assert_raise ArgumentError, ~r"join", fn ->
       socket_ref(%Phoenix.Socket{joined: false})


### PR DESCRIPTION
* Reply with an empty payload in case of the second arg is an atom
* Add test for reply/2 replying just status to transport