### PR TITLE
Throw errors instead of strings

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -423,7 +423,7 @@ export class Channel {
    */
   join(timeout = this.timeout){
     if(this.joinedOnce){
-      throw(`tried to join multiple times. 'join' can only be called a single time per channel instance`)
+      throw new Error(`tried to join multiple times. 'join' can only be called a single time per channel instance`)
     } else {
       this.joinedOnce = true
       this.rejoin(timeout)
@@ -493,7 +493,7 @@ export class Channel {
    */
   push(event, payload, timeout = this.timeout){
     if(!this.joinedOnce){
-      throw(`tried to push '${event}' to '${this.topic}' before joining. Use channel.join() before pushing events`)
+      throw new Error(`tried to push '${event}' to '${this.topic}' before joining. Use channel.join() before pushing events`)
     }
     let pushEvent = new Push(this, event, function(){ return payload }, timeout)
     if(this.canPush()){
@@ -595,7 +595,7 @@ export class Channel {
    */
   trigger(event, payload, ref, joinRef){
     let handledPayload = this.onMessage(event, payload, ref, joinRef)
-    if(payload && !handledPayload){ throw("channel onMessage callbacks must return the payload, modified or unmodified") }
+    if(payload && !handledPayload){ throw new Error("channel onMessage callbacks must return the payload, modified or unmodified") }
 
     for (let i = 0; i < this.bindings.length; i++) {
       const bind = this.bindings[i]
@@ -1067,7 +1067,7 @@ export class LongPoll {
           this.onerror()
           this.closeAndRetry()
           break
-        default: throw(`unhandled poll status ${status}`)
+        default: throw new Error(`unhandled poll status ${status}`)
       }
     })
   }

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -102,7 +102,7 @@ describe("join", () => {
   it("throws if attempting to join multiple times", () => {
     channel.join()
 
-    assert.throws(() => channel.join(), /tried to join multiple times/)
+    assert.throws(() => channel.join(), /^Error: tried to join multiple times/)
   })
 
   it("triggers socket push with channel params", () => {
@@ -926,7 +926,7 @@ describe("push", () => {
   })
 
   it("throws if channel has not been joined", () => {
-    assert.throws(() => channel.push("event", {}), /tried to push.*before joining/)
+    assert.throws(() => channel.push("event", {}), /^Error: tried to push.*before joining/)
   })
 })
 


### PR DESCRIPTION
Stack traces are added by throwing errors.