### PR TITLE
Update the Cowboy 2 dep to be >= 2.2.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,7 @@ defmodule Phoenix.Mixfile do
   end
 
   defp cowboy_dep("1" <> _), do: {:cowboy, "~> 1.0", optional: true}
-  defp cowboy_dep(_), do: {:cowboy, ">= 2.2.1", optional: true}
+  defp cowboy_dep(_), do: {:cowboy, "~> 2.2.1 or ~> 2.3", optional: true}
 
   defp lockfile() do
     case System.get_env("COWBOY_VERSION") do

--- a/mix.exs
+++ b/mix.exs
@@ -75,7 +75,7 @@ defmodule Phoenix.Mixfile do
   end
 
   defp cowboy_dep("1" <> _), do: {:cowboy, "~> 1.0", optional: true}
-  defp cowboy_dep(_), do: {:cowboy, "~> 2.1", optional: true}
+  defp cowboy_dep(_), do: {:cowboy, ">= 2.2.1", optional: true}
 
   defp lockfile() do
     case System.get_env("COWBOY_VERSION") do

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
-%{"cowboy": {:hex, :cowboy, "2.1.0", "69f9db3b23c24ab6b3a169a6357130c16b39cda1a1f8c582f818883ee552589d", [:rebar3], [{:cowlib, "~> 2.0.1", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.4.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
-  "cowlib": {:hex, :cowlib, "2.0.1", "4dfffb1db296eab9f2e8b95ee3017007f674bc920ce30aeb5a53bbda82fc38c0", [:rebar3], [], "hexpm"},
+%{
+  "cowboy": {:hex, :cowboy, "2.2.1", "43e9f86a22922a7512a7ca50b61e9f9f90519cc042b3c060861a6aee7f323cc9", [:rebar3], [{:cowlib, "~> 2.1.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.4.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "2.1.0", "f73658b93dd043af40400c3e4fd997068ebd0c617f8c8f4cd003a1a78ebf94f5", [:rebar3], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], []},
@@ -11,4 +12,5 @@
   "plug": {:hex, :plug, "1.5.0-rc.0", "66edb6dcf10421ed935495f0efbf6018de42b17f0b73552dd9cb1e6d284cf29c", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ranch": {:hex, :ranch, "1.4.0", "10272f95da79340fa7e8774ba7930b901713d272905d0012b06ca6d994f8826b", [:rebar3], [], "hexpm"},
-  "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "9a6f65d05ebf2725d62fb19262b21f1805a59fbf", []}}
+  "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "9a6f65d05ebf2725d62fb19262b21f1805a59fbf", []},
+}


### PR DESCRIPTION
Cowboy 2.2.1 includes a fix that addresses an H2 issue for the Safari web browser.

Fixes #2686
(there is a discussion of the issue there along with sample code that demonstrates the problem)