### PR TITLE
improve consistency regarding code formatting (function parentheses)

### DIFF
--- a/guides/adding_pages.md
+++ b/guides/adding_pages.md
@@ -152,7 +152,7 @@ defmodule HelloWeb.HelloController do
   use HelloWeb, :controller
 
   def index(conn, _params) do
-    render conn, "index.html"
+    render(conn, "index.html")
   end
 end
 ```
@@ -160,9 +160,9 @@ We'll save a discussion of `use HelloWeb, :controller` for the [Controllers Guid
 
 All controller actions take two arguments. The first is `conn`, a struct which holds a ton of data about the request. The second is `params`, which are the request parameters. Here, we are not using `params`, and we avoid compiler warnings by adding the leading `_`.
 
-The core of this action is `render conn, "index.html"`. This tells Phoenix to find a template called `index.html.eex` and render it. Phoenix will look for the template in a directory named after our controller, so `lib/hello_web/templates/hello`.
+The core of this action is `render(conn, "index.html")`. This tells Phoenix to find a template called `index.html.eex` and render it. Phoenix will look for the template in a directory named after our controller, so `lib/hello_web/templates/hello`.
 
-> Note: Using an atom as the template name will also work here, `render conn, :index`, but the template will be chosen based off the Accept headers, e.g. `"index.html"` or `"index.json"`.
+> Note: Using an atom as the template name will also work here, `render(conn, :index)`, but the template will be chosen based off the Accept headers, e.g. `"index.html"` or `"index.json"`.
 
 The modules responsible for rendering are views, and we'll make a new one of those next.
 
@@ -200,7 +200,7 @@ Now that we've got the route, controller, view, and template, we should be able 
 
 There are a couple of interesting things to notice about what we just did. We didn't need to stop and re-start the server while we made these changes. Yes, Phoenix has hot code reloading! Also, even though our `index.html.eex` file consisted of only a single `div` tag, the page we get is a full HTML document. Our index template is rendered into the application layout - `lib/hello_web/templates/layout/app.html.eex`. If you open it, you'll see a line that looks like this:
 
-    <%= render @view_module, @view_template, assigns %>
+    <%= render(@view_module, @view_template, assigns) %>
 
 which is what renders our template into the layout before the HTML is sent off to the browser.
 
@@ -235,7 +235,7 @@ Requests to our new route will be handled by the `HelloWeb.HelloController` `sho
 
 ```elixir
 def show(conn, %{"messenger" => messenger}) do
-  render conn, "show.html", messenger: messenger
+  render(conn, "show.html", messenger: messenger)
 end
 ```
 

--- a/guides/channels.md
+++ b/guides/channels.md
@@ -353,7 +353,7 @@ defmodule HelloWeb.RoomChannel do
   end
 
   def handle_in("new_msg", %{"body" => body}, socket) do
-    broadcast! socket, "new_msg", %{body: body}
+    broadcast!(socket, "new_msg", %{body: body})
     {:noreply, socket}
   end
 end
@@ -371,7 +371,7 @@ def handle_out("user_joined", msg, socket) do
   if Accounts.ignoring_user?(socket.assigns[:user], msg.user_id) do
     {:noreply, socket}
   else
-    push socket, "user_joined", msg
+    push(socket, "user_joined", msg)
     {:noreply, socket}
   end
 end

--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -11,7 +11,7 @@ defmodule HelloWeb.PageController do
   use HelloWeb, :controller
 
   def index(conn, _params) do
-    render conn, "index.html"
+    render(conn, "index.html")
   end
 end
 ```
@@ -42,7 +42,7 @@ defmodule HelloWeb.PageController do
   . . .
 
   def test(conn, _params) do
-    render conn, "index.html"
+    render(conn, "index.html")
   end
 end
 ```
@@ -68,7 +68,7 @@ defmodule HelloWeb.HelloController do
   . . .
 
   def show(conn, %{"messenger" => messenger}) do
-    render conn, "show.html", messenger: messenger
+    render(conn, "show.html", messenger: messenger)
   end
 end
 ```
@@ -126,7 +126,7 @@ Let's say we have a `show` action which receives an id from the params map, and 
 
 ```elixir
 def show(conn, %{"id" => id}) do
-  text conn, "Showing id #{id}"
+  text(conn, "Showing id #{id}")
 end
 ```
 Assuming we had a route for `get "/our_path/:id"` mapped to this `show` action, going to `/our_path/15` in your browser should display `Showing id 15` as plain text without any HTML.
@@ -135,7 +135,7 @@ A step beyond this is rendering pure JSON with the `json/2` function. We need to
 
 ```elixir
 def show(conn, %{"id" => id}) do
-  json conn, %{id: id}
+  json(conn, %{id: id})
 end
 ```
 If we again visit `our_path/15` in the browser, we should see a block of JSON with the key `id` mapped to the number `15`.
@@ -147,7 +147,7 @@ Phoenix controllers can also render HTML without a template. As you may have alr
 
 ```elixir
 def show(conn, %{"id" => id}) do
-  html conn, """
+  html(conn, """
      <html>
        <head>
           <title>Passing an Id</title>
@@ -156,7 +156,7 @@ def show(conn, %{"id" => id}) do
          <p>You sent in id #{id}</p>
        </body>
      </html>
