### PR TITLE
Use “static_url” helper instead of “static_path” in templates

### DIFF
--- a/guides/channels.md
+++ b/guides/channels.md
@@ -401,7 +401,7 @@ Next we need to pass this token to JavaScript. We can do so inside a script tag 
 
 ```html
 <script>window.userToken = "<%= assigns[:user_token] %>";</script>
-<script src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+<script src="<%= Routes.static_url(@conn, "/js/app.js") %>"></script>
 ```
 
 **Step 3 - Pass the Token to the Socket Constructor and Verify**

--- a/installer/templates/phx_web/templates/layout/app.html.eex
+++ b/installer/templates/phx_web/templates/layout/app.html.eex
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, shrink-to-fit=no, user-scalable=no"/>
     <title><%= app_module %> · Phoenix Framework</title>
-    <link rel="stylesheet" href="<%%= Routes.static_path(@conn, "/css/app.css") %>"/>
+    <link rel="stylesheet" href="<%%= Routes.static_url(@conn, "/css/app.css") %>"/>
   </head>
   <body>
     <header>
@@ -16,7 +16,7 @@
           </ul>
         </nav>
         <a href="http://phoenixframework.org/" class="phx-logo">
-          <img src="<%%= Routes.static_path(@conn, "/images/phoenix.png") %>" alt="Phoenix Framework Logo"/>
+          <img src="<%%= Routes.static_url(@conn, "/images/phoenix.png") %>" alt="Phoenix Framework Logo"/>
         </a>
       </section>
     </header>
@@ -25,6 +25,6 @@
       <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
       <%%= render @view_module, @view_template, assigns %>
     </main>
-    <script type="text/javascript" src="<%%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+    <script type="text/javascript" src="<%%= Routes.static_url(@conn, "/js/app.js") %>"></script>
   </body>
 </html>


### PR DESCRIPTION
I don’t think there is a valid reason to use `static_path` instead of `static_url` in default templates 😄 

`Phoenix.Endpoint` exposes (and documents) the `:static_url` runtime configuration but it’s not used by `static_path` when the user configures it.

If the `static_url` helper is used but `:static_url` is not configured, the fallback makes sure assets are still served from the application URL (eg. `localhost`).