### PR TITLE
Show a better router error message when a non-Enumerable is passed as params

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -194,14 +194,14 @@ defmodule Phoenix.Router.Helpers do
 
       defp segments!(segments, query, reserved, {helper, opts, var_length}) do
         arity = var_length + 3
-        call_vars = if var_length > 0, do: Enum.map(1..(var_length), &(":arg#{&1}")), else: []
+        call_vars = if var_length > 0, do: Enum.map(1..(var_length), &("arg#{&1}")), else: []
 
         raise ArgumentError, """
         #{__MODULE__}.#{helper}_path/#{arity} called with invalid params. The last argument to \
         this function should be a keyword list or a map.
         For example:
 
-          Router.#{helper}_path(conn, :#{opts}, #{Enum.join(call_vars ++ [""], ", ")}page: 5, per_page: 10)
+          Router.#{helper}_path(#{Enum.join(["conn", ":#{opts}" | call_vars], ", ")}, page: 5, per_page: 10)
 
         It is possible you have called this function without defining the proper \
         number of path segments in your router.

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -176,24 +176,37 @@ defmodule Phoenix.Router.Helpers do
       defp to_param(true), do: "true"
       defp to_param(data), do: Phoenix.Param.to_param(data)
 
-      defp segments(segments, [], _reserved) do
-        {:ok, segments}
+      defp segments!(segments, [], _reserved, _opts) do
+        segments
       end
 
-      defp segments(segments, query, reserved) when is_list(query) or is_map(query) do
+      defp segments!(segments, query, reserved, _opts) when is_list(query) or is_map(query) do
         dict = for {k, v} <- query,
                not ((k = to_string(k)) in reserved),
                do: {k, v}
 
 
         case Conn.Query.encode dict, &to_param/1 do
-          "" -> {:ok, segments}
-          o  -> {:ok, segments <> "?" <> o}
+          "" -> segments
+          o  -> segments <> "?" <> o
         end
       end
 
-      defp segments(segments, query, reserved) do
-        {:error, :invalid_query}
+      defp segments!(segments, query, reserved, opts) do
+        helper = Keyword.get(opts, :helper)
+        var_length = Keyword.get(opts, :var_length)
+        opts = Keyword.get(opts, :opts)
+        arity = var_length + 3
+        call_vars = if var_length > 0, do: Enum.map(1..(var_length), &(":arg#{&1}")), else: []
+
+        raise ArgumentError, "#{__MODULE__}.#{helper}_path/#{arity} " <>
+          "called with invalid params. The last argument to this function should " <>
+          "be a keyword list or a map.\n" <>
+          "For example:\n\n" <>
+          "  Router.#{helper}_path(conn, :#{opts}, " <>
+          "#{Enum.join(call_vars ++ [""], ", ")}page: 5, per_page: 10)\n\n" <>
+          "It is possible you have called this function without defining the proper " <>
+          "number of path segments in your router."
       end
     end
 
@@ -228,26 +241,11 @@ defmodule Phoenix.Router.Helpers do
       end
 
       def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote_splicing(vars), params) do
-        case segments(unquote(segs), params, unquote(bins)) do
-          {:ok, segments} ->
-            path(conn_or_endpoint, segments)
-
-          {:error, :invalid_query} ->
-            call_vars =
-              Enum.map(unquote(vars), fn
-                param when is_atom(param) -> ":#{param}"
-                other -> to_string(other)
-              end)
-            arity = length(unquote(vars)) + 3
-            raise ArgumentError, "#{__MODULE__}.#{unquote(helper)}_path/#{arity} " <>
-              "called with invalid params. The last argument to this function should " <>
-              "be a keyword list or a map.\n" <>
-              "For example:\n\n" <>
-              "  Router.#{unquote(helper)}_path(conn, :#{unquote(opts)}, " <>
-              "#{Enum.join(call_vars ++ [""], ", ")}page: 5, per_page: 10)\n\n" <>
-              "It is possible you have called this function without defining the proper " <>
-              "number of path segments in your router."
-        end
+        path(conn_or_endpoint, segments!(unquote(segs), params, unquote(bins), [
+          opts: unquote(opts),
+          helper: unquote(helper),
+          var_length: length(unquote(vars))
+        ]))
       end
 
       def unquote(:"#{helper}_url")(conn_or_endpoint, unquote(opts), unquote_splicing(vars)) do

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -192,9 +192,8 @@ defmodule Phoenix.Router.Helpers do
         end
       end
 
-      defp segments!(segments, query, reserved, {helper, opts, var_length}) do
-        arity = var_length + 3
-        call_vars = if var_length > 0, do: Enum.map(1..(var_length), &("arg#{&1}")), else: []
+      defp segments!(segments, query, reserved, {helper, opts, call_vars}) do
+        arity = length(call_vars) + 3
 
         raise ArgumentError, """
         #{__MODULE__}.#{helper}_path/#{arity} called with invalid params.
