### PR TITLE
Use double quotes for consistency

### DIFF
--- a/installer/templates/phx_assets/webpack/app.js
+++ b/installer/templates/phx_assets/webpack/app.js
@@ -1,7 +1,7 @@
 // We need to import the CSS so that webpack will load it.
 // The ExtractTextPlugin is used to separate it out into
 // its own CSS file.
-import css from '../css/app.css';
+import css from "../css/app.css";
 
 // webpack automatically bundles all modules in your
 // entry points. Those entry points can be configured


### PR DESCRIPTION
For consistency, we should chose one and switch all .js files over to single or double quotes. 

webpack.config.js currently uses single quotes, and the rest (app.js, socket.js) use double. Same with app.css - let me know which you prefer!