### PR TITLE
Remove redundant [Y/n] in shell prompt in context generator

### DIFF
--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -255,7 +255,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
       If you are not sure, prefer a new context over adding to the existing one.
 
       """
-      unless Mix.shell.yes?("Would you like proceed? [Y/n]") do
+      unless Mix.shell.yes?("Would you like proceed?") do
         System.halt()
       end
     end

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -150,7 +150,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
 
       assert_received {:mix_shell, :info, ["You are generating into an existing context" <> notice]}
       assert notice =~ "Phoenix.Blog context currently has 6 functions and\n2 files in its directory"
-      assert_received {:mix_shell, :yes?, ["Would you like proceed? [Y/n]"]}
+      assert_received {:mix_shell, :yes?, ["Would you like proceed?"]}
 
       assert_file "lib/phoenix/blog/comment.ex", fn file ->
         assert file =~ "field :title, :string"


### PR DESCRIPTION
Mix.Shell.IO's `yes?` function already [adds a `[Yn]` hint](https://github.com/elixir-lang/elixir/blob/v1.6.6/lib/mix/lib/mix/shell/io.ex#L56) to the prompt. Without this change we currently have a `Would you like proceed? [Y/n] [Yn] ` prompt.