### PR TITLE
Update urls to be links for reader convenience

### DIFF
--- a/guides/presence.md
+++ b/guides/presence.md
@@ -131,7 +131,7 @@ presence.onSync(() => renderOnlineUsers(presence))
 channel.join()
 ```
 
-We can ensure this is working by opening 3 browser tabs. If we navigate to http://localhost:4000/?name=Alice on two browser tabs and http://localhost:4000/?name=Bob then we should see:
+We can ensure this is working by opening 3 browser tabs. If we navigate to [http://localhost:4000/?name=Alice](http://localhost:4000/?name=Alice) on two browser tabs and [http://localhost:4000/?name=Bob](http://localhost:4000/?name=Bob) then we should see:
 
 ```
 Alice (count: 2)


### PR DESCRIPTION
This is an update to make the final urls listed in the tutorial be actual links the reader can click through on.

Assuming that the reader was actually following the tutorial, this adds a tiny bit of convenience.