### PR TITLE
Fix incorrect assert in websocket channel test

### DIFF
--- a/test/phoenix/integration/websocket_channels_test.exs
+++ b/test/phoenix/integration/websocket_channels_test.exs
@@ -261,7 +261,7 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
               @serializer
             )
         end)
-        assert log =~ ""
+        assert log == ""
       end
 
       test "logs and filter params on join and handle_in" do


### PR DESCRIPTION
Stumbled upon this when reading some code. This `assert` obviously doesn't assert much. 😄 