### PR TITLE
Use FunctionClauseError for Phoenix.ActionClauseError

### DIFF
--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -133,8 +133,8 @@ defmodule Phoenix.Controller.Pipeline do
 
   @doc false
   def __catch__(%Plug.Conn{}, :function_clause, controller, action,
-                [{controller, action, [%Plug.Conn{} = conn | _], _loc} | _] = stack) do
-    args = [controller: controller, action: action, params: conn.params]
+      [{controller, action, [%Plug.Conn{} | _] = action_args, _loc} | _] = stack) do
+    args = [module: controller, function: action, arity: length(action_args), args: action_args]
     reraise Phoenix.ActionClauseError, args, stack
   end
   def __catch__(%Plug.Conn{} = conn, reason, _controller, _action, stack) do


### PR DESCRIPTION
Using `FunctionClauseError` results in showing the available clauses
when displaying the error message. This also renders nicely in the plug
exceptions page.

Instead of using `plug_status` in the exception, the `Plug.Exception`
protocol is explicitly defined for the `ActionClauseError` to allow easy
transitioning between `ActionClauseError` and `FunctionClauseError`.`

This closes #2657