### PR TITLE
 Block phx.gen.cert task at umbrella level 

### DIFF
--- a/lib/mix/tasks/phx.gen.cert.ex
+++ b/lib/mix/tasks/phx.gen.cert.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Phx.Gen.Cert do
   @doc false
   def run(all_args) do
     if Mix.Project.umbrella?() do
-      Mix.raise("mix phx.gen.channel can only be run inside an application directory")
+      Mix.raise("mix phx.gen.cert can only be run inside an application directory")
     end
 
     {opts, args} =

--- a/lib/mix/tasks/phx.gen.cert.ex
+++ b/lib/mix/tasks/phx.gen.cert.ex
@@ -116,7 +116,7 @@ defmodule Mix.Tasks.Phx.Gen.Cert do
     Mix.shell().info("""
 
     If you have not already done so, please update your HTTPS Endpoint
-    configuration in #{Mix.Phoenix.web_path(app)}/config/dev.exs:
+    configuration in config/dev.exs:
 
       config #{inspect(app)}, #{base}Web.Endpoint,
         http: [port: 4000],

--- a/lib/mix/tasks/phx.gen.cert.ex
+++ b/lib/mix/tasks/phx.gen.cert.ex
@@ -48,6 +48,10 @@ defmodule Mix.Tasks.Phx.Gen.Cert do
 
   @doc false
   def run(all_args) do
+    if Mix.Project.umbrella?() do
+      Mix.raise("mix phx.gen.channel can only be run inside an application directory")
+    end
+
     {opts, args} =
       OptionParser.parse!(
         all_args,


### PR DESCRIPTION
Addressing #3085

One remaining issue: the printed instructions assume the Endpoint lives under the `#{base}Web` namespace, which may be typically correct for standalone apps, but not for child apps under an umbrella. I looked at some other Mix tasks, but I didn't see an easy way to determine the correct namespace.