### PR TITLE
Add security header to avoid window control attacks - Closes #2906

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -998,6 +998,8 @@ defmodule Phoenix.Controller do
         context of the application (like critical domain cookies)
       * x-permitted-cross-domain-policies - set to none to restrict
         Adobe Flash Player’s access to data
+      * cross-origin-window-policy - set to deny to avoid window
+        control attacks
 
   A custom headers map may also be given to be merged with defaults.
   """
@@ -1016,7 +1018,8 @@ defmodule Phoenix.Controller do
       {"x-xss-protection", "1; mode=block"},
       {"x-content-type-options", "nosniff"},
       {"x-download-options", "noopen"},
-      {"x-permitted-cross-domain-policies", "none"}
+      {"x-permitted-cross-domain-policies", "none"},
+      {"cross-origin-window-policy", "deny"}
     ])
   end
 

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -527,6 +527,7 @@ defmodule Phoenix.Controller.ControllerTest do
     assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
     assert get_resp_header(conn, "x-download-options") == ["noopen"]
     assert get_resp_header(conn, "x-permitted-cross-domain-policies") == ["none"]
+    assert get_resp_header(conn, "cross-origin-window-policy") == ["deny"]
 
     custom_headers = %{"x-frame-options" => "custom", "foo" => "bar"}
     conn = conn(:get, "/") |> put_secure_browser_headers(custom_headers)
@@ -534,6 +535,7 @@ defmodule Phoenix.Controller.ControllerTest do
     assert get_resp_header(conn, "x-xss-protection") == ["1; mode=block"]
     assert get_resp_header(conn, "x-download-options") == ["noopen"]
     assert get_resp_header(conn, "x-permitted-cross-domain-policies") == ["none"]
+    assert get_resp_header(conn, "cross-origin-window-policy") == ["deny"]
     assert get_resp_header(conn, "foo") == ["bar"]
   end
 


### PR DESCRIPTION
Hello guys,

This PR adds a new security header that avoid window control attacks as described on issue #2906.

As mentioned in the issue/[presentation](https://developer.apple.com/videos/play/wwdc2018/207/) this new header is already [released on Safari 12](https://developer.apple.com/safari/whats-new/).

PS: This is my first contribution to an Elixir project so please let me know if I need to do something more. The `level:starter` tag was helpful. 👍 


