### PR TITLE
Add info on the :reloadable_apps option to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The old APIs for building transports are also deprecated. The good news is: adap
   * [Presence] Add `Presence.get_by_key` to fetch presences for specific user
   * [Socket] Add new `phoenix_socket_connect` instrumentation
   * [Logger] Log calls to user socket connect
+  * [CodeReloader] Add `reloadable_apps` endpoint configuration option, to allow recompiling local dependencies
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ The old APIs for building transports are also deprecated. The good news is: adap
   * [Presence] Add `Presence.get_by_key` to fetch presences for specific user
   * [Socket] Add new `phoenix_socket_connect` instrumentation
   * [Logger] Log calls to user socket connect
-  * [CodeReloader] Add `reloadable_apps` endpoint configuration option, to allow recompiling local dependencies
+  * [CodeReloader] Add `:reloadable_apps` endpoint configuration option to allow recompiling local dependencies
 
 ### Bug Fixes
 


### PR DESCRIPTION
This has been merged in quite early in 1.4 development I think but never been released for 1.3, so I propose we add info to first released version of 1.4 changelog entry. The feature itself was discussed here: https://github.com/phoenixframework/phoenix/pull/2887