### PR TITLE
Fix context alias generation

### DIFF
--- a/lib/mix/phoenix/context.ex
+++ b/lib/mix/phoenix/context.ex
@@ -25,7 +25,7 @@ defmodule Mix.Phoenix.Context do
     ctx_app   = opts[:context_app] || Mix.Phoenix.context_app()
     base      = Module.concat([Mix.Phoenix.context_base(ctx_app)])
     module    = Module.concat(base, context_name)
-    alias     = module |> Module.split() |> tl() |> Module.concat()
+    alias     = Module.concat([module |> Module.split() |> List.last()])
     basedir   = Phoenix.Naming.underscore(context_name)
     basename  = Path.basename(basedir)
     dir       = Mix.Phoenix.context_lib_path(ctx_app, basedir)

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       context = Context.new("Site.Blog", schema, [])
 
       assert %Context{
-        alias: Site.Blog,
+        alias: Blog,
         base_module: Phoenix,
         basename: "blog",
         module: Phoenix.Site.Blog,


### PR DESCRIPTION
If the app name was `Prefixed.App`, the generated tests had
```
alias Prefixed.App.Accounts
```
but then called
```
App.Accounts.create_user
```
The same would happen for contexts with names like ```Management.Accounts```.

This fixes that.