### PR TITLE
Update webpack-cli, fix npm install warnings, colorful webpack output in mix phx.server

### DIFF
--- a/installer/templates/phx_assets/webpack/package.json
+++ b/installer/templates/phx_assets/webpack/package.json
@@ -1,5 +1,6 @@
 {
   "repository": {},
+  "description": " ",
   "license": "MIT",
   "scripts": {
     "deploy": "webpack --mode production",

--- a/installer/templates/phx_assets/webpack/package.json
+++ b/installer/templates/phx_assets/webpack/package.json
@@ -19,6 +19,6 @@
     "optimize-css-assets-webpack-plugin": "^4.0.0",
     "terser-webpack-plugin": "^1.1.0",
     "webpack": "4.4.0",
-    "webpack-cli": "^2.0.10"
+    "webpack-cli": "^3.1.2"
   }
 }

--- a/installer/templates/phx_assets/webpack/webpack.config.js
+++ b/installer/templates/phx_assets/webpack/webpack.config.js
@@ -19,6 +19,9 @@ module.exports = (env, options) => ({
     filename: 'app.js',
     path: path.resolve(__dirname, '../priv/static/js')
   },
+  stats: {
+    colors: true
+  },
   module: {
     rules: [
       {

--- a/installer/templates/phx_assets/webpack/webpack.config.js
+++ b/installer/templates/phx_assets/webpack/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = (env, options) => ({
     path: path.resolve(__dirname, '../priv/static/js')
   },
   stats: {
-    colors: true
+    colors: !/^win/i.test(process.platform)
   },
   module: {
     rules: [


### PR DESCRIPTION
I noticed there are a few npm warnings showing up when running `npm install` on a new phoenix project:

```
npm WARN deprecated babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
npm WARN deprecated nomnom@1.8.1: Package no longer supported. Contact support@npmjs.com for more info.
npm WARN assets No description
```

This PR fixes them.