### PR TITLE
Validate params

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1399,6 +1399,72 @@ defmodule Phoenix.Controller do
     Phoenix.Router.Helpers.url(router_module(conn), conn) <> current_path(conn, params)
   end
 
+  @doc """
+  Validates params according to the given `schema`.
+  Schema is a map where key is an atom and corresponds
+  to outside param key. Value is one of the three possibilities:
+
+  1. `type`
+  2. `{type, :required}`
+  3. `{type, default_value}`
+
+  Where type is a castable Ecto type.
+  When `params` are missing a key which was marked `:required` in `schema`,
+  result will be an error tuple.
+  A `changeset_fun` can be passed as optional last argument,
+  which will be applied to the resulting changeset.
+
+  ## Examples
+      iex> schema = %{id: {:integer, :required}}
+      iex> validate_params(schema, %{"id" => "1"})
+      {:ok, %{id: 1}}
+
+      iex> schema = %{year: {:integer, Date.utc_today.year}}
+      iex> validate_params(schema, %{})
+      {:ok, %{year: 2018}}
+
+      iex> schema = %{quarter: {:integer, :required}}
+      iex> transformer = &Ecto.Changeset.validate_inclusion(&1, :quarter, 1..4)
+      iex> validate_params(schema, %{"quarter" => "5"}, transformer)
+      {:error, changeset}
+
+  The return value is either successful map of params which can be safely
+  passed to other functions or error with invalid changeset which can
+  be presented to users so they can fix the request.
+  """
+  @spec validate_params(map, map, (Ecto.Changeset.t -> Ecto.Changeset.t)) ::
+          {:ok, map} |
+          {:error, Ecto.Changeset.t}
+  def validate_params(schema, params, changeset_fun \\ & &1) do
+    import Ecto.Changeset
+
+    {defaults, types, required} =
+      Enum.reduce(schema, {%{}, %{}, []}, fn elem, {defaults, types, required} ->
+        case elem do
+          {field, {type, :required}} ->
+            {defaults, Map.put(types, field, type), [field | required]}
+          {field, {type, default}} ->
+            {
+              Map.put(defaults, field, default),
+              Map.put(types, field, type),
+              [field | required]
+            }
+          {field, type} ->
+            {defaults, Map.put(types, field, type), required}
+        end
+      end)
+
+    changeset =
+      {defaults, types}
+      |> cast(params, Map.keys(types))
+      |> validate_required(required)
+      |> changeset_fun.()
+
+    if changeset.valid?,
+      do: {:ok, apply_changes(changeset)},
+      else: {:error, changeset}
+  end
+
   @doc false
   def __view__(controller_module) do
     controller_module

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1443,14 +1443,18 @@ defmodule Phoenix.Controller do
         case elem do
           {field, {type, :required}} ->
             {defaults, Map.put(types, field, type), [field | required]}
-          {field, {type, default}} ->
-            {
-              Map.put(defaults, field, default),
-              Map.put(types, field, type),
-              [field | required]
-            }
-          {field, type} ->
-            {defaults, Map.put(types, field, type), required}
+          {field, type_or_type_with_default} ->
+            if Ecto.Type.primitive?(type_or_type_with_default) do
+              type = type_or_type_with_default
+              {defaults, Map.put(types, field, type), required}
+            else
+              {type, default} = type_or_type_with_default
+              {
+                Map.put(defaults, field, default),
+                Map.put(types, field, type),
+                [field | required]
+              }
+            end
         end
       end)
 

--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,8 @@ defmodule Phoenix.Mixfile do
       {:gettext, "~> 0.8", only: :test},
       # TODO v1.4: release bump to next stable release with relaxed plug dep
       {:phoenix_html, "~> 2.10", only: :test},
-      {:websocket_client, git: "https://github.com/jeremyong/websocket_client.git", only: :test}
+      {:websocket_client, git: "https://github.com/jeremyong/websocket_client.git", only: :test},
+      {:ecto, "~> 2.2.0-rc.1"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
 %{
   "cowboy": {:hex, :cowboy, "2.2.2", "6cde634da1da8b1d17dd2b20f5f6f91ab8ac7fa1b5106d13dad63c905ab76004", [:rebar3], [{:cowlib, "~> 2.1.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.4.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.1.0", "f73658b93dd043af40400c3e4fd997068ebd0c617f8c8f4cd003a1a78ebf94f5", [:rebar3], [], "hexpm"},
+  "decimal": {:hex, :decimal, "1.4.1", "ad9e501edf7322f122f7fc151cce7c2a0c9ada96f2b0155b8a09a795c2029770", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], []},
+  "ecto": {:hex, :ecto, "2.2.8", "a4463c0928b970f2cee722cd29aaac154e866a15882c5737e0038bbfcf03ec2c", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], []},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
@@ -12,6 +14,7 @@
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], []},
   "plug": {:hex, :plug, "1.5.0-rc.2", "fcf9e93b0dada35fa0b3c0839c41328dd1680415a365753de988666ff167df25", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.4.0", "10272f95da79340fa7e8774ba7930b901713d272905d0012b06ca6d994f8826b", [:rebar3], [], "hexpm"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "9a6f65d05ebf2725d62fb19262b21f1805a59fbf", []},
 }

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -630,7 +630,13 @@ defmodule Phoenix.Controller.ControllerTest do
     assert {:error, _changeset} = validate_params(schema, %{}, transformer)
     assert {:error, _changeset} = validate_params(schema, %{"quarter" => "5"}, transformer)
 
