### PR TITLE
Guides hyperlinks fixes

### DIFF
--- a/guides/phoenix_mix_tasks.md
+++ b/guides/phoenix_mix_tasks.md
@@ -30,7 +30,7 @@ mix phx.server         # Starts applications and their servers
 
 We have seen all of these at one point or another in the guides, but having all the information about them in one place seems like a good idea. And here we are.
 
-#### `mix phx.new`
+### [`mix phx.new`](Mix.Tasks.Phx.New.html)
 
 This is how we tell Phoenix the framework to generate a new Phoenix application for us. We saw it early on in the [Up and Running Guide](up_and_running.html).
 
@@ -187,7 +187,7 @@ defmodule Hello.MixProject do
 . . .
 ```
 
-#### [mix phx.gen.html](`Mix.Tasks.Phx.Gen.Html.run/1`)
+### [`mix phx.gen.html`](Mix.Tasks.Phx.Gen.Html.html)
 
 Phoenix now offers the ability to generate all the code to stand up a complete HTML resource - ecto migration, ecto context, controller with all the necessary actions, view, and templates. This can be a tremendous timesaver. Let's take a look at how to make this happen.
 
@@ -301,7 +301,7 @@ warning: function HelloWeb.Router.Helpers.post_path/3 is undefined or private
   lib/hello_web/templates/post/edit.html.eex:3
 ```
 
-#### [mix phx.gen.json](`Mix.Tasks.Phx.Gen.Json.run/1`)
+### [`mix phx.gen.json`](Mix.Tasks.Phx.Gen.Json.html)
 
 Phoenix also offers the ability to generate all the code to stand up a complete JSON resource - ecto migration, ecto schema, controller with all the necessary actions and view. This command will not create any template for the app.
 
@@ -415,7 +415,7 @@ Compiling 18 files (.ex)
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
 ```
 
-#### [mix phx.gen.context](`Mix.Tasks.Phx.Gen.Context.run/1`)
+### [`mix phx.gen.context`](Mix.Tasks.Phx.Gen.Context.html)
 
 If we don't need a complete HTML/JSON resource and instead are only interested in a context, we can use the `phx.gen.context` task. It will generate a context, a schema, a migration and a test case.
 
@@ -442,7 +442,7 @@ $ mix phx.gen.context Accounts User users name:string age:integer
 * injecting test/hello/admin/accounts/accounts_test.exs
 ```
 
-#### [mix phx.gen.schema](`Mix.Tasks.Phx.Gen.Schema.run/1`)
+### [`mix phx.gen.schema`](Mix.Tasks.Phx.Gen.Schema.html)
 
 If we don't need a complete HTML/JSON resource and are not interested in generating or altering a context we can use the `phx.gen.schema` task. It will generate a schema, and a migration.
 
@@ -454,7 +454,7 @@ $ mix phx.gen.schema Accounts.Credential credentials email:string:unique user_id
 * creating priv/repo/migrations/20170906162013_create_credentials.exs
 ```
 
-#### [mix phx.gen.channel](`Mix.Tasks.Phx.Gen.Channel.run/1`)
+### [`mix phx.gen.channel`](Mix.Tasks.Phx.Gen.Channel.html)
 
 This task will generate a basic Phoenix channel as well a test case for it. It takes the module name for the channel as argument:
 
@@ -472,7 +472,7 @@ Add the channel to your `lib/hello_web/channels/user_socket.ex` handler, for exa
     channel "rooms:lobby", HelloWeb.RoomChannel
 ```
 
-#### [mix phx.gen.presence](`Mix.Tasks.Phx.Gen.Presence.run/1`)
+### [`mix phx.gen.presence`](Mix.Tasks.Phx.Gen.Presence.html)
 
 This task will generate a Presence tracker. The module name can be passed as an argument,
 `Presence` is used if no module name is passed.
