### PR TITLE
Update documentation on `socket.js`

### DIFF
--- a/installer/templates/phx_assets/webpack/socket.js
+++ b/installer/templates/phx_assets/webpack/socket.js
@@ -1,8 +1,11 @@
 // NOTE: The contents of this file will only be executed if
 // you uncomment its entry in "assets/js/app.js".
 
-// To use Phoenix channels, the first step is to import Socket
-// and connect at the socket path in "lib/web/endpoint.ex":
+// To use Phoenix channels, the first step is to import Socket,
+// and connect at the socket path in "lib/web/endpoint.ex".
+//
+// Pass the token on params as below. Or remove it
+// from the params if you don't care about authentication.
 import {Socket} from "phoenix"
 
 let socket = new Socket("/socket", {params: {token: window.userToken}})
@@ -48,9 +51,7 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 //       end
 //     end
 //
-// Finally, pass the token on connect as below. Or remove it
-// from connect if you don't care about authentication.
-
+// Finally, connect to the socket:
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:


### PR DESCRIPTION
The code comments above `socket.connect()` were outdated, as they're
still referencing the passing of the token when connecting to the
socket. This commit fixes that, by moving this comment to where the
`Socket` is instantiated, and rephrases the comment above
`socket.connect()`.

Closes #2858