### PR TITLE
Router Update: Allow a map for a path with multiple identifiers

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -215,8 +215,25 @@ defmodule Phoenix.Router.Helpers do
     {bins, vars} = :lists.unzip(exprs.binding)
     segs = expand_segments(exprs.path)
 
-    # We are using @anno to avoid warnings in case a path has already been defined.
-    quote @anno do
+    q1 = if Enum.count(bins) > 0 do
+      match = Enum.into(bins, [], fn(k) -> {String.to_atom(k), Macro.var(:"#{k}", nil)} end)
+      pattern = {:%{}, [], match}
+
+      quote do
+        def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), vars) when is_map(vars) do
+          unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), vars, [])
+        end
+
+        def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote(pattern), params)
+            when is_list(params) or is_map(params) do
+          path(conn_or_endpoint, segments(unquote(segs), params, unquote(bins), {}))
+        end
+      end
+    else
+      quote(do: nil)
+    end
+
+    q2 = quote do
       def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote_splicing(vars)) do
         unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote_splicing(vars), [])
       end
@@ -235,6 +252,11 @@ defmodule Phoenix.Router.Helpers do
           when is_list(params) or is_map(params) do
         url(conn_or_endpoint) <> unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote_splicing(vars), params)
       end
+    end
+
+    # We are using @anno to avoid warnings in case a path has already been defined.
+    quote @anno do
+      unquote_splicing([q1, q2])
     end
   end
 

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -176,6 +176,11 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.top_path(__MODULE__, :top, %{"id" => "foo"}) == "/posts/top?id=foo"
     assert Helpers.top_path(__MODULE__, :top, %{"id" => "foo bar"}) == "/posts/top?id=foo+bar"
 
+    assert Helpers.bottom_path(__MODULE__, :bottom, :asc, 8) == "/posts/bottom/asc/8"
+    assert Helpers.bottom_path(__MODULE__, :bottom, :asc, 8, foo: :bar) == "/posts/bottom/asc/8?foo=bar"
+    assert Helpers.bottom_path(__MODULE__, :bottom, %{order: :asc, count: 8}) == "/posts/bottom/asc/8"
+    assert Helpers.bottom_path(__MODULE__, :bottom, %{order: :asc, count: 8}, foo: :bar) == "/posts/bottom/asc/8?foo=bar"
+
     error_message = fn helper, arity ->
       """
       no function clause for #{inspect Helpers}.#{helper}/#{arity} and action :skip. The following actions/clauses are supported:

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -9,12 +9,24 @@ defmodule Phoenix.Router.HelpersTest do
   test "defhelper with :identifiers" do
     route = build(:match, :get, "/foo/:bar", nil, Hello, :world, "hello_world")
     assert extract_defhelper(route, 0) == String.trim """
+    def(hello_world_path(conn_or_endpoint, :world, vars) when is_map(vars)) do
+      hello_world_path(conn_or_endpoint, :world, vars, [])
+    end
+    """
+
+    assert extract_defhelper(route, 1) == String.trim """
+    def(hello_world_path(conn_or_endpoint, :world, %{bar: bar}, params) when is_list(params) or is_map(params)) do
+      path(conn_or_endpoint, segments(("" <> "/foo") <> "/" <> URI.encode(to_param(bar), &URI.char_unreserved?/1), params, ["bar"], {}))
+    end
+    """
+
+    assert extract_defhelper(route, 2) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar)) do
       hello_world_path(conn_or_endpoint, :world, bar, [])
     end
     """
 
-    assert extract_defhelper(route, 1) == String.trim """
+    assert extract_defhelper(route, 3) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar, params) when is_list(params) or is_map(params)) do
       path(conn_or_endpoint, segments(("" <> "/foo") <> "/" <> URI.encode(to_param(bar), &URI.char_unreserved?/1), params, ["bar"], {"hello_world", :world, ["bar"]}))
     end
@@ -25,12 +37,24 @@ defmodule Phoenix.Router.HelpersTest do
     route = build(:match, :get, "/foo/*bar", nil, Hello, :world, "hello_world")
 
     assert extract_defhelper(route, 0) == String.trim """
+    def(hello_world_path(conn_or_endpoint, :world, vars) when is_map(vars)) do
+      hello_world_path(conn_or_endpoint, :world, vars, [])
+    end
+    """
+
+    assert extract_defhelper(route, 1) == String.trim """
+    def(hello_world_path(conn_or_endpoint, :world, %{bar: bar}, params) when is_list(params) or is_map(params)) do
+      path(conn_or_endpoint, segments(("" <> "/foo") <> "/" <> Enum.map_join(bar, "/", fn s -> URI.encode(s, &URI.char_unreserved?/1) end), params, ["bar"], {}))
+    end
+    """
+
+    assert extract_defhelper(route, 2) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar)) do
       hello_world_path(conn_or_endpoint, :world, bar, [])
     end
     """
 
-    assert extract_defhelper(route, 1) == String.trim """
+    assert extract_defhelper(route, 3) == String.trim """
     def(hello_world_path(conn_or_endpoint, :world, bar, params) when is_list(params) or is_map(params)) do
       path(conn_or_endpoint, segments(("" <> "/foo") <> "/" <> Enum.map_join(bar, "/", fn s -> URI.encode(s, &URI.char_unreserved?/1) end), params, ["bar"], {"hello_world", :world, ["bar"]}))
     end


### PR DESCRIPTION
I created a non-standard route: 
```
get "/month_projection_records/:year/:month/roles/:role_id", MonthRoleProjectionRecordController, :show, as: :month_role_projection_record
```

It's basically a page from a report (that is not stored in a database), so the multiple identifiers act as a composite primary key. `mix phx.routes` said it was defined:

```elixir
month_role_projection_record_path  GET     /month_projection_records/:year/:month/roles/:role_id  MonthRoleProjectionRecordController :show
```

But my initial usage failed:
```
<%= link "Show", to: month_role_projection_record_path(@conn, :show, month_role_projection_record) %>
```

with the exception:
```
(CompileError)  undefined function month_role_projection_record_path/3
```

I thought it might have been related to the Phoenix.Param protocol, but a simple map also failed:
```
<%= link "Show", to: month_role_projection_record_path(@conn, :show, %{year: 1, month: 1, role_id: 1}) %>
```

A colleague pointed out that the defined paths had a different arity, and this worked:
```
<%= link "Show", to: month_role_projection_record_path(@conn, :show, month_role_projection_record.year, month_role_projection_record.month, month_role_projection_record.role_id) %>
```

That seemed counter-intuitive, and I didn't like that I'd have to refer to the route to figure out the argument order.

I modified the router to create a function that pattern matches on a map with all the required identifiers. I wasn't happy with my use of `unquote_splicing`, but my metaprogramming skills are poor. In fact, this was basically a repackaging of a [stack overflow solution](https://stackoverflow.com/questions/48413292/how-to-dynamically-generate-a-phoenix-controller-function-with-a-map-argument) by José Valim. 

I'm happy to add a few more tests, but I wanted to get feedback in case this isn't a worthwhile feature. Thank You