### PR TITLE
Add changelog link to new template

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -5,6 +5,8 @@ defmodule Phx.New.Generator do
 
   @phoenix Path.expand("../..", __DIR__)
 
+  @phoenix_version Version.parse!("1.3.0")
+
   @callback prepare_project(Project.t) :: Project.t
   @callback generate(Project.t) :: Project.t
 
@@ -101,6 +103,8 @@ defmodule Phx.New.Generator do
         :error -> adapter_config
       end
 
+    version = @phoenix_version
+
     binding = [
       elixir_version: elixir_version(),
       app_name: project.app,
@@ -111,6 +115,7 @@ defmodule Phx.New.Generator do
       web_app_name: project.web_app,
       endpoint_module: inspect(Module.concat(project.web_namespace, Endpoint)),
       web_namespace: inspect(project.web_namespace),
+      phoenix_github_version_tag: "v#{version.major}.#{version.minor}",
       phoenix_dep: phoenix_dep(phoenix_path),
       phoenix_path: phoenix_path,
       phoenix_webpack_path: phoenix_webpack_path(project, dev),
@@ -248,7 +253,7 @@ defmodule Phx.New.Generator do
   defp phoenix_html_webpack_path(%Project{in_umbrella?: false}),
     do: "../deps/phoenix_html"
 
-  # defp phoenix_dep("deps/phoenix"), do: ~s[{:phoenix, "~> 1.3.0"}]
+  # defp phoenix_dep("deps/phoenix"), do: ~s[{:phoenix, "~> #{@phoenix_version}"}]
   defp phoenix_dep("deps/phoenix"), do: ~s[{:phoenix, github: "phoenixframework/phoenix", override: true}]
   defp phoenix_dep(path), do: ~s[{:phoenix, path: #{inspect path}, override: true}]
 

--- a/installer/templates/phx_web/templates/page/index.html.eex
+++ b/installer/templates/phx_web/templates/page/index.html.eex
@@ -13,6 +13,9 @@
       <li>
         <a href="https://github.com/phoenixframework/phoenix">Source</a>
       </li>
+      <li>
+        <a href="https://github.com/phoenixframework/phoenix/blob/<%= phoenix_github_version_tag %>/CHANGELOG.md"><%= phoenix_github_version_tag %> Changelog</a>
+      </li>
     </ul>
   </article>
   <article class="column">

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -25,6 +25,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/README.md"
       assert_file "phx_blog/mix.exs", fn file ->
+        assert file =~ ~s[:phoenix, "~> #{Application.spec(:phx_new, :vsn)}"]
         assert file =~ "app: :phx_blog"
         refute file =~ "deps_path: \"../../deps\""
         refute file =~ "lockfile: \"../../mix.lock\""
@@ -72,6 +73,12 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/lib/phx_blog_web.ex", "defmodule PhxBlogWeb"
       assert_file "phx_blog/lib/phx_blog_web/templates/layout/app.html.eex",
                   "<title>PhxBlog · Phoenix Framework</title>"
+      assert_file "phx_blog/lib/phx_blog_web/templates/page/index.html.eex", fn file ->
+        version = Application.spec(:phx_new, :vsn) |> to_string() |> Version.parse!()
+        changelog_vsn = "v#{version.major}.#{version.minor}"
+        assert file =~
+          "https://github.com/phoenixframework/phoenix/blob/#{changelog_vsn}/CHANGELOG.md"
+      end
 
       # webpack
       assert_file "phx_blog/.gitignore", "/assets/node_modules/"


### PR DESCRIPTION
The phoenix version string that was previously used in the dependency
string has been moved to a module attribute so it can be easily reused.
The `Version` module is used so that both "1.4.0" and "1.4" formats can
easily be generated. The latter format is used when linking to the
changelog in the template.

A test has also been added to ensure the correct version is specified in
mix.exs based on the version of the installer.