### PR TITLE
Deprecate phoenix-talk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ MIX_ENV=docs mix docs
 * [#elixir-lang][1] on [Freenode][2] IRC
 * [elixir-lang slack channel][3]
 * [Issue tracker][4]
-* [phoenix-talk Mailing list (questions)][5]
+* [Phoenix Forum (questions)][5]
 * [phoenix-core Mailing list (development)][6]
 * Visit Phoenix's sponsor, DockYard, for expert [phoenix consulting](https://dockyard.com/phoenix-consulting)
 * Privately disclose security vulnerabilities to phoenix-security@googlegroups.com
@@ -68,7 +68,7 @@ $ MIX_ENV=docs mix docs
   [2]: http://www.freenode.net/
   [3]: https://elixir-slackin.herokuapp.com/
   [4]: https://github.com/phoenixframework/phoenix/issues
-  [5]: http://groups.google.com/group/phoenix-talk
+  [5]: https://elixirforum.com/c/phoenix-forum
   [6]: http://groups.google.com/group/phoenix-core
 
 ## Copyright and License


### PR DESCRIPTION
Chris McCord has deprecated the phoenix-talk mailing list in July 2017
(see [1]) in favor of the Phoenix subforum on elixirforum.com, so
let's update the README accordingly.

[1]: https://groups.google.com/forum/#!topic/phoenix-talk/Z_Uk3foCyfY