### PR TITLE
Fix fetching the wrong version of cowboy when deps update

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,6 +3,11 @@ Code.require_file("support/router_helper.exs", __DIR__)
 # Starts web server applications
 Application.ensure_all_started(:cowboy)
 
+case {System.get_env("COWBOY_VERSION"), Application.spec(:cowboy, :vsn)} do
+  {"1" <> _, [?2 | _]} -> raise "Invalid cowboy version, please check lockfile"
+  _ -> nil
+end
+
 # Used whenever a router fails. We default to simply
 # rendering a short string.
 defmodule Phoenix.ErrorView do


### PR DESCRIPTION
Previously, if the version of a dependency which depends on cowboy (such
as plug) is updated beyond the version specified in the lock file, it
will also update cowboy. This will cause the tests to run against Cowboy
2 even when COWBOY_VERSION is set to 1.0.

This commit raises on the test helper when the version specified in
COWBOY_VERSION is "1.x" and the version of Cowboy in version 2.