### PR TITLE
Allow running phoenix endpoint on unix domain socket

### DIFF
--- a/lib/phoenix/endpoint/cowboy2_adapter.ex
+++ b/lib/phoenix/endpoint/cowboy2_adapter.ex
@@ -69,13 +69,18 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
     "Running #{inspect endpoint} with #{server} at #{uri(scheme, ref)}"
   end
   defp uri(scheme, ref) do
-    {addr, port} = :ranch.get_addr(ref)
-    host =
-      case to_string(:inet.ntoa(addr)) do
-        "0.0.0.0" -> "localhost"
-        host -> host
-      end
+    case :ranch.get_addr(ref) do
+      {:local, unix_path} ->
+        %URI{host: URI.encode_www_form(unix_path), scheme: "#{scheme}+unix"}
 
-    %URI{host: host, port: port, scheme: to_string(scheme)}
+      {addr, port} ->
+        host =
+          case to_string(:inet.ntoa(addr)) do
+            "0.0.0.0" -> "localhost"
+            host -> host
+          end
+
+        %URI{host: host, port: port, scheme: to_string(scheme)}
+    end
   end
 end


### PR DESCRIPTION
Hello,

This PR adds support for running a phoenix endpoint with the Cowboy adapters on a local unix socket.
This configuration could be useful when reverse-proxying cowboy using NGINX or other web server.

The only change required to phoenix is to handle the `{:local, path}` tuple result from `:ranch:get_addr` when producing the startup message.

To enable a unix socket, the endpoint is configured with `port` 0 and a `{:local, path}` tuple for `ip` ([erlang docs reference](http://erlang.org/doc/man/inet.html#type-local_address)):

```elixir
# config.exs
config :my_app, MyAppWeb.Endpoint,
  http: [port: 0, ip: {:local, "/path/to/my_app.sock"}],
```

Additionally, the application should remove any existing file at startup, otherwise it will fail to bind:

```elixir
  # application.ex
  def start(_type, _args) do
    File.rm("/path/to/my_app.sock")
    children = [
      MyApp.Repo,
      MyApp.Endpoint
    ]
    opts = [strategy: :one_for_one, name: MyApp.Supervisor]
    Supervisor.start_link(children, opts)
  end
```

Note Erlang/OTP 21.0 is required to have a working `Plug.Static` with unix sockets. In earlier versions the implementation of `:file.sendfile` would fail. (https://bugs.erlang.org/browse/ERL-596)