### PR TITLE
Add origin check for transports using an MFA tuple

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -102,8 +102,8 @@ defmodule Phoenix.Endpoint do
       by `mix phx.digest`.
 
     * `:check_origin` - configure transports to check origins or not. May
-      be false, true or a list of hosts that are allowed. Hosts also support
-      wildcards. For example:
+      be false, true, a list of hosts that are allowed or a function provided as
+      MFA tuple. Hosts also support wildcards. For example:
 
           check_origin: ["//phoenixframework.org", "//*.example.com"]
 

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -392,6 +392,8 @@ defmodule Phoenix.Socket.Transport do
             Enum.map(origins, &parse_origin/1)
           boolean when is_boolean(boolean) ->
             boolean
+          {module, function, arguments} ->
+            {module, function, arguments}
         end
 
       {:cache, check_origin}
@@ -417,6 +419,8 @@ defmodule Phoenix.Socket.Transport do
     do: compare?(uri.host, host_to_binary(endpoint.config(:url)[:host]))
   defp origin_allowed?(check_origin, uri, _endpoint) when is_list(check_origin),
     do: origin_allowed?(uri, check_origin)
+  defp origin_allowed?({module, function, arguments}, uri, _endpoint),
+    do: apply(module, function, [uri | arguments])
 
   defp origin_allowed?(uri, allowed_origins) do
     %{scheme: origin_scheme, host: origin_host, port: origin_port} = uri

--- a/test/phoenix/socket/transport_test.exs
+++ b/test/phoenix/socket/transport_test.exs
@@ -120,6 +120,35 @@ defmodule Phoenix.Socket.TransportTest do
       assert conn.halted
       assert conn.status == 403
     end
+
+    def check_origin_callback(origin, allowed_host \\ "example.com")
+    def check_origin_callback(origin, allowed_host), do: origin.host == allowed_host
+
+    test "checks the origin of requests against an MFA" do
+      # callback without additional arguments
+      mfa = {__MODULE__, :check_origin_callback, []}
+
+      # a not allowed host
+      conn = check_origin("http://notallowed.com/", check_origin: mfa)
+      assert conn.halted
+      assert conn.status == 403
+
+      # an allowed host
+      refute check_origin("http://example.com/", check_origin: mfa).halted
+    end
+
+    test "checks the origin of requests against an MFA, passing additional arguments" do
+      # callback with additional argument
+      mfa = {__MODULE__, :check_origin_callback, ["host.com"]}
+
+      # a not allowed host
+      conn = check_origin("http://notallowed.com/", check_origin: mfa)
+      assert conn.halted
+      assert conn.status == 403
+
+      # an allowed host
+      refute check_origin("https://host.com/", check_origin: mfa).halted
+    end
   end
 
   describe "force_ssl/4" do


### PR DESCRIPTION
As briefly discussed on IRC a few days ago (with @josevalim), this PR introduces the possibility for transports to receive an MFA tuple as configuration option for their origin check.

If there are things wrong, missing or to be improved, please let me know.