### PR TITLE
Introduce `put_static_url` for more dynamic static url generation

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -837,8 +837,9 @@ defmodule Phoenix.Controller do
   @doc """
   Puts the URL or `%URI{}` to be used for the static url generation.
 
-  This function overrides the default URL generation pulled
-  from the `%Plug.Conn{}`'s endpoint configuration.
+  Using this function on a `%Plug.Conn{}` struct tells `static_url/2` to use
+  the given information for URL generation instead of the the `%Plug.Conn{}`'s
+  endpoint configuration (much like `put_router_url/2` but for static URLs).
   """
   def put_static_url(conn, %URI{} = uri) do
     put_private(conn, :phoenix_static_url, uri)

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -835,6 +835,19 @@ defmodule Phoenix.Controller do
   end
 
   @doc """
+  Puts the URL or `%URI{}` to be used for the static url generation.
+
+  This function overrides the default URL generation pulled
+  from the `%Plug.Conn{}`'s endpoint configuration.
+  """
+  def put_static_url(conn, %URI{} = uri) do
+    put_private(conn, :phoenix_static_url, uri)
+  end
+  def put_static_url(conn, url) when is_binary(url) do
+    put_private(conn, :phoenix_static_url, url)
+  end
+
+  @doc """
   Puts the format in the connection.
 
   See `get_format/1` for retrieval.

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -157,12 +157,14 @@ defmodule Phoenix.Router.Helpers do
       """
       def static_url(%Conn{private: private} = conn, path) do
         case private do
-          %{phoenix_static_url: %URI{} = uri} ->
-            %URI{uri | path: static_path(conn, path)}
-            |> URI.to_string()
+          %{phoenix_static_url: %URI{path: nil} = uri} ->
+            URI.to_string(%URI{uri | path: path})
+
+          %{phoenix_static_url: %URI{path: static_path} = uri} ->
+            URI.to_string(%URI{uri | path: static_path <> path})
 
           %{phoenix_static_url: url} when is_binary(url) ->
-            url <> static_path(conn, path)
+            url <> path
 
           %{phoenix_endpoint: endpoint} ->
             static_url(endpoint, path)

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -158,10 +158,10 @@ defmodule Phoenix.Router.Helpers do
       def static_url(%Conn{private: private} = conn, path) do
         case private do
           %{phoenix_static_url: %URI{path: nil} = uri} ->
-            URI.to_string(%URI{uri | path: path})
+            URI.to_string(%URI{uri | path: static_path(conn, path)})
 
-          %{phoenix_static_url: %URI{path: static_path} = uri} ->
-            URI.to_string(%URI{uri | path: static_path <> path})
+          %{phoenix_static_url: %URI{path: static_prefix} = uri} ->
+            URI.to_string(%URI{uri | path: static_prefix <> static_path(conn, path)})
 
           %{phoenix_static_url: url} when is_binary(url) ->
             url <> path

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -156,7 +156,17 @@ defmodule Phoenix.Router.Helpers do
       Generates url to a static asset given its file path.
       """
       def static_url(%Conn{private: private} = conn, path) do
-        static_url(private.phoenix_endpoint, path)
+        case private do
+          %{phoenix_static_url: %URI{} = uri} ->
+            %URI{uri | path: static_path(conn, path)}
+            |> URI.to_string()
+
+          %{phoenix_static_url: url} when is_binary(url) ->
+            url <> static_path(conn, path)
+
+          %{phoenix_endpoint: endpoint} ->
+            static_url(endpoint, path)
+        end
       end
 
       def static_url(%Socket{endpoint: endpoint} = conn, path) do

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -478,7 +478,7 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.static_url(conn, "/images/foo.png") == "https://phoenixframework.org:123/images/foo.png"
   end
 
-  test "phoenix_static_url with URI re-uses the included path information" do
+  test "phoenix_static_url set to URI with path results in static url with that path" do
     uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123, path: "/path"}
     conn = Phoenix.Controller.put_static_url(conn_with_endpoint(), uri)
 

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -471,6 +471,13 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.static_url(conn, "/images/foo.png") == url <> "/images/foo.png"
   end
 
+  test "phoenix_static_url set to string with path results in static url with that path" do
+    url = "https://phoenixframework.org/path"
+    conn = Phoenix.Controller.put_static_url(conn_with_endpoint(), url)
+
+    assert Helpers.static_url(conn, "/images/foo.png") == url <> "/images/foo.png"
+  end
+
   test "phoenix_static_url with URI takes precedence over endpoint" do
     uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123}
     conn = Phoenix.Controller.put_static_url(conn_with_endpoint(), uri)

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -472,10 +472,17 @@ defmodule Phoenix.Router.HelpersTest do
   end
 
   test "phoenix_static_url with URI takes precedence over endpoint" do
-    uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123, path: "/path"}
+    uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123}
     conn = Phoenix.Controller.put_static_url(conn_with_endpoint(), uri)
 
     assert Helpers.static_url(conn, "/images/foo.png") == "https://phoenixframework.org:123/images/foo.png"
+  end
+
+  test "phoenix_static_url with URI re-uses the included path information" do
+    uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123, path: "/path"}
+    conn = Phoenix.Controller.put_static_url(conn_with_endpoint(), uri)
+
+    assert Helpers.static_url(conn, "/images/foo.png") == "https://phoenixframework.org:123/path/images/foo.png"
   end
 
   test "helpers module generates a path helper" do

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -464,6 +464,20 @@ defmodule Phoenix.Router.HelpersTest do
       "https://phoenixframework.org:123/admin/new/messages/1"
   end
 
+  test "phoenix_static_url with string takes precedence over endpoint" do
+    url = "https://phoenixframework.org"
+    conn = Phoenix.Controller.put_static_url(conn_with_endpoint(), url)
+
+    assert Helpers.static_url(conn, "/images/foo.png") == url <> "/images/foo.png"
+  end
+
+  test "phoenix_static_url with URI takes precedence over endpoint" do
+    uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123, path: "/path"}
+    conn = Phoenix.Controller.put_static_url(conn_with_endpoint(), uri)
+
+    assert Helpers.static_url(conn, "/images/foo.png") == "https://phoenixframework.org:123/images/foo.png"
+  end
+
   test "helpers module generates a path helper" do
     assert Helpers.path(__MODULE__, "/") == "/"
     assert Helpers.path(conn_with_endpoint(), "/") == "/"


### PR DESCRIPTION
Similar to the `Phoenix.Controller.put_router_url/1` introduced in 1.4, this PR introduces a `Phoenix.Controller.put_static_url/1` function that allows to set the information used to generate the static url within the route helpers more dynamically.

My use-case for this is to enable one phoenix installation to serve multiple domains from one endpoint while having a way to set the correct url to use for static file serving seperately for all of them in cases when I have to use absolute urls. Basically what `put_router_url/1` does but then for static urls.