### PR TITLE
Document `cd` option on watchers

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -169,6 +169,12 @@ defmodule Phoenix.Endpoint do
 
           [node: ["node_modules/brunch/bin/brunch", "watch"]]
 
+      The `:cd` option can be used on a watcher to override the folder from 
+      which the watcher will run. By default this will be the project's root:
+      `File.cwd!()`
+
+          [node: ["node_Modules/brunch/bin/brunch", "watch", cd: "my_frontend"]]
+
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of
       file patterns to watch. When these files change, it will trigger a reload.


### PR DESCRIPTION
Hi,

I recently had to start a new project in which I needed my watcher to run on a sub folder of my app. I dug a bit on the watchers code and found about the `:cd` option which wasn't documented and solved my problem.

This PR adds a bit of documentation about it.