### PR TITLE
changed guides mentioning *_path and moduledoc in lib/phoenix/view.ex

### DIFF
--- a/guides/channels.md
+++ b/guides/channels.md
@@ -401,7 +401,7 @@ Next we need to pass this token to JavaScript. We can do so inside a script tag 
 
 ```html
 <script>window.userToken = "<%= assigns[:user_token] %>";</script>
-<script src="<%= static_path(@conn, "/js/app.js") %>"></script>
+<script src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
 ```
 
 **Step 3 - Pass the Token to the Socket Constructor and Verify**

--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -147,7 +147,7 @@ defmodule HelloWeb.UserController do
       {:ok, user} ->
         conn
         |> put_flash(:info, "User created successfully.")
-        |> redirect(to: user_path(conn, :show, user))
+        |> redirect(to: Routes.user_path(conn, :show, user))
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
     end
@@ -480,7 +480,7 @@ defmodule HelloWeb.SessionController do
       {:error, :unauthorized} ->
         conn
         |> put_flash(:error, "Bad email/password combination")
-        |> redirect(to: session_path(conn, :new))
+        |> redirect(to: Routes.session_path(conn, :new))
     end
   end
 
@@ -540,7 +540,7 @@ Next, add a new template in `lib/hello_web/templates/session/new.html.eex:`
 ```eex
 <h1>Sign in</h1>
 
-<%= form_for @conn, session_path(@conn, :create), [method: :post, as: :user], fn f -> %>
+<%= form_for @conn, Routes.session_path(@conn, :create), [method: :post, as: :user], fn f -> %>
   <div class="form-group">
     <%= text_input f, :email, placeholder: "Email" %>
   </div>
@@ -554,7 +554,7 @@ Next, add a new template in `lib/hello_web/templates/session/new.html.eex:`
   </div>
 <% end %>
 
-<%= form_for @conn, session_path(@conn, :delete), [method: :delete, as: :user], fn _ -> %>
+<%= form_for @conn, Routes.session_path(@conn, :delete), [method: :delete, as: :user], fn _ -> %>
   <div class="form-group">
     <%= submit "logout" %>
   </div>
@@ -893,7 +893,7 @@ Open up your generated `lib/hello_web/controllers/cms/page_controller.ex` and ma
     else
       conn
       |> put_flash(:error, "You can't modify that page")
-      |> redirect(to: cms_page_path(conn, :index))
+      |> redirect(to: Routes.cms_page_path(conn, :index))
       |> halt()
     end
   end
@@ -921,7 +921,7 @@ With our new plugs in place, we can now modify our `create`, `edit`, `update`, a
       {:ok, page} ->
         conn
         |> put_flash(:info, "Page created successfully.")
-        |> redirect(to: cms_page_path(conn, :show, page))
+        |> redirect(to: Routes.cms_page_path(conn, :show, page))
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
     end
@@ -935,7 +935,7 @@ With our new plugs in place, we can now modify our `create`, `edit`, `update`, a
       {:ok, page} ->
         conn
         |> put_flash(:info, "Page updated successfully.")
-        |> redirect(to: cms_page_path(conn, :show, page))
+        |> redirect(to: Routes.cms_page_path(conn, :show, page))
       {:error, %Ecto.Changeset{} = changeset} ->
 -       render(conn, "edit.html", page: page, changeset: changeset)
 +       render(conn, "edit.html", changeset: changeset)
@@ -950,7 +950,7 @@ With our new plugs in place, we can now modify our `create`, `edit`, `update`, a
 
     conn
     |> put_flash(:info, "Page deleted successfully.")
-    |> redirect(to: cms_page_path(conn, :index))
+    |> redirect(to: Routes.cms_page_path(conn, :index))
   end
 ```
 

--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -518,7 +518,7 @@ defmodule HelloWeb.PageController do
   use HelloWeb, :controller
 
   def index(conn, _params) do
-    redirect(conn, to: redirect_test_path(conn, :redirect_test))
+    redirect(conn, to: Routes.redirect_test_path(conn, :redirect_test))
   end
 end
 ```
@@ -527,7 +527,7 @@ Note that we can't use the url helper here because `redirect/2` using the atom `
 
 ```elixir
 def index(conn, _params) do
-  redirect(conn, to: redirect_test_url(conn, :redirect_test))
+  redirect(conn, to: Routes.redirect_test_url(conn, :redirect_test))
 end
 ```
 
