### PR TITLE
Make explicit the status code in case of redirect

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -381,6 +381,9 @@ defmodule Phoenix.Controller do
 
   For security, `:to` only accepts paths. Use the `:external`
   option to redirect to any URL.
+  
+  It will use the status code defined in the conn. If no 
+  status code is set, it sends a 302.
 
   ## Examples
 


### PR DESCRIPTION
As there are multiple code with slightly different redirect behaviour nowadays (302, 303 and 307 at least), this is just making explicit the behaviour of redirect for status code.

I am not sure of the wording. Would be happy to change it if you think it need more work.