### PR TITLE
Document the use of `Phoenix.Tracker` instead of `Phoenix.Presence`

### DIFF
--- a/guides/presence.md
+++ b/guides/presence.md
@@ -4,8 +4,6 @@ Phoenix Presence is a feature which allows you to register process information o
 
 Phoenix Presence is special for a number of reasons. It has no single point of failure, no single source of truth, relies entirely on the standard library with no operational dependencies and self heals. This is all handled with a conflict-free replicated data type (CRDT) protocol.
 
-Presence is designed for situations where topic subscription information should be broadcast to connected channels. It is possible to use `Phoenix.Tracker` directly in other use cases, such as wanting to manually dispatch or skip change events.
-
 To get started with Presence we'll first need to generate a presence module. We can do this with the `mix phx.gen.presence` task:
 
 ```console

--- a/guides/presence.md
+++ b/guides/presence.md
@@ -4,6 +4,8 @@ Phoenix Presence is a feature which allows you to register process information o
 
 Phoenix Presence is special for a number of reasons. It has no single point of failure, no single source of truth, relies entirely on the standard library with no operational dependencies and self heals. This is all handled with a conflict-free replicated data type (CRDT) protocol.
 
+Presence is designed for situations where topic subscription information should be broadcast to connected channels. It is possible to use `Phoenix.Tracker` directly in other use cases, such as wanting to manually dispatch or skip change events.
+
 To get started with Presence we'll first need to generate a presence module. We can do this with the `mix phx.gen.presence` task:
 
 ```console

--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -4,10 +4,12 @@ defmodule Phoenix.Presence do
 
   This behaviour provides presence features such as fetching
   presences for a given topic, as well as handling diffs of
-  join and leave events as they occur in real-time. Using this
-  module defines a supervisor and allows the calling module to
-  implement the `Phoenix.Tracker` behaviour which starts a
-  tracker process to handle presence information.
+  join and leave events as they occur in real-time. It is better
+  to define your own `Phoenix.Tracker` implementation if you do
+  not desire the broadcasting of diff events. Using this module
+  defines a supervisor and allows the calling module to implement
+  the `Phoenix.Tracker` behaviour which starts a tracker process
+  to handle presence information.
 
   ## Example Usage
 

--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -4,12 +4,16 @@ defmodule Phoenix.Presence do
 
   This behaviour provides presence features such as fetching
   presences for a given topic, as well as handling diffs of
-  join and leave events as they occur in real-time. It is better
-  to define your own `Phoenix.Tracker` implementation if you do
-  not desire the broadcasting of diff events. Using this module
-  defines a supervisor and allows the calling module to implement
-  the `Phoenix.Tracker` behaviour which starts a tracker process
-  to handle presence information.
+  join and leave events as they occur in real-time. Using this
+  module defines a supervisor and a module that implements the
+  `Phoenix.Tracker` behaviour that uses `Phoenix.PubSub` to
+  broadcast presence updates.
+
+  In case you want to use only a subset of the functionality
+  provided by `Phoenix.Presence`, such as tracking processes
+  but without broadcasting updates, we recommend you to look
+  at the `Phoenix.Tracker` functionality from the `phoenix_pubsub`
+  project.
 
   ## Example Usage
 

--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -11,7 +11,7 @@ defmodule Phoenix.Presence do
 
   In case you want to use only a subset of the functionality
   provided by `Phoenix.Presence`, such as tracking processes
-  but without broadcasting updates, we recommend you to look
+  but without broadcasting updates, we recommend that you look
   at the `Phoenix.Tracker` functionality from the `phoenix_pubsub`
   project.
 


### PR DESCRIPTION
This PR adds some documentation to clear up some confusion I had. My use case was around using `Phoenix.Presence` but not broadcasting diff events (handle_diff -> no op). Phoenix.Tracker is a better fit than Presence in this situation, but I was not aware of it from the docs.