### PR TITLE
A working first pass at using npm scripts instead of brunch.

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -4,4 +4,4 @@ Provides `phx.new` installer as an archive. To build and install it locally:
 
     $ cd installer
     $ MIX_ENV=prod mix archive.build
-    $ mix archive.install
+    $ MIX_ENV=prod mix mix archive.install

--- a/installer/lib/mix/tasks/phx.new.ecto.ex
+++ b/installer/lib/mix/tasks/phx.new.ecto.ex
@@ -57,6 +57,6 @@ defmodule Mix.Tasks.Phx.New.Ecto do
       Mix.raise "The ecto task can only be run within an umbrella's apps directory"
     end
 
-    Mix.Tasks.Phx.New.run(args ++ ["--no-brunch", "--ecto"], Phx.New.Ecto)
+    Mix.Tasks.Phx.New.run(args ++ ["--no-npm", "--ecto"], Phx.New.Ecto)
   end
 end

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -82,7 +82,8 @@ defmodule Phx.New.Generator do
     db           = Keyword.get(opts, :database, "postgres")
     ecto         = Keyword.get(opts, :ecto, true)
     html         = Keyword.get(opts, :html, true)
-    brunch       = Keyword.get(opts, :brunch, true)
+    brunch       = Keyword.get(opts, :brunch, false)
+    npm          = Keyword.get(opts, :npm, true)
     dev          = Keyword.get(opts, :dev, false)
     phoenix_path = phoenix_path(project, dev)
 
@@ -116,6 +117,8 @@ defmodule Phx.New.Generator do
       phoenix_path: phoenix_path,
       phoenix_brunch_path: phoenix_brunch_path(project, dev),
       phoenix_html_brunch_path: phoenix_html_brunch_path(project),
+      phoenix_npm_path: phoenix_npm_path(project, dev),
+      phoenix_html_npm_path: phoenix_html_npm_path(project),
       phoenix_static_path: phoenix_static_path(phoenix_path),
       pubsub_server: pubsub_server,
       secret_key_base: random_string(64),
@@ -123,6 +126,7 @@ defmodule Phx.New.Generator do
       signing_salt: random_string(8),
       in_umbrella: project.in_umbrella?,
       brunch: brunch,
+      npm: npm,
       ecto: ecto,
       html: html,
       adapter_app: adapter_app,
@@ -255,6 +259,20 @@ defmodule Phx.New.Generator do
   defp phoenix_html_brunch_path(%Project{in_umbrella?: true}),
     do: "../../../deps/phoenix_html"
   defp phoenix_html_brunch_path(%Project{in_umbrella?: false}),
+    do: "../deps/phoenix_html"
+
+  defp phoenix_npm_path(%Project{in_umbrella?: true}, true = _dev),
+    do: "../../../../../"
+  defp phoenix_npm_path(%Project{in_umbrella?: true}, false = _dev),
+    do: "../../../deps/phoenix"
+  defp phoenix_npm_path(%Project{in_umbrella?: false}, true = _dev),
+    do: "../../../"
+  defp phoenix_npm_path(%Project{in_umbrella?: false}, false = _dev),
+    do: "../deps/phoenix"
+
+  defp phoenix_html_npm_path(%Project{in_umbrella?: true}),
+    do: "../../../deps/phoenix_html"
+  defp phoenix_html_npm_path(%Project{in_umbrella?: false}),
     do: "../deps/phoenix_html"
 
   defp phoenix_dep("deps/phoenix"), do: ~s[{:phoenix, "~> 1.3.0"}]

--- a/installer/lib/phx_new/project.ex
+++ b/installer/lib/phx_new/project.ex
@@ -43,6 +43,10 @@ defmodule Phx.New.Project do
     Keyword.fetch!(binding, :brunch)
   end
 
+  def npm?(%Project{binding: binding}) do
+    Keyword.fetch!(binding, :npm)
+  end
+
   def join_path(%Project{} = project, location, path)
       when location in [:project, :app, :web] do
 

