### PR TITLE
Removes extra line break on phx.gen.schema template

### DIFF
--- a/priv/templates/phx.gen.schema/schema.ex
+++ b/priv/templates/phx.gen.schema/schema.ex
@@ -1,7 +1,6 @@
 defmodule <%= inspect schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
-
 <%= if schema.binary_id do %>
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id<% end %>

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -270,6 +270,16 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
     end
   end
 
+  test "generates schema without extra line break", config do
+    in_tmp_project config.test, fn ->
+      Gen.Schema.run(~w(Blog.Post posts title))
+
+      assert_file "lib/phoenix/blog/post.ex", fn file ->
+        assert file =~ "import Ecto.Changeset\n\n  schema"
+      end
+    end
+  end
+
   describe "inside umbrella" do
     test "raises with false context_app", config do
       in_tmp_umbrella_project config.test, fn ->


### PR DESCRIPTION
Removes extra line break that makes the formatter update newly generated schema file