### PR TITLE
Show a better error when trying use plug forward in router

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -776,8 +776,7 @@ defmodule Phoenix.Router do
 
     quote unquote: true, bind_quoted: [path: path, plug: plug] do
       plug = Scope.expand_alias(__MODULE__, plug)
-      path_segments = Route.forward_path_segments(path, plug, @phoenix_forwards)
-      @phoenix_forwards Map.put(@phoenix_forwards, plug, path_segments)
+      Scope.register_forwards(__MODULE__, path, plug)
       unquote(add_route(:forward, :*, path, plug, plug_opts, router_opts))
     end
   end

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -775,8 +775,7 @@ defmodule Phoenix.Router do
     router_opts = Keyword.put(router_opts, :as, nil)
 
     quote unquote: true, bind_quoted: [path: path, plug: plug] do
-      plug = Scope.expand_alias(__MODULE__, plug)
-      Scope.register_forwards(__MODULE__, path, plug)
+      plug = Scope.register_forwards(__MODULE__, path, plug)
       unquote(add_route(:forward, :*, path, plug, plug_opts, router_opts))
     end
   end

--- a/lib/phoenix/router/scope.ex
+++ b/lib/phoenix/router/scope.ex
@@ -119,7 +119,7 @@ defmodule Phoenix.Router.Scope do
   @doc """
   Expands alias within scoped block.
   """
-  def expand_alias(module, alias) when is_atom(alias) do
+  def expand_alias(module, alias) do
     if inside_scope?(module) do
       module
       |> get_stack()
@@ -128,16 +128,17 @@ defmodule Phoenix.Router.Scope do
       alias
     end
   end
-  def expand_alias(_, alias), do: alias
 
   @doc """
   Add a forward to the router.
   """
   def register_forwards(module, path, plug) when is_atom(plug) do
+    plug = expand_alias(module, plug)
     phoenix_forwards = Module.get_attribute(module, :phoenix_forwards)
     path_segments = Route.forward_path_segments(path, plug, phoenix_forwards)
     phoenix_forwards = Map.put(phoenix_forwards, plug, path_segments)
     Module.put_attribute(module, :phoenix_forwards, phoenix_forwards)
+    plug
   end
 
   def register_forwards(_, _, plug) do

--- a/lib/phoenix/router/scope.ex
+++ b/lib/phoenix/router/scope.ex
@@ -117,19 +117,6 @@ defmodule Phoenix.Router.Scope do
   def inside_scope?(module), do: length(get_stack(module)) > 1
 
   @doc """
-  Expands alias within scoped block.
-  """
-  def expand_alias(module, alias) do
-    if inside_scope?(module) do
-      module
-      |> get_stack()
-      |> join_alias(alias)
-    else
-      alias
-    end
-  end
-
-  @doc """
   Add a forward to the router.
   """
   def register_forwards(module, path, plug) when is_atom(plug) do
@@ -143,6 +130,16 @@ defmodule Phoenix.Router.Scope do
 
   def register_forwards(_, _, plug) do
     raise ArgumentError, "forward expects a module as the second argument, #{inspect plug} given"
+  end
+
+  defp expand_alias(module, alias) do
+    if inside_scope?(module) do
+      module
+      |> get_stack()
+      |> join_alias(alias)
+    else
+      alias
+    end
   end
 
   defp join(module, path, alias, as, private, assigns) do

--- a/test/phoenix/router/forward_test.exs
+++ b/test/phoenix/router/forward_test.exs
@@ -142,4 +142,16 @@ defmodule Phoenix.Router.ForwardTest do
     assert conn.resp_body == "health"
     assert conn.private[ApiRouter] == {[], %{Phoenix.Test.HealthController => []}}
   end
+
+  test "forwards raises if using the plug to arguments" do
+    error_message = ~r/expects a module/
+    assert_raise(ArgumentError, error_message, fn ->
+      defmodule BrokenRouter do
+        use Phoenix.Router
+        scope "/" do
+          forward "/health", to: HealthController
+        end
+      end
+    end)
+  end
 end


### PR DESCRIPTION
Previously, passing a non-atom argument to the forward macro:

    forward "/admin", to: AdminController

Would result in the following error message;

    == Compilation error in file web/router.ex ==
    ** (ArgumentError) cannot convert the given list to a string.

    To be converted to a string, a list must contain only:

      * strings
      * integers representing Unicode codepoints
      * or a list containing one of these three elements

    Please check the given list or call inspect/1 to get the list
    representation, got:

    [to: SomePlug, init_opts: [foo: :bar]]

Now the following error message is displayed:

    forward expects a module as the second argument, [to: AdminController]
    given.

This closes #2995