### PR TITLE
Fix code block format

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -54,12 +54,12 @@ defmodule Phoenix.ConnTest do
   For such cases, you need to set the `@endpoint` attribute to your controller
   and pass an atom representing the action to dispatch:
 
-    @endpoint MyAppWeb.HomeController
+      @endpoint MyAppWeb.HomeController
     
-    test "says welcome on the home page" do
-      conn = get(build_conn(), :index)
-      assert conn.resp_body =~ "Welcome!"
-    end
+      test "says welcome on the home page" do
+        conn = get(build_conn(), :index)
+        assert conn.resp_body =~ "Welcome!"
+      end
 
   Keep in mind that, once the `@endpoint` variable is set, all tests after
   setting it will be affected.


### PR DESCRIPTION
There's a formatting problem https://hexdocs.pm/phoenix/1.4.0/Phoenix.ConnTest.html#module-controller-testing

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/1091472/48991717-289f6a00-f16f-11e8-8c01-e40fc4b140bc.png">