### PR TITLE
Added 3rd party elixir client library to guide

### DIFF
--- a/guides/channels.md
+++ b/guides/channels.md
@@ -179,6 +179,8 @@ Phoenix ships with a JavaScript client that is available when generating a new P
 + C#
   - [PhoenixSharp](https://github.com/Mazyod/PhoenixSharp)
   - [dn-phoenix](https://github.com/jfis/dn-phoenix)
++ Elixir
+  - [phoenix_gen_socket_client](https://github.com/Aircloak/phoenix_gen_socket_client)
 
 ## Tying it all together
 Let's tie all these ideas together by building a simple chat application. After [generating a new Phoenix application](https://hexdocs.pm/phoenix/up_and_running.html) we'll see that the endpoint is already set up for us in `lib/hello_web/endpoint.ex`:


### PR DESCRIPTION
* Added link to Phoenix.Channels.GenSocketClient, a stable Elixir client library for Channels
* This is especially useful for anyone that desires to use Channels from a Nerves project
* hat tip to @sasa1977