### PR TITLE
Make path example consistent with generators

### DIFF
--- a/installer/templates/phx_assets/webpack/app.js
+++ b/installer/templates/phx_assets/webpack/app.js
@@ -13,7 +13,5 @@ import css from "../css/app.css"
 
 // Import local files
 //
-// Local files can be imported directly using relative
-// paths "./socket" or full ones "web/static/js/socket".
-
+// Local files can be imported directly using relative paths, for example:
 // import socket from "./socket"


### PR DESCRIPTION
I think the path in the example probably points to an older generated directory structure. 