### PR TITLE
Unify assertion for context test case template.

### DIFF
--- a/priv/templates/phx.gen.context/test_cases.exs
+++ b/priv/templates/phx.gen.context/test_cases.exs
@@ -36,8 +36,8 @@
 
     test "update_<%= schema.singular %>/2 with valid data updates the <%= schema.singular %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, @update_attrs)
-      assert %<%= inspect schema.alias %>{} = <%= schema.singular %><%= for {field, value} <- schema.params.update do %>
+      assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, @update_attrs)
+      <%= for {field, value} <- schema.params.update do %>
       assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>
     end
 


### PR DESCRIPTION
The `create` and `delete` tests were matching on the struct inside the {:ok, %Thing{} = thing} tuple, whereas the `update` test was matching in a separate assertion. They now all match inside the `{:ok, %Thing{} = thing}` assertion.

This screenshot shows the difference as it exists on `master` currently:

<img width="478" alt="screen shot 2018-04-12 at 09 53 43" src="https://user-images.githubusercontent.com/838674/38688917-800d703e-3e37-11e8-86c6-39263fe6df08.png">

This was a simple/logical enough change that I figured I'd propose the solution instead of bringing it up on the mailing list, feel free to reject if not pertinent.
