### PR TITLE
Update README's travis badge to point to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > ### Productive. Reliable. Fast.
 > A productive web framework that does not compromise speed and maintainability.
 
-[![Build Status](https://api.travis-ci.org/phoenixframework/phoenix.svg)](https://travis-ci.org/phoenixframework/phoenix)
+[![Build Status](https://api.travis-ci.org/phoenixframework/phoenix.svg?branch=master)](https://travis-ci.org/phoenixframework/phoenix)
 [![Inline docs](http://inch-ci.org/github/phoenixframework/phoenix.svg)](http://inch-ci.org/github/phoenixframework/phoenix)
 
 ## Getting started


### PR DESCRIPTION
Not 100% if this tiny edit makes sense but I noticed that the badge in the README was "failing" while the master branch on Travis was green. This change makes the travis badge in the README point directly to the master branch.