### PR TITLE
update heroku deployment guide for webpack

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -106,21 +106,24 @@ Buildpack added. Next release on mysterious-meadow-6277 will use:
 Run `git push heroku master` to create a new release using these buildpacks.
 ```
 
-next you'll need to add a config file named `phoenix_static_buildpack.config`
-with the following
+This phoenix static buildpack pack can be configured to change the node version and compile options. Please refer to the [configuration section](https://github.com/gjaldon/heroku-buildpack-phoenix-static#configuration) for full details, including setting the node and npm versions. We will override the compile options here.
+
+Create a config file named `phoenix_static_buildpack.config` in the root directory for your project with the following:
+
 ```
 compile="compile"
 ```
-and a file named `compile` with the following
+
+And a file named `compile` with the following contents:
+
 ```
 npm run deploy
-cd ..
-mix phx.digest
+cd $phoenix_dir
+mix "${phoenix_ex}.digest"
 ```
-both these files should be in the root of your project
 
-This phoenix static buildpack pack can be configured to change the node version and compile options. Please refer to this configuration section for details.
-(For example, by default the buildpack doesn't use node's latest LTS version, you might want to customize that)
+This will ensure that the `deploy` script in the package.json is used instead of the static buildpack default of `brunch`.
+
 ## Making our Project ready for Heroku
 
 Every new Phoenix project ships with a config file `config/prod.secret.exs` which stores configuration that should not be committed along with our source code. By default Phoenix adds it to our `.gitignore` file.

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -110,10 +110,7 @@ next you'll need to add a config file named `phoenix_static_buildpack.config`
 with the following
 ```
 compile="compile"
-node_version=8.11.1
 ```
-(use node's [latest lts version](https://nodejs.org/en/))
-
 and a file named `compile` with the following
 ```
 npm run deploy
@@ -122,6 +119,8 @@ mix phx.digest
 ```
 both these files should be in the root of your project
 
+This phoenix static buildpack pack can be configured to change the node version and compile options. Please refer to this configuration section for details.
+(For example, by default the buildpack doesn't use node's latest LTS version, you might want to customize that)
 ## Making our Project ready for Heroku
 
 Every new Phoenix project ships with a config file `config/prod.secret.exs` which stores configuration that should not be committed along with our source code. By default Phoenix adds it to our `.gitignore` file.

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -106,6 +106,22 @@ Buildpack added. Next release on mysterious-meadow-6277 will use:
 Run `git push heroku master` to create a new release using these buildpacks.
 ```
 
+next you'll need to add a config file named `phoenix_static_buildpack.config`
+with the following
+```
+compile="compile"
+node_version=8.11.1
+```
+(use node's [latest lts version](https://nodejs.org/en/))
+
+and a file named `compile` with the following
+```
+npm run deploy
+cd ..
+mix phx.digest
+```
+both these files should be in the root of your project
+
 ## Making our Project ready for Heroku
 
 Every new Phoenix project ships with a config file `config/prod.secret.exs` which stores configuration that should not be committed along with our source code. By default Phoenix adds it to our `.gitignore` file.

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -106,7 +106,7 @@ Buildpack added. Next release on mysterious-meadow-6277 will use:
 Run `git push heroku master` to create a new release using these buildpacks.
 ```
 
-This phoenix static buildpack pack can be configured to change the node version and compile options. Please refer to the [configuration section](https://github.com/gjaldon/heroku-buildpack-phoenix-static#configuration) for full details, including setting the node and npm versions. We will override the compile options here.
+This phoenix static buildpack pack can be configured to change the node version and compile options. Please refer to the [configuration section](https://github.com/gjaldon/heroku-buildpack-phoenix-static#configuration) for full details. We will override the compile options here.
 
 Create a config file named `phoenix_static_buildpack.config` in the root directory for your project with the following:
 


### PR DESCRIPTION
# What
update the heroku deployment guide for webpack
# Comments
- by default the buildpack doesn't use node's latest LTS so it's running node 6.9, I thought it would be a nice improvement to use the LTS version (even if that version changes)
- It seems phoenix wants to use npm by default so I kept the compile file with npm.

refs #2827 