### PR TITLE
Remove extra newline in generated context test cases

### DIFF
--- a/priv/templates/phx.gen.context/test_cases.exs
+++ b/priv/templates/phx.gen.context/test_cases.exs
@@ -36,9 +36,7 @@
 
     test "update_<%= schema.singular %>/2 with valid data updates the <%= schema.singular %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, @update_attrs)
-
-      <%= for {field, value} <- schema.params.update do %>
+      assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, @update_attrs)<%= for {field, value} <- schema.params.update do %>
       assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>
     end
 


### PR DESCRIPTION
Currently, context tests generated by running the html generator (`mix phx.gen.context Accounts User users name:string`), produce a test with an extra line with some trailing whitespace (illustrated with dots here):

        test "update_user/2 with valid data updates the user" do
          user = user_fixture()
          assert {:ok, %User{} = user} = Accounts.update_user(user, @update_attrs)

    ······
          assert user.name == "some updated name"
        end

This patch removes both newlines from the template, resulting in a generated test like this:

        test "update_user/2 with valid data updates the user" do
          user = user_fixture()
          assert {:ok, %User{} = user} = Accounts.update_user(user, @update_attrs)
          assert user.name == "some updated name"
        end

