### PR TITLE
give a warning when a plug is forwarded more than once

### DIFF
--- a/lib/phoenix/router/route.ex
+++ b/lib/phoenix/router/route.ex
@@ -4,6 +4,7 @@ defmodule Phoenix.Router.Route do
   # as it contains internal routing information.
   @moduledoc false
 
+  require Logger
   alias Phoenix.Router.Route
 
   @doc """
@@ -160,7 +161,9 @@ defmodule Phoenix.Router.Route do
     case Plug.Router.Utils.build_path_match(path) do
       {[], path_segments} ->
         if phoenix_forwards[plug] do
-          raise ArgumentError, "`#{inspect plug}` has already been forwarded to. A module can only be forwarded a single time."
+          Logger.warn(
+            "`#{inspect(plug)}` has already been forwarded to. Normally a module can only be forwarded a single time. Please make sure you intended to do so."
+          )
         end
         path_segments
       _ ->

--- a/test/phoenix/router/forward_test.exs
+++ b/test/phoenix/router/forward_test.exs
@@ -6,6 +6,7 @@ end
 defmodule Phoenix.Router.ForwardTest do
   use ExUnit.Case, async: true
   use RouterHelper
+  import ExUnit.CaptureLog
 
   defmodule Controller do
     use Phoenix.Controller
@@ -99,9 +100,8 @@ defmodule Phoenix.Router.ForwardTest do
       end
     end
 
-    assert_raise ArgumentError, ~r{`Phoenix.Router.ForwardTest.ApiRouter` has already been forwarded}, fn ->
-      Code.eval_quoted(router)
-    end
+    log = capture_log([level: :warn], fn -> Code.eval_quoted(router) end)
+    assert log =~ "`Phoenix.Router.ForwardTest.ApiRouter` has already been forwarded"
   end
 
   test "accumulates phoenix_forwards" do


### PR DESCRIPTION
For some plugs, like Absinthe, it uses init opts to take data so that the plug can behave differently (e.g. for different graphql schema). Thus below cases are valid by using plug, but cannot compile by using phoenix since it complains plug has already been forwarded to.

Use case:

```
  scope "/api" do
    pipe_through(:graphql)

    forward("/btc", Absinthe.Plug, schema: Bitcoin)
    forward("/eth", Absinthe.Plug, schema: Ethereum)
  end
```