### PR TITLE
Generate child_spec for presence

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -28,7 +28,7 @@ defmodule Phoenix.Presence do
 
       children = [
         ...
-        supervisor(MyApp.Presence, []),
+        MyApp.Presence,
       ]
 
   Once added, presences can be tracked in your channel after joining:
@@ -126,6 +126,15 @@ defmodule Phoenix.Presence do
       @behaviour unquote(__MODULE__)
       @task_supervisor Module.concat(__MODULE__, TaskSupervisor)
 
+      @doc false
+      def child_spec(opts) do
+        %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [opts]},
+          type: :supervisor
+        }
+      end
+
       def start_link(opts \\ []) do
         opts = Keyword.merge(@opts, opts)
         Phoenix.Presence.start_link(__MODULE__, @otp_app, @task_supervisor, opts)
@@ -173,7 +182,7 @@ defmodule Phoenix.Presence do
         {:ok, state}
       end
 
-      defoverridable fetch: 2
+      defoverridable fetch: 2, child_spec: 1
     end
   end
 

--- a/test/phoenix/presence_test.exs
+++ b/test/phoenix/presence_test.exs
@@ -28,6 +28,14 @@ defmodule Phoenix.PresenceTest do
     {:ok, topic: to_string(config.test)}
   end
 
+  test "defines child_spec/1" do
+    assert DefaultPresence.child_spec([]) == %{
+      id: DefaultPresence,
+      start: {DefaultPresence, :start_link, [[]]},
+      type: :supervisor
+    }
+  end
+
   test "default fetch/2 returns pass-through data", config do
     presences = %{"u1" => %{metas: [%{name: "u1", phx_ref: "ref"}]}}
     assert DefaultPresence.fetch(config.topic, presences) == presences


### PR DESCRIPTION
I saw that the required elixir version has already been changed to ~>1.5 on master branch and it would be nice not to have to add child_spec manually in every presence module.