@@ -482,7 +482,7 @@ $ mix phx.gen.presence Presence
 $ lib/hello_web/channels/presence.ex
 ```
 
-#### `mix [mix phx.routes](`Mix.Tasks.Phx.Routes.run/1`)
+### [`mix phx.routes`](Mix.Tasks.Phx.Routes.html)
 
 This task has a single purpose, to show us all the routes defined for a given router. We saw it used extensively in the [Routing Guide](routing.html).
 
@@ -499,7 +499,7 @@ $ mix phx.routes TaskTesterWeb.Router
 page_path  GET  /  TaskTesterWeb.PageController.index/2
 ```
 
-#### [mix phx.server](`Mix.Tasks.Phx.Server.run/1`)
+### [`mix phx.server`](Mix.Tasks.Phx.Server.html)
 
 This is the task we use to get our application running. It takes no arguments at all. If we pass any in, they will be silently ignored.
 
@@ -524,7 +524,7 @@ Interactive Elixir (1.0.4) - press Ctrl+C to exit (type h() ENTER for help)
 iex(1)>
 ```
 
-#### [mix phx.digest](`Mix.Tasks.Phx.Digest.run/1`)
+### [`mix phx.digest`](Mix.Tasks.Phx.Digest.html)
 
 This task does two things, it creates a digest for our static assets and then compresses them.
 
@@ -593,7 +593,7 @@ mix ecto.rollback        # Reverts migrations down on a repo
 
 Note: We can run any of the tasks above with the `--no-start` flag to execute the task without starting the application.
 
-#### `ecto.create`
+### `mix ecto.create`
 This task will create the database specified in our repo. By default it will look for the repo named after our application (the one generated with our app unless we opted out of ecto), but we can pass in another repo if we want.
 
 Here's what it looks like in action.
@@ -677,7 +677,7 @@ $ mix ecto.drop -r OurCustom.Repo
 The database for OurCustom.Repo has been dropped.
 ```
 
-#### `ecto.gen.repo`
+### `mix ecto.gen.repo`
 
 Many applications require more than one data store. For each data store, we'll need a new repo, and we can generate them automatically with `ecto.gen.repo`.
 
@@ -724,7 +724,7 @@ children = [
 . . .
 ```
 
-#### `ecto.gen.migration`
+### `mix ecto.gen.migration`
 
 Migrations are a programmatic, repeatable way to affect changes to a database schema. Migrations are also just modules, and we can create them with the `ecto.gen.migration` task. Let's walk through the steps to create a migration for a new comments table.
 
@@ -779,7 +779,7 @@ For example, to alter an existing schema see the documentation on ecto’s
 
 That's it! We're ready to run our migration.
 
-#### `ecto.migrate`
+### `mix ecto.migrate`
 
 Once we have our migration module ready, we can simply run `mix ecto.migrate` to have our changes applied to the database.
 
@@ -837,7 +837,7 @@ The `--to` option will behave the same way.
 mix ecto.migrate --to 20150317170448
 ```
 
-#### `ecto.rollback`
+### `mix ecto.rollback`
 
 The `ecto.rollback` task will reverse the last migration we have run, undoing the schema changes. `ecto.migrate` and `ecto.rollback` are mirror images of each other.
 

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -881,7 +881,7 @@ defmodule HelloWeb.Endpoint do
 end
 ```
 
-By default, Phoenix supports both websockets and longpoll when invoking Phoenix.Endpoint.socket/3 in your endpoint. Here we're specifying that incoming socket connections can be made via a WebSocket connection.
+By default, Phoenix supports both websockets and longpoll when invoking `Phoenix.Endpoint.socket/3` in your endpoint. Here we're specifying that incoming socket connections can be made via a WebSocket connection.
 
 Next, we need to open our `lib/hello_web/channels/user_socket.ex` file and use the `channel/3` macro to define our channel routes. The routes will match a topic pattern to a channel to handle events. If we have a channel module called `RoomChannel` and a topic called `"rooms:*"`, the code to do this is straightforward.
 

