### PR TITLE
Guides: correct exunit async feature description

### DIFF
--- a/guides/docs/testing/testing.md
+++ b/guides/docs/testing/testing.md
@@ -96,7 +96,7 @@ defmodule HelloWeb.ErrorViewTest do
 end
 ```
 
-`HelloWeb.ErrorViewTest` sets `async: true` which means that each individual test will run in parallel, greatly speeding up the test run. This works because none of the tests access any resources which share state, such as a database. If we set `async: true` for a test case which does access a database, different test processes might modify the same data, corrupting the test results.
+`HelloWeb.ErrorViewTest` sets `async: true` which means that this test case will be run in parallel with other test cases. While individual tests within the case still run serially, this can greatly increase overall test speeds. This works because none of the tests access any resources which share state, such as a database. If we set `async: true` for a test case which does access a database, different test processes might modify the same data, corrupting the test results.
 
 It also imports `Phoenix.View` in order to use the `render_to_string/3` function. With that, all the assertions can be simple string equality tests.
 


### PR DESCRIPTION
Per exunit docs, `async` doesn't parallelize individual tests: it only parallelizes the case modules themselves.

from exunit [main namespace docs](https://hexdocs.pm/ex_unit/ExUnit.html)
```
  # 3) Notice we pass "async: true", this runs the test case
  #    concurrently with other test cases. The individual tests
  #    within each test case are still run serially.
  use ExUnit.Case, async: true
```

and again, from the actual [Case docs](https://hexdocs.pm/ex_unit/ExUnit.Case.html#content)
>  :async - configure this specific test case to run in parallel with other test cases. May be used for performance when this test case does not change any global state. Defaults to false.