--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -53,6 +53,18 @@ defmodule Phx.New.Single do
     {:keep, "phx_assets/vendor",                  :project, "assets/vendor"},
   ]
 
+  template :npm, [
+    {:text, "phx_assets/npm/gitignore",       :project, ".gitignore"},
+    {:text,  "phx_assets/npm/babelrc",         :project, "assets/.babelrc"},
+    {:text, "phx_assets/app.css",             :project, "assets/css/app.css"},
+    {:text, "phx_assets/phoenix.css",         :project, "assets/css/phoenix.css"},
+    {:eex,  "phx_assets/npm/app.js",          :project, "assets/js/app.js"},
+    {:eex,  "phx_assets/npm/socket.js",       :project, "assets/js/socket.js"},
+    {:eex,  "phx_assets/npm/package.json",    :project, "assets/package.json"},
+    {:text, "phx_assets/robots.txt",          :project, "assets/static/robots.txt"},
+    {:keep, "phx_assets/vendor",              :project, "assets/vendor"},
+  ]
+
   template :html, [
     {:eex, "phx_web/controllers/page_controller.ex",         :project, "lib/:lib_web_name/controllers/page_controller.ex"},
     {:eex, "phx_web/templates/layout/app.html.eex",          :project, "lib/:lib_web_name/templates/layout/app.html.eex"},
@@ -110,10 +122,11 @@ defmodule Phx.New.Single do
     if Project.ecto?(project), do: gen_ecto(project)
     if Project.html?(project), do: gen_html(project)
 
-    case {Project.brunch?(project), Project.html?(project)} do
-      {true, _}      -> gen_brunch(project)
-      {false, true}  -> gen_static(project)
-      {false, false} -> gen_bare(project)
+    case {Project.brunch?(project), Project.npm?(project), Project.html?(project)} do
+      {true, false, _}      -> gen_brunch(project)
+      {false, true, _}      -> gen_npm(project)
+      {false, false, true}  -> gen_static(project)
+      {false, false, false} -> gen_bare(project)
     end
 
     project
@@ -137,6 +150,12 @@ defmodule Phx.New.Single do
 
   defp gen_brunch(%Project{web_path: web_path} = project) do
     copy_from project, __MODULE__, :brunch
+    create_file Path.join(web_path, "assets/static/images/phoenix.png"), phoenix_png_text()
+    create_file Path.join(web_path, "assets/static/favicon.ico"), phoenix_favicon_text()
+  end
+
+  defp gen_npm(%Project{web_path: web_path} = project) do
+    copy_from project, __MODULE__, :npm
     create_file Path.join(web_path, "assets/static/images/phoenix.png"), phoenix_png_text()
     create_file Path.join(web_path, "assets/static/favicon.ico"), phoenix_favicon_text()
   end

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -47,6 +47,18 @@ defmodule Phx.New.Web do
     {:keep, "phx_assets/vendor",                  :web, "assets/vendor"},
   ]
 
