### PR TITLE
Fix typo and redundancy in remark in gettext template.

### DIFF
--- a/installer/templates/phx_gettext/errors.pot
+++ b/installer/templates/phx_gettext/errors.pot
@@ -1,11 +1,11 @@
-## This file is a PO Template file.
+## This is a PO Template file.
 ##
 ## `msgid`s here are often extracted from source code.
 ## Add new translations manually only if they're dynamic
 ## translations that can't be statically extracted.
 ##
 ## Run `mix gettext.extract` to bring this file up to
-## date. Leave `msgstr`s empty as changing them here as no
+## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
 <%= if ecto do %>
 ## From Ecto.Changeset.cast/4


### PR DESCRIPTION
This PR simply fixes typo in gettext remarks.