### PR TITLE
Allow Websocket Transport to copy conn fields to params

### DIFF
--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -34,6 +34,14 @@ defmodule Phoenix.Transports.WebSocket do
     * `:code_reloader` - optionally override the default `:code_reloader` value
       from the socket's endpoint
 
+    * `:conn_fields` - optionally copy extra fields from the conn to the params
+      for use in connecting the socket.
+
+      For example, if you need access to the request headers, you can set
+      
+      conn_fields: [:req_header]
+
+
   ## Serializer
 
   By default, JSON encoding is used to broker messages to and from clients.
@@ -82,6 +90,7 @@ defmodule Phoenix.Transports.WebSocket do
       conn
       |> code_reload(opts, endpoint)
       |> fetch_query_params()
+      |> copy_conn_fields(opts)
       |> Transport.transport_log(opts[:transport_log])
       |> Transport.force_ssl(handler, endpoint, opts)
       |> Transport.check_origin(handler, endpoint, opts)
@@ -211,5 +220,18 @@ defmodule Phoenix.Transports.WebSocket do
     if reload?, do: Phoenix.CodeReloader.reload!(endpoint)
 
     conn
+  end
+
+  defp copy_conn_fields(conn, opts) do
+    Keyword.get(opts, :conn_fields)
+    |> Enum.reduce(conn, fn(field, conn) -> 
+      case Map.get(conn, field) do
+        nil -> 
+          conn
+
+        value ->
+          %{conn | params: Map.put_new(conn.params, field, value)}
+      end
+    end)
   end
 end


### PR DESCRIPTION
When authenticating websockets, sometimes its necessary to have access to the headers from the initial HTTP request prior to the connection being upgraded. 

The PR would allow the Websocket transport to take a list of conn fields which it would copy into the params before the websocket upgrade.

For Example, 

```elixir
## Transports
  transport :websocket, Phoenix.Transports.WebSocket, conn_fields: [:req_headers]

def connect(params, socket) do
    %{req_headers: req_headers} = params
    {:ok, socket}
  end
```