### PR TITLE
Raise if the pubsub server name is not configured at compile time

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -507,7 +507,8 @@ defmodule Phoenix.Endpoint do
       server
     else
       raise ArgumentError, """
-      no :pubsub server configured, please setup :pubsub in your config.
+      no :pubsub server was configured at compile time, please setup :pubsub
+      in your config.
 
       By default this looks like:
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -54,7 +54,7 @@ defmodule Phoenix.Endpoint.Supervisor do
 
     if adapter = pub_conf[:adapter] do
       pub_conf = [fastlane: Phoenix.Channel.Server] ++ pub_conf
-      [supervisor(adapter, [mod.__pubsub_server__(), pub_conf])]
+      [supervisor(adapter, [Phoenix.Endpoint.__pubsub_server__!(mod), pub_conf])]
     else
       []
     end


### PR DESCRIPTION
If the pubsub server is configured at runtime (e.g. in the init callback) then
everything will appear to work as normal, but the pubsub server will have the
name of `Elixir.Supervisor` due to having nil as a name.

This closes #2992