@@ -241,7 +240,7 @@ defmodule Phoenix.Router.Helpers do
 
       def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote_splicing(vars), params) do
         path(conn_or_endpoint, segments!(unquote(segs), params, unquote(bins),
-              {unquote(helper), unquote(opts), length(unquote(vars))}))
+              {unquote(helper), unquote(opts), unquote(Enum.map(vars, &Macro.to_string/1))}))
       end
 
       def unquote(:"#{helper}_url")(conn_or_endpoint, unquote(opts), unquote_splicing(vars)) do

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -192,21 +192,20 @@ defmodule Phoenix.Router.Helpers do
         end
       end
 
-      defp segments!(segments, query, reserved, opts) do
-        helper = Keyword.get(opts, :helper)
-        var_length = Keyword.get(opts, :var_length)
-        opts = Keyword.get(opts, :opts)
+      defp segments!(segments, query, reserved, {helper, opts, var_length}) do
         arity = var_length + 3
         call_vars = if var_length > 0, do: Enum.map(1..(var_length), &(":arg#{&1}")), else: []
 
-        raise ArgumentError, "#{__MODULE__}.#{helper}_path/#{arity} " <>
-          "called with invalid params. The last argument to this function should " <>
-          "be a keyword list or a map.\n" <>
-          "For example:\n\n" <>
-          "  Router.#{helper}_path(conn, :#{opts}, " <>
-          "#{Enum.join(call_vars ++ [""], ", ")}page: 5, per_page: 10)\n\n" <>
-          "It is possible you have called this function without defining the proper " <>
-          "number of path segments in your router."
+        raise ArgumentError, """
+        #{__MODULE__}.#{helper}_path/#{arity} called with invalid params. The last argument to \
+        this function should be a keyword list or a map.
+        For example:
+
+          Router.#{helper}_path(conn, :#{opts}, #{Enum.join(call_vars ++ [""], ", ")}page: 5, per_page: 10)
+
+        It is possible you have called this function without defining the proper \
+        number of path segments in your router.
+        """
       end
     end
 
@@ -241,11 +240,8 @@ defmodule Phoenix.Router.Helpers do
       end
 
       def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote_splicing(vars), params) do
-        path(conn_or_endpoint, segments!(unquote(segs), params, unquote(bins), [
-          opts: unquote(opts),
-          helper: unquote(helper),
-          var_length: length(unquote(vars))
-        ]))
+        path(conn_or_endpoint, segments!(unquote(segs), params, unquote(bins),
+              {unquote(helper), unquote(opts), length(unquote(vars))}))
       end
 
       def unquote(:"#{helper}_url")(conn_or_endpoint, unquote(opts), unquote_splicing(vars)) do

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -197,13 +197,13 @@ defmodule Phoenix.Router.Helpers do
         call_vars = if var_length > 0, do: Enum.map(1..(var_length), &("arg#{&1}")), else: []
 
         raise ArgumentError, """
-        #{__MODULE__}.#{helper}_path/#{arity} called with invalid params. The last argument to \
-        this function should be a keyword list or a map.
+        #{__MODULE__}.#{helper}_path/#{arity} called with invalid params.
+        The last argument to this function should be a keyword list or a map.
         For example:
 
-          Router.#{helper}_path(#{Enum.join(["conn", ":#{opts}" | call_vars], ", ")}, page: 5, per_page: 10)
+            Router.#{helper}_path(#{Enum.join(["conn", ":#{opts}" | call_vars], ", ")}, page: 5, per_page: 10)
 
-        It is possible you have called this function without defining the proper \
+        It is possible you have called this function without defining the proper
         number of path segments in your router.
         """
       end

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -138,30 +138,15 @@ defmodule Phoenix.Router.HelpersTest do
   end
 
   test "url helper shows an error if an id is accidentally passed" do
