### PR TITLE
Fixes the `references` switch should requires an explict fkey name.

### DIFF
--- a/priv/templates/phx.gen.schema/migration.exs
+++ b/priv/templates/phx.gen.schema/migration.exs
@@ -5,7 +5,7 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.
     create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %>) do
 <%= if schema.binary_id do %>      add :id, :binary_id, primary_key: true
 <% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect v %><%= schema.migration_defaults[k] %>
-<% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= if(String.ends_with?(inspect(i), "_id"), do: inspect(i), else: inspect(i) <> "_id") %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)
+<% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= inspect(i) %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)
 <% end %>
       timestamps()
     end


### PR DESCRIPTION
Running with the CLI:

```bash
$ mix phx.gen.html Sales Agent agents invited_by:references:agents
```

Will generate:

```elixir
 add(:invited_by_id, references(:agents, on_delete: :nothing, type: :binary_id))
```

But the expected result should be the following as the discussion here: https://github.com/phoenixframework/phoenix/pull/3044#issuecomment-418120799

```elixir
add :invited_by, references(:agents, on_delete: :nothing, type: :binary_id)
```

