### PR TITLE
Authorization request header is now persisted during conn recycling

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -461,7 +461,7 @@ defmodule Phoenix.ConnTest do
     build_conn()
     |> Map.put(:host, conn.host)
     |> Plug.Test.recycle_cookies(conn)
-    |> copy_headers(conn.req_headers, ~w(accept))
+    |> copy_headers(conn.req_headers, ~w(accept authorization))
   end
 
   defp copy_headers(conn, headers, copy) do


### PR DESCRIPTION
When `conn` gets recycled during tests, only the `accept` request header got persisted. This PR adds `authorization` to that list.

Fixes #2452.