### PR TITLE
Update installer webpack config to minify CSS in production

### DIFF
--- a/installer/templates/phx_assets/webpack/webpack.config.js
+++ b/installer/templates/phx_assets/webpack/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
-module.exports = {
+module.exports = (env, options) => ({
   entry: './js/app.js',
   output: {
     filename: 'app.js',
@@ -21,7 +21,9 @@ module.exports = {
         test: /\.css$/,
         use: ExtractTextPlugin.extract({
           fallback: 'style-loader',
-          use: 'css-loader'
+          use: {
+            loader: 'css-loader', options: { minimize: options.mode === 'production' }
+          }
         })
       }
     ]
@@ -30,4 +32,4 @@ module.exports = {
     new ExtractTextPlugin('../css/app.css'),
     new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
   ]
-};
+});


### PR DESCRIPTION
This change requires access to the `options` for webpack. To access
this, the webpack config has been changed to use a function instead of
an object.

Closes #2809