### PR TITLE
Use @impl in application templates

### DIFF
--- a/installer/templates/phx_single/lib/app_name/application.ex
+++ b/installer/templates/phx_single/lib/app_name/application.ex
@@ -5,6 +5,7 @@ defmodule <%= app_module %>.Application do
 
   use Application
 
+  @impl Application
   def start(_type, _args) do
     # List all child processes to be supervised
     children = [<%= if ecto do %>

--- a/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
@@ -9,6 +9,7 @@ defmodule <%= app_module %>.Application do
   """
   use Application
 
+  @impl Application
   def start(_type, _args) do<%= if ecto do %>
     Supervisor.start_link([
       <%= app_module %>.Repo,

--- a/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name/application.ex
@@ -2,6 +2,7 @@ defmodule <%= web_namespace %>.Application do
   @moduledoc false
   use Application
 
+  @impl Application
   def start(_type, _args) do
     # List all child processes to be supervised
     children = [


### PR DESCRIPTION
Since https://github.com/phoenixframework/phoenix/commit/49def42a9220198527807176f84ba92d131daa72, Phoenix requires Elixir v1.5 for new apps, so it should be safe now to use `@impl`.