### PR TITLE
Prevent overiding existing http configuration parameters that are passed to Cowboy

### DIFF
--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -49,7 +49,14 @@ defmodule <%= endpoint_module %> do
   def init(_key, config) do
     if config[:load_from_system_env] do
       port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
-      {:ok, Keyword.put(config, :http, [:inet6, port: port])}
+
+      http_config = if Keyword.get(config, :http) do
+        config |> Keyword.get(:http) |> Keyword.put(:port, port)
+      else
+        [:inet6, port: port]
+      end
+
+      {:ok, Keyword.put(config, :http, http_config)}
     else
       {:ok, config}
     end


### PR DESCRIPTION
I wanted to increase the maximum allowed size for a HTTP header by passing this option to Cowboy. However, I've noticed that the configuration I've set in my config files is not passed to the Cowboy adapter.

Example configuration:

``` elixir
config :my_app, MyApp.Enpoint,
  http: [protocol_options: [max_header_value_length: 8192]]
```

This option was overriden in the generated endpoint, when we called `Keyword.put(config, :http, [:inet6, port: port])`.

The new code checks if the `http` configuration is present and appends the port option.