### PR TITLE
Fix Dializer error when using Phoenix.Controller.layout/1

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -559,7 +559,7 @@ defmodule Phoenix.Controller do
   @doc """
   Retrieves the current layout.
   """
-  @spec layout(Plug.Conn.t) :: {atom, String.t} | false
+  @spec layout(Plug.Conn.t) :: {atom, String.t | atom} | false
   def layout(conn), do: conn.private |> Map.get(:phoenix_layout, false)
 
   @doc """


### PR DESCRIPTION
Hey Chris,

I noticed a minor issue with the `@spec` in `Phoenix.Controller.layout/1`: It can return a binary *or an atom* as the 2nd element of the tuple. The issue is closely related to #1435.

~~I took the liberty to fix that but formatting the file resulted in a bunch of changes (running `mix format` on `Elixir 1.7.3 (compiled with Erlang/OTP 21)`). I decided to leave them in for now, happy to commit just the one line if that's preferred.~~

Thanks,
Michael

EDIT:

Sorry, just saw this: https://github.com/phoenixframework/phoenix/pull/3033#pullrequestreview-150184980

I have adjusted my PR accordingly.