+  template :npm, [
+    {:text, "phx_assets/npm/gitignore",       :web, ".gitignore"},
+    {:text,  "phx_assets/npm/babelrc",        :web, "assets/.babelrc"},
+    {:text, "phx_assets/app.css",             :web, "assets/css/app.css"},
+    {:text, "phx_assets/phoenix.css",         :web, "assets/css/phoenix.css"},
+    {:eex,  "phx_assets/npm/app.js",          :web, "assets/js/app.js"},
+    {:eex,  "phx_assets/npm/socket.js",       :web, "assets/js/socket.js"},
+    {:eex,  "phx_assets/npm/package.json",    :web, "assets/package.json"},
+    {:text, "phx_assets/robots.txt",          :web, "assets/static/robots.txt"},
+    {:keep, "phx_assets/vendor",              :web, "assets/vendor"},
+  ]
+
   template :html, [
     {:eex,  "phx_web/controllers/page_controller.ex",         :web, "lib/:web_app/controllers/page_controller.ex"},
     {:eex,  "phx_web/templates/layout/app.html.eex",          :web, "lib/:web_app/templates/layout/app.html.eex"},
@@ -88,10 +100,11 @@ defmodule Phx.New.Web do
 
     if Project.html?(project), do: gen_html(project)
 
-    case {Project.brunch?(project), Project.html?(project)} do
-      {true, _}      -> gen_brunch(project)
-      {false, true}  -> gen_static(project)
-      {false, false} -> gen_bare(project)
+    case {Project.brunch?(project), Project.npm?(project), Project.html?(project)} do
+      {false, true, _}      -> gen_npm(project)
+      {true, false, _}      -> gen_brunch(project)
+      {false, false, true}  -> gen_static(project)
+      {false, false, false} -> gen_bare(project)
     end
 
     project
@@ -110,6 +123,12 @@ defmodule Phx.New.Web do
 
   defp gen_brunch(%Project{web_path: web_path} = project) do
     copy_from project, __MODULE__, :brunch
+    create_file Path.join(web_path, "assets/static/images/phoenix.png"), phoenix_png_text()
+    create_file Path.join(web_path, "assets/static/favicon.ico"), phoenix_favicon_text()
+  end
+
+  defp gen_npm(%Project{web_path: web_path} = project) do
+    copy_from project, __MODULE__, :npm
     create_file Path.join(web_path, "assets/static/images/phoenix.png"), phoenix_png_text()
     create_file Path.join(web_path, "assets/static/favicon.ico"), phoenix_favicon_text()
   end

--- a/installer/templates/phx_assets/npm/app.js
+++ b/installer/templates/phx_assets/npm/app.js
@@ -1,0 +1,21 @@
+// npm scripts automatically concatenate all files in your
+// watched paths. Those paths can be configured at
+// config.paths.watched in "package.json".
+//
+// However, those files will only be executed if
+// explicitly imported. The only exception are files
+// in vendor, which are never wrapped in imports and
+// therefore are always executed.
+
+// Import dependencies
+//
+// If you no longer want to use a dependency, remember
+// to also remove its path from "config.paths.watched".
+<%= if html do %>import "phoenix_html"<% end %>
+
+// Import local files
+//
+// Local files can be imported directly using relative
+// paths "./socket" or full ones "web/static/js/socket".
+
+// import socket from "./socket"

--- a/installer/templates/phx_assets/npm/babelrc
+++ b/installer/templates/phx_assets/npm/babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [["env", {
+    "targets": {
+      "browsers": ["last 2 versions"]
+    }
+  }], "react"]
+}