-    schema = %{ids: {{:array, :integer}, :required}}
+    schema = %{ids: {:array, :integer}}
     assert validate_params(schema, %{"ids" => ["1", "2"]}) == {:ok, %{ids: [1, 2]}}
+
+    schema = %{ids: {{:array, :integer}, [1, 2]}}
+    assert validate_params(schema, %{}) == {:ok, %{ids: [1, 2]}}
+
+    schema = %{ids: {{:array, :integer}, :required}}
+    assert {:error, _changeset} = validate_params(schema, %{})
   end
 end

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -615,4 +615,22 @@ defmodule Phoenix.Controller.ControllerTest do
       assert current_url(conn, %{three: 3}) == "https://www.example.com/foo?three=3"
     end
   end
+
+  test "validate_params/3" do
+    schema = %{id: {:integer, :required}}
+    assert validate_params(schema, %{"id" => "1"}) == {:ok, %{id: 1}}
+
+    schema = %{year: {:integer, 2018}}
+    assert validate_params(schema, %{}) == {:ok, %{year: 2018}}
+    assert {:error, changeset} = validate_params(schema, %{"year" => "foo"})
+
+    schema = %{quarter: {:integer, :required}}
+    transformer = &Ecto.Changeset.validate_inclusion(&1, :quarter, 1..4)
+    assert validate_params(schema, %{"quarter" => "1"}, transformer) == {:ok, %{quarter: 1}}
+    assert {:error, _changeset} = validate_params(schema, %{}, transformer)
+    assert {:error, _changeset} = validate_params(schema, %{"quarter" => "5"}, transformer)
+
+    schema = %{ids: {{:array, :integer}, :required}}
+    assert validate_params(schema, %{"ids" => ["1", "2"]}) == {:ok, %{ids: [1, 2]}}
+  end
 end


### PR DESCRIPTION
I doubt this will be accepted but I would like to at least touch this topic and discuss it with the community. This code sets Ecto as a dependency which I suspect is unfortunately a no-go for this PR. It defines new `Phoenix.Controller.validate_params/3` function which purpose is to transform string params into valid arguments accepted by domain functions.

There are a lot of useful functions for presenting data to user be it json or html but there is nothing more than pattern matching on actions for controlling params coming to action.
I'm talking about missing * in this data flow:

```
request -> controller -> * -> call domain -> present response
```

It is hard to call domain functions with the current featureset or I didn't discover it yet.
Lets say there a is a function which is to be called from controller:

```elixir
defmodule Report do
  def build(dates) do
    ...
  end
end
```

As written in Programming Erlang, I'm following the principle that functions shouldn't fix its arguments and rather assume that it is a caller responsibility to pass them correctly. When I'm in control of the arguments and call it from iex or automated job which sends it over the email I would call it like that
```elixir
iex> Report.build([~D[2018-03-01], ~D[2018-03-02]])
```

When calling on behalf of a user in controller action, it is a hard job to do it right. With the `validate_params` I can do:

```elixir
def index(conn, params) do
  schema = %{dates: {{:array, :date}, :required}}

  case validate_params(schema, params) do
    {:ok, %{dates: dates}} ->
      render_200 conn, Report.build(dates)
    {:error, changeset} ->
      render_422 conn, changeset
  end
end
```

What I like about this solution is that we are explicit about the input to the controller instead or map of strings.
Actually problem is still there even in basic CRUD application.

```elixir
def show(conn, %{"id" => id}) do
  case Repo.get(Foo, id) do
    nil -> send_resp(conn, 404, "not found")
    foo -> json(conn, %{id: foo.id})
  end
end
```
`Repo.get` will accept here string which is fine as primary key can be actually a string but in this context is is integer. If passed `1` or `"1"` it works fine, but one can easily pass `"foo"` and get an exception. Actually now I've checked and looks like Phoenix catches `Ecto.Query.CastError` exception and returns 400. But still, catching an exception here for an argument which can be validated upfront is a bit sneaky. It is good that Phoenix handles Ecto case but domain can call different database library or service.

I use this approach in production for a few projects and it has been solid. I hope that I didn't miss something, please let me know if I'm doing this wrong.