### PR TITLE
Remove Plug.Static from endpoint.ex template when both --no-brunch and --no-html are passed

### DIFF
--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -2,7 +2,7 @@ defmodule <%= endpoint_module %> do
   use Phoenix.Endpoint, otp_app: :<%= web_app_name %>
 
   socket "/socket", <%= web_namespace %>.UserSocket
-
+<%= if html or brunch do %>
   # Serve at "/" the static files from "priv/static" directory.
   #
   # You should set gzip to true if you are running phoenix.digest
@@ -10,7 +10,7 @@ defmodule <%= endpoint_module %> do
   plug Plug.Static,
     at: "/", from: :<%= web_app_name %>, gzip: false,
     only: ~w(css fonts images js favicon.ico robots.txt)
-
+<% end %>
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do<%= if html do %>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -49,6 +49,7 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~ "use Phoenix.View, root: \"lib/phx_blog_web/templates\""
       end
       assert_file "phx_blog/lib/phx_blog_web/endpoint.ex", ~r/defmodule PhxBlogWeb.Endpoint do/
+      assert_file "phx_blog/lib/phx_blog_web/endpoint.ex", ~r/plug Plug.Static/
 
       assert_file "phx_blog/test/phx_blog_web/controllers/page_controller_test.exs"
       assert_file "phx_blog/test/phx_blog_web/views/page_view_test.exs"
@@ -151,6 +152,9 @@ defmodule Mix.Tasks.Phx.NewTest do
       refute_file "phx_blog/priv/static/images/phoenix.png"
       refute_file "phx_blog/priv/static/js/phoenix.js"
       refute_file "phx_blog/priv/static/js/app.js"
+      assert_file "phx_blog/lib/phx_blog_web/endpoint.ex", fn file ->
+        refute file =~ "plug Plug.Static"
+      end
 
       # No Ecto
       config = ~r/config :phx_blog, PhxBlog.Repo,/


### PR DESCRIPTION
When both `--no-brunch` and `--no-html` options are passed, the [directory `priv/static` is not generated](https://github.com/phoenixframework/phoenix/blob/49def42a9220198527807176f84ba92d131daa72/installer/lib/phx_new/single.ex#L116). However, the template for `<app>_web/endpoint.ex` is configured to always include `plug Plug.Static`, which doesn't seem correct.