@@ -535,7 +535,7 @@ If we want to use the url helper to pass a full url to `redirect/2`, we must use
 
 ```elixir
 def index(conn, _params) do
-  redirect(conn, external: redirect_test_url(conn, :redirect_test))
+  redirect(conn, external: Routes.redirect_test_url(conn, :redirect_test))
 end
 ```
 

--- a/guides/phoenix_mix_tasks.md
+++ b/guides/phoenix_mix_tasks.md
@@ -231,11 +231,8 @@ Important: If we don't do this, we will see the following warnings in our logs, 
 $ mix phx.server
 Compiling 17 files (.ex)
 
-== Compilation error in file lib/hello_web/controllers/post_controller.ex ==
-** (CompileError) lib/hello_web/controllers/post_controller.ex:22: undefined function HelloWeb.Router.Helpers.post_path/3
-    (stdlib) lists.erl:1338: :lists.foreach/2
-    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
-    (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
+warning: function HelloWeb.Router.Helpers.post_path/3 is undefined or private
+  lib/hello_web/controllers/post_controller.ex:22: 
 ```
 
 If we don't want to create a context or schema for our resource we can use the `--no-context` flag. Note that this still requires a context module name as a parameter.
@@ -260,17 +257,14 @@ Add the resource to your browser scope in lib/hello_web/router.ex:
     resources "/posts", PostController
 ```
 
-Important: If we don't do this, our application won't compile, and we'll get an error.
+Important: If we don't do this, we'll get the following warning in our logs and the application will error when attempting to load the page:
 
 ```console
 $ mix phx.server
 Compiling 15 files (.ex)
 
-== Compilation error in file lib/hello_web/views/post_view.ex ==
-** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function HelloWeb.Router.Helpers.post_path/3
-    (stdlib) lists.erl:1338: :lists.foreach/2
-    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
-    (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
+warning: function HelloWeb.Router.Helpers.post_path/3 is undefined or private
+  lib/hello_web/templates/post/edit.html.eex:3
 ```
 
 Similarly - if we want a context created without a schema for our resource we can use the `--no-schema` flag.
@@ -299,17 +293,14 @@ Add the resource to your browser scope in lib/hello_web/router.ex:
     resources "/posts", PostController
 ```
 
-Important: If we don't do this, our application won't compile, and we'll get an error.
+Important: If we don't do this, we'll get the following warning in our logs and the application will error when attempting to load the page:
 
 ```console
 $ mix phx.server
 Compiling 15 files (.ex)
 
-== Compilation error in file lib/hello_web/views/post_view.ex ==
-** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function HelloWeb.Router.Helpers.post_path/3
-    (stdlib) lists.erl:1338: :lists.foreach/2
-    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
-    (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
+warning: function HelloWeb.Router.Helpers.post_path/3 is undefined or private
+  lib/hello_web/templates/post/edit.html.eex:3
 ```
 
 #### [mix phx.gen.json](`Mix.Tasks.Phx.Gen.Json.run/1`)
@@ -346,17 +337,14 @@ Remember to update your repository by running migrations:
     $ mix ecto.migrate
 ```
 
-Important: If we don't do this, our application won't compile, and we'll get an error.
+Important: If we don't do this, we'll get the following warning in our logs and the application will error when attempting to load the page:
 
 ```console
 $ mix phx.server
 Compiling 19 files (.ex)
 
-== Compilation error in file lib/hello_web/controllers/post_controller.ex ==
-** (CompileError) lib/hello_web/controllers/post_controller.ex:18: undefined function HelloWeb.Router.Helpers.post_path/3
-    (stdlib) lists.erl:1338: :lists.foreach/2
-    (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
-    (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
+warning: function HelloWeb.Router.Helpers.post_path/3 is undefined or private
+  lib/hello_web/controllers/post_controller.ex:18
 ```
 
 If we don't want to create a context or schema for our resource we can use the `--no-context` flag. Note that this still requires a context module name as a parameter.

--- a/guides/phoenix_mix_tasks.md
+++ b/guides/phoenix_mix_tasks.md
@@ -232,7 +232,7 @@ $ mix phx.server
 Compiling 17 files (.ex)
 
 == Compilation error in file lib/hello_web/controllers/post_controller.ex ==
-** (CompileError) lib/hello_web/controllers/post_controller.ex:22: undefined function post_path/3
+** (CompileError) lib/hello_web/controllers/post_controller.ex:22: undefined function Routes.post_path/3
     (stdlib) lists.erl:1338: :lists.foreach/2
     (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
@@ -267,7 +267,7 @@ $ mix phx.server
 Compiling 15 files (.ex)
 
 == Compilation error in file lib/hello_web/views/post_view.ex ==
-** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function post_path/3
+** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function Routes.post_path/3
     (stdlib) lists.erl:1338: :lists.foreach/2
     (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
@@ -306,7 +306,7 @@ $ mix phx.server
 Compiling 15 files (.ex)
 
 == Compilation error in file lib/hello_web/views/post_view.ex ==
-** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function post_path/3
+** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function Routes.post_path/3
     (stdlib) lists.erl:1338: :lists.foreach/2
     (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
@@ -353,7 +353,7 @@ $ mix phx.server
 Compiling 19 files (.ex)
 
 == Compilation error in file lib/hello_web/controllers/post_controller.ex ==
-** (CompileError) lib/hello_web/controllers/post_controller.ex:18: undefined function post_path/3
+** (CompileError) lib/hello_web/controllers/post_controller.ex:18: undefined function Routes.post_path/3
     (stdlib) lists.erl:1338: :lists.foreach/2
     (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1

--- a/guides/phoenix_mix_tasks.md
+++ b/guides/phoenix_mix_tasks.md
@@ -225,14 +225,14 @@ Remember to update your repository by running migrations:
     $ mix ecto.migrate
 ```
 
-Important: If we don't do this, our application won't compile, and we'll get an error.
+Important: If we don't do this, we will see the following warnings in our logs, and our application will error when trying to execute the function.
 
 ```console
 $ mix phx.server
 Compiling 17 files (.ex)
 
 == Compilation error in file lib/hello_web/controllers/post_controller.ex ==
-** (CompileError) lib/hello_web/controllers/post_controller.ex:22: undefined function Routes.post_path/3
+** (CompileError) lib/hello_web/controllers/post_controller.ex:22: undefined function HelloWeb.Router.Helpers.post_path/3
     (stdlib) lists.erl:1338: :lists.foreach/2
     (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
@@ -267,7 +267,7 @@ $ mix phx.server
 Compiling 15 files (.ex)
 
 == Compilation error in file lib/hello_web/views/post_view.ex ==
-** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function Routes.post_path/3
+** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function HelloWeb.Router.Helpers.post_path/3
     (stdlib) lists.erl:1338: :lists.foreach/2
     (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
@@ -306,7 +306,7 @@ $ mix phx.server
 Compiling 15 files (.ex)
 
 == Compilation error in file lib/hello_web/views/post_view.ex ==
-** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function Routes.post_path/3
+** (CompileError) lib/hello_web/templates/post/edit.html.eex:3: undefined function HelloWeb.Router.Helpers.post_path/3
     (stdlib) lists.erl:1338: :lists.foreach/2
     (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
@@ -353,7 +353,7 @@ $ mix phx.server
 Compiling 19 files (.ex)
 
 == Compilation error in file lib/hello_web/controllers/post_controller.ex ==
-** (CompileError) lib/hello_web/controllers/post_controller.ex:18: undefined function Routes.post_path/3
+** (CompileError) lib/hello_web/controllers/post_controller.ex:18: undefined function HelloWeb.Router.Helpers.post_path/3
     (stdlib) lists.erl:1338: :lists.foreach/2
     (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -250,10 +250,10 @@ iex> HelloWeb.Router.Helpers.page_path(HelloWeb.Endpoint, :index)
 This is significant because we can use the `page_path` function in a template to link to the root of our application. We can then use this helper in our templates:
 
 ```html
-<a href="<%= page_path(@conn, :index) %>">To the Welcome Page!</a>
+<a href="<%= Routes.page_path(@conn, :index) %>">To the Welcome Page!</a>
 ```
 
-The `page_path` function is imported into our template with `use HelloWeb, :view`. Please see the [View Guide](views.html) for more information.
+The reason we can use `Routes.page_path` instead of the full `HelloWeb.Router.Helpers.page_path` name is because `HelloWeb.Router.Helpers` is aliased as `Routes` by default in the `view/0` definition (`lib/hello_web.ex`) and made available to our templates through `use HelloWeb, :view`. We can, of course, use `HelloWeb.Router.Helpers.page_path(@conn, :index)` instead, but the convention is to use the aliased version for conciseness (note that the alias is only set automatically for use in views, controllers and templates - outside these you need either the full name, or to alias it yourself inside the module definition: `alias HelloWeb.Router.Helpers, as: Routes`). Please see the [View Guide](views.html) for more information.
 
 This pays off tremendously if we should ever have to change the path of our route in the router. Since the path helpers are built dynamically from the routes, any calls to `page_path` in our templates will still work.
 
@@ -262,41 +262,41 @@ This pays off tremendously if we should ever have to change the path of our rout
 When we ran the `phx.routes` task for our user resource, it listed the `user_path` as the path helper function for each line of output. Here is what that translates to for each action:
 
 ```elixir
-iex> import HelloWeb.Router.Helpers
+iex> alias HelloWeb.Router.Helpers, as: Routes
 iex> alias HelloWeb.Endpoint
-iex> user_path(Endpoint, :index)
+iex> Routes.user_path(Endpoint, :index)
 "/users"
 
-iex> user_path(Endpoint, :show, 17)
+iex> Routes.user_path(Endpoint, :show, 17)
 "/users/17"
 
-iex> user_path(Endpoint, :new)
+iex> Routes.user_path(Endpoint, :new)
 "/users/new"
 
-iex> user_path(Endpoint, :create)
+iex> Routes.user_path(Endpoint, :create)
 "/users"
 
-iex> user_path(Endpoint, :edit, 37)
+iex> Routes.user_path(Endpoint, :edit, 37)
 "/users/37/edit"
 
-iex> user_path(Endpoint, :update, 37)
+iex> Routes.user_path(Endpoint, :update, 37)
 "/users/37"
 
-iex> user_path(Endpoint, :delete, 17)
+iex> Routes.user_path(Endpoint, :delete, 17)
 "/users/17"
 ```
 
 What about paths with query strings? By adding an optional fourth argument of key value pairs, the path helpers will return those pairs in the query string.
 
 ```elixir
-iex> user_path(Endpoint, :show, 17, admin: true, active: false)
+iex> Routes.user_path(Endpoint, :show, 17, admin: true, active: false)
 "/users/17?admin=true&active=false"
 ```
 
 What if we need a full url instead of a path? Just replace `_path` with `_url`:
 
 ```elixir
-iex(3)> user_url(Endpoint, :index)
+iex(3)> Routes.user_url(Endpoint, :index)
 "http://localhost:4000/users"
 ```
 
@@ -341,6 +341,15 @@ Again, if we add a key/value pair to the end of the function call, it is added t
 
 ```elixir
 iex> HelloWeb.Router.Helpers.user_post_path(Endpoint, :index, 42, active: true)
+"/users/42/posts?active=true"
+```
+
+If we had aliased the `Helpers` module as before (it is only automatically aliased for views, templates and controllers, in this case, since we're inside `iex` we need to do it ourselves), we could instead do:
+
+```elixir
+iex> alias HelloWeb.Router.Helpers, as: Routes
+iex> alias HelloWeb.Endpoint
+iex> Routes.user_post_path(Endpoint, :index, 42, active: true)
 "/users/42/posts?active=true"
 ```
 

--- a/guides/testing/testing_controllers.md
+++ b/guides/testing/testing_controllers.md
@@ -136,7 +136,7 @@ defmodule HelloWeb.UserControllerTest do
 
     response =
       conn
-      |> get(user_path(conn, :index))
+      |> get(Routes.user_path(conn, :index))
       |> json_response(200)
 
     expected = %{
@@ -267,7 +267,7 @@ test "Responds with user info if the user is found", %{conn: conn} do
 
   response =
     conn
-    |> get(user_path(conn, :show, user.id))
+    |> get(Routes.user_path(conn, :show, user.id))
     |> json_response(200)
 
   expected = %{"data" => %{"email" => user.email, "name" => user.name}}
@@ -302,7 +302,7 @@ describe "show/2" do
 
     response =
       conn
-      |> get(user_path(conn, :show, user.id))
+      |> get(Routes.user_path(conn, :show, user.id))
       |> json_response(200)
 
     expected = %{"data" => %{"email" => user.email, "name" => user.name}}
@@ -324,7 +324,7 @@ Finally, let's change our `index/2` test to also use the new `create_user` funct
 
       response =
         conn
-        |> get(user_path(conn, :index))
+        |> get(Routes.user_path(conn, :index))
         |> json_response(200)
 
       expected = %{"data" => [%{"name" => user.name, "email" => user.email}]}
@@ -393,7 +393,7 @@ Walking through our TDD steps, we add a test that supplies a non-existent user i
 
 ```elixir
 test "Responds with a message indicating user not found", %{conn:  conn} do
-  conn = get(conn, user_path(conn, :show, -1))
+  conn = get(conn, Routes.user_path(conn, :show, -1))
 
   assert text_response(conn, 404) =~ "User not found"
 end

--- a/guides/views.md
+++ b/guides/views.md
@@ -67,7 +67,8 @@ rendering with assigns [:conn, :view_module, :view_template]
 
 Pretty neat, right? At compile-time, Phoenix precompiles all `*.html.eex` templates and turns them into `render/2` function clauses on their respective view modules. At runtime, all templates are already loaded in memory. There's no disk reads, complex file caching, or template engine computation involved. This is also why we were able to define functions like `title/0` in our `LayoutView` and they were immediately available inside the layout's `app.html.eex` – the call to `title/0` was just a local function call!
 
-When we `use HelloWeb, :view`, we get other conveniences as well. Since the `view/0` function imports `HelloWeb.Router.Helpers`, we don't have to fully qualify path helpers in templates. Let's see how that works by changing the template for our Welcome to Phoenix page.
+When we `use HelloWeb, :view`, we get other conveniences as well. Since `view/0` aliases `HelloWeb.Router.Helpers` as `Routes` (look in `lib/hello_web.ex`), we can simply call these helpers by using `Routes.*_path` in templates. Let's see how that works by changing the template for our Welcome to Phoenix page.
+
 
 Let's open up the `lib/hello_web/templates/page/index.html.eex` and locate this stanza.
 
@@ -84,7 +85,7 @@ Then let's add a line with a link back to the same page. (The objective is to se
 <div class="jumbotron">
   <h2><%= gettext("Welcome to %{name}!", name: "Phoenix") %></h2>
   <p class="lead">A productive web framework that<br>does not compromise speed and maintainability.</p>
-  <p><a href="<%= page_path(@conn, :index) %>">Link back to this page</a></p>
+  <p><a href="<%= Routes.page_path(@conn, :index) %>">Link back to this page</a></p>
 </div>
 ```
 
@@ -94,7 +95,9 @@ Now we can reload the page and view source to see what we have.
 <a href="/">Link back to this page</a>
 ```
 
-Great, `page_path/2` evaluated to `/` as we would expect, and we didn't need to qualify it with `Phoenix.View`.
+Great, `Routes.page_path/2` evaluated to `/` as we would expect, we just had to use the alias set in `Phoenix.View`.
+
+If you happen to need access to the path helpers outside views, controllers or templates, you can either call them by the full qualified name, `HelloWeb.Router.Helpers.*_path()` or alias it yourself in the calling module, by defining `alias HelloWeb.Router.Helpers, as: Routes` in the module you want to use, and then calling `Routes.*_path()`, where `Hello*` is the name of your actual application.
 
 ### More About Views
 

--- a/guides/views.md
+++ b/guides/views.md
@@ -97,7 +97,7 @@ Now we can reload the page and view source to see what we have.
 
 Great, `Routes.page_path/2` evaluated to `/` as we would expect, we just had to use the alias set in `Phoenix.View`.
 
-If you happen to need access to the path helpers outside views, controllers or templates, you can either call them by the full qualified name, `HelloWeb.Router.Helpers.*_path()` or alias it yourself in the calling module, by defining `alias HelloWeb.Router.Helpers, as: Routes` in the module you want to use, and then calling `Routes.*_path()`, where `Hello*` is the name of your actual application.
+If you happen to need access to the path helpers outside views, controllers or templates, you can either call them by the full qualified name, e.g. `HelloWeb.Router.Helpers.page_path(@conn, :index)` or alias it yourself in the calling module, by defining `alias HelloWeb.Router.Helpers, as: Routes` in the module you want to use, and then calling, e.g., `Routes.page_path(@conn, :index)`.
 
 ### More About Views
 

--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -15,11 +15,19 @@ defmodule Phoenix.View do
       defmodule YourAppWeb do
         def view do
           quote do
-            use Phoenix.View, root: "lib/web/templates"
+            use Phoenix.View, root: "lib/app_web/templates", namespace: "web"
+            
+            # Import convenience functions from controllers
+            import Phoenix.Controller, only: [get_flash: 1, get_flash: 2, view_module: 1]<%= if html do %>
+            # Use all HTML functionality (forms, tags, etc)
+            use Phoenix.HTML<% end %>
+          
+            import AppWeb.ErrorHelpers
+            import AppWeb.Gettext
 
-            # Import common functionality
-            import YourApp.Router.Helpers
-
+            # Alias the Helpers module as Routes
+            alias  AppWeb.Router.Helpers, as: Routes
+  
             # Use Phoenix.HTML to import all HTML functions (forms, tags, etc)
             use Phoenix.HTML
           end

--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -10,26 +10,25 @@ defmodule Phoenix.View do
 
   ## Examples
 
-  Phoenix defines the view template at `lib/web/web.ex`:
+  Phoenix defines the view template at `lib/your_app_web.ex`:
 
       defmodule YourAppWeb do
+        # ...
+
         def view do
           quote do
-            use Phoenix.View, root: "lib/app_web/templates", namespace: "web"
+            use Phoenix.View, root: "lib/your_app_web/templates", namespace: "web"
             
             # Import convenience functions from controllers
             import Phoenix.Controller, only: [get_flash: 1, get_flash: 2, view_module: 1]<%= if html do %>
             # Use all HTML functionality (forms, tags, etc)
-            use Phoenix.HTML<% end %>
+            use Phoenix.HTML
           
-            import AppWeb.ErrorHelpers
-            import AppWeb.Gettext
+            import YourAppWeb.ErrorHelpers
+            import YourAppWeb.Gettext
 
             # Alias the Helpers module as Routes
-            alias  AppWeb.Router.Helpers, as: Routes
-  
-            # Use Phoenix.HTML to import all HTML functions (forms, tags, etc)
-            use Phoenix.HTML
+            alias  YourAppWeb.Router.Helpers, as: Routes
           end
         end
 
@@ -42,11 +41,11 @@ defmodule Phoenix.View do
         use YourAppWeb, :view
       end
 
-  Because we have defined the template root to be "lib/web/templates", `Phoenix.View`
-  will automatically load all templates at "web/templates/user" and include them
+  Because we have defined the template root to be "lib/your_app_web/templates", `Phoenix.View`
+  will automatically load all templates at "your_app_web/templates/user" and include them
   in the `YourApp.UserView`. For example, imagine we have the template:
 
-      # web/templates/user/index.html.eex
+      # your_app_web/templates/user/index.html.eex
       Hello <%= @name %>
 
   The `.eex` extension maps to a template engine which tells Phoenix how
@@ -284,7 +283,7 @@ defmodule Phoenix.View do
 
   To use a precompiled template, create a `scripts.html.eex` file in the `templates`
   directory for the corresponding view you want it to render for. For example,
-  for the `UserView`, create the `scripts.html.eex` file at `web/templates/user/`.
+  for the `UserView`, create the `scripts.html.eex` file at `your_app_web/templates/user/`.
 
   ## Rendering based on controller template
 

--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -20,7 +20,8 @@ defmodule Phoenix.View do
             use Phoenix.View, root: "lib/your_app_web/templates", namespace: "web"
             
             # Import convenience functions from controllers
-            import Phoenix.Controller, only: [get_flash: 1, get_flash: 2, view_module: 1]<%= if html do %>
+            import Phoenix.Controller, only: [get_flash: 1, get_flash: 2, view_module: 1]
+
             # Use all HTML functionality (forms, tags, etc)
             use Phoenix.HTML
           


### PR DESCRIPTION
I think I changed it in all relevant points. I also changed the notes/explanations, let me know if the language is fine and if anything else is missing/needs change. I tried rgrep for _path outside the guides, but it's a never ending list of hits for unrelated stuff, I don't think I have missed something but it could happen