### PR TITLE
Fixes wrong assoc's index name if not specify `id` with the CLI.

### DIFF
--- a/lib/mix/phoenix/schema.ex
+++ b/lib/mix/phoenix/schema.ex
@@ -289,7 +289,12 @@ defmodule Mix.Phoenix.Schema do
 
   defp indexes(table, assocs, uniques) do
     uniques = Enum.map(uniques, fn key -> {key, true} end)
-    assocs = Enum.map(assocs, fn {_, key, _, _} -> {key, false} end)
+    assocs =
+      assocs
+      |> Enum.map(fn {_, key, _, _} ->
+        key = if(String.ends_with?(inspect(key), "_id"), do: key, else: "#{key}_id")
+        {key, false}
+      end)
 
     (uniques ++ assocs)
     |> Enum.uniq_by(fn {key, _} -> key end)


### PR DESCRIPTION
Running with the CLI:

```bash
$ mix phx.gen.html Sales Agent agents token invited_by:references:agents
```

Will generate:

```elixir
defmodule YDL.Repo.Migrations.CreateAgents do
  use Ecto.Migration

  def change do
    create table(:agents, primary_key: false) do
      add(:id, :binary_id, primary_key: true)
      add(:token, :string)
      add(:invited_by_id, references(:agents, on_delete: :nothing, type: :binary_id))

      timestamps()
    end

    create(index(:agents, [:invited_by]))
  end
end
```

Which the index should generate with a `_id` suffix.

```elixir
defmodule YDL.Repo.Migrations.CreateAgents do
  use Ecto.Migration

  def change do
    create table(:agents, primary_key: false) do
      add :id, :binary_id, primary_key: true
      add :token, :string
      add :invited_by_id, references(:agents, on_delete: :nothing, type: :binary_id)

      timestamps()
    end

    create index(:agents, [:invited_by_id])
  end
end
```