-    error_message = """
-    Elixir.Phoenix.Router.HelpersTest.Router.Helpers.bottom_path/5 called with invalid params. The last argument to this function should be a keyword list or a map.
-    For example:
+    error_suggestion = ~r/Router.bottom_path\(conn, :bottom, arg1, arg2, page: 5, per_page: 10\)/
 
-      Router.bottom_path(conn, :bottom, :arg1, :arg2, page: 5, per_page: 10)
-
-    It is possible you have called this function without defining the proper number of path segments in your router.
-    """
-
-    assert_raise ArgumentError, error_message, fn ->
+    assert_raise ArgumentError, error_suggestion, fn ->
       Helpers.bottom_path(__MODULE__, :bottom, :asc, 8, {:not, :enumerable})
     end
 
-    error_message = """
-    Elixir.Phoenix.Router.HelpersTest.Router.Helpers.top_path/3 called with invalid params. The last argument to this function should be a keyword list or a map.
-    For example:
+    error_suggestion = ~r/Router.top_path\(conn, :top, page: 5, per_page: 10\)/
 
-      Router.top_path(conn, :top, page: 5, per_page: 10)
-
-    It is possible you have called this function without defining the proper number of path segments in your router.
-    """
-
-
-    assert_raise ArgumentError, error_message, fn ->
+    assert_raise ArgumentError, error_suggestion, fn ->
       Helpers.top_path(__MODULE__, :top, "invalid")
     end
   end

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -15,12 +15,10 @@ defmodule Phoenix.Router.HelpersTest do
     end
     """
 
-    assert extract_defhelper(route, 1) =~ String.trim """
+    assert extract_defhelper(route, 1) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar, params)) do
-      case(segments(("" <> "/foo") <> "/" <> URI.encode(to_param(bar), &URI.char_unreserved?/1), params, ["bar"])) do
-        {:ok, segments} ->
-          path(conn_or_endpoint, segments)
-        {:error, :invalid_query} ->
+      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> URI.encode(to_param(bar), &URI.char_unreserved?/1), params, [\"bar\"], opts: :world, helper: \"hello_world\", var_length: length([bar])))
+    end
     """
   end
 
@@ -33,12 +31,10 @@ defmodule Phoenix.Router.HelpersTest do
     end
     """
 
-    assert extract_defhelper(route, 1) =~ String.trim """
+    assert extract_defhelper(route, 1) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar, params)) do
-      case(segments(("" <> "/foo") <> "/" <> Enum.map_join(bar, "/", fn s -> URI.encode(s, &URI.char_unreserved?/1) end), params, ["bar"])) do
-        {:ok, segments} ->
-          path(conn_or_endpoint, segments)
-        {:error, :invalid_query} ->
+      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> Enum.map_join(bar, \"/\", fn s -> URI.encode(s, &URI.char_unreserved?/1) end), params, [\"bar\"], opts: :world, helper: \"hello_world\", var_length: length([bar])))
+    end
     """
   end
 
@@ -146,7 +142,7 @@ defmodule Phoenix.Router.HelpersTest do
     Elixir.Phoenix.Router.HelpersTest.Router.Helpers.bottom_path/5 called with invalid params. The last argument to this function should be a keyword list or a map.
     For example:
 
-      Router.bottom_path(conn, :bottom, :asc, 8, page: 5, per_page: 10)
+      Router.bottom_path(conn, :bottom, :arg1, :arg2, page: 5, per_page: 10)
 
     It is possible you have called this function without defining the proper number of path segments in your router.
     """ |> String.trim_trailing()

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -17,7 +17,7 @@ defmodule Phoenix.Router.HelpersTest do
 
     assert extract_defhelper(route, 1) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar, params)) do
-      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> URI.encode(to_param(bar), &URI.char_unreserved?/1), params, [\"bar\"], {\"hello_world\", :world, length([bar])}))
+      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> URI.encode(to_param(bar), &URI.char_unreserved?/1), params, [\"bar\"], {\"hello_world\", :world, [\"bar\"]}))
     end
     """
   end
@@ -33,7 +33,7 @@ defmodule Phoenix.Router.HelpersTest do
 
     assert extract_defhelper(route, 1) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar, params)) do
