### PR TITLE
Add :reloadable_apps endpoint configuration

### DIFF
--- a/lib/phoenix/code_reloader.ex
+++ b/lib/phoenix/code_reloader.ex
@@ -14,15 +14,24 @@ defmodule Phoenix.CodeReloader do
 
   @doc """
   Reloads code for the current Mix project by invoking the
-  `:reloadable_compilers`.
+  `:reloadable_compilers` on the list of `:reloadable_apps`.
 
   This is configured in your application environment like:
 
       config :your_app, YourApp.Endpoint,
-        reloadable_compilers: [:gettext, :phoenix, :elixir]
+        reloadable_compilers: [:gettext, :phoenix, :elixir],
+        reloadable_apps: [:ui, :backend]
 
   Keep in mind `:reloadable_compilers` must be a subset of the
   `:compilers` specified in `project/0` in your `mix.exs`.
+
+  The `:reloadable_apps` defaults to `nil`. In such case
+  default behaviour is to reload current project if it
+  consists of single app, or all applications within umbrella
+  project. You can set `:reloadable_apps` to subset of default
+  applications to reload only some of them, empty list - to
+  effectively disable code reloader, or include external
+  applications from library dependencies.
   """
   @spec reload!(module) :: :ok | {:error, binary()}
   defdelegate reload!(endpoint), to: Phoenix.CodeReloader.Server

--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -155,6 +155,8 @@ defmodule Phoenix.CodeReloader.Server do
         mix_compile_unless_stale_config(compilers)
       end
     end
+    
+    :ok
   end
 
   defp mix_compile_project(nil, _, _), do: :ok
@@ -162,6 +164,7 @@ defmodule Phoenix.CodeReloader.Server do
     if app in apps_to_reload do
       mix_compile_unless_stale_config(compilers)
     end
+
     :ok
   end
 

--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -47,13 +47,14 @@ defmodule Phoenix.CodeReloader.Server do
 
   def handle_call({:reload!, endpoint}, from, state) do
     compilers = endpoint.config(:reloadable_compilers)
+    reloadable_apps = endpoint.config(:reloadable_apps) || default_reloadable_apps()
     backup = load_backup(endpoint)
     froms  = all_waiting([from], endpoint)
 
     {res, out} =
       proxy_io(fn ->
         try do
-          mix_compile(Code.ensure_loaded(Mix.Task), compilers)
+          mix_compile(Code.ensure_loaded(Mix.Task), compilers, reloadable_apps)
         catch
           :exit, {:shutdown, 1} ->
             :error
@@ -74,6 +75,14 @@ defmodule Phoenix.CodeReloader.Server do
 
     Enum.each(froms, &GenServer.reply(&1, reply))
     {:noreply, state}
+  end
+
+  defp default_reloadable_apps() do
+    if Mix.Project.umbrella? do
+      Enum.map(Mix.Dep.Umbrella.cached, &(&1.app))
+    else
+      [Mix.Project.config()[:app]]
+    end
   end
 
   def handle_info(_, state) do
@@ -129,23 +138,31 @@ defmodule Phoenix.CodeReloader.Server do
     end
   end
 
-  defp mix_compile({:module, Mix.Task}, compilers) do
-    if Mix.Project.umbrella? do
-      Enum.each Mix.Dep.Umbrella.cached, fn dep ->
-        Mix.Dep.in_dependency(dep, fn _ ->
-          mix_compile_unless_stale_config(compilers)
-        end)
-      end
-    else
-      mix_compile_unless_stale_config(compilers)
-      :ok
-    end
+  defp mix_compile({:module, Mix.Task}, compilers, apps_to_reload) do
+    mix_compile_deps(Mix.Dep.cached, apps_to_reload, compilers)
+    mix_compile_project(Mix.Project.config()[:app], apps_to_reload, compilers)
   end
-  defp mix_compile({:error, _reason}, _) do
+  defp mix_compile({:error, _reason}, _, _) do
     raise "the Code Reloader is enabled but Mix is not available. If you want to " <>
           "use the Code Reloader in production or inside an escript, you must add " <>
           ":mix to your applications list. Otherwise, you must disable code reloading " <>
           "in such environments"
+  end
+
+  defp mix_compile_deps(deps, apps_to_reload, compilers) do
+    for dep <- deps, dep.app in apps_to_reload do
+      Mix.Dep.in_dependency dep, fn _ ->
+        mix_compile_unless_stale_config(compilers)
+      end
+    end
+  end
+
+  defp mix_compile_project(nil, _, _), do: :ok
+  defp mix_compile_project(app, apps_to_reload, compilers) do
+    if app in apps_to_reload do
+      mix_compile_unless_stale_config(compilers)
+    end
+    :ok
   end
 
   defp mix_compile_unless_stale_config(compilers) do

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -72,7 +72,9 @@ defmodule Phoenix.Endpoint do
 
   ### Compile-time configuration
 
-    * `:code_reloader` - when `true`, enables code reloading functionality
+    * `:code_reloader` - when `true`, enables code reloading functionality.
+      For code the list of code reloader configuration options see
+      `Phoenix.CodeReloader.reload!/1`.
 
     * `:debug_errors` - when `true`, uses `Plug.Debugger` functionality for
       debugging failures in the application. Recommended to be set to `true`

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -183,6 +183,7 @@ defmodule Phoenix.Endpoint.Supervisor do
      check_origin: true,
      http: false,
      https: false,
+     reloadable_apps: nil,
      reloadable_compilers: [:gettext, :phoenix, :elixir],
      secret_key_base: nil,
      static_url: nil,

--- a/test/phoenix/code_reloader_test.exs
+++ b/test/phoenix/code_reloader_test.exs
@@ -6,6 +6,10 @@ defmodule Phoenix.CodeReloaderTest do
     def config(:reloadable_compilers) do
       [:gettext, :phoenix, :elixir]
     end
+
+    def config(:reloadable_apps) do
+      nil
+    end
   end
 
   def reload!(_) do


### PR DESCRIPTION
Whenever I am working in a non-umbrella project that consists of Phoenix application, and a few dependencies, or I am working on a library and have it temporarily available on disk, I am missing the functionality of Phoenix code reloader picking up changes in those projects. I *think* it was possible to configure it before with specifying paths to additional to `web` folders (I have been adding `lib/` this way for example too), but that option is no longer around to specify which folders I want to reload and which not.

This pull request adds support for `:reloadable_apps` Endpoint configuration variable. Let's say I have a project (non-umbrella) consisting of `:ui` and `:core` applications. Currently, Phoenix code reloader will only pick up the changes in :ui.

With my pull request, the default behavior will remain the same. But you can, however specify:

    config :ui, UI.Endpoint,
      reloadable_apps: [:core, :ui],
      ...

This configuration will make both apps code reload. In similar manner you can make any dependency, also for example a library you are working on at the moment that's stored on your disk somewhere - reloadable.

When specified, this configuration option takes precedence over default behavior (in umbrella project or otherwise). So you can, for example, request that reloader compiles only a sub-set of your umbrella project - that might come in handy for big ones.

I am looking for feedback first if you think it's useful. I think if yes, I'll do some little clean up and update documentation before this is ready to being merged.

Let me know what you think about that feature. For me it'd be super useful as I do not use umbrella projects, but maybe that's not the general consensus.