--- a/installer/templates/phx_assets/npm/gitignore
+++ b/installer/templates/phx_assets/npm/gitignore
@@ -1,0 +1,27 @@
+# App artifacts
+/_build
+/db
+/deps
+/*.ez
+
+# Generated on crash by the VM
+erl_crash.dump
+
+# Generated on crash by NPM
+npm-debug.log
+
+# Static artifacts
+/assets/node_modules
+
+# Since we are building assets from assets/,
+# we ignore priv/static. You may want to comment
+# this depending on your deployment strategy.
+/priv/static/
+
+# Files matching config/*.secret.exs pattern contain sensitive
+# data and you should not commit them into version control.
+#
+# Alternatively, you may comment the line below and commit the
+# secrets files as long as you replace their contents by environment
+# variables.
+/config/*.secret.exs

--- a/installer/templates/phx_assets/npm/package.json
+++ b/installer/templates/phx_assets/npm/package.json
@@ -1,0 +1,36 @@
+{
+  "repository": {},
+  "license": "MIT",
+  "scripts": {
+    "build:prepare": "mkdir -p ../priv/static/js ../priv/static/css",
+    "build:css": "cat css/phoenix.css css/app.css | postcss --use autoprefixer | cleancss > ../priv/static/css/app.css",
+    "build:css:dev": "cat css/phoenix.css css/app.css | postcss --use autoprefixer > ../priv/static/css/app.css",
+    "build:js": "browserify js/app.js -t [ babelify ] > ../priv/static/js/app.js",
+    "build:js:dev": "browserify js/app.js -t [ babelify ] --debug | exorcist ../priv/static/js/app.map.js > ../priv/static/js/app.js",
+    "build:copy": "cp -R static/* ../priv/static/",
+    "build": "yarn build:prepare && yarn build:js:dev && yarn build:css:dev && yarn build:copy",
+    "deploy": "yarn build:prepare && yarn build:js && yarn build:css && yarn build:copy",
+    "watch:js": "watchify js/app.js -t [ babelify ] --debug -o 'exorcist ../priv/static/js/app.map.js > ../priv/static/js/app.js'",
+    "watch": "parallelshell \"yarn watch:js\" \"watch 'yarn build:css:dev' css\"",
+    "clean": "rm -fr node_modules ../priv/static/*"
+  },
+  "dependencies": {
+    "phoenix": "file:<%= phoenix_npm_path %>"<%= if html do %>,
+    "phoenix_html": "file:<%= phoenix_html_npm_path %>"<% end %>
+  },
+  "devDependencies": {
+    "autoprefixer": "latest",
+    "babel-core": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-react": "^6",
+    "babelify": "^8.0.0",
+    "browserify": "latest",
+    "clean-css": "^4.1.9",
+    "exorcist": "^1.0.0",
+    "parallelshell": "^3.0.2",
+    "postcss-cli": "^4.1.1",
+    "watch": "^1.0.2",
+    "watchify": "^3.10.0",
+    "yarn": "^1.3.2"
+  }
+}

--- a/installer/templates/phx_assets/npm/socket.js
+++ b/installer/templates/phx_assets/npm/socket.js
@@ -1,0 +1,62 @@
+// NOTE: The contents of this file will only be executed if
+// you uncomment its entry in "assets/js/app.js".
+
+// To use Phoenix channels, the first step is to import Socket
+// and connect at the socket path in "lib/web/endpoint.ex":
+import {Socket} from "phoenix"
+
+let socket = new Socket("/socket", {params: {token: window.userToken}})
+
+// When you connect, you'll often need to authenticate the client.
+// For example, imagine you have an authentication plug, `MyAuth`,
+// which authenticates the session and assigns a `:current_user`.
+// If the current user exists you can assign the user's token in
+// the connection for use in the layout.
+//
+// In your "lib/web/router.ex":
+//
+//     pipeline :browser do
+//       ...
+//       plug MyAuth
+//       plug :put_user_token
+//     end
+//
+//     defp put_user_token(conn, _) do
+//       if current_user = conn.assigns[:current_user] do
+//         token = Phoenix.Token.sign(conn, "user socket", current_user.id)
+//         assign(conn, :user_token, token)
+//       else
+//         conn
+//       end
+//     end
+//
+// Now you need to pass this token to JavaScript. You can do so
+// inside a script tag in "lib/web/templates/layout/app.html.eex":
+//
+//     <script>window.userToken = "<%%= assigns[:user_token] %>";</script>
+//
+// You will need to verify the user token in the "connect/2" function
+// in "lib/web/channels/user_socket.ex":
+//
+//     def connect(%{"token" => token}, socket) do
+//       # max_age: 1209600 is equivalent to two weeks in seconds
+//       case Phoenix.Token.verify(socket, "user socket", token, max_age: 1209600) do
+//         {:ok, user_id} ->
+//           {:ok, assign(socket, :user, user_id)}
+//         {:error, reason} ->
+//           :error
+//       end
+//     end
+//
+// Finally, pass the token on connect as below. Or remove it
+// from connect if you don't care about authentication.
+
+socket.connect()
+
+// Now that you are connected, you can join channels with a topic:
+let channel = socket.channel("topic:subtopic", {})
+channel.join()
+  .receive("ok", resp => { console.log("Joined successfully", resp) })
+  .receive("error", resp => { console.log("Unable to join", resp) })
+
+export default socket

--- a/installer/templates/phx_single/README.md
+++ b/installer/templates/phx_single/README.md
@@ -3,7 +3,7 @@
 To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`<%= if ecto do %>
-  * Create and migrate your database with `mix ecto.create && mix ecto.migrate`<% end %><%= if brunch do %>
+  * Create and migrate your database with `mix ecto.create && mix ecto.migrate`<% end %><%= if brunch || npm do %>
   * Install Node.js dependencies with `cd assets && npm install`<% end %>
   * Start Phoenix endpoint with `mix phx.server`
 

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -12,7 +12,8 @@ config :<%= app_name %>, <%= endpoint_module %>,
   code_reloader: true,
   check_origin: false,
   watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
-                    cd: Path.expand("../assets", __DIR__)]]<% else %>[]<% end %>
+                    cd: Path.expand("../assets", __DIR__)]]<% else %><%= if npm do %>[npm: ["run", "watch",
+                    cd: Path.expand("../assets", __DIR__)]]<% else %>[]<% end %><% end %>
 
 # ## SSL Support
 #

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -12,7 +12,8 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
   code_reloader: true,
   check_origin: false,
   watchers: <%= if brunch do %>[node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
-                    cd: Path.expand("../assets", __DIR__)]]<% else %>[]<% end %>
+                    cd: Path.expand("../assets", __DIR__)]]<% else %><%= if npm do %>[npm: ["run", "watch",
+                    cd: Path.expand("../assets", __DIR__)]]<% else %>[]<% end %><% end %>
 
 # ## SSL Support
 #

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -140,12 +140,12 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/lib/phx_blog_web/templates/layout/app.html.eex",
                   "<title>Hello PhxBlog!</title>"
 
-      # Brunch
+      # npm
       assert_file "phx_blog/.gitignore", "/node_modules"
       assert_file "phx_blog/.gitignore", ~r/\n$/
-      assert_file "phx_blog/assets/brunch-config.js", ~s("js/app.js": ["js/app"])
+      assert_file "phx_blog/assets/.babelrc", ~s("last 2 versions"])
       assert_file "phx_blog/config/dev.exs", fn file ->
-        assert file =~ "watchers: [node:"
+        assert file =~ "watchers: [npm:"
         assert file =~ "lib/phx_blog_web/views/.*(ex)"
         assert file =~ "lib/phx_blog_web/templates/.*(eex)"
       end
@@ -210,14 +210,14 @@ defmodule Mix.Tasks.Phx.NewTest do
 
   test "new without defaults" do
     in_tmp "new without defaults", fn ->
-      Mix.Tasks.Phx.New.run([@app_name, "--no-html", "--no-brunch", "--no-ecto"])
+      Mix.Tasks.Phx.New.run([@app_name, "--no-html", "--no-npm", "--no-ecto"])
 
-      # No Brunch
+      # No npm
       refute File.read!("phx_blog/.gitignore") |> String.contains?("/node_modules")
       assert_file "phx_blog/.gitignore", ~r/\n$/
       assert_file "phx_blog/config/dev.exs", ~r/watchers: \[\]/
 
-      # No Brunch & No Html
+      # No npm & No Html
       refute_file "phx_blog/priv/static/css/app.css"
       refute_file "phx_blog/priv/static/favicon.ico"
       refute_file "phx_blog/priv/static/images/phoenix.png"
@@ -266,9 +266,9 @@ defmodule Mix.Tasks.Phx.NewTest do
     end
   end
 
-  test "new with no_brunch" do
-    in_tmp "new with no_brunch", fn ->
-      Mix.Tasks.Phx.New.run([@app_name, "--no-brunch"])
+  test "new with no_npm" do
+    in_tmp "new with no_npm", fn ->
+      Mix.Tasks.Phx.New.run([@app_name, "--no-npm"])
 
       assert_file "phx_blog/.gitignore"
       assert_file "phx_blog/.gitignore", ~r/\n$/

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -205,12 +205,12 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file web_path(@app, "test/#{@app}_web/views/page_view_test.exs"),
                   "defmodule PhxUmbWeb.PageViewTest"
 
-      # Brunch
+      # npm
       assert_file web_path(@app, ".gitignore"), "/node_modules"
       assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
-      assert_file web_path(@app, "assets/brunch-config.js"), ~s("js/app.js": ["js/app"])
+      assert_file web_path(@app, "assets/.babelrc"), ~s(last 2 versions)
       assert_file web_path(@app, "config/dev.exs"), fn file ->
-        assert file =~ "watchers: [node:"
+        assert file =~ "watchers: [npm:"
         assert file =~ "lib/#{@app}_web/views/.*(ex)"
         assert file =~ "lib/#{@app}_web/templates/.*(eex)"
       end
@@ -287,14 +287,14 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
   test "new without defaults" do
     in_tmp "new without defaults", fn ->
-      Mix.Tasks.Phx.New.run([@app, "--umbrella", "--no-html", "--no-brunch", "--no-ecto"])
+      Mix.Tasks.Phx.New.run([@app, "--umbrella", "--no-html", "--no-npm", "--no-ecto"])
 
-      # No Brunch
+      # No npm
       refute File.read!(web_path(@app, ".gitignore")) |> String.contains?("/node_modules")
       assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
       assert_file web_path(@app, "config/dev.exs"), ~r/watchers: \[\]/
 
-      # No Brunch & No Html
+      # No npm & No Html
       refute_file web_path(@app, "priv/static/css/app.css")
       refute_file web_path(@app, "priv/static/favicon.ico")
       refute_file web_path(@app, "priv/static/images/phoenix.png")
@@ -345,9 +345,9 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
     end
   end
 
-  test "new with no_brunch" do
-    in_tmp "new with no_brunch", fn ->
-      Mix.Tasks.Phx.New.run([@app, "--umbrella", "--no-brunch"])
+  test "new with no_npm" do
+    in_tmp "new with no_npm", fn ->
+      Mix.Tasks.Phx.New.run([@app, "--umbrella", "--no-npm"])
 
       assert_file web_path(@app, ".gitignore")
       assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
@@ -579,11 +579,11 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         assert_file "another/lib/another/templates/layout/app.html.eex",
                     "<title>Hello Another!</title>"
 
-        # Brunch
+        # npm
         assert_file "another/.gitignore", "/node_modules"
         assert_file "another/.gitignore",  ~r/\n$/
-        assert_file "another/assets/brunch-config.js", ~s("js/app.js": ["js/app"])
-        assert_file "another/config/dev.exs", "watchers: [node:"
+        assert_file "another/assets/.babelrc", ~s(last 2 versions)
+        assert_file "another/config/dev.exs", "watchers: [npm:"
         assert_file "another/assets/static/favicon.ico"
         assert_file "another/assets/static/images/phoenix.png"
         assert_file "another/assets/css/app.css"


### PR DESCRIPTION
Based on discussion on elixir-forum about brunch not being maintained I figured rather than griping about it I'd contribute some code. This PR adds an npm option to generate npm scripts to maintain javascript and css assets. This isn't meant to be the final solution. I'm not an expert at JavaScript/CSS build pipelines so I may have done a few things wrong. It's a starting point for conversation and contributions from folks who know more.

- All tests pass.
- The default is to use npm scripts rather than brunch.
- It generates a valid working project (at least with no-ecto) and includes watching app.js and app.css.
- Using npm should imply --no-brunch but isn't handled properly
- Probably some other issue too.

