### PR TITLE
Fix issue when umbrella apps don’t use `web` in the name

### DIFF
--- a/lib/mix/phoenix/context.ex
+++ b/lib/mix/phoenix/context.ex
@@ -76,10 +76,15 @@ defmodule Mix.Phoenix.Context do
 
   defp web_module do
     base = Mix.Phoenix.base()
-    if String.ends_with?(base, "Web") do
-      Module.concat([base])
-    else
-      Module.concat(["#{base}Web"])
+    cond do
+      Mix.Phoenix.context_app() != Mix.Phoenix.otp_app() ->
+        Module.concat([base])
+
+      String.ends_with?(base, "Web") ->
+        Module.concat([base])
+
+      true ->
+        Module.concat(["#{base}Web"])
     end
   end
 end

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -313,17 +313,17 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
         assert_file "another_app/lib/another_app/accounts/user.ex"
 
         assert_file "lib/phoenix/controllers/user_controller.ex", fn file ->
-          assert file =~ "defmodule PhoenixWeb.UserController"
-          assert file =~ "use PhoenixWeb, :controller"
+          assert file =~ "defmodule Phoenix.UserController"
+          assert file =~ "use Phoenix, :controller"
         end
 
         assert_file "lib/phoenix/templates/user/form.html.eex"
         assert_file "lib/phoenix/views/user_view.ex", fn file ->
-          assert file =~ "defmodule PhoenixWeb.UserView"
+          assert file =~ "defmodule Phoenix.UserView"
         end
 
         assert_file "test/phoenix/controllers/user_controller_test.exs", fn file ->
-          assert file =~ "defmodule PhoenixWeb.UserControllerTest"
+          assert file =~ "defmodule Phoenix.UserControllerTest"
         end
       end
     end

--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -217,16 +217,16 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
         assert_file "another_app/lib/another_app/accounts/user.ex"
 
         assert_file "lib/phoenix/controllers/user_controller.ex", fn file ->
-          assert file =~ "defmodule PhoenixWeb.UserController"
-          assert file =~ "use PhoenixWeb, :controller"
+          assert file =~ "defmodule Phoenix.UserController"
+          assert file =~ "use Phoenix, :controller"
         end
 
         assert_file "lib/phoenix/views/user_view.ex", fn file ->
-          assert file =~ "defmodule PhoenixWeb.UserView"
+          assert file =~ "defmodule Phoenix.UserView"
         end
 
         assert_file "test/phoenix/controllers/user_controller_test.exs", fn file ->
-          assert file =~ "defmodule PhoenixWeb.UserControllerTest"
+          assert file =~ "defmodule Phoenix.UserControllerTest"
         end
       end
     end


### PR DESCRIPTION
When Phoenix is added to an umbrella app with a name that doesn't contain `web`, it maintains that name with the generators when using a separate context app.

Fixes #2656.