### PR TITLE
Reset pendingHeartbeatRef on connection open

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -838,6 +838,7 @@ export class Socket {
     this.flushSendBuffer()
     this.reconnectTimer.reset()
     if(!this.conn.skipHeartbeat){
+      this.pendingHeartbeatRef = null;
       clearInterval(this.heartbeatTimer)
       this.heartbeatTimer = setInterval(() => this.sendHeartbeat(), this.heartbeatIntervalMs)
     }


### PR DESCRIPTION
Fix for Issue #3083 

Reset the reference to pending heartbeat to prevent unnecessary reconnect.

It's possible to reproduce the behaviour (see #3083 for details) with two separate machines or a docker container as the server.