### PR TITLE
Enable autocomplete for generated functions in IEx

### DIFF
--- a/priv/templates/phx.gen.embedded/embedded_schema.ex
+++ b/priv/templates/phx.gen.embedded/embedded_schema.ex
@@ -7,7 +7,9 @@ defmodule <%= inspect schema.module %> do
 <%= for {k, v} <- schema.types do %>    field <%= inspect k %>, <%= inspect v %><%= schema.defaults[k] %>
 <% end %>  end
 
-  @doc false
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
   def changeset(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
     <%= schema.singular %>
     |> cast(attrs, [<%= Enum.map_join(schema.attrs, ", ", &inspect(elem(&1, 0))) %>])

--- a/priv/templates/phx.gen.embedded/embedded_schema.ex
+++ b/priv/templates/phx.gen.embedded/embedded_schema.ex
@@ -8,7 +8,7 @@ defmodule <%= inspect schema.module %> do
 <% end %>  end
 
   @doc """
-  Builds a changeset based on the `struct` and `params`.
+  Builds a changeset based on the `<%= schema.singular %>` and `attrs`.
   """
   def changeset(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
     <%= schema.singular %>

--- a/priv/templates/phx.gen.schema/schema.ex
+++ b/priv/templates/phx.gen.schema/schema.ex
@@ -13,7 +13,7 @@ defmodule <%= inspect schema.module %> do
   end
 
   @doc """
-  Builds a changeset based on the `struct` and `params`.
+  Builds a changeset based on the `<%= schema.singular %>` and `attrs`.
   """
   def changeset(<%= schema.singular %>, attrs) do
     <%= schema.singular %>

--- a/priv/templates/phx.gen.schema/schema.ex
+++ b/priv/templates/phx.gen.schema/schema.ex
@@ -12,7 +12,9 @@ defmodule <%= inspect schema.module %> do
     timestamps()
   end
 
-  @doc false
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
   def changeset(<%= schema.singular %>, attrs) do
     <%= schema.singular %>
     |> cast(attrs, [<%= Enum.map_join(schema.attrs, ", ", &inspect(elem(&1, 0))) %>])


### PR DESCRIPTION
When a function has `@doc false`, users won't get autocomplete on those
functions and for new users this could be confusing.

more on that : https://github.com/elixir-lang/elixir/blob/master/lib/elixir/pages/Writing%20Documentation.md#hiding-internal-modules-and-functions