### PR TITLE
Remove warnings `mix test`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,7 @@ defmodule Phoenix.MixProject do
       {:inch_ex, "~> 0.2", only: :docs},
 
       # Test dependencies
-      {:gettext, "~> 0.8", only: :test},
+      {:gettext, "~> 0.15.0", only: :test},
       {:phoenix_html, "~> 2.11", only: :test},
       {:websocket_client, git: "https://github.com/jeremyong/websocket_client.git", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "cowlib": {:hex, :cowlib, "2.3.0", "bbd58ef537904e4f7c1dd62e6aa8bc831c8183ce4efa9bd1150164fe15be4caa", [:rebar3], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [repo: "hexpm", hex: :earmark, optional: false]}], "hexpm"},
-  "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], [], "hexpm"},
+  "gettext": {:hex, :gettext, "0.15.0", "40a2b8ce33a80ced7727e36768499fc9286881c43ebafccae6bab731e2b2b8ce", [], [], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},


### PR DESCRIPTION
```
warning: Enum.partition/2 is deprecated, use Enum.split_with/2
  lib/gettext/extractor_agent.ex:64

warning: Enum.partition/2 is deprecated, use Enum.split_with/2
  lib/gettext/po/parser.ex:44

warning: String.strip/1 is deprecated, use String.trim/1
  lib/gettext/po/parser.ex:47

warning: String.strip/1 is deprecated, use String.trim/1
  lib/gettext/po/parser.ex:55

warning: String.lstrip/1 is deprecated, use String.trim_leading/1
  lib/gettext/po/parser.ex:65

warning: Enum.partition/2 is deprecated, use Enum.split_with/2
  lib/gettext/po/parser.ex:71

warning: String.to_char_list/1 is deprecated, use String.to_charlist/1
  lib/gettext/po/tokenizer.ex:147
```