### PR TITLE
Rework the introduction and organization of the Channels guide

### DIFF
--- a/guides/docs/channels.md
+++ b/guides/docs/channels.md
@@ -11,7 +11,7 @@ Some possible use cases include:
 
 Conceptually, Channels are pretty simple.
 Clients connect and subscribe to one or more topics, whether that's `public_chat` or `updates:user1`.
-Any message sent on a topic, whether from the server or from a client, is sent to all clients subscribed to that topic, like this:
+Any message sent on a topic, whether from the server or from a client, is sent to all clients subscribed to that topic (including the sender, if it's subscribed), like this:
 
 <pre>
 <code>
@@ -118,10 +118,10 @@ Within the handler, you can authenticate and identify a socket connection and se
 Channel routes are defined in socket handlers, such as `HelloWeb.UserSocket` in the example above.
 They match on the topic string and dispatch matching requests to the given Channel module.
 
-The star character `*` acts as a wildcard matcher, so in the following example route, requests for `elixir:ecto` and `elixir:phoenix` would both be dispatched to the `ElixirTopicChannel`.
+The star character `*` acts as a wildcard matcher, so in the following example route, requests for `room:lobby` and `room:123` would both be dispatched to the `RoomChannel`.
 
 ```elixir
-channel "elixir:*", HelloWeb.ElixirTopicChannel
+channel "room:*", HelloWeb.RoomChannel
 ```
 
 ### Channels

--- a/guides/docs/channels.md
+++ b/guides/docs/channels.md
@@ -32,7 +32,7 @@ Any message sent on a topic, whether from the server or from a client, is sent t
 
 Channels can support any kind of client: a browser, native app, smart watch, embedded device, or anything else that can connect to a network.
 All the client needs is a suitable library; see the [Client Libraries](#client-libraries) section below.
-Each client library communicates using one of the "transports" that Channels understands.
+Each client library communicates using one of the "transports" that Channels understand.
 Currently, that's either Websockets or long polling, but other transports may be added in the future.
 
 Unlike stateless HTTP connections, Channels support long-lived connections, each backed by a lightweight BEAM process, working in parallel and maintaining its own state.


### PR DESCRIPTION
Having gotten lost in some of these abstractions myself, I tried to make
this introduction as concrete and clear as possible. The examples and
new diagram at the top should help readers quickly grasp what channels
can be used for and the flexibility and scalability they offer.

Beyond that, I added a few clarifications and examples, and reordered
the parts so that PubSub is last, since it's the least visible to an
application developer.