### PR TITLE
Allow variables to be used when defining socket paths

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -730,9 +730,11 @@ defmodule Phoenix.Endpoint do
 
     dispatches =
       for {path, socket, socket_opts} <- sockets,
-          {path, return} <- socket_paths(module, path, socket, socket_opts) do
+          {path, type, conn_ast, socket, opts} <- socket_paths(module, path, socket, socket_opts) do
         quote do
-          def __handler__(unquote(path), _opts), do: unquote(Macro.escape(return))
+          defp do_handler(unquote(path), conn, _opts) do
+            {unquote(type), unquote(conn_ast), unquote(socket), unquote(Macro.escape(opts))}
+          end
         end
       end
 
@@ -762,11 +764,12 @@ defmodule Phoenix.Endpoint do
       def __sockets__, do: unquote(Macro.escape(sockets))
 
       @doc false
-      def __handler__(path, opts)
-      unquote(dispatches)
-      def __handler__(_, opts), do: {:plug, __MODULE__, opts}
+      def __handler__(%{path_info: path} = conn, opts), do: do_handler(path, conn, opts)
 
       unquote(instrumentation)
+
+      unquote(dispatches)
+      defp do_handler(_path, conn, opts), do: {:plug, conn, __MODULE__, opts}
     end
   end
 
@@ -778,8 +781,8 @@ defmodule Phoenix.Endpoint do
     paths =
       if websocket do
         config = socket_config(websocket, Phoenix.Transports.WebSocket)
-        triplet = {:websocket, socket, config}
-        [{socket_path(path, config), triplet} | paths]
+        {conn_ast, match_path} = socket_path(path, config)
+        [{match_path, :websocket, conn_ast, socket, config} | paths]
       else
         paths
       end
@@ -788,7 +791,8 @@ defmodule Phoenix.Endpoint do
       if longpoll do
         config = socket_config(longpoll, Phoenix.Transports.LongPoll)
         plug_init = {endpoint, socket, config}
-        [{socket_path(path, config), {:plug, Phoenix.Transports.LongPoll, plug_init}} | paths]
+        {conn_ast, match_path} = socket_path(path, config)
+        [{match_path, :plug, conn_ast, Phoenix.Transports.LongPoll, plug_init} | paths]
       else
         paths
       end
@@ -798,7 +802,25 @@ defmodule Phoenix.Endpoint do
 
   defp socket_path(path, config) do
     end_path_fragment = Keyword.fetch!(config, :path)
-    String.split(path <> "/" <> end_path_fragment, "/", trim: true)
+    {vars, path} =
+      String.split(path <> "/" <> end_path_fragment, "/", trim: true)
+      |> Enum.join("/")
+      |> Plug.Router.Utils.build_path_match()
+
+      conn_ast =
+        if vars == [] do
+          quote do
+            conn
+          end
+        else
+          params_map = {:%{}, [], Plug.Router.Utils.build_path_params_match(vars)}
+          quote do
+            params = unquote(params_map)
+            %{conn | path_params: params, params: params}
+          end
+        end
+
+    {conn_ast, path}
   end
 
   defp socket_config(true, module), do: module.default_config()
@@ -836,6 +858,16 @@ defmodule Phoenix.Endpoint do
       socket "/ws/admin", MyApp.AdminUserSocket,
         longpoll: true,
         websocket: [compress: true]
+
+  ## Path params
+
+  It is possible to include variables in the path, these will be
+  available in the `params` that are passed to the socket.
+
+      socket "/ws/:user_id", MyApp.UserSocket,
+        websocket: [path: "/project/:project_id"]
+
+  Note: This feature is not supported with the Cowboy 1 adapter.
 
   ## Shared configuration
 

--- a/lib/phoenix/endpoint/cowboy2_handler.ex
+++ b/lib/phoenix/endpoint/cowboy2_handler.ex
@@ -12,11 +12,10 @@ defmodule Phoenix.Endpoint.Cowboy2Handler do
   # Note we keep the websocket state as [handler | state]
   # to avoid conflicts with {endpoint, opts}.
   def init(req, {endpoint, opts}) do
-    %{path_info: path_info} = conn = @connection.conn(req)
-
+    conn = @connection.conn(req)
     try do
-      case endpoint.__handler__(path_info, opts) do
-        {:websocket, handler, opts} ->
+      case endpoint.__handler__(conn, opts) do
+        {:websocket, conn, handler, opts} ->
           case Phoenix.Transports.WebSocket.connect(conn, endpoint, handler, opts) do
             {:ok, %{adapter: {@connection, req}}, state} ->
               timeout = Keyword.fetch!(opts, :timeout)
@@ -28,7 +27,7 @@ defmodule Phoenix.Endpoint.Cowboy2Handler do
               {:ok, req, {handler, opts}}
           end
 
-        {:plug, handler, opts} ->
+        {:plug, conn, handler, opts} ->
           %{adapter: {@connection, req}} =
             conn
             |> handler.call(opts)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -30,5 +30,6 @@ assert_timeout = String.to_integer(
   System.get_env("ELIXIR_ASSERT_TIMEOUT") || "200"
 )
 
-exclude = if Version.match?(System.version, "~> 1.5"), do: [], else: [phx_new: true]
+exclude = if Version.match?(System.version, "~> 1.5"), do: [], else: [:phx_new]
+exclude = if hd(Application.spec(:plug_cowboy, :vsn)) == ?1, do: [:cowboy2 | exclude], else: exclude
 ExUnit.start(assert_receive_timeout: assert_timeout, exclude: exclude)


### PR DESCRIPTION
This commit allows sockets (websocket/longpoll) to use variables in the path.
For example, a socket can be defined with:

    socket "/ws/:user_id", MyApp.UserSocket,
      websocket: [path: "/project/:project_id"]

The params will be available in the connect map:

    def connect(%{"user_id" => user_id, "project_id" => project_id}), do: ...

The `__handler__/2` function now hands off the a `do_handler` which is
responsible for modifying the passed `conn` to add the `path_params` and
`params`. `__handler__/2` is now called with the entire `conn` instead of just
the `path_info` and expects a `conn` to be available in the returned tuple.

As this is only supported in Cowboy 2, the `test_helper.exs` has been
updated to ignore `:cowboy2` tests when testing with `plug_cowboy` 1.x.