### PR TITLE
Adjust headings level to form proper document outline

### DIFF
--- a/installer/templates/phx_web/templates/page/index.html.eex
+++ b/installer/templates/phx_web/templates/page/index.html.eex
@@ -1,11 +1,11 @@
 <section class="phx-hero">
-  <h2><%%= gettext "Welcome to %{name}!", name: "Phoenix" %></h2>
+  <h1><%%= gettext "Welcome to %{name}!", name: "Phoenix" %></h1>
   <p>A productive web framework that<br/>does not compromise speed and maintainability.</p>
 </section>
 
 <section class="row">
   <article class="column">
-    <h4>Resources</h4>
+    <h2>Resources</h2>
     <ul>
       <li>
         <a href="https://hexdocs.pm/phoenix/overview.html">Guides &amp; Docs</a>
@@ -19,7 +19,7 @@
     </ul>
   </article>
   <article class="column">
-    <h4>Help</h4>
+    <h2>Help</h2>
     <ul>
       <li>
         <a href="https://elixirforum.com/c/phoenix-forum">Forum</a>

--- a/priv/templates/phx.gen.html/edit.html.eex
+++ b/priv/templates/phx.gen.html/edit.html.eex
@@ -1,4 +1,4 @@
-<h2>Edit <%= schema.human_singular %></h2>
+<h1>Edit <%= schema.human_singular %></h1>
 
 <%%= render "form.html", Map.put(assigns, :action, Routes.<%= schema.route_helper %>_path(@conn, :update, @<%= schema.singular %>)) %>
 

--- a/priv/templates/phx.gen.html/index.html.eex
+++ b/priv/templates/phx.gen.html/index.html.eex
@@ -1,4 +1,4 @@
-<h2>Listing <%= schema.human_plural %></h2>
+<h1>Listing <%= schema.human_plural %></h1>
 
 <table>
   <thead>

--- a/priv/templates/phx.gen.html/new.html.eex
+++ b/priv/templates/phx.gen.html/new.html.eex
@@ -1,4 +1,4 @@
-<h2>New <%= schema.human_singular %></h2>
+<h1>New <%= schema.human_singular %></h1>
 
 <%%= render "form.html", Map.put(assigns, :action, Routes.<%= schema.route_helper %>_path(@conn, :create)) %>
 

--- a/priv/templates/phx.gen.html/show.html.eex
+++ b/priv/templates/phx.gen.html/show.html.eex
@@ -1,4 +1,4 @@
-<h2>Show <%= schema.human_singular %></h2>
+<h1>Show <%= schema.human_singular %></h1>
 
 <ul>
 <%= for {k, _} <- schema.attrs do %>


### PR DESCRIPTION
I noticed that all the generated HTML contained nonconsecutive heading level which is a problem for accessibility (screen readers needs a proper document outline to understand the content of the page). As a bonus, it provides better SEO as well.

By changing the levels they are now living up to the WCAG standards.

This means that the headings now look a bit different since the styling used for the headings are a bit different. In my opinion, this makes it more readable.  I've added screen shots for you to see.
<img width="902" alt="screen shot 2018-07-16 at 19 00 23" src="https://user-images.githubusercontent.com/1408595/42772692-8096c494-892b-11e8-9db7-51317926d8cc.png">
<img width="819" alt="screen shot 2018-07-16 at 19 02 02" src="https://user-images.githubusercontent.com/1408595/42772694-80b6c6a4-892b-11e8-9779-d09de8bd6758.png">
<img width="841" alt="screen shot 2018-07-16 at 19 02 20" src="https://user-images.githubusercontent.com/1408595/42772696-80d8545e-892b-11e8-8f7e-44a8a55a361a.png">
<img width="829" alt="screen shot 2018-07-16 at 19 02 28" src="https://user-images.githubusercontent.com/1408595/42772697-80f65896-892b-11e8-86ea-3897d685909c.png">



