### PR TITLE
Update Link to phoenix.js in Channels Guide

### DIFF
--- a/guides/channels.md
+++ b/guides/channels.md
@@ -168,7 +168,7 @@ The following libraries exist today, and new ones are always welcome.
 
 #### Official
 
-Phoenix ships with a JavaScript client that is available when generating a new Phoenix project. The documentation for the JavaScript module is available at [https://hexdocs.pm/phoenix/js/](https://hexdocs.pm/phoenix/js/); the code is in [phoenix.js](https://github.com/phoenixframework/phoenix/blob/v1.3/assets/js/phoenix.js).
+Phoenix ships with a JavaScript client that is available when generating a new Phoenix project. The documentation for the JavaScript module is available at [https://hexdocs.pm/phoenix/js/](https://hexdocs.pm/phoenix/js/); the code is in [phoenix.js](https://github.com/phoenixframework/phoenix/blob/v1.4/assets/js/phoenix.js).
 
 #### 3rd Party
 


### PR DESCRIPTION
The `phoenix.js` link [in the Channels Guide](https://hexdocs.pm/phoenix/channels.html#client-libraries) was still pointing to the `v1.3` branch.