### PR TITLE
Mark phoenix.js npm package as side effect free

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -23,6 +23,7 @@
     "webpack": "4.0.0",
     "webpack-cli": "^2.0.10"
   },
+  "sideEffects": false,
   "scripts": {
     "test": "mocha ./test/**/*.js --compilers js:babel-register -r jsdom-global/register",
     "docs": "documentation build js/phoenix.js -f html -o ../doc/js",


### PR DESCRIPTION
Rationale:
When importing anything from phoenix.js all the module ends up bundled. Marking the package as side effect free enables build optimizers to do tree shaking and scope hoisting and only the used code lands in bundle.
https://github.com/webpack/webpack/tree/master/examples/side-effects
