### PR TITLE
Don't rely on Ecto.Changeset when `--no-schema` is passed.

### DIFF
--- a/priv/templates/phx.gen.json/fallback_controller.ex
+++ b/priv/templates/phx.gen.json/fallback_controller.ex
@@ -6,14 +6,14 @@ defmodule <%= inspect context.web_module %>.FallbackController do
   """
   use <%= inspect context.web_module %>, :controller
 
-  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+  <%= if schema.generate? do %>def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)
     |> put_view(<%= inspect context.web_module %>.ChangesetView)
     |> render("error.json", changeset: changeset)
   end
 
-  def call(conn, {:error, :not_found}) do
+  <% end %>def call(conn, {:error, :not_found}) do
     conn
     |> put_status(:not_found)
     |> put_view(<%= inspect context.web_module %>.ErrorView)


### PR DESCRIPTION
To fix #2968.

Since FallbackController is usually not edited for a while after being generated, we shouldn't write an automatic compiler error into it.