### PR TITLE
Update application.ex templates with default docs

### DIFF
--- a/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
@@ -1,12 +1,8 @@
 defmodule <%= app_module %>.Application do
-  @moduledoc """
-  The <%= app_module %> Application Service.
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
 
-  The <%= app_name %> system business domain lives in this application.
-
-  Exposes API to clients such as the `<%= app_module%>Web` application
-  for use in channels, controllers, and elsewhere.
-  """
   use Application
 
   def start(_type, _args) do<%= if ecto do %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name/application.ex
@@ -1,5 +1,8 @@
 defmodule <%= web_namespace %>.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
   @moduledoc false
+
   use Application
 
   def start(_type, _args) do


### PR DESCRIPTION
The [default documentation of the `*.Application` module for single apps](https://github.com/phoenixframework/phoenix/blob/master/installer/templates/phx_single/lib/app_name/application.ex#L2-L4) matches the template in the new [Library Guidelines](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/Library%20Guidelines.md#avoid-spawning-unsupervised-processes), but not the ones for umbrella apps.  