### PR TITLE
Update docs about async tests

### DIFF
--- a/guides/docs/testing/testing.md
+++ b/guides/docs/testing/testing.md
@@ -96,7 +96,7 @@ defmodule HelloWeb.ErrorViewTest do
 end
 ```
 
-`HelloWeb.ErrorViewTest` sets `async: true` which means that this test case will be run in parallel with other test cases. While individual tests within the case still run serially, this can greatly increase overall test speeds. This works because none of the tests access any resources which share state, such as a database. If we set `async: true` for a test case which does access a database, different test processes might modify the same data, corrupting the test results.
+`HelloWeb.ErrorViewTest` sets `async: true` which means that this test case will be run in parallel with other test cases. While individual tests within the case still run serially, this can greatly increase overall test speeds. It is possible to encounter strange behavior with asynchronous tests, but thanks to the [`Ecto.Adapters.SQL.Sandbox`](https://hexdocs.pm/ecto/Ecto.Adapters.SQL.Sandbox.html), async tests involving a database can be done without worry. This means that the vast majority of tests in your Phoenix application will be able to be run asynchronously.
 
 It also imports `Phoenix.View` in order to use the `render_to_string/3` function. With that, all the assertions can be simple string equality tests.
 


### PR DESCRIPTION
The section warning about async tests for tests involving a database
was a little confusing to people since it's pretty out dated. This
language was introduce almost [3 years ago](https://github.com/phoenixframework/phoenix/commit/2b456abcea782684861f466d932b451b37279945),
back when async tests touching the database _were_ dangerous. Now that
this is no longer the case thanks to Ecto 2.0, this should be updated
in the guides.