### PR TITLE
Fix DataCase.errors_on/1 when using changeset with array field

### DIFF
--- a/installer/templates/phx_ecto/data_case.ex
+++ b/installer/templates/phx_ecto/data_case.ex
@@ -45,9 +45,13 @@ defmodule <%= app_module %>.DataCase do
   """
   def errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
-      Enum.reduce(opts, message, fn {key, value}, acc ->
-        String.replace(acc, "%{#{key}}", to_string(value))
-      end)
+      Enum.reduce(opts, message, &replace_message_embed/2)
     end)
+  end
+
+  defp replace_message_embed({_key, value}, message) when is_tuple(value), do: message
+
+  defp replace_message_embed({key, value}, message) do
+    String.replace(message, "%{#{key}}", to_string(value))
   end
 end

--- a/installer/templates/phx_ecto/data_case.ex
+++ b/installer/templates/phx_ecto/data_case.ex
@@ -45,13 +45,9 @@ defmodule <%= app_module %>.DataCase do
   """
   def errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
-      Enum.reduce(opts, message, &replace_message_embed/2)
+      Regex.replace(~r"%{(\w+)}", message, fn _, key ->
+        Map.get(opts, String.to_atom(key), key) |> to_string()
+      end)
     end)
-  end
-
-  defp replace_message_embed({_key, value}, message) when is_tuple(value), do: message
-
-  defp replace_message_embed({key, value}, message) do
-    String.replace(message, "%{#{key}}", to_string(value))
   end
 end


### PR DESCRIPTION
## Overview
`DataCase.errors_on/1` raises an error when it receives a changeset with an array field which was `cast`-ed with an invalid type.

## Details
When validating the type of an array field fails, `cast/4` it will put an error on the changeset, such as:
```elixir
[my_list_field: {"is invalid", [type: {:array, :string}, validation: :cast]}]
```

While processing this error, `errors_on/1` will try to `to_string/1` the `{:array, :string}` tuple, which produces the error:
```
** (Protocol.UndefinedError) protocol String.Chars not implemented for {:array, :string}. This protocol is implemented for: Atom, BitString, Date, DateTime, Decimal, Float, Integer, List, NaiveDateTime, Postgrex.Copy, Postgrex.Query, Time, URI, Version, Version.Requirement
```

## Solution
`to_string/1` is called on error metadata as part of processing template error messages (eg. error message `"must be equal to %{number}"` and metadata `[number: 19]`). Thus, **the implemented solution is to skip trying to interpolate error message embeds when the value to be embedded is a tuple.**

## Test Case
I didn't write a test for this, as there aren't any tests for installer templates -- nor do I know where I would add them. I tested locally with a setup like:
```elixir
defmodule MyAppWeb.Drzewo do
  use Ecto.Schema
  import Ecto.Changeset

  embedded_schema do
    field :kolory, {:array, :string}
  end

  def changeset(attrs) do
    cast(%Drzewo{}, attrs, [:kolory])
  end
end

defmodule MyAppWeb.DrzewoTest do
  use MyApp.DataCase

  alias MyAppWeb.Drzewo

  test "errors_on raises an error when passed an invalid type for the array field" do
    drzewo_params = %{kolory: 1}

    changeset = Drzewo.changeset(drzewo_params)
    changeset.valid?

    errors_on(changeset)
  end
end
```