### PR TITLE
Add support for context_app with schema generator

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -276,6 +276,9 @@ defmodule Mix.Phoenix do
         via cli option:
 
             mix phx.gen.[task] --context-app some_app
+
+        Note: cli option only works when `context_app` is not set to `false`
+        in the config.
         """
       {app, _path} ->
         {:ok, app}

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -268,4 +268,38 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
       end
     end
   end
+
+  describe "inside umbrella" do
+    test "raises with false context_app", config do
+      in_tmp_umbrella_project config.test, fn ->
+        Application.put_env(:phoenix, :generators, context_app: false)
+
+        assert_raise Mix.Error, ~r/no context_app configured/, fn ->
+          Gen.Schema.run(~w(Blog.Post blog_posts title:string))
+        end
+      end
+    end
+
+    test "with context_app set to nil", config do
+      in_tmp_umbrella_project config.test, fn ->
+        Application.put_env(:phoenix, :generators, context_app: nil)
+
+        Gen.Schema.run(~w(Blog.Post blog_posts title:string))
+
+        assert_file "lib/phoenix/blog/post.ex"
+        assert [_] = Path.wildcard("priv/repo/migrations/*_create_blog_posts.exs")
+      end
+    end
+
+    test "with context_app", config do
+      in_tmp_umbrella_project config.test, fn ->
+        Application.put_env(:phoenix, :generators, context_app: {:another_app, "another_app"})
+
+        Gen.Schema.run(~w(Blog.Post blog_posts title:string))
+
+        assert_file "another_app/lib/another_app/blog/post.ex"
+        assert [_] = Path.wildcard("another_app/priv/repo/migrations/*_create_blog_posts.exs")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds context_app support for generating schema files based on `:context_app` in the config and `--context_app` in the CLI.

Fixes #2699