### PR TITLE
Allow channels to immediately reconnect when the socket does

### DIFF
--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -605,6 +605,25 @@ describe("onConnOpen", () => {
     assert.ok(spy.calledOnce)
   })
 
+  it("resets all channel timers and schedules a timeout if the timer was in progress", () => {
+    const channel = socket.channel("topic", {})
+    const channel2 = socket.channel("topic2", {})
+
+    channel.rejoinTimer.tries = 1
+    channel2.rejoinTimer.tries = 2
+    channel2.rejoinTimer.scheduleTimeout()
+
+    assert.equal(channel.rejoinTimer.timer, null)
+    assert.notEqual(channel2.rejoinTimer.timer, null)
+
+    socket.onConnOpen()
+
+    assert.equal(channel.rejoinTimer.tries, 0)
+    assert.equal(channel2.rejoinTimer.tries, 0)
+    assert.equal(channel.rejoinTimer.timer, null)
+    assert.notEqual(channel2.rejoinTimer.timer, null)
+  })
+
   it("triggers onOpen callback", () => {
     const spy = sinon.spy()
 


### PR DESCRIPTION
The timer state must be known in order to know if the channel was attempting to rejoin or not. It is
not correct to start a channel rejoin timer if it was not previously running. This involved changing the timer logic up a bit to clear out `this.timer` when it's done processing

Related to #3139 