### PR TITLE
Generate a static_push function in the RouteHelpers

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -153,7 +153,7 @@ defmodule Phoenix.Router.Helpers do
       end
 
       @doc """
-      Perform a server push and return the path to a static asset given its file path.
+      Performs a server push and returns the path to a static asset given its file path.
 
       The server push will only happen if using HTTP/2 with a supported plug adapter.
       If not supported, this function will simply return the path to the static

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -153,6 +153,19 @@ defmodule Phoenix.Router.Helpers do
       end
 
       @doc """
+      Perform a server push and return the path to a static asset given its file path.
+
+      The server push will only happen if using HTTP/2 with a supported plug adapter.
+      If not supported, this function will simply return the path to the static
+      asset.
+      """
+      def static_push(%Conn{} = conn, path) do
+        path = static_path(conn, path)
+        Plug.Conn.push(conn, path)
+        path
+      end
+
+      @doc """
       Generates url to a static asset given its file path.
       """
       def static_url(%Conn{private: private} = conn, path) do

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -415,6 +415,12 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.static_path(socket_with_endpoint(), "/images/foo.png") == "/images/foo.png"
   end
 
+  test "helpers module generates a static_push helper" do
+    conn = conn_with_endpoint()
+    assert Helpers.static_push(conn, "/images/foo.png") == "/images/foo.png"
+    assert {"/images/foo.png", [{"accept", "image/png"}]} in sent_pushes(conn)
+  end
+
   test "helpers module generates a static_url helper" do
     url = "https://static.example.com/images/foo.png"
     assert Helpers.static_url(__MODULE__, "/images/foo.png") == url


### PR DESCRIPTION
The `static_push/2` function is a drop in replacement for `static_path/2` with
the addition of performing a server push if the adapter allows. This function
only supports using a `Plug.Conn` struct - attempting to use it with an endpoint
will result in an error.