### PR TITLE
Fix installer archive installation instructions to use prod build

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -3,5 +3,4 @@
 Provides `phx.new` installer as an archive. To build and install it locally:
 
     $ cd installer
-    $ MIX_ENV=prod mix archive.build
-    $ mix archive.install
+    $ MIX_ENV=prod mix do archive.build, archive.install


### PR DESCRIPTION
Following current instructions from README.md caused two builds: first command built the installer with prod env, and second command was building again with dev env, and only after that installing the installer. I believe the installer should be installed after compiling with prod env?