### PR TITLE
Add some type safety for presence state

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -1139,6 +1139,8 @@ Ajax.states = {complete: 4}
 export var Presence = {
 
   syncState(currentState, newState, onJoin, onLeave){
+    this.testCurrentState(currentState)
+
     let state = this.clone(currentState)
     let joins = {}
     let leaves = {}
@@ -1171,6 +1173,8 @@ export var Presence = {
   },
 
   syncDiff(currentState, {joins, leaves}, onJoin, onLeave){
+    this.testCurrentState(currentState)
+
     let state = this.clone(currentState)
     if(!onJoin){ onJoin = function(){} }
     if(!onLeave){ onLeave = function(){} }
@@ -1214,7 +1218,13 @@ export var Presence = {
     return Object.getOwnPropertyNames(obj).map(key => func(key, obj[key]))
   },
 
-  clone(obj){ return JSON.parse(JSON.stringify(obj)) }
+  clone(obj){ return JSON.parse(JSON.stringify(obj)) },
+
+  testCurrentState(currentState) {
+    if (Array.isArray(currentState)) {
+      throw new Error("Current state can't be an array")
+    }
+  }
 }
 
 

--- a/assets/test/presence_test.js
+++ b/assets/test/presence_test.js
@@ -78,6 +78,10 @@ describe("syncState", () => {
     })
     assert.deepEqual(left, {})
   })
+
+  it("should throw an error if state is an array", () => {
+    assert.throws(() => Presence.syncState([], {}))
+  })
 })
 
 describe("syncDiff", () => {
@@ -113,6 +117,10 @@ describe("syncDiff", () => {
     assert.deepEqual(state, {
       u1: {metas: [{id: 1, phx_ref: "1.2"}]},
     })
+  })
+
+  it("should throw an error if state is an array", () => {
+    assert.throws(() => Presence.syncState([], {}))
   })
 })
 


### PR DESCRIPTION
I spent yesterday afternoon debugging my code only to later found out I used an array as a presence state maintener instead of a plain old object. I think it's something that either should be checked at runtime (given JS has no type enforcement and the library is not using typescript...) or explicitely stated in the doc.
I went with the first for my pull request because I guessed why not ?