### PR TITLE
Add .formatter import from ecto

### DIFF
--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -66,6 +66,7 @@ defmodule Phx.New.Single do
 
   template :bare, [
     {:text, "phx_assets/bare/gitignore", :project, ".gitignore"},
+    {:text, "phx_assets/bare/formatter.exs", :project, ".formatter.exs"},
   ]
 
   template :static, [

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -60,6 +60,7 @@ defmodule Phx.New.Web do
 
   template :bare, [
     {:text, "phx_assets/bare/gitignore", :web, ".gitignore"},
+    {:text, "phx_assets/bare/formatter.exs", :web, ".formatter.exs"},
   ]
 
   template :static, [

--- a/installer/templates/phx_assets/bare/formatter.exs
+++ b/installer/templates/phx_assets/bare/formatter.exs
@@ -1,0 +1,3 @@
+[
+  import_deps: [:ecto]
+]


### PR DESCRIPTION
For Elixir 1.6 format feature, [Ecto will export formatter config](https://github.com/elixir-ecto/ecto/pull/2385) in the future. I propose to add the `.formatter.exs` to import the configuration accordingly while generating the `Single` and `Web` projects.

I've done some experiment that `mix format` feature seems work as normal while Ecto doesn't have the `.formatter.exs`, in other words, not exporting the configuration. 