### PR TITLE
Update  error messages of Phoenix.Channel.Server

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -399,7 +399,7 @@ defmodule Phoenix.Channel.Server do
 
   defp handle_result(result, :handle_in) do
     raise """
-    Expected `handle_in/3` to return one of:
+    Expected handle_in/3 to return one of:
 
         {:noreply, Socket.t} |
         {:noreply, Socket.t, timeout | :hibernate} |
@@ -415,7 +415,7 @@ defmodule Phoenix.Channel.Server do
 
   defp handle_result(result, callback) do
     raise """
-    Expected `#{callback}` to return one of:
+    Expected #{callback} to return one of:
 
         {:noreply, Socket.t} |
         {:noreply, Socket.t, timeout | :hibernate} |
@@ -459,7 +459,7 @@ defmodule Phoenix.Channel.Server do
 
   defp handle_reply(_socket, reply) do
     raise """
-    Channel replies from `handle_in/3` are expected to be one of:
+    Channel replies from handle_in/3 are expected to be one of:
 
         status :: atom
         {status :: atom, response :: map}

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -230,6 +230,7 @@ defmodule Phoenix.Channel.Server do
       topic: #{inspect topic}
       event: #{inspect event}
       payload: #{inspect payload}
+
     """
   end
 


### PR DESCRIPTION
I also wanted to comment about the error messages in the private function `handle_result/2`, could be an option to use the new `FunctionClauseError`s? I'm not that familiar with the project to know if that could be a good idea, nor that breaking change is worth considering :)