### PR TITLE
Fix typespec for ConnTest.bypass_through/3

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -550,7 +550,7 @@ defmodule Phoenix.ConnTest do
 
   See `bypass_through/1`.
   """
-  @spec bypass_through(Conn.t, module, :atom | list) :: Conn.t
+  @spec bypass_through(Conn.t, module, atom | list) :: Conn.t
   def bypass_through(conn, router, pipelines \\ []) do
     Plug.Conn.put_private(conn, :phoenix_bypass, {router, List.wrap(pipelines)})
   end


### PR DESCRIPTION
Fix typespec for `Phoenix.ConnTest.bypass_through/3`

The literal `:atom` should be `atom` :)