### PR TITLE
Downcase error starts

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -494,8 +494,8 @@ defmodule Phoenix.Channel do
 
   defp assert_joined!(%Socket{joined: false}) do
     raise """
-    `push`, `reply`, and `broadcast` can only be called after the socket has finished joining.
-    To push a message on join, send to self and handle in handle_info/2, ie:
+    push/3, reply/2, and broadcast/3 can only be called after the socket has finished joining.
+    To push a message on join, send to self and handle in handle_info/2. For example:
 
         def join(topic, auth_msg, socket) do
           ...

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -195,7 +195,6 @@ defmodule Phoenix.Channel do
       restarts in transient mode, and linked processes exit with the same reason
       unless they're trapping exits
 
-
   ## Subscribing to external topics
 
   Sometimes you may need to programmatically subscribe a socket to external
@@ -485,7 +484,7 @@ defmodule Phoenix.Channel do
   end
   def socket_ref(_socket) do
     raise ArgumentError, """
-    Socket refs can only be generated for a socket that has joined with a push ref
+    socket refs can only be generated for a socket that has joined with a push ref
     """
   end
 
@@ -508,6 +507,7 @@ defmodule Phoenix.Channel do
           push(socket, "feed", %{list: feed_items(socket)})
           {:noreply, socket}
         end
+
     """
   end
 end

--- a/lib/phoenix/template/eex_engine.ex
+++ b/lib/phoenix/template/eex_engine.ex
@@ -13,7 +13,7 @@ defmodule Phoenix.Template.EExEngine do
     case Phoenix.Template.format_encoder(name) do
       Phoenix.Template.HTML ->
         unless Code.ensure_loaded?(Phoenix.HTML.Engine) do
-          raise "Could not load Phoenix.HTML.Engine to use with .html.eex templates. " <>
+          raise "could not load Phoenix.HTML.Engine to use with .html.eex templates. " <>
                 "You can configure your own format encoder for HTML but we recommend " <>
                 "adding phoenix_html as a dependency as it provides XSS protection."
         end


### PR DESCRIPTION
Looking at other errors in the codebase, it seems errors should not start with capital letters.

In addition, I think error messages should not contain backticks.

As a side note, I changed three error messages and all the tests are still green 😅 Probably there is nothing wrong with the test suite, but I found it "suspicious".