### PR TITLE
Only use css-loader syntax when generate with Webpack

### DIFF
--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -44,8 +44,8 @@ defmodule Phx.New.Single do
 
   template :webpack, [
     {:eex,  "phx_assets/webpack/webpack.config.js", :project, "assets/webpack.config.js"},
-    {:text,  "phx_assets/webpack/babelrc",          :project, "assets/.babelrc"},
-    {:text, "phx_assets/app.css",                   :project, "assets/css/app.css"},
+    {:text, "phx_assets/webpack/babelrc",           :project, "assets/.babelrc"},
+    {:eex,  "phx_assets/app.css",                   :project, "assets/css/app.css"},
     {:text, "phx_assets/phoenix.css",               :project, "assets/css/phoenix.css"},
     {:eex,  "phx_assets/webpack/app.js",            :project, "assets/js/app.js"},
     {:eex,  "phx_assets/webpack/socket.js",         :project, "assets/js/socket.js"},
@@ -68,7 +68,7 @@ defmodule Phx.New.Single do
   template :bare, []
 
   template :static, [
-    {:text,   "phx_assets/app.css",        :project, "priv/static/css/app.css"},
+    {:eex,    "phx_assets/app.css",        :project, "priv/static/css/app.css"},
     {:append, "phx_assets/phoenix.css",    :project, "priv/static/css/app.css"},
     {:text,   "phx_assets/bare/app.js",    :project, "priv/static/js/app.js"},
     {:text,   "phx_assets/robots.txt",     :project, "priv/static/robots.txt"},

--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -44,8 +44,8 @@ defmodule Phx.New.Single do
 
   template :webpack, [
     {:eex,  "phx_assets/webpack/webpack.config.js", :project, "assets/webpack.config.js"},
-    {:text, "phx_assets/webpack/babelrc",           :project, "assets/.babelrc"},
-    {:eex,  "phx_assets/app.css",                   :project, "assets/css/app.css"},
+    {:text,  "phx_assets/webpack/babelrc",          :project, "assets/.babelrc"},
+    {:text, "phx_assets/app.css",                   :project, "assets/css/app.css"},
     {:text, "phx_assets/phoenix.css",               :project, "assets/css/phoenix.css"},
     {:eex,  "phx_assets/webpack/app.js",            :project, "assets/js/app.js"},
     {:eex,  "phx_assets/webpack/socket.js",         :project, "assets/js/socket.js"},
@@ -68,7 +68,7 @@ defmodule Phx.New.Single do
   template :bare, []
 
   template :static, [
-    {:eex,    "phx_assets/app.css",        :project, "priv/static/css/app.css"},
+    {:text,   "phx_assets/app.css",        :project, "priv/static/css/app.css"},
     {:append, "phx_assets/phoenix.css",    :project, "priv/static/css/app.css"},
     {:text,   "phx_assets/bare/app.js",    :project, "priv/static/js/app.js"},
     {:text,   "phx_assets/robots.txt",     :project, "priv/static/robots.txt"},

--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -68,10 +68,10 @@ defmodule Phx.New.Single do
   template :bare, []
 
   template :static, [
-    {:text,   "phx_assets/app.css",        :project, "priv/static/css/app.css"},
-    {:append, "phx_assets/phoenix.css",    :project, "priv/static/css/app.css"},
-    {:text,   "phx_assets/bare/app.js",    :project, "priv/static/js/app.js"},
-    {:text,   "phx_assets/robots.txt",     :project, "priv/static/robots.txt"},
+    {:text, "phx_assets/app.css",     :project, "priv/static/css/app.css"},
+    {:text, "phx_assets/phoenix.css", :project, "priv/static/css/phoenix.css"},
+    {:text, "phx_assets/bare/app.js", :project, "priv/static/js/app.js"},
+    {:text, "phx_assets/robots.txt",  :project, "priv/static/robots.txt"},
   ]
 
   def prepare_project(%Project{app: app} = project) when not is_nil(app) do

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -40,7 +40,7 @@ defmodule Phx.New.Web do
   template :webpack, [
     {:eex,  "phx_assets/webpack/webpack.config.js", :web, "assets/webpack.config.js"},
     {:text, "phx_assets/webpack/babelrc",           :web, "assets/.babelrc"},
-    {:eex, "phx_assets/app.css",                    :web, "assets/css/app.css"},
+    {:text, "phx_assets/app.css",                   :web, "assets/css/app.css"},
     {:text, "phx_assets/phoenix.css",               :web, "assets/css/phoenix.css"},
     {:eex,  "phx_assets/webpack/app.js",            :web, "assets/js/app.js"},
     {:eex,  "phx_assets/webpack/socket.js",         :web, "assets/js/socket.js"},
@@ -63,7 +63,7 @@ defmodule Phx.New.Web do
   template :bare, []
 
   template :static, [
-    {:eex,   "phx_assets/app.css",         :web, "priv/static/css/app.css"},
+    {:text,   "phx_assets/app.css",        :web, "priv/static/css/app.css"},
     {:append, "phx_assets/phoenix.css",    :web, "priv/static/css/app.css"},
     {:text,   "phx_assets/bare/app.js",    :web, "priv/static/js/app.js"},
     {:text,   "phx_assets/robots.txt",     :web, "priv/static/robots.txt"},

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -40,7 +40,7 @@ defmodule Phx.New.Web do
   template :webpack, [
     {:eex,  "phx_assets/webpack/webpack.config.js", :web, "assets/webpack.config.js"},
     {:text, "phx_assets/webpack/babelrc",           :web, "assets/.babelrc"},
-    {:text, "phx_assets/app.css",                   :web, "assets/css/app.css"},
+    {:eex, "phx_assets/app.css",                    :web, "assets/css/app.css"},
     {:text, "phx_assets/phoenix.css",               :web, "assets/css/phoenix.css"},
     {:eex,  "phx_assets/webpack/app.js",            :web, "assets/js/app.js"},
     {:eex,  "phx_assets/webpack/socket.js",         :web, "assets/js/socket.js"},
@@ -63,7 +63,7 @@ defmodule Phx.New.Web do
   template :bare, []
 
   template :static, [
-    {:text,   "phx_assets/app.css",        :web, "priv/static/css/app.css"},
+    {:eex,   "phx_assets/app.css",         :web, "priv/static/css/app.css"},
     {:append, "phx_assets/phoenix.css",    :web, "priv/static/css/app.css"},
     {:text,   "phx_assets/bare/app.js",    :web, "priv/static/js/app.js"},
     {:text,   "phx_assets/robots.txt",     :web, "priv/static/robots.txt"},

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -63,10 +63,10 @@ defmodule Phx.New.Web do
   template :bare, []
 
   template :static, [
-    {:text,   "phx_assets/app.css",        :web, "priv/static/css/app.css"},
-    {:append, "phx_assets/phoenix.css",    :web, "priv/static/css/app.css"},
-    {:text,   "phx_assets/bare/app.js",    :web, "priv/static/js/app.js"},
-    {:text,   "phx_assets/robots.txt",     :web, "priv/static/robots.txt"},
+    {:text, "phx_assets/app.css",     :web, "priv/static/css/app.css"},
+    {:text, "phx_assets/phoenix.css", :web, "priv/static/css/phoenix.css"},
+    {:text, "phx_assets/bare/app.js", :web, "priv/static/js/app.js"},
+    {:text, "phx_assets/robots.txt",  :web, "priv/static/robots.txt"},
   ]
 
   def prepare_project(%Project{app: app} = project) when not is_nil(app) do

--- a/installer/templates/phx_assets/app.css
+++ b/installer/templates/phx_assets/app.css
@@ -1,3 +1,3 @@
 /* This file is for your main application css. */
 
-@import "./phoenix.css";
+<%= if webpack do %>@import "./phoenix.css";<% end %>

--- a/installer/templates/phx_assets/app.css
+++ b/installer/templates/phx_assets/app.css
@@ -1,3 +1,3 @@
 /* This file is for your main application css. */
 
-<%= if webpack do %>@import "./phoenix.css";<% end %>
+@import "./phoenix.css";

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -92,7 +92,8 @@ defmodule Mix.Tasks.Phx.NewTest do
       end
       assert_file "phx_blog/assets/static/favicon.ico"
       assert_file "phx_blog/assets/static/images/phoenix.png"
-      assert_file "phx_blog/assets/css/app.css"
+      assert_file "phx_blog/assets/css/app.css",
+                  ~s[@import "./phoenix.css"]
       assert_file "phx_blog/assets/js/app.js",
                   ~s[import socket from "./socket"]
       assert_file "phx_blog/assets/js/socket.js",
@@ -217,7 +218,9 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/.gitignore"
       assert_file "phx_blog/.gitignore", ~r/\n$/
-      assert_file "phx_blog/priv/static/css/app.css"
+      assert_file "phx_blog/priv/static/css/app.css",
+                  &refute(&1 =~ ~s[@import "./phoenix.css"])
+
       assert_file "phx_blog/priv/static/favicon.ico"
       assert_file "phx_blog/priv/static/images/phoenix.png"
       assert_file "phx_blog/priv/static/js/phoenix.js"

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -92,8 +92,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       end
       assert_file "phx_blog/assets/static/favicon.ico"
       assert_file "phx_blog/assets/static/images/phoenix.png"
-      assert_file "phx_blog/assets/css/app.css",
-                  ~s[@import "./phoenix.css"]
+      assert_file "phx_blog/assets/css/app.css"
       assert_file "phx_blog/assets/js/app.js",
                   ~s[import socket from "./socket"]
       assert_file "phx_blog/assets/js/socket.js",
@@ -218,9 +217,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/.gitignore"
       assert_file "phx_blog/.gitignore", ~r/\n$/
-      assert_file "phx_blog/priv/static/css/app.css",
-                  &refute(&1 =~ ~s[@import "./phoenix.css"])
-
+      assert_file "phx_blog/priv/static/css/app.css"
       assert_file "phx_blog/priv/static/favicon.ico"
       assert_file "phx_blog/priv/static/images/phoenix.png"
       assert_file "phx_blog/priv/static/js/phoenix.js"

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -93,6 +93,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/assets/static/favicon.ico"
       assert_file "phx_blog/assets/static/images/phoenix.png"
       assert_file "phx_blog/assets/css/app.css"
+      assert_file "phx_blog/assets/css/phoenix.css"
       assert_file "phx_blog/assets/js/app.js",
                   ~s[import socket from "./socket"]
       assert_file "phx_blog/assets/js/socket.js",
@@ -104,6 +105,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       end
 
       refute File.exists? "phx_blog/priv/static/css/app.css"
+      refute File.exists? "phx_blog/priv/static/css/phoenix.css"
       refute File.exists? "phx_blog/priv/static/js/phoenix.js"
       refute File.exists? "phx_blog/priv/static/js/app.js"
 
@@ -160,6 +162,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       # No webpack & No HTML
       refute_file "phx_blog/priv/static/css/app.css"
+      refute_file "phx_blog/priv/static/css/phoenix.css"
       refute_file "phx_blog/priv/static/favicon.ico"
       refute_file "phx_blog/priv/static/images/phoenix.png"
       refute_file "phx_blog/priv/static/js/phoenix.js"
@@ -218,6 +221,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/.gitignore"
       assert_file "phx_blog/.gitignore", ~r/\n$/
       assert_file "phx_blog/priv/static/css/app.css"
+      assert_file "phx_blog/priv/static/css/phoenix.css"
       assert_file "phx_blog/priv/static/favicon.ico"
       assert_file "phx_blog/priv/static/images/phoenix.png"
       assert_file "phx_blog/priv/static/js/phoenix.js"

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -126,6 +126,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file web_path(@app, "assets/static/favicon.ico")
       assert_file web_path(@app, "assets/static/images/phoenix.png")
       assert_file web_path(@app, "assets/css/app.css")
+      assert_file web_path(@app, "assets/css/phoenix.css")
       assert_file web_path(@app, "assets/js/app.js"),
                   ~s[import socket from "./socket"]
       assert_file web_path(@app, "assets/js/socket.js"),
@@ -137,6 +138,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       end
 
       refute File.exists?(web_path(@app, "priv/static/css/app.css"))
+      refute File.exists?(web_path(@app, "priv/static/css/phoenix.css"))
       refute File.exists?(web_path(@app, "priv/static/js/phoenix.js"))
       refute File.exists?(web_path(@app, "priv/static/js/app.js"))
 
@@ -205,6 +207,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       # No webpack & No HTML
       refute_file web_path(@app, "priv/static/css/app.css")
+      refute_file web_path(@app, "priv/static/css/phoenix.css")
       refute_file web_path(@app, "priv/static/favicon.ico")
       refute_file web_path(@app, "priv/static/images/phoenix.png")
       refute_file web_path(@app, "priv/static/js/phoenix.js")
@@ -264,6 +267,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file web_path(@app, ".gitignore")
       assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
       assert_file web_path(@app, "priv/static/css/app.css")
+      assert_file web_path(@app, "priv/static/css/phoenix.css")
       assert_file web_path(@app, "priv/static/favicon.ico")
       assert_file web_path(@app, "priv/static/images/phoenix.png")
       assert_file web_path(@app, "priv/static/js/phoenix.js")
@@ -497,6 +501,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         assert_file "another/assets/static/favicon.ico"
         assert_file "another/assets/static/images/phoenix.png"
         assert_file "another/assets/css/app.css"
+        assert_file "another/assets/css/phoenix.css"
         assert_file "another/assets/js/app.js",
                     ~s[import socket from "./socket"]
         assert_file "another/assets/js/socket.js",
@@ -508,6 +513,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         end
 
         refute File.exists? "another/priv/static/css/app.css"
+        refute File.exists? "another/priv/static/css/phoenix.css"
         refute File.exists? "another/priv/static/js/phoenix.js"
         refute File.exists? "another/priv/static/js/app.js"
 

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -125,8 +125,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       end
       assert_file web_path(@app, "assets/static/favicon.ico")
       assert_file web_path(@app, "assets/static/images/phoenix.png")
-      assert_file web_path(@app, "assets/css/app.css"),
-                  ~s[@import "./phoenix.css"]
+      assert_file web_path(@app, "assets/css/app.css")
       assert_file web_path(@app, "assets/js/app.js"),
                   ~s[import socket from "./socket"]
       assert_file web_path(@app, "assets/js/socket.js"),
@@ -263,9 +262,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       Mix.Tasks.Phx.New.run([@app, "--umbrella", "--no-webpack"])
 
       assert_file web_path(@app, ".gitignore")
-      assert_file web_path(@app, ".gitignore"),  ~r/\n$/
-      assert_file web_path(@app, "priv/static/css/app.css"),
-                  &refute(&1 =~ ~s[@import "./phoenix.css"])
+      assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
+      assert_file web_path(@app, "priv/static/css/app.css")
       assert_file web_path(@app, "priv/static/favicon.ico")
       assert_file web_path(@app, "priv/static/images/phoenix.png")
       assert_file web_path(@app, "priv/static/js/phoenix.js")

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -125,7 +125,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       end
       assert_file web_path(@app, "assets/static/favicon.ico")
       assert_file web_path(@app, "assets/static/images/phoenix.png")
-      assert_file web_path(@app, "assets/css/app.css")
+      assert_file web_path(@app, "assets/css/app.css"),
+                  ~s[@import "./phoenix.css"]
       assert_file web_path(@app, "assets/js/app.js"),
                   ~s[import socket from "./socket"]
       assert_file web_path(@app, "assets/js/socket.js"),
@@ -262,8 +263,9 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       Mix.Tasks.Phx.New.run([@app, "--umbrella", "--no-webpack"])
 
       assert_file web_path(@app, ".gitignore")
-      assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
-      assert_file web_path(@app, "priv/static/css/app.css")
+      assert_file web_path(@app, ".gitignore"),  ~r/\n$/
+      assert_file web_path(@app, "priv/static/css/app.css"),
+                  &refute(&1 =~ ~s[@import "./phoenix.css"])
       assert_file web_path(@app, "priv/static/favicon.ico")
       assert_file web_path(@app, "priv/static/images/phoenix.png")
       assert_file web_path(@app, "priv/static/js/phoenix.js")


### PR DESCRIPTION
This fixes "no route found for GET /css/phoenix.css" from phoenix
installed with --no-webpack option. Use `:append` from the generator
instead of css-loader for static template generation.

This is the improvement of https://github.com/phoenixframework/phoenix/pull/2779 so it could go with version 1.4.