### PR TITLE
Add conditional on onclose code in order to prevent retrying logic on…

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -854,7 +854,7 @@ export class Socket {
     this.log("transport", "close", event)
     this.triggerChanError()
     clearInterval(this.heartbeatTimer)
-    if (event.code !== 1000) {
+    if (!(event instanceof Event) || ((event instanceof Event) && event.code !== 1000)) {
       this.reconnectTimer.scheduleTimeout()
     }
     this.stateChangeCallbacks.close.forEach( callback => callback(event) )

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -854,7 +854,7 @@ export class Socket {
     this.log("transport", "close", event)
     this.triggerChanError()
     clearInterval(this.heartbeatTimer)
-    if (!(event instanceof Event) || ((event instanceof Event) && event.code !== 1000)) {
+    if (event && event.code !== 1000) {
       this.reconnectTimer.scheduleTimeout()
     }
     this.stateChangeCallbacks.close.forEach( callback => callback(event) )

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -854,7 +854,7 @@ export class Socket {
     this.log("transport", "close", event)
     this.triggerChanError()
     clearInterval(this.heartbeatTimer)
-    if (event && event.code !== 1000) {
+    if (event && event.code !== WS_CLOSE_NORMAL) {
       this.reconnectTimer.scheduleTimeout()
     }
     this.stateChangeCallbacks.close.forEach( callback => callback(event) )

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -854,7 +854,9 @@ export class Socket {
     this.log("transport", "close", event)
     this.triggerChanError()
     clearInterval(this.heartbeatTimer)
-    this.reconnectTimer.scheduleTimeout()
+    if (event.code !== 1000) {
+      this.reconnectTimer.scheduleTimeout()
+    }
     this.stateChangeCallbacks.close.forEach( callback => callback(event) )
   }
 

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -632,7 +632,9 @@ describe("onConnClose", () => {
   it("schedules reconnectTimer timeout", () => {
     const spy = sinon.spy(socket.reconnectTimer, "scheduleTimeout")
 
-    socket.onConnClose()
+    const event = new Event("onClose", { code: 1000 })
+
+    socket.onConnClose(event)
 
     assert.ok(spy.calledOnce)
   })

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -629,10 +629,20 @@ describe("onConnClose", () => {
     socket.connect()
   })
 
-  it("schedules reconnectTimer timeout", () => {
-    const spy = sinon.spy(socket.reconnectTimer, "scheduleTimeout")
+  it('does not schedules reconnectTimer timeout if normal close', () => {
+    const spy = sinon.spy(socket.reconnectTimer, 'scheduleTimeout')
 
-    const event = new Event("onClose", { code: 1000 })
+    const event = { code: 1000 }
+
+    socket.onConnClose(event)
+
+    assert.ok(spy.notCalled)
+  })
+
+  it('schedules reconnectTimer timeout if not normal close', () => {
+    const spy = sinon.spy(socket.reconnectTimer, 'scheduleTimeout')
+
+    const event = { code: 1001 }
 
     socket.onConnClose(event)
 


### PR DESCRIPTION
We are working on a project in which we are using sockets. 
But we had an issue when we tried to disconnect the socket (we are doing that when the user logs out).
On our logout method on the backend side we are doing `Endpoint.broadcast("user_socket:#{user_id}", "disconnect", %{})`  as is stated in the docs. But this is not correctly finishing the connection so it keeps trying to reconnect. 
On the browser we can see that as:
![image](https://user-images.githubusercontent.com/12262532/38391096-a1a78092-38f9-11e8-954a-80a1e5fade1b.png)

so, what I understood from inspecting the `phoenix.js` code is that executes the same logic [https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js#L853](https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js#L853)  if we are closing the socket as I said, or if I shutdown the server (simulating an error on the socket).

and here ( [https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js#L857](https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js#L857)) it starts the timer which is in charge of trying to reconnect.

And that's not what we were after, we want to close the conection without retrying.

So after inspecting the code, I found that when we disconect the socket on the backend has a different onClose code than if we shutdown the server. 

The onClose codes can be found here [https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent) 

So for the socket disconect event on the backend, the code is 1000, that is “Normal closure; the connection successfully completed whatever purpose for which it was created.”. When I shutdown the server I got 1006 that is "Abnormal Closure"

that’s why I’ve added the if statement in order to prevent retrying when we do `Endpoint.broadcast("user_socket:#{user_id}", "disconnect", %{})`. So it’s gonna execute only if the closure was not normal (server shutdown, exceptions… whatever)