### PR TITLE
Switch from uglifyjs-webpack-plugin to terser-webpack-plugin

### DIFF
--- a/installer/templates/phx_assets/webpack/package.json
+++ b/installer/templates/phx_assets/webpack/package.json
@@ -17,7 +17,7 @@
     "css-loader": "^0.28.10",
     "mini-css-extract-plugin": "^0.4.0",
     "optimize-css-assets-webpack-plugin": "^4.0.0",
-		"terser-webpack-plugin": "^1.1.0",
+    "terser-webpack-plugin": "^1.1.0",
     "webpack": "4.4.0",
     "webpack-cli": "^2.0.10"
   }

--- a/installer/templates/phx_assets/webpack/package.json
+++ b/installer/templates/phx_assets/webpack/package.json
@@ -17,7 +17,7 @@
     "css-loader": "^0.28.10",
     "mini-css-extract-plugin": "^0.4.0",
     "optimize-css-assets-webpack-plugin": "^4.0.0",
-    "uglifyjs-webpack-plugin": "^1.2.4",
+		"terser-webpack-plugin": "^1.1.0",
     "webpack": "4.4.0",
     "webpack-cli": "^2.0.10"
   }

--- a/installer/templates/phx_assets/webpack/webpack.config.js
+++ b/installer/templates/phx_assets/webpack/webpack.config.js
@@ -1,14 +1,14 @@
 const path = require('path');
 const glob = require('glob');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = (env, options) => ({
   optimization: {
     minimizer: [
-      new UglifyJsPlugin({ cache: true, parallel: true, sourceMap: false }),
+			new TerserPlugin({ cache: true, parallel: true, sourceMap: false }),
       new OptimizeCSSAssetsPlugin({})
     ]
   },

--- a/installer/templates/phx_assets/webpack/webpack.config.js
+++ b/installer/templates/phx_assets/webpack/webpack.config.js
@@ -8,7 +8,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 module.exports = (env, options) => ({
   optimization: {
     minimizer: [
-			new TerserPlugin({ cache: true, parallel: true, sourceMap: false }),
+      new TerserPlugin({ cache: true, parallel: true, sourceMap: false }),
       new OptimizeCSSAssetsPlugin({})
     ]
   },


### PR DESCRIPTION
* uglifyjs-webpack-plugin  uses uglify-es, which is [no longer maintained](https://github.com/mishoo/UglifyJS2/issues/3156#issuecomment-392943058).

> uglify-es has been forked and the new project is called terser. For projects that need ES6 support, use it instead of uglify-es, since all new development will be happening over there (and things like webpack are switching over to it shortly too):
> https://github.com/fabiosantoscode/terser

* uglify-js does not have support for ES6, and the existing ES6 support (uglify-es) has been deprecated
* [Webpack 5 will use Terser as well as default minimizer](https://github.com/webpack/webpack/issues/7923).
* seems Webpack 4 switched to terser as well because they consider this a non-breaking change
[webpack/webpack#8350 (comment)](https://github.com/webpack/webpack/issues/8350#issuecomment-437076507)