-    """
+    """)
 end
 ```
 
@@ -177,7 +177,7 @@ defmodule HelloWeb.HelloController do
   use HelloWeb, :controller
 
   def show(conn, %{"messenger" => messenger}) do
-    render conn, "show.html", messenger: messenger
+    render(conn, "show.html", messenger: messenger)
   end
 end
 ```
@@ -348,7 +348,7 @@ As an example, let's take the `PageController` index action from a newly generat
 
 ```elixir
 def index(conn, _params) do
-  render conn, "index.html"
+  render(conn, "index.html")
 end
 ```
 What it doesn't have is an alternative template for rendering text. Let's add one at `lib/hello_web/templates/page/index.text.eex`. Here is our example `index.text.eex` template.
@@ -376,7 +376,7 @@ We also need to tell the controller to render a template with the same format as
 
 ```elixir
 def index(conn, _params) do
-  render conn, :index
+  render(conn, :index)
 end
 ```
 
@@ -386,7 +386,7 @@ Of course, we can pass data into our template as well. Let's change our action t
 
 ```elixir
 def index(conn, params) do
-  render conn, "index.text", message: params["message"]
+  render(conn, "index.text", message: params["message"])
 end
 ```
 
@@ -434,7 +434,7 @@ end
 
 The status code we provide must be valid - [Cowboy](https://github.com/ninenines/cowboy), the web server Phoenix runs on, will throw an error on invalid codes. If we look at our development logs (which is to say, the iex session), or use our browser's web inspection network tool, we will see the status code being set as we reload the page.
 
-If the action sends a response - either renders or redirects - changing the code will not change the behavior of the response. If, for example, we set the status to 404 or 500 and then `render "index.html"`, we do not get an error page. Similarly, no 300 level code will actually redirect. (It wouldn't know where to redirect to, even if the code did affect behavior.)
+If the action sends a response - either renders or redirects - changing the code will not change the behavior of the response. If, for example, we set the status to 404 or 500 and then `render("index.html")`, we do not get an error page. Similarly, no 300 level code will actually redirect. (It wouldn't know where to redirect to, even if the code did affect behavior.)
 
 The following implementation of the `HelloWeb.PageController` `index` action, for example, will _not_ render the default `not_found` behavior as expected.
 
@@ -487,7 +487,7 @@ Then we'll change the `index` action to do nothing but redirect to our new route
 
 ```elixir
 def index(conn, _params) do
-  redirect conn, to: "/redirect_test"
+  redirect(conn, to: "/redirect_test")
 end
 ```
 
@@ -495,7 +495,7 @@ Finally, let's define in the same file the action we redirect to, which simply r
 
 ```elixir
 def redirect_test(conn, _params) do
-  text conn, "Redirect!"
+  text(conn, "Redirect!")
 end
 ```
 
@@ -507,7 +507,7 @@ Notice that the redirect function takes `conn` as well as a string representing 
 
 ```elixir
 def index(conn, _params) do
-  redirect conn, external: "https://elixir-lang.org/"
+  redirect(conn, external: "https://elixir-lang.org/")
 end
 ```
 
@@ -518,7 +518,7 @@ defmodule HelloWeb.PageController do
   use HelloWeb, :controller
 
   def index(conn, _params) do
-    redirect conn, to: redirect_test_path(conn, :redirect_test)
+    redirect(conn, to: redirect_test_path(conn, :redirect_test))
   end
 end
 ```
@@ -527,7 +527,7 @@ Note that we can't use the url helper here because `redirect/2` using the atom `
 
 ```elixir
 def index(conn, _params) do
-  redirect conn, to: redirect_test_url(conn, :redirect_test)
+  redirect(conn, to: redirect_test_url(conn, :redirect_test))
 end
 ```
 
@@ -535,7 +535,7 @@ If we want to use the url helper to pass a full url to `redirect/2`, we must use
 
 ```elixir
 def index(conn, _params) do
-  redirect conn, external: redirect_test_url(conn, :redirect_test)
+  redirect(conn, external: redirect_test_url(conn, :redirect_test))
 end
 ```
 

--- a/guides/errors.md
+++ b/guides/errors.md
@@ -23,7 +23,7 @@ defmodule Hello.ErrorView do
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do
-    render "500.html", assigns
+    render("500.html", assigns)
   end
 end
 ```

--- a/guides/phoenix_mix_tasks.md
+++ b/guides/phoenix_mix_tasks.md
@@ -772,7 +772,7 @@ def change do
   create table(:comments) do
     add :body,       :string
     add :word_count, :integer
-    timestamps
+    timestamps()
   end
 end
 . . .
@@ -886,7 +886,7 @@ defmodule Mix.Tasks.Hello.Greeting do
   """
 
   def run(_args) do
-    Mix.shell.info "Greetings from the Hello Phoenix Application!"
+    Mix.shell.info("Greetings from the Hello Phoenix Application!")
   end
 
   # We can define other functions as needed here.
@@ -939,8 +939,8 @@ If you want to make your new mix task to use your application's infrastructure, 
 ```elixir
   . . .
   def run(_args) do
-    Mix.Task.run "app.start"
-    Mix.shell.info "Now I have access to Repo and other goodies!"
+    Mix.Task.run("app.start")
+    Mix.shell.info("Now I have access to Repo and other goodies!")
   end
   . . .
 ```

--- a/guides/plug.md
+++ b/guides/plug.md
@@ -47,7 +47,7 @@ defmodule HelloWeb.MessageController do
           message ->
             case authorize_message(conn, params["id"]) do
               :ok ->
-                render conn, :show, page: find_message(params["id"])
+                render(conn, :show, page: find_message(params["id"]))
               :error ->
                 conn |> put_flash(:info, "You can't access that page") |> redirect(to: "/")
             end
@@ -70,7 +70,7 @@ defmodule HelloWeb.MessageController do
   plug :authorize_message
 
   def show(conn, params) do
-    render conn, :show, page: find_message(params["id"])
+    render(conn, :show, page: find_message(params["id"]))
   end
 
   defp authenticate(conn, _) do

--- a/guides/presence.md
+++ b/guides/presence.md
@@ -86,7 +86,7 @@ defmodule HelloWeb.RoomChannel do
   end
 
   def handle_info(:after_join, socket) do
-    push socket, "presence_state", Presence.list(socket)
+    push(socket, "presence_state", Presence.list(socket))
     {:ok, _} = Presence.track(socket, socket.assigns.user_id, %{
       online_at: inspect(System.system_time(:seconds))
     })

--- a/guides/templates.md
+++ b/guides/templates.md
@@ -43,7 +43,7 @@ defmodule HelloWeb.PageController do
   ...
 
   def test(conn, _params) do
-    render conn, "test.html"
+    render(conn, "test.html")
   end
 end
 ```
@@ -74,7 +74,7 @@ defmodule HelloWeb.PageView do
   use HelloWeb, :view
 
   def handler_info(conn) do
-    "Request Handled By: #{controller_module conn}.#{action_name conn}"
+    "Request Handled By: #{controller_module(conn)}.#{action_name(conn)}"
   end
 
   def connection_keys(conn) do
@@ -89,7 +89,7 @@ We have a route. We created a new controller action. We have made modifications 
 
 ```html
 <div class="jumbotron">
-  <p><%= handler_info @conn %></p>
+  <p><%= handler_info(@conn) %></p>
 </div>
 ```
 
@@ -111,11 +111,11 @@ We can add a header and a list comprehension like this.
 
 ```html
 <div class="jumbotron">
-  <p><%= handler_info @conn %></p>
+  <p><%= handler_info(@conn) %></p>
 
   <h3>Keys for the conn Struct</h3>
 
-  <%= for key <- connection_keys @conn do %>
+  <%= for key <- connection_keys(@conn) do %>
     <p><%= key %></p>
   <% end %>
 </div>
@@ -148,12 +148,12 @@ Now that we have a template, we simply render it within our list comprehension i
 
 ```html
 <div class="jumbotron">
-  <p><%= handler_info @conn %></p>
+  <p><%= handler_info(@conn) %></p>
 
   <h3>Keys for the conn Struct</h3>
 
-  <%= for key <- connection_keys @conn do %>
-    <%= render "key.html", key: key %>
+  <%= for key <- connection_keys(@conn) do %>
+    <%= render("key.html", key: key) %>
   <% end %>
 </div>
 ```
@@ -172,8 +172,8 @@ Let's move our template into a shared view.
 <div class="jumbotron">
   ...
 
-  <%= for key <- connection_keys @conn do %>
-    <%= render HelloWeb.PageView, "key.html", key: key %>
+  <%= for key <- connection_keys(@conn) do %>
+    <%= render(HelloWeb.PageView, "key.html", key: key) %>
   <% end %>
 </div>
 ```
@@ -189,8 +189,8 @@ end
 Now we can move `key.html.eex` from the `lib/hello_web/templates/page` directory into the `lib/hello_web/templates/shared` directory. Once that happens, we can change the render call in `lib/hello_web/templates/page/test.html.eex` to use the new `HelloWeb.SharedView`.
 
 ```html
-<%= for key <- connection_keys @conn do %>
-  <%= render HelloWeb.SharedView, "key.html", key: key %>
+<%= for key <- connection_keys(@conn) do %>
+  <%= render(HelloWeb.SharedView, "key.html", key: key) %>
 <% end %>
 ```
 Going back to [localhost:4000/test](http://localhost:4000/test) again. The page should look exactly as it did before.

--- a/guides/testing/testing.md
+++ b/guides/testing/testing.md
@@ -58,7 +58,7 @@ defmodule HelloWeb.PageControllerTest do
   use HelloWeb.ConnCase
 
   test "GET /", %{conn: conn} do
-    conn = get conn, "/"
+    conn = get(conn, "/")
     assert html_response(conn, 200) =~ "Welcome to Phoenix!"
   end
 end

--- a/guides/testing/testing_channels.md
+++ b/guides/testing/testing_channels.md
@@ -105,7 +105,7 @@ The first test block in our generated channel test looks like:
 
 ```elixir
 test "ping replies with status ok", %{socket: socket} do
-  ref = push socket, "ping", %{"hello" => "there"}
+  ref = push(socket, "ping", %{"hello" => "there"})
   assert_reply ref, :ok, %{"hello" => "there"}
 end
 ```
@@ -130,7 +130,7 @@ In the `test "ping replies with status ok", %{socket: socket} do` line, we see t
 map `%{socket: socket}`. This gives us access to the `socket` in the setup block.
 
 We emulate the client pushing a message to the channel with `push/3`. In the line
-`ref = push socket, "ping", %{"hello" => "there"}`, we push the event `"ping"` with the payload
+`ref = push(socket, "ping", %{"hello" => "there"})`, we push the event `"ping"` with the payload
 `%{"hello" => "there"}` to the channel. This triggers the `handle_in/3` callback we have for the
 `"ping"` event in our channel. Note that we store the `ref` since we need that on the next line for
 asserting the reply. With `assert_reply ref, :ok, %{"hello" => "there"}`, we assert that the
@@ -146,7 +146,7 @@ current topic. This common pattern is simple to express in Phoenix and is one of
 
 ```elixir
 def handle_in("shout", payload, socket) do
-  broadcast socket, "shout", payload
+  broadcast(socket, "shout", payload)
   {:noreply, socket}
 end
 ```
@@ -155,7 +155,7 @@ Its corresponding test looks like:
 
 ```elixir
 test "shout broadcasts to room:lobby", %{socket: socket} do
-  push socket, "shout", %{"hello" => "all"}
+  push(socket, "shout", %{"hello" => "all"})
   assert_broadcast "shout", %{"hello" => "all"}
 end
 ```
@@ -177,7 +177,7 @@ to the client. Unlike the previous tests discussed, we are indirectly testing th
 
 ```elixir
 def handle_out(event, payload, socket) do
-  push socket, event, payload
+  push(socket, event, payload)
   {:noreply, socket}
 end
 ```
@@ -187,7 +187,7 @@ we will need to emulate that in our test. We do that by calling `broadcast_from`
 `broadcast_from!`. Both serve the same purpose with the only difference of `broadcast_from!`
 raising an error when broadcast fails.
 
-The line `broadcast_from! socket, "broadcast", %{"some" => "data"}` will trigger our `handle_out/3`
+The line `broadcast_from!(socket, "broadcast", %{"some" => "data"})` will trigger our `handle_out/3`
 callback above which pushes the same event and payload back to the client. To test this, we do
 `assert_push "broadcast", %{"some" => "data"}`.
 

--- a/guides/views.md
+++ b/guides/views.md
@@ -73,7 +73,7 @@ Let's open up the `lib/hello_web/templates/page/index.html.eex` and locate this 
 
 ```html
 <div class="jumbotron">
-  <h2><%= gettext "Welcome to %{name}!", name: "Phoenix" %></h2>
+  <h2><%= gettext("Welcome to %{name}!", name: "Phoenix") %></h2>
   <p class="lead">A productive web framework that<br>does not compromise speed and maintainability.</p>
 </div>
 ```
@@ -82,9 +82,9 @@ Then let's add a line with a link back to the same page. (The objective is to se
 
 ```html
 <div class="jumbotron">
-  <h2><%= gettext "Welcome to %{name}!", name: "Phoenix" %></h2>
+  <h2><%= gettext("Welcome to %{name}!", name: "Phoenix") %></h2>
   <p class="lead">A productive web framework that<br>does not compromise speed and maintainability.</p>
-  <p><a href="<%= page_path @conn, :index %>">Link back to this page</a></p>
+  <p><a href="<%= page_path(@conn, :index) %>">Link back to this page</a></p>
 </div>
 ```
 
@@ -123,8 +123,7 @@ This is the message: <%= message() %>
 This doesn't correspond to any action in our controller, but we'll exercise it in an `iex` session. At the root of our project, we can run `iex -S mix`, and then explicitly render our template.
 
 ```console
-iex(1)> Phoenix.View.render(HelloWeb.PageView, "test.html",
-%{})
+iex(1)> Phoenix.View.render(HelloWeb.PageView, "test.html", %{})
   {:safe, [["" | "This is the message: "] | "Hello from the view!"]}
 ```
 As we can see, we're calling `render/3` with the individual view responsible for our test template, the name of our test template, and an empty map representing any data we might have wanted to pass in. The return value is a tuple beginning with the atom `:safe` and the resultant io list of the interpolated template. "Safe" here means that Phoenix has escaped the contents of our rendered template. Phoenix defines its own `Phoenix.HTML.Safe` protocol with implementations for atoms, bitstrings, lists, integers, floats, and tuples to handle this escaping for us as our templates are rendered into strings.
@@ -173,7 +172,7 @@ If we need only the rendered string, without the whole tuple, we can use the `re
 Layouts are just templates. They have a view, just like other templates. In a newly generated app, this is `lib/hello_web/views/layout_view.ex`. You may be wondering how the string resulting from a rendered view ends up inside a layout. That's a great question! If we look at `lib/hello_web/templates/layout/app.html.eex`, just about in the middle of the `<body>`, we will see this.
 
 ```html
-<%= render @view_module, @view_template, assigns %>
+<%= render(@view_module, @view_template, assigns) %>
 ```
 
 This is where the view module and its template from the controller are rendered to a string and placed in the layout.
@@ -197,7 +196,7 @@ defmodule HelloWeb.ErrorView do
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do
-    render "500.html", assigns
+    render("500.html", assigns)
   end
 end
 ```
@@ -289,13 +288,13 @@ defmodule HelloWeb.PageController do
   def show(conn, _params) do
     page = %{title: "foo"}
 
-    render conn, "show.json", page: page
+    render(conn, "show.json", page: page)
   end
 
   def index(conn, _params) do
     pages = [%{title: "foo"}, %{title: "bar"}]
 
-    render conn, "index.json", pages: pages
+    render(conn, "index.json", pages: pages)
   end
 end
 ```
@@ -320,7 +319,7 @@ defmodule HelloWeb.PageView do
 end
 ```
 
-In the view we see our `render/2` function pattern matching on `"index.json"`, `"show.json"`, and `"page.json"`. In our controller `show/2` function, `render conn, "show.json", page: page` will pattern match on the matching name and extension in the view's `render/2` functions. In other words, `render conn, "index.json", pages: pages` will call `render("index.json", %{pages: pages})`. The `render_many/3` function takes the data we want to respond with (`pages`), a `View`, and a string to pattern match on the `render/2` function defined on `View`. It will map over each item in `pages`, and pass the item to the `render/2` function in `View` matching the file string. `render_one/3` follows, the same signature, ultimately using the `render/2` matching `page.json` to specify what each `page` looks like. The `render/2` matching `"index.json"` will respond with JSON as you would expect:
+In the view we see our `render/2` function pattern matching on `"index.json"`, `"show.json"`, and `"page.json"`. In our controller `show/2` function, `render(conn, "show.json", page: page)` will pattern match on the matching name and extension in the view's `render/2` functions. In other words, `render(conn, "index.json", pages: pages)` will call `render("index.json", %{pages: pages})`. The `render_many/3` function takes the data we want to respond with (`pages`), a `View`, and a string to pattern match on the `render/2` function defined on `View`. It will map over each item in `pages`, and pass the item to the `render/2` function in `View` matching the file string. `render_one/3` follows, the same signature, ultimately using the `render/2` matching `page.json` to specify what each `page` looks like. The `render/2` matching `"index.json"` will respond with JSON as you would expect:
 
 ```javascript
   {

--- a/installer/templates/phx_gettext/gettext.ex
+++ b/installer/templates/phx_gettext/gettext.ex
@@ -8,15 +8,15 @@ defmodule <%= web_namespace %>.Gettext do
       import <%= web_namespace %>.Gettext
 
       # Simple translation
-      gettext "Here is the string to translate"
+      gettext("Here is the string to translate")
 
       # Plural translation
-      ngettext "Here is the string to translate",
+      ngettext("Here is the string to translate",
                "Here are the strings to translate",
-               3
+               3)
 
       # Domain-based translation
-      dgettext "errors", "Here is the error message to translate"
+      dgettext("errors", "Here is the error message to translate")
 
   See the [Gettext Docs](https://hexdocs.pm/gettext) for detailed usage.
   """

--- a/installer/templates/phx_web/views/error_helpers.ex
+++ b/installer/templates/phx_web/views/error_helpers.ex
@@ -22,10 +22,10 @@ defmodule <%= web_namespace %>.ErrorHelpers do
     # to translate as a static argument:
     #
     #     # Translate "is invalid" in the "errors" domain
-    #     dgettext "errors", "is invalid"
+    #     dgettext("errors", "is invalid")
     #
     #     # Translate the number of files with plural rules
-    #     dngettext "errors", "1 file", "%{count} files", count
+    #     dngettext("errors", "1 file", "%{count} files", count)
     #
     # Because the error messages we show in our forms and APIs
     # are defined inside Ecto, we need to translate them dynamically.

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -52,7 +52,7 @@ defmodule Phoenix.Channel do
   and broadcasting the message to all topic subscribers for this socket.
 
       def handle_in("new_msg", %{"uid" => uid, "body" => body}, socket) do
-        broadcast! socket, "new_msg", %{uid: uid, body: body}
+        broadcast!(socket, "new_msg", %{uid: uid, body: body})
         {:noreply, socket}
       end
 
@@ -60,7 +60,7 @@ defmodule Phoenix.Channel do
 
       # client asks for their current rank, push sent directly as a new event.
       def handle_in("current_rank", socket) do
-        push socket, "current_rank", %{val: Game.get_rank(socket.assigns[:user])}
+        push(socket, "current_rank", %{val: Game.get_rank(socket.assigns[:user])})
         {:noreply, socket}
       end
 
@@ -113,9 +113,9 @@ defmodule Phoenix.Channel do
       # for every socket subscribing to this topic, append an `is_editable`
       # value for client metadata.
       def handle_out("new_msg", msg, socket) do
-        push socket, "new_msg", Map.merge(msg,
+        push(socket, "new_msg", Map.merge(msg,
           %{is_editable: User.can_edit_message?(socket.assigns[:user], msg)}
-        )
+        ))
         {:noreply, socket}
       end
 
@@ -123,7 +123,7 @@ defmodule Phoenix.Channel do
       # is ignoring the user who joined.
       def handle_out("user_joined", msg, socket) do
         unless User.ignoring?(socket.assigns[:user], msg.user_id) do
-          push socket, "user_joined", msg
+          push(socket, "user_joined", msg)
         end
         {:noreply, socket}
       end
@@ -138,18 +138,18 @@ defmodule Phoenix.Channel do
       # within channel
       def handle_in("new_msg", %{"uid" => uid, "body" => body}, socket) do
         ...
-        broadcast_from! socket, "new_msg", %{uid: uid, body: body}
-        MyApp.Endpoint.broadcast_from! self(), "room:superadmin",
-          "new_msg", %{uid: uid, body: body}
+        broadcast_from!(socket, "new_msg", %{uid: uid, body: body})
+        MyApp.Endpoint.broadcast_from!(self(), "room:superadmin",
+          "new_msg", %{uid: uid, body: body})
         {:noreply, socket}
       end
 
       # within controller
       def create(conn, params) do
         ...
-        MyApp.Endpoint.broadcast! "room:" <> rid, "new_msg", %{uid: uid, body: body}
-        MyApp.Endpoint.broadcast! "room:superadmin", "new_msg", %{uid: uid, body: body}
-        redirect conn, to: "/"
+        MyApp.Endpoint.broadcast!("room:" <> rid, "new_msg", %{uid: uid, body: body})
+        MyApp.Endpoint.broadcast!("room:superadmin", "new_msg", %{uid: uid, body: body})
+        redirect(conn, to: "/")
       end
 
   ## Terminate
@@ -245,7 +245,7 @@ defmodule Phoenix.Channel do
 
       alias Phoenix.Socket.Broadcast
       def handle_info(%Broadcast{topic: _, event: ev, payload: payload}, socket) do
-        push socket, ev, payload
+        push(socket, ev, payload)
         {:noreply, socket}
       end
 
@@ -346,9 +346,9 @@ defmodule Phoenix.Channel do
       intercept ["new_msg"]
 
       def handle_out("new_msg", payload, socket) do
-        push socket, "new_msg", Map.merge(payload,
+        push(socket, "new_msg", Map.merge(payload,
           is_editable: User.can_edit_message?(socket.assigns[:user], payload)
-        )
+        ))
         {:noreply, socket}
       end
 
@@ -384,7 +384,7 @@ defmodule Phoenix.Channel do
 
   ## Examples
 
-      iex> broadcast socket, "new_message", %{id: 1, content: "hello"}
+      iex> broadcast(socket, "new_message", %{id: 1, content: "hello"})
       :ok
 
   """
@@ -409,7 +409,7 @@ defmodule Phoenix.Channel do
 
   ## Examples
 
-      iex> broadcast_from socket, "new_message", %{id: 1, content: "hello"}
+      iex> broadcast_from(socket, "new_message", %{id: 1, content: "hello"})
       :ok
 
   """
@@ -433,7 +433,7 @@ defmodule Phoenix.Channel do
 
   ## Examples
 
-      iex> push socket, "new_message", %{id: 1, content: "hello"}
+      iex> push(socket, "new_message", %{id: 1, content: "hello"})
       :ok
 
   """
@@ -465,7 +465,7 @@ defmodule Phoenix.Channel do
       end
 
       def handle_info({:work_complete, result, ref}, socket) do
-        reply ref, {:ok, result}
+        reply(ref, {:ok, result})
         {:noreply, socket}
       end
 
@@ -509,7 +509,7 @@ defmodule Phoenix.Channel do
         end
 
         def handle_info(:after_join, socket) do
-          push socket, "feed", %{list: feed_items(socket)}
+          push(socket, "feed", %{list: feed_items(socket)})
           {:noreply, socket}
         end
     """

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -22,7 +22,7 @@ defmodule Phoenix.Controller do
 
         def show(conn, %{"id" => id}) do
           user = Repo.get(User, id)
-          render conn, "show.html", user: user
+          render(conn, "show.html", user: user)
         end
       end
 
@@ -271,7 +271,7 @@ defmodule Phoenix.Controller do
 
   ## Examples
 
-      iex> json conn, %{id: 123}
+      iex> json(conn, %{id: 123})
 
   """
   @spec json(Plug.Conn.t, term) :: Plug.Conn.t
@@ -353,9 +353,9 @@ defmodule Phoenix.Controller do
 
   ## Examples
 
-      iex> text conn, "hello"
+      iex> text(conn, "hello")
 
-      iex> text conn, :implements_to_string
+      iex> text(conn, :implements_to_string)
 
   """
   @spec text(Plug.Conn.t, String.Chars.t) :: Plug.Conn.t
@@ -368,7 +368,7 @@ defmodule Phoenix.Controller do
 
   ## Examples
 
-      iex> html conn, "<html><head>..."
+      iex> html(conn, "<html><head>...")
 
   """
   @spec html(Plug.Conn.t, iodata) :: Plug.Conn.t
@@ -384,9 +384,9 @@ defmodule Phoenix.Controller do
 
   ## Examples
 
-      iex> redirect conn, to: "/login"
+      iex> redirect(conn, to: "/login")
 
-      iex> redirect conn, external: "http://elixir-lang.org"
+      iex> redirect(conn, external: "http://elixir-lang.org")
 
   """
   def redirect(conn, opts) when is_list(opts) do
@@ -531,11 +531,11 @@ defmodule Phoenix.Controller do
 
   ## Examples
 
-      iex> layout_formats conn
+      iex> layout_formats(conn)
       ["html"]
 
-      iex> put_layout_formats conn, ["html", "mobile"]
-      iex> layout_formats conn
+      iex> put_layout_formats(conn, ["html", "mobile"])
+      iex> layout_formats(conn)
       ["html", "mobile"]
 
   Raises `Plug.Conn.AlreadySentError` if the conn was already sent.
@@ -606,7 +606,7 @@ defmodule Phoenix.Controller do
         use Phoenix.Controller
 
         def show(conn, _params) do
-          render conn, "show.html", message: "Hello"
+          render(conn, "show.html", message: "Hello")
         end
       end
 
@@ -618,7 +618,7 @@ defmodule Phoenix.Controller do
   the extension):
 
       def show(conn, _params) do
-        render conn, :show, message: "Hello"
+        render(conn, :show, message: "Hello")
       end
 
   In order for the example above to work, we need to do content negotiation with
@@ -648,7 +648,7 @@ defmodule Phoenix.Controller do
         plug :put_view, MyAppWeb.SpecialView
 
         def show(conn, _params) do
-          render conn, :show, message: "Hello"
+          render(conn, :show, message: "Hello")
         end
       end
 
@@ -661,7 +661,7 @@ defmodule Phoenix.Controller do
         use Phoenix.Controller
 
         def show(conn, _params) do
-          render conn, "show.html", message: "Hello"
+          render(conn, "show.html", message: "Hello")
         end
       end
 

--- a/lib/phoenix/endpoint/instrument.ex
+++ b/lib/phoenix/endpoint/instrument.ex
@@ -23,7 +23,7 @@ defmodule Phoenix.Endpoint.Instrument do
       ## Examples
 
           instrument :render_view, %{view: "index.html"}, fn ->
-            render conn, "index.html"
+            render(conn, "index.html")
           end
 
       """

--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -43,7 +43,7 @@ defmodule Phoenix.Presence do
         end
 
         def handle_info(:after_join, socket) do
-          push socket, "presence_state", Presence.list(socket)
+          push(socket, "presence_state", Presence.list(socket))
           {:ok, _} = Presence.track(socket, socket.assigns.user_id, %{
             online_at: inspect(System.system_time(:seconds))
           })

--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -40,13 +40,13 @@ defmodule Phoenix.ChannelTest do
   For example, we can use the `push/3` function in the test
   to push messages to the channel (it will invoke `handle_in/3`):
 
-      push socket, "my_event", %{"some" => "data"}
+      push(socket, "my_event", %{"some" => "data"})
 
   Similarly, we can broadcast messages from the test itself
   on the topic that both test and channel are subscribed to,
   triggering `handle_out/3` on the channel:
 
-      broadcast_from socket, "my_event", %{"some" => "data"}
+      broadcast_from(socket, "my_event", %{"some" => "data"})
 
   > Note only `broadcast_from/3` and `broadcast_from!/3` are
   available in tests to avoid broadcast messages to be resent
@@ -66,7 +66,7 @@ defmodule Phoenix.ChannelTest do
   a reference is returned. We can use this reference to
   assert a particular reply was sent from the server:
 
-      ref = push socket, "counter", %{}
+      ref = push(socket, "counter", %{})
       assert_reply ref, :ok, %{"counter" => 1}
 
   ## Checking side-effects
@@ -85,7 +85,7 @@ defmodule Phoenix.ChannelTest do
   Because the whole communication is asynchronous, the
   following test would be very brittle:
 
-      push socket, "publish", %{"id" => 3}
+      push(socket, "publish", %{"id" => 3})
       assert Repo.get_by(Post, id: 3, published: true)
 
   The issue is that we have no guarantees the channel has
@@ -101,7 +101,7 @@ defmodule Phoenix.ChannelTest do
 
   Then expect them in the test:
 
-      ref = push socket, "publish", %{"id" => 3}
+      ref = push(socket, "publish", %{"id" => 3})
       assert_reply ref, :ok
       assert Repo.get_by(Post, id: 3, published: true)
 
@@ -370,7 +370,7 @@ defmodule Phoenix.ChannelTest do
 
   ## Examples
 
-      iex> push socket, "new_message", %{id: 1, content: "hello"}
+      iex> push(socket, "new_message", %{id: 1, content: "hello"})
       reference
 
   """
@@ -408,7 +408,7 @@ defmodule Phoenix.ChannelTest do
 
   ## Examples
 
-      iex> broadcast_from socket, "new_message", %{id: 1, content: "hello"}
+      iex> broadcast_from(socket, "new_message", %{id: 1, content: "hello"})
       :ok
 
   """
@@ -490,7 +490,7 @@ defmodule Phoenix.ChannelTest do
 
   Notice status and payload are patterns. This means one can write:
 
-      ref = push channel, "some_event"
+      ref = push(channel, "some_event")
       assert_reply ref, :ok, %{"data" => _}
 
   In the assertion above, we don't particularly care about

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -14,10 +14,10 @@ defmodule Phoenix.ConnTest do
   the preferred way to test anything that your router dispatches
   to.
 
-      conn = get build_conn(), "/"
+      conn = get(build_conn(), "/")
       assert conn.resp_body =~ "Welcome!"
 
-      conn = post build_conn(), "/login", [username: "john", password: "doe"]
+      conn = post(build_conn(), "/login", [username: "john", password: "doe"])
       assert conn.resp_body =~ "Logged in!"
 
   As in your application, the connection is also the main abstraction
@@ -46,7 +46,7 @@ defmodule Phoenix.ConnTest do
   For such cases, just pass an atom representing the action
   to dispatch:
 
-      conn = get build_conn(), :index
+      conn = get(build_conn(), :index)
       assert conn.resp_body =~ "Welcome!"
 
   ## Views testing
@@ -56,8 +56,8 @@ defmodule Phoenix.ConnTest do
   For such cases, a connection can be created using the
   `conn/3` helper:
 
-      MyApp.UserView.render "hello.html",
-                             conn: conn(:get, "/")
+      MyApp.UserView.render("hello.html",
+                             conn: conn(:get, "/"))
 
   ## Recycling
 
@@ -79,10 +79,10 @@ defmodule Phoenix.ConnTest do
   before the next dispatch:
 
       # No recycling as the connection is fresh
-      conn = get build_conn(), "/"
+      conn = get(build_conn(), "/")
 
       # The connection is recycled, creating a new one behind the scenes
-      conn = post conn, "/login"
+      conn = post(conn, "/login")
 
       # We can also recycle manually in case we want custom headers
       conn =
@@ -91,7 +91,7 @@ defmodule Phoenix.ConnTest do
         |> put_req_header("x-special", "nice")
 
       # No recycling as we did it explicitly
-      conn = delete conn, "/logout"
+      conn = delete(conn, "/logout")
 
   Recycling also recycles the "accept" header.
   """
@@ -190,8 +190,8 @@ defmodule Phoenix.ConnTest do
   This function, as well as `get/3`, `post/3` and friends, accepts the
   request body or parameters as last argument:
 
-        get build_conn(), "/", some: "param"
-        get build_conn(), "/", "some=param&url=encoded"
+        get(build_conn(), "/", some: "param")
+        get(build_conn(), "/", "some=param&url=encoded")
 
   The allowed values are:
 
@@ -338,7 +338,7 @@ defmodule Phoenix.ConnTest do
 
   ## Examples
 
-      conn = get build_conn(), "/"
+      conn = get(build_conn(), "/")
       assert response(conn, 200) =~ "hello world"
 
   """
@@ -348,7 +348,7 @@ defmodule Phoenix.ConnTest do
     expected connection to have a response but no response was set/sent.
     Please verify that you assign to "conn" after a request:
 
-        conn = get conn, "/"
+        conn = get(conn, "/")
         assert html_response(conn) =~ "Hello"
     """
   end
@@ -584,11 +584,11 @@ defmodule Phoenix.ConnTest do
   ## Examples
 
       assert_error_sent :not_found, fn ->
-        get build_conn(), "/users/not-found"
+        get(build_conn(), "/users/not-found")
       end
 
       response = assert_error_sent 404, fn ->
-        get build_conn(), "/users/not-found"
+        get(build_conn(), "/users/not-found")
       end
       assert {404, [_h | _t], "Page not found"} = response
   """

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -58,8 +58,8 @@ defmodule Phoenix.Token do
 
       def create(conn, params) do
         user = User.create(params)
-        render conn, "user.json",
-               %{token: Phoenix.Token.sign(conn, "user salt", user.id), user: user}
+        render(conn, "user.json",
+               %{token: Phoenix.Token.sign(conn, "user salt", user.id), user: user})
       end
 
   Once the token is sent, the client may now send it back to the server

--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -223,7 +223,7 @@ defmodule Phoenix.View do
   To render the template within the layout, simply call `render/3`
   using the `@view_module` and `@view_template` assign:
 
-      <%= render @view_module, @view_template, assigns %>
+      <%= render(@view_module, @view_template, assigns) %>
 
   """
   def render(module, template, assigns) do

--- a/priv/templates/phx.gen.presence/presence.ex
+++ b/priv/templates/phx.gen.presence/presence.ex
@@ -19,7 +19,7 @@ defmodule <%= module %> do
         end
 
         def handle_info(:after_join, socket) do
-          push socket, "presence_state", Presence.list(socket)
+          push(socket, "presence_state", Presence.list(socket))
           {:ok, _} = Presence.track(socket, socket.assigns.user_id, %{
             online_at: inspect(System.system_time(:seconds))
           })


### PR DESCRIPTION
This is mostly about adjusting guides and docs for https://github.com/phoenixframework/phoenix/issues/2605 since the formatter won't be able to fix these but I also added / removed parentheses in code in many places. I did not touch:

1. `Kernel.send` - it seems that `send` is not in the formatter's [interal locals_without_parens list](https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/code/formatter.ex) so it's written with parens in Elixir codebase since it's being formatted but it's without parens in docs and getting started guide so I was not sure what should be the way
2. `Logger.info`, `warn` and `error` - similarily
3. `Phoenix.HTML`'s functions in eex snippets - seems like these should stay without parens?