### PR TITLE
Allow runtime configuration of PubSub

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -525,7 +525,11 @@ defmodule Phoenix.Endpoint do
 
   defp pubsub() do
     quote do
-      def __pubsub_server__, do: __MODULE__.config(:pubsub)[:name]
+      def __pubsub_server__ do
+        Phoenix.Config.cache(__MODULE__,
+          :__phoenix_pubsub_server__,
+          &Phoenix.Endpoint.Supervisor.pubsub_server/1)
+      end
 
       # TODO v2: Remove pid version
       @doc false

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -510,8 +510,7 @@ defmodule Phoenix.Endpoint do
       server
     else
       raise ArgumentError, """
-      no :pubsub server was configured at compile time, please setup :pubsub
-      in your config.
+      no :pubsub server configured at, please setup :pubsub in your config.
 
       By default this looks like:
 
@@ -526,13 +525,7 @@ defmodule Phoenix.Endpoint do
 
   defp pubsub() do
     quote do
-      @pubsub_server var!(config)[:pubsub][:name] ||
-        (if var!(config)[:pubsub][:adapter] do
-          raise ArgumentError, "an adapter was given to :pubsub but no :name was defined, " <>
-                               "please pass the :name option accordingly"
-        end)
-
-      def __pubsub_server__, do: @pubsub_server
+      def __pubsub_server__, do: __MODULE__.config(:pubsub)[:name]
 
       # TODO v2: Remove pid version
       @doc false

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -49,12 +49,16 @@ defmodule Phoenix.Endpoint.Supervisor do
     {:ok, {{:one_for_one, 3, 5}, children}}
   end
 
-  defp pubsub_children(mod, conf) do
+  defp pubsub_children(_mod, conf) do
     pub_conf = conf[:pubsub]
 
     if adapter = pub_conf[:adapter] do
+      unless pub_conf[:name] do
+        raise ArgumentError, "an adapter was given to :pubsub but no :name was defined, " <>
+          "please pass the :name option accordingly"
+      end
       pub_conf = [fastlane: Phoenix.Channel.Server] ++ pub_conf
-      [supervisor(adapter, [Phoenix.Endpoint.__pubsub_server__!(mod), pub_conf])]
+      [supervisor(adapter, [pub_conf[:name], pub_conf])]
     else
       []
     end

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -347,6 +347,10 @@ defmodule Phoenix.Endpoint.Supervisor do
   defp port_to_integer(port) when is_binary(port), do: String.to_integer(port)
   defp port_to_integer(port) when is_integer(port), do: port
 
+  def pubsub_server(endpoint) do
+    {:cache, endpoint.config(:pubsub)[:name]}
+  end
+
   @doc """
   Invoked to warm up caches on start and config change.
   """

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -11,8 +11,7 @@ defmodule Phoenix.Endpoint.EndpointTest do
            cache_static_manifest: "../../../../test/fixtures/cache_manifest.json",
            pubsub: [adapter: Phoenix.PubSub.PG2, name: :endpoint_pub]]
   Application.put_env(:phoenix, __MODULE__.Endpoint, @config)
-
-  Application.put_env(:phoenix, __MODULE__.NoPubSubEndpoint, Keyword.delete(@config, :pubsub))
+  Application.put_env(:phoenix, __MODULE__.NoPubSubNameEndpoint, [])
 
   defmodule Endpoint do
     use Phoenix.Endpoint, otp_app: :phoenix
@@ -23,11 +22,11 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert code_reloading? == false
   end
 
-  defmodule NoPubSubEndpoint do
+  defmodule NoPubSubNameEndpoint do
     use Phoenix.Endpoint, otp_app: :phoenix
 
     def init(_, config) do
-      pubsub = [adapter: Phoenix.PubSub.PG2, name: :named_at_runtime_endpoint_pub]
+      pubsub = [adapter: Phoenix.PubSub.PG2]
       {:ok, Keyword.put(config, :pubsub, pubsub)}
     end
   end
@@ -46,10 +45,10 @@ defmodule Phoenix.Endpoint.EndpointTest do
     }
   end
 
-  test "errors if pubsub is not set at runtime and not compile time" do
+  test "errors if pubsub adapter is set but not a name" do
     Process.flag(:trap_exit, true)
-    {:error, {%ArgumentError{message: message}, _}} = NoPubSubEndpoint.start_link()
-    assert message =~ "no :pubsub server was configured at compile time"
+    {:error, {%ArgumentError{message: message}, _}} = NoPubSubNameEndpoint.start_link()
+    assert message =~ "an adapter was given to :pubsub but no :name"
   end
 
   test "has reloadable configuration" do


### PR DESCRIPTION
Previously PubSub was required at compile time. This commit allows configuration
at runtime by looking up the PubSub module for the endpoint from the config
instead of compiling it into the module. The compile time errors have been move
to runtime and will trigger when attempting to start the pubsub children.