### PR TITLE
fix ecto not loaded view error occur

### DIFF
--- a/priv/templates/phx.gen.json/view.ex
+++ b/priv/templates/phx.gen.json/view.ex
@@ -14,8 +14,4 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     %{id: <%= schema.singular %>.id<%= for {k, _} <- schema.attrs do %>,
       <%= k %>: <%= schema.singular %>.<%= k %><% end %>}
   end
-
-  def render("<%= schema.singular %>.json", _) do
-    %{}
-  end
 end

--- a/priv/templates/phx.gen.json/view.ex
+++ b/priv/templates/phx.gen.json/view.ex
@@ -10,8 +10,12 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     %{data: render_one(<%= schema.singular %>, <%= inspect schema.alias %>View, "<%= schema.singular %>.json")}
   end
 
-  def render("<%= schema.singular %>.json", %{<%= schema.singular %>: <%= schema.singular %>}) do
+  def render("<%= schema.singular %>.json", %{<%= schema.singular %>:  %<%= inspect schema.module %>{} = <%= schema.singular %>}) do
     %{id: <%= schema.singular %>.id<%= for {k, _} <- schema.attrs do %>,
       <%= k %>: <%= schema.singular %>.<%= k %><% end %>}
+  end
+
+  def render("<%= schema.singular %>.json", _) do
+    %{}
   end
 end


### PR DESCRIPTION
when ecto not preload, the view can not render this situation. So use pattern match to identify which modoule(Ecto.NotLoaded or the view modoule) can be rendered.