### PR TITLE
Clean css class from bootstrap

### DIFF
--- a/installer/templates/phx_web/views/error_helpers.ex
+++ b/installer/templates/phx_web/views/error_helpers.ex
@@ -10,7 +10,7 @@ defmodule <%= web_namespace %>.ErrorHelpers do
   """
   def error_tag(form, field) do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
-      content_tag(:span, translate_error(error), class: "help-block")
+      content_tag(:span, translate_error(error))
     end)
   end
 <% end %>


### PR DESCRIPTION
Now that Phoenix doesn't use bootstrap anymore, I think the `help-block` from bootstrap 3 is no longer needed here.