### PR TITLE
add :compress options to websocket transport

### DIFF
--- a/lib/phoenix/endpoint/cowboy2_websocket.ex
+++ b/lib/phoenix/endpoint/cowboy2_websocket.ex
@@ -16,7 +16,8 @@ defmodule Phoenix.Endpoint.Cowboy2WebSocket do
       case module.init(conn, opts) do
         {:ok, %{adapter: {@connection, req}}, {_module, {_socket, opts} = args}} ->
           timeout = Keyword.fetch!(opts, :timeout)
-          {:cowboy_websocket, req, {module, args}, %{idle_timeout: timeout}}
+          compress = Keyword.fetch!(opts, :compress)
+          {:cowboy_websocket, req, {module, args}, %{idle_timeout: timeout, compress: compress}}
         {:error, %{adapter: {@connection, req}}} ->
           {:error, req}
       end

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -59,7 +59,8 @@ defmodule Phoenix.Transports.WebSocket do
     [serializer: [{Phoenix.Transports.WebSocketSerializer, "~> 1.0.0"},
                   {Phoenix.Transports.V2.WebSocketSerializer, "~> 2.0.0"}],
      timeout: 60_000,
-     transport_log: false]
+     transport_log: false,
+     compress: false]
   end
 
   ## Callbacks


### PR DESCRIPTION
return :compress option in Phoenix.Endpoint.Cowboy2WebSocket.init/2 to enable cowboy 2 websocket compression, refers: https://ninenines.eu/docs/en/cowboy/2.3/guide/ws_protocol/