### PR TITLE
Fix warning about cowboy_websocket behaviour

### DIFF
--- a/lib/phoenix/endpoint/cowboy2_handler.ex
+++ b/lib/phoenix/endpoint/cowboy2_handler.ex
@@ -1,7 +1,8 @@
 defmodule Phoenix.Endpoint.Cowboy2Handler do
   @moduledoc false
 
-  if Code.ensure_loaded?(:cowboy_websocket) do
+  if Code.ensure_loaded?(:cowboy_websocket) and
+    function_exported?(:cowboy_websocket, :behaviour_info, 1) do
     @behaviour :cowboy_websocket
   end
 


### PR DESCRIPTION
When using Cowboy 1.x, the `cowboy_websocket` module is available, but
not a behaviour. This commit ensures that the module defines a
behaviour.

 > warning: module :cowboy_websocket is not a behaviour
 > (in module Phoenix.Endpoint.Cowboy2Handler)
 >   lib/phoenix/endpoint/cowboy2_handler.ex:1