-      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> Enum.map_join(bar, \"/\", fn s -> URI.encode(s, &URI.char_unreserved?/1) end), params, [\"bar\"], {\"hello_world\", :world, length([bar])}))
+      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> Enum.map_join(bar, \"/\", fn s -> URI.encode(s, &URI.char_unreserved?/1) end), params, [\"bar\"], {\"hello_world\", :world, [\"bar\"]}))
     end
     """
   end
@@ -138,7 +138,7 @@ defmodule Phoenix.Router.HelpersTest do
   end
 
   test "url helper shows an error if an id is accidentally passed" do
-    error_suggestion = ~r/Router.bottom_path\(conn, :bottom, arg1, arg2, page: 5, per_page: 10\)/
+    error_suggestion = ~r/Router.bottom_path\(conn, :bottom, order, count, page: 5, per_page: 10\)/
 
     assert_raise ArgumentError, error_suggestion, fn ->
       Helpers.bottom_path(__MODULE__, :bottom, :asc, 8, {:not, :enumerable})

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -17,7 +17,7 @@ defmodule Phoenix.Router.HelpersTest do
 
     assert extract_defhelper(route, 1) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar, params)) do
-      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> URI.encode(to_param(bar), &URI.char_unreserved?/1), params, [\"bar\"], opts: :world, helper: \"hello_world\", var_length: length([bar])))
+      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> URI.encode(to_param(bar), &URI.char_unreserved?/1), params, [\"bar\"], {\"hello_world\", :world, length([bar])}))
     end
     """
   end
@@ -33,7 +33,7 @@ defmodule Phoenix.Router.HelpersTest do
 
     assert extract_defhelper(route, 1) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar, params)) do
-      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> Enum.map_join(bar, \"/\", fn s -> URI.encode(s, &URI.char_unreserved?/1) end), params, [\"bar\"], opts: :world, helper: \"hello_world\", var_length: length([bar])))
+      path(conn_or_endpoint, segments!((\"\" <> \"/foo\") <> \"/\" <> Enum.map_join(bar, \"/\", fn s -> URI.encode(s, &URI.char_unreserved?/1) end), params, [\"bar\"], {\"hello_world\", :world, length([bar])}))
     end
     """
   end
@@ -145,7 +145,7 @@ defmodule Phoenix.Router.HelpersTest do
       Router.bottom_path(conn, :bottom, :arg1, :arg2, page: 5, per_page: 10)
 
     It is possible you have called this function without defining the proper number of path segments in your router.
-    """ |> String.trim_trailing()
+    """
 
     assert_raise ArgumentError, error_message, fn ->
       Helpers.bottom_path(__MODULE__, :bottom, :asc, 8, {:not, :enumerable})
@@ -158,7 +158,7 @@ defmodule Phoenix.Router.HelpersTest do
       Router.top_path(conn, :top, page: 5, per_page: 10)
 
     It is possible you have called this function without defining the proper number of path segments in your router.
-    """ |> String.trim_trailing()
+    """
 
 
     assert_raise ArgumentError, error_message, fn ->


### PR DESCRIPTION
Currently calling a path such as:

  page_page(conn, :show, :id, "extra-params")

Will raise a `Protocol.UndefinedError` as "extra-params" is not enumerable. A
custom error message is now raised in this scenario to prompt the user what to
do next.