### PR TITLE
Expose router path as defined in router

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -566,7 +566,7 @@ defmodule Phoenix.ConnTest do
     %URI{path: path, host: host} = conn |> redirected_to() |> URI.parse()
     path_info = split_path(path)
 
-    {conn, _pipes, _dispatch} = router.__match_route__(conn, "GET", path_info, host || conn.host)
+    {conn, _pipes, _dispatch, _defined_path} = router.__match_route__(conn, "GET", path_info, host || conn.host)
     Enum.into(conn.path_params, %{}, fn {key, val} -> {String.to_atom(key), val} end)
   end
   defp split_path(path) do


### PR DESCRIPTION
I'm interested in this when someone posted a related question in #prometheus channel on elixir-lang slack, because currently we're doing something similar (for metrics) in a (non-Elixir) project. But I just realized [the exact situation has been discussed a year ago](https://github.com/phoenixframework/phoenix/issues/2031)... I'll submit this PR anyway since it's a relatively simple change and I think this is the only way for Instrumenter (e.g. [prometheus-phoenix](https://github.com/deadtrickster/prometheus-phoenix)) to have access to this information.

Posting this in case anything changed since a year ago. And also if anyone else needs such functionality this can serve as a reference or inspiration.