### PR TITLE
Update plug dep to use hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Phoenix.MixProject do
   defp deps do
     [
       {:cowboy, "~> 1.0 or ~> 2.3", optional: true},
-      {:plug, "~> 1.5", github: "elixir-plug/plug", override: true},
+      {:plug, "~> 1.5"},
       {:phoenix_pubsub, "~> 1.0"},
       {:jason, "~> 1.0", optional: true},
 

--- a/mix.lock
+++ b/mix.lock
@@ -10,7 +10,7 @@
   "phoenix_guides": {:git, "https://github.com/phoenixframework/phoenix_guides.git", "cc1899054e31704f1ae92645d4b0534e6aac407e", []},
   "phoenix_html": {:hex, :phoenix_html, "2.11.0", "ead10dd1e36d5b8b5cc55642ba337832ec62617efd5765cddaa1a36c8b3891ca", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
-  "plug": {:git, "https://github.com/elixir-plug/plug.git", "aea4fef799638250d51fcdb0af0796256b2a3e8c", []},
+  "plug": {:hex, :plug, "1.5.0", "224b25b4039bedc1eac149fb52ed456770b9678bbf0349cdd810460e1e09195b", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [:rebar3], [], "hexpm"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "9a6f65d05ebf2725d62fb19262b21f1805a59fbf", []},


### PR DESCRIPTION
It looks like this was added as a git override because phoenix master depended on plug ~> 1.5 and it wasn't pushed to hex yet. I was unsure if this was still needed.