### PR TITLE
Escape Plug opts in routes

### DIFF
--- a/lib/phoenix/router/route.ex
+++ b/lib/phoenix/router/route.ex
@@ -121,13 +121,16 @@ defmodule Phoenix.Router.Route do
     {_params, fwd_segments} = build_path_match(route.path)
 
     quote do
-      {Phoenix.Router.Route, {unquote(fwd_segments), unquote(route.plug), unquote(route.opts)}}
+      {
+        Phoenix.Router.Route,
+        {unquote(fwd_segments), unquote(route.plug), unquote(Macro.escape(route.opts))}
+      }
     end
   end
 
   defp build_dispatch(%Route{} = route) do
     quote do
-      {unquote(route.plug), unquote(route.opts)}
+      {unquote(route.plug), unquote(Macro.escape(route.opts))}
     end
   end
 

--- a/test/phoenix/router/route_test.exs
+++ b/test/phoenix/router/route_test.exs
@@ -63,4 +63,15 @@ defmodule Phoenix.Router.RouteTest do
     assert conn.path_info == ["admin", "stats"]
     assert conn.script_name == ["phoenix"]
   end
+
+  test "exprs/1 returns quoted expressions" do
+    opts = %{a: ~r/foo/}
+    escaped_opts = Macro.escape(opts)
+
+    route = build(1, :match, :*, "/foo", nil, __MODULE__, opts, "hello_world", [], %{}, %{})
+    assert {__MODULE__, escaped_opts} == exprs(route).dispatch
+
+    fwd_route = build(1, :forward, :*, "/foo", nil, __MODULE__, opts, "hello_world", [], %{}, %{})
+    assert {_, {:{}, _, [_, __MODULE__, ^escaped_opts]}} = exprs(fwd_route).dispatch
+  end
 end


### PR DESCRIPTION
The Plug options passed when building the route are not escaped while building the `:dispatch` expression in `Phoenix.Router.Route.exprs/1`.

That produces `CompileError`s when building and unquoting the matches in `Phoenix.Router.__before_compile__/1`.

This is the [offending commit](https://github.com/phoenixframework/phoenix/commit/29a1f01e6b0134534cf617efbfc5d54b54c9cd55#diff-4b61711a8ead48b802b5b21df56705a4L99).

This bug affects v1.4.0-rc.1.