### PR TITLE
Honor ExUnit default receive timeouts in Channel tests

### DIFF
--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -436,7 +436,8 @@ defmodule Phoenix.ChannelTest do
   In the assertion above, we don't particularly care about
   the data being sent, as long as something was sent.
 
-  The timeout is in milliseconds and defaults to 100ms.
+  The timeout is in milliseconds and defaults to the :assert_receive_timeout
+  set on the :ex_unit application (which defaults to 100ms).
 
   **NOTE:** Because event and payload are patterns, they will be matched.  This
   means that if you wish to assert that the received payload is equivalent to
@@ -455,7 +456,7 @@ defmodule Phoenix.ChannelTest do
       # The code above does not assert the payload matches the described map.
 
   """
-  defmacro assert_push(event, payload, timeout \\ 100) do
+  defmacro assert_push(event, payload, timeout \\ Application.fetch_env!(:ex_unit, :assert_receive_timeout)) do
     quote do
       assert_receive %Phoenix.Socket.Message{
                         event: unquote(event),
@@ -469,12 +470,13 @@ defmodule Phoenix.ChannelTest do
 
   Like `assert_push`, the event and payload are patterns.
 
-  The timeout is in milliseconds and defaults to 100ms.
+  The timeout is in milliseconds and defaults to the :refute_receive_timeout
+  set on the :ex_unit application (which defaults to 100ms).
   Keep in mind this macro will block the test by the
   timeout value, so use it only when necessary as overuse
   will certainly slow down your test suite.
   """
-  defmacro refute_push(event, payload, timeout \\ 100) do
+  defmacro refute_push(event, payload, timeout \\ Application.fetch_env!(:ex_unit, :refute_receive_timeout)) do
     quote do
       refute_receive %Phoenix.Socket.Message{
                         event: unquote(event),
@@ -494,9 +496,10 @@ defmodule Phoenix.ChannelTest do
   In the assertion above, we don't particularly care about
   the data being sent, as long as something was replied.
 
-  The timeout is in milliseconds and defaults to 100ms.
+  The timeout is in milliseconds and defaults to the :assert_receive_timeout
+  set on the :ex_unit application (which defaults to 100ms).
   """
-  defmacro assert_reply(ref, status, payload \\ Macro.escape(%{}), timeout \\ 100) do
+  defmacro assert_reply(ref, status, payload \\ Macro.escape(%{}), timeout \\ Application.fetch_env!(:ex_unit, :assert_receive_timeout)) do
     quote do
       ref = unquote(ref)
       assert_receive %Phoenix.Socket.Reply{
@@ -512,12 +515,13 @@ defmodule Phoenix.ChannelTest do
 
   Like `assert_reply`, the event and payload are patterns.
 
-  The timeout is in milliseconds and defaults to 100ms.
+  The timeout is in milliseconds and defaults to the :refute_receive_timeout
+  set on the :ex_unit application (which defaults to 100ms).
   Keep in mind this macro will block the test by the
   timeout value, so use it only when necessary as overuse
   will certainly slow down your test suite.
   """
-  defmacro refute_reply(ref, status, payload \\ Macro.escape(%{}), timeout \\ 100) do
+  defmacro refute_reply(ref, status, payload \\ Macro.escape(%{}), timeout \\ Application.fetch_env!(:ex_unit, :refute_receive_timeout)) do
     quote do
       ref = unquote(ref)
       refute_receive %Phoenix.Socket.Reply{
@@ -542,9 +546,10 @@ defmodule Phoenix.ChannelTest do
   In the assertion above, we don't particularly care about
   the data being sent, as long as something was sent.
 
-  The timeout is in milliseconds and defaults to 100ms.
+  The timeout is in milliseconds and defaults to the :assert_receive_timeout
+  set on the :ex_unit application (which defaults to 100ms).
   """
-  defmacro assert_broadcast(event, payload, timeout \\ 100) do
+  defmacro assert_broadcast(event, payload, timeout \\ Application.fetch_env!(:ex_unit, :assert_receive_timeout)) do
     quote do
       assert_receive %Phoenix.Socket.Broadcast{event: unquote(event),
                                                payload: unquote(payload)}, unquote(timeout)
@@ -556,12 +561,13 @@ defmodule Phoenix.ChannelTest do
 
   Like `assert_broadcast`, the event and payload are patterns.
 
-  The timeout is in milliseconds and defaults to 100ms.
+  The timeout is in milliseconds and defaults to the :refute_receive_timeout
+  set on the :ex_unit application (which defaults to 100ms).
   Keep in mind this macro will block the test by the
   timeout value, so use it only when necessary as overuse
   will certainly slow down your test suite.
   """
-  defmacro refute_broadcast(event, payload, timeout \\ 100) do
+  defmacro refute_broadcast(event, payload, timeout \\ Application.fetch_env!(:ex_unit, :refute_receive_timeout)) do
     quote do
       refute_receive %Phoenix.Socket.Broadcast{event: unquote(event),
                                                payload: unquote(payload)}, unquote(timeout)


### PR DESCRIPTION
When running in CI, sometimes the tests run slowly and cause these Channel tests to fail simply because it took more than 100 ms for the reply to come. This makes the tests almost always work fine locally but flakey in CI.

When using a standard ExUnit `assert_receive`, the default timeout can be adjusted to 1000ms like so:

```elixir
config :ex_unit, :assert_receive_timeout, 1000
```

Since these Channel test macros are always explicitly passing the timeout to the underlying `assert_receive` or `refute_receive`, we lose the option to configure the default globally and have to set a higher default on each test individually.

This PR honors the same `config :ex_unit, :assert_receive_timeout` configuration setting so that [the explicit value that's passed down is set to the default value](https://github.com/elixir-lang/elixir/blob/v1.5.3/lib/ex_unit/lib/ex_unit/assertions.ex#L353). This feels like the path of least surprise to me, but does couple Phoenix to ExUnit in a way that might not be appropriate. It would also be possible to define another `defmacro assert_push(event, payload)` head that _doesn't_ explicitly set the timeout, but I think that would require more duplication of code.