--- a/guides/up_and_running.md
+++ b/guides/up_and_running.md
@@ -8,17 +8,15 @@ At this point, we should have Elixir, Erlang, Hex, and the Phoenix archive insta
 
 Ok, we're ready to go!
 
-We can run `mix phx.new` from any directory in order to bootstrap our Phoenix application. Phoenix will accept either an absolute or relative path for the directory of our new project. Assuming that the name of our application is `hello`, let's run the following command:
+We can run [`mix phx.new`](phoenix_mix_tasks.html#mix-phx-new) from any directory in order to bootstrap our Phoenix application. Phoenix will accept either an absolute or relative path for the directory of our new project. Assuming that the name of our application is `hello`, let's run the following command:
 
 ```console
 $ mix phx.new hello
 ```
 
-> A note about [webpack](https://webpack.js.org/) before we begin: Phoenix will use webpack for asset management by default. Webpacks' dependencies are installed via the node package manager, not mix. Phoenix will prompt us to install them at the end of the `mix phx.new` task. If we say "no" at that point, and if we don't install those dependencies later with `npm install`, our application will raise errors when we try to start it, and our assets may not load properly. If we don't want to use webpack at all, we can simply pass `--no-webpack` to `mix phx.new`.
+> A note about [webpack](https://webpack.js.org/) before we begin: Phoenix will use webpack for asset management by default. Webpacks' dependencies are installed via the node package manager, not mix. Phoenix will prompt us to install them at the end of the `phx.new` mix task. If we say "no" at that point, and if we don't install those dependencies later with `npm install`, our application will raise errors when we try to start it, and our assets may not load properly. If we don't want to use webpack at all, we can simply pass `--no-webpack` to `mix phx.new`.
 
-> A note about [Ecto](https://hexdocs.pm/phoenix/ecto.html): Ecto allows our Phoenix application to communicate with a data store, such as PostgreSQL or MongoDB. If our application will not require this component we can skip this dependency by passing the `--no-ecto` flag to the `mix phx.new`. This flag may also be combined with `--no-webpack` to create a skeleton application.
-
-> Note to learn more about `mix phx.new` read [Phoenix Mix Tasks](phoenix_mix_tasks.html).
+> A note about [Ecto](https://hexdocs.pm/phoenix/ecto.html): Ecto allows our Phoenix application to communicate with a data store, such as PostgreSQL or MongoDB. If our application will not require this component we can skip this dependency by passing `--no-ecto` to `mix phx.new`. This flag may also be combined with `--no-webpack` to create a skeleton application.
 
 ```console
 mix phx.new hello
@@ -59,7 +57,7 @@ You can also run your app inside IEx (Interactive Elixir) as:
 
 Once our dependencies are installed, the task will prompt us to change into our project directory and start our application.
 
-Phoenix assumes that our PostgreSQL database will have a `postgres` user account with the correct permissions and a password of "postgres". If that isn't the case, please see the instructions for the [ecto.create](phoenix_mix_tasks.html#ecto-specific-mix-tasks) mix task.
+Phoenix assumes that our PostgreSQL database will have a `postgres` user account with the correct permissions and a password of "postgres". If that isn't the case, please see the instructions for the [`ecto.create`](phoenix_mix_tasks.html#mix-ecto-create) mix task.
 
 Ok, let's give it a try. First, we'll `cd` into the `hello/` directory we've just created:
 
@@ -86,7 +84,7 @@ Webpack is watching the files…
 ...
 ```
 
-If we choose not to have Phoenix install our dependencies when we generate a new application, the `phx.new` task will prompt us to take the necessary steps when we do want to install them.
+If we choose not to have Phoenix install our dependencies when we generate a new application, the `phx.new` mix task will prompt us to take the necessary steps when we do want to install them.
 
 ```console
 Fetch and install dependencies? [Yn] n


### PR DESCRIPTION
Add missing hyperlink to socket/3 in the Routing guide;
Fix links to mix tasks in the Mix Tasks guide;
Add precise links to Mix Tasks guide in the Up and Running guide;