### PR TITLE
Use `phx-hero` class instead of `jumbotron`

### DIFF
--- a/guides/adding_pages.md
+++ b/guides/adding_pages.md
@@ -189,7 +189,7 @@ Templates are scoped to a view, which are scoped to controller. Phoenix creates 
 Let's do that now. Create `lib/hello_web/templates/hello/index.html.eex` and make it look like this:
 
 ```html
-<div class="jumbotron">
+<div class="phx-hero">
   <h2>Hello World, from Phoenix!</h2>
 </div>
 ```
@@ -262,7 +262,7 @@ To do that, we'll use the special EEx tags for executing Elixir expressions - `<
 And this is what the template should look like:
 
 ```html
-<div class="jumbotron">
+<div class="phx-hero">
   <h2>Hello World, from <%= @messenger %>!</h2>
 </div>
 ```

--- a/guides/templates.md
+++ b/guides/templates.md
@@ -88,7 +88,7 @@ end
 We have a route. We created a new controller action. We have made modifications to the main application view. Now all we need is a new template to display the string we get from `handler_info/1`. Let's create a new one at `lib/hello_web/templates/page/test.html.eex`.
 
 ```html
-<div class="jumbotron">
+<div class="phx-hero">
   <p><%= handler_info(@conn) %></p>
 </div>
 ```
@@ -110,7 +110,7 @@ Now that we have a function, visible to our template, that returns a list of key
 We can add a header and a list comprehension like this.
 
 ```html
-<div class="jumbotron">
+<div class="phx-hero">
   <p><%= handler_info(@conn) %></p>
 
   <h3>Keys for the conn Struct</h3>
@@ -147,7 +147,7 @@ We need to change `key` to `@key` here because this is a new template, not part 
 Now that we have a template, we simply render it within our list comprehension in the `test.html.eex` template.
 
 ```html
-<div class="jumbotron">
+<div class="phx-hero">
   <p><%= handler_info(@conn) %></p>
 
   <h3>Keys for the conn Struct</h3>
@@ -169,7 +169,7 @@ Let's move our template into a shared view.
 `key.html.eex` is currently rendered by the `HelloWeb.PageView` module, but we use a render call which assumes that the current schema is what we want to render with. We could make that explicit, and re-write it like this:
 
 ```html
-<div class="jumbotron">
+<div class="phx-hero">
   ...
 
   <%= for key <- connection_keys(@conn) do %>

--- a/guides/views.md
+++ b/guides/views.md
@@ -73,7 +73,7 @@ When we `use HelloWeb, :view`, we get other conveniences as well. Since `view/0`
 Let's open up the `lib/hello_web/templates/page/index.html.eex` and locate this stanza.
 
 ```html
-<div class="jumbotron">
+<div class="phx-hero">
   <h2><%= gettext("Welcome to %{name}!", name: "Phoenix") %></h2>
   <p class="lead">A productive web framework that<br>does not compromise speed and maintainability.</p>
 </div>
@@ -82,7 +82,7 @@ Let's open up the `lib/hello_web/templates/page/index.html.eex` and locate this 
 Then let's add a line with a link back to the same page. (The objective is to see how path helpers respond in a template, not to add any functionality.)
 
 ```html
-<div class="jumbotron">
+<div class="phx-hero">
   <h2><%= gettext("Welcome to %{name}!", name: "Phoenix") %></h2>
   <p class="lead">A productive web framework that<br>does not compromise speed and maintainability.</p>
   <p><a href="<%= Routes.page_path(@conn, :index) %>">Link back to this page</a></p>
@@ -250,7 +250,7 @@ Great, so we have a `render/2` function that takes a template and an `assigns` m
         <span class="logo"></span>
       </div>
 
-      <div class="jumbotron">
+      <div class="phx-hero">
         <p>Sorry, the page you are looking for does not exist.</p>
       </div>
 


### PR DESCRIPTION
Starting at phoenix 1.4, the class `jumbotron` does no longer exist, and `phx-hero` is used instead.