### PR TITLE
Converts non-mutated js vars from let to const

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -8,7 +8,7 @@
  * Connect to the server using the `Socket` class:
  *
  * ```javascript
- * let socket = new Socket("/socket", {params: {userToken: "123"}})
+ * const socket = new Socket("/socket", {params: {userToken: "123"}})
  * socket.connect()
  * ```
  *
@@ -27,7 +27,7 @@
  * the channel is joined with ok/error/timeout matches:
  *
  * ```javascript
- * let channel = socket.channel("room:123", {token: roomToken})
+ * const channel = socket.channel("room:123", {token: roomToken})
  * channel.on("new_msg", msg => console.log("Got message", msg) )
  * $input.onEnter( e => {
  *   channel.push("new_msg", {body: e.target.val}, 10000)
@@ -115,8 +115,8 @@
  * pass your channel in to track lifecycle events:
  *
  * ```javascript
- * let channel = new socket.channel("some:topic")
- * let presence = new Presence(channel)
+ * const channel = new socket.channel("some:topic")
+ * const presence = new Presence(channel)
  * ```
  *
  * Next, use the `presence.onSync` callback to react to state changes
@@ -144,12 +144,12 @@
  * they came online from:
  *
  * ```javascript
- * let listBy = (id, {metas: [first, ...rest]}) => {
+ * const listBy = (id, {metas: [first, ...rest]}) => {
  *   first.count = rest.length + 1 // count of this user's presences
  *   first.id = id
  *   return first
  * }
- * let onlineUsers = presence.list(listBy)
+ * const onlineUsers = presence.list(listBy)
  * ```
  *
  * ### Handling individual presence join and leave events
@@ -158,7 +158,7 @@
  * react to individual presences joining and leaving the app. For example:
  *
  * ```javascript
- * let presence = new Presence(channel)
+ * const presence = new Presence(channel)
  *
  * // detect if user has joined for the 1st time or from another tab/device
  * presence.onJoin((id, current, newPres) => {
@@ -219,12 +219,11 @@ const TRANSPORTS = {
 }
 
 // wraps value in closure or returns closure
-let closure = (value) => {
+const closure = (value) => {
   if(typeof value === "function"){
     return value
   } else {
-    let closure = function(){ return value }
-    return closure
+    return function(){ return value }
   }
 }
 
@@ -395,7 +394,7 @@ export class Channel {
     })
     this.joinPush.receive("timeout", () => { if(!this.isJoining()){ return }
       if (this.socket.hasLogger()) this.socket.log("channel", `timeout ${this.topic} (${this.joinRef()})`, this.joinPush.timeout)
-      let leavePush = new Push(this, CHANNEL_EVENTS.leave, closure({}), this.timeout)
+      const leavePush = new Push(this, CHANNEL_EVENTS.leave, closure({}), this.timeout)
       leavePush.send()
       this.state = CHANNEL_STATES.errored
       this.joinPush.reset()
@@ -465,7 +464,7 @@ export class Channel {
    * @returns {integer} ref
    */
   on(event, callback){
-    let ref = this.bindingRef++
+    const ref = this.bindingRef++
     this.bindings.push({event, ref, callback})
     return ref
   }
@@ -495,7 +494,7 @@ export class Channel {
     if(!this.joinedOnce){
       throw(`tried to push '${event}' to '${this.topic}' before joining. Use channel.join() before pushing events`)
     }
-    let pushEvent = new Push(this, event, function(){ return payload }, timeout)
+    const pushEvent = new Push(this, event, function(){ return payload }, timeout)
     if(this.canPush()){
       pushEvent.send()
     } else {
@@ -524,11 +523,11 @@ export class Channel {
    */
   leave(timeout = this.timeout){
     this.state = CHANNEL_STATES.leaving
-    let onClose = () => {
+    const onClose = () => {
       if (this.socket.hasLogger()) this.socket.log("channel", `leave ${this.topic}`)
       this.trigger(CHANNEL_EVENTS.close, "leave")
     }
-    let leavePush = new Push(this, CHANNEL_EVENTS.leave, closure({}), timeout)
+    const leavePush = new Push(this, CHANNEL_EVENTS.leave, closure({}), timeout)
     leavePush.receive("ok", () => onClose() )
              .receive("timeout", () => onClose() )
     leavePush.send()
@@ -594,7 +593,7 @@ export class Channel {
    * @private
    */
   trigger(event, payload, ref, joinRef){
-    let handledPayload = this.onMessage(event, payload, ref, joinRef)
+    const handledPayload = this.onMessage(event, payload, ref, joinRef)
     if(payload && !handledPayload){ throw("channel onMessage callbacks must return the payload, modified or unmodified") }
 
     for (let i = 0; i < this.bindings.length; i++) {
@@ -637,14 +636,14 @@ export class Channel {
 
 const Serializer = {
   encode(msg, callback){
-    let payload = [
+    const payload = [
       msg.join_ref, msg.ref, msg.topic, msg.event, msg.payload
     ]
     return callback(JSON.stringify(payload))
   },
 
   decode(rawPayload, callback){
-    let [join_ref, ref, topic, event, payload] = JSON.parse(rawPayload)
+    const [join_ref, ref, topic, event, payload] = JSON.parse(rawPayload)
 
     return callback({join_ref, ref, topic, event, payload})
   }
@@ -752,7 +751,7 @@ export class Socket {
    * @returns {string}
    */
   endPointURL(){
-    let uri = Ajax.appendParams(
+    const uri = Ajax.appendParams(
       Ajax.appendParams(this.endPoint, this.params()), {vsn: VSN})
     if(uri.charAt(0) !== "/"){ return uri }
     if(uri.charAt(1) === "/"){ return `${this.protocol()}:${uri}` }
@@ -921,7 +920,7 @@ export class Socket {
    * @returns {Channel}
    */
   channel(topic, chanParams = {}){
-    let chan = new Channel(topic, chanParams, this)
+    const chan = new Channel(topic, chanParams, this)
     this.channels.push(chan)
     return chan
   }
@@ -931,7 +930,7 @@ export class Socket {
    */
   push(data){
     if (this.hasLogger()) {
-      let {topic, event, payload, ref, join_ref} = data
+      const {topic, event, payload, ref, join_ref} = data
       this.log("push", `${topic} ${event} (${join_ref}, ${ref})`, payload)
     }
 
@@ -947,7 +946,7 @@ export class Socket {
    * @returns {string}
    */
   makeRef(){
-    let newRef = this.ref + 1
+    const newRef = this.ref + 1
     if(newRef === this.ref){ this.ref = 0 } else { this.ref = newRef }
 
     return this.ref.toString()
@@ -973,7 +972,7 @@ export class Socket {
 
   onConnMessage(rawMessage){
     this.decode(rawMessage.data, msg => {
-      let {topic, event, payload, ref, join_ref} = msg
+      const {topic, event, payload, ref, join_ref} = msg
       if(ref && ref === this.pendingHeartbeatRef){ this.pendingHeartbeatRef = null }
 
       if (this.hasLogger()) this.log("receive", `${payload.status || ""} ${topic} ${event} ${ref && "(" + ref + ")" || ""}`, payload)
@@ -1091,10 +1090,10 @@ export class Ajax {
 
   static request(method, endPoint, accept, body, timeout, ontimeout, callback){
     if(global.XDomainRequest){
-      let req = new XDomainRequest() // IE8, IE9
+      const req = new XDomainRequest() // IE8, IE9
       this.xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback)
     } else {
-      let req = global.XMLHttpRequest ?
+      const req = global.XMLHttpRequest ?
                   new global.XMLHttpRequest() : // IE7+, Firefox, Chrome, Opera, Safari
                   new ActiveXObject("Microsoft.XMLHTTP") // IE6, IE5
       this.xhrRequest(req, method, endPoint, accept, body, timeout, ontimeout, callback)
@@ -1105,7 +1104,7 @@ export class Ajax {
     req.timeout = timeout
     req.open(method, endPoint)
     req.onload = () => {
-      let response = this.parseJSON(req.responseText)
+      const response = this.parseJSON(req.responseText)
       callback && callback(response)
     }
     if(ontimeout){ req.ontimeout = ontimeout }
@@ -1123,7 +1122,7 @@ export class Ajax {
     req.onerror = () => { callback && callback(null) }
     req.onreadystatechange = () => {
       if(req.readyState === this.states.complete && callback){
-        let response = this.parseJSON(req.responseText)
+        const response = this.parseJSON(req.responseText)
         callback(response)
       }
     }
@@ -1144,10 +1143,10 @@ export class Ajax {
   }
 
   static serialize(obj, parentKey){
-    let queryStr = []
+    const queryStr = []
     for(var key in obj){ if(!obj.hasOwnProperty(key)){ continue }
-      let paramKey = parentKey ? `${parentKey}[${key}]` : key
-      let paramVal = obj[key]
+      const paramKey = parentKey ? `${parentKey}[${key}]` : key
+      const paramVal = obj[key]
       if(typeof paramVal === "object"){
         queryStr.push(this.serialize(paramVal, paramKey))
       } else {
@@ -1160,7 +1159,7 @@ export class Ajax {
   static appendParams(url, params){
     if(Object.keys(params).length === 0){ return url }
 
-    let prefix = url.match(/\?/) ? "&" : "?"
+    const prefix = url.match(/\?/) ? "&" : "?"
     return `${url}${prefix}${this.serialize(params)}`
   }
 }
@@ -1176,7 +1175,7 @@ Ajax.states = {complete: 4}
 export class Presence {
 
   constructor(channel, opts = {}){
-    let events = opts.events || {state: "presence_state", diff: "presence_diff"}
+    const events = opts.events || {state: "presence_state", diff: "presence_diff"}
     this.state = {}
     this.pendingDiffs = []
     this.channel = channel
@@ -1188,7 +1187,7 @@ export class Presence {
     }
 
     this.channel.on(events.state, newState => {
-      let {onJoin, onLeave, onSync} = this.caller
+      const {onJoin, onLeave, onSync} = this.caller
 
       this.joinRef = this.channel.joinRef()
       this.state = Presence.syncState(this.state, newState, onJoin, onLeave)
@@ -1201,7 +1200,7 @@ export class Presence {
     })
 
     this.channel.on(events.diff, diff => {
-      let {onJoin, onLeave, onSync} = this.caller
+      const {onJoin, onLeave, onSync} = this.caller
 
       if(this.inPendingSyncState()){
         this.pendingDiffs.push(diff)
@@ -1235,9 +1234,9 @@ export class Presence {
    * @returns {Presence}
    */
   static syncState(currentState, newState, onJoin, onLeave){
-    let state = this.clone(currentState)
-    let joins = {}
-    let leaves = {}
+    const state = this.clone(currentState)
+    const joins = {}
+    const leaves = {}
 
     this.map(state, (key, presence) => {
       if(!newState[key]){
@@ -1245,12 +1244,12 @@ export class Presence {
       }
     })
     this.map(newState, (key, newPresence) => {
-      let currentPresence = state[key]
+      const currentPresence = state[key]
       if(currentPresence){
-        let newRefs = newPresence.metas.map(m => m.phx_ref)
-        let curRefs = currentPresence.metas.map(m => m.phx_ref)
-        let joinedMetas = newPresence.metas.filter(m => curRefs.indexOf(m.phx_ref) < 0)
-        let leftMetas = currentPresence.metas.filter(m => newRefs.indexOf(m.phx_ref) < 0)
+        const newRefs = newPresence.metas.map(m => m.phx_ref)
+        const curRefs = currentPresence.metas.map(m => m.phx_ref)
+        const joinedMetas = newPresence.metas.filter(m => curRefs.indexOf(m.phx_ref) < 0)
+        const leftMetas = currentPresence.metas.filter(m => newRefs.indexOf(m.phx_ref) < 0)
         if(joinedMetas.length > 0){
           joins[key] = newPresence
           joins[key].metas = joinedMetas
@@ -1276,24 +1275,24 @@ export class Presence {
    * @returns {Presence}
    */
   static syncDiff(currentState, {joins, leaves}, onJoin, onLeave){
-    let state = this.clone(currentState)
+    const state = this.clone(currentState)
     if(!onJoin){ onJoin = function(){} }
     if(!onLeave){ onLeave = function(){} }
 
     this.map(joins, (key, newPresence) => {
-      let currentPresence = state[key]
+      const currentPresence = state[key]
       state[key] = newPresence
       if(currentPresence){
-        let joinedRefs = state[key].metas.map(m => m.phx_ref)
-        let curMetas = currentPresence.metas.filter(m => joinedRefs.indexOf(m.phx_ref) < 0)
+        const joinedRefs = state[key].metas.map(m => m.phx_ref)
+        const curMetas = currentPresence.metas.filter(m => joinedRefs.indexOf(m.phx_ref) < 0)
         state[key].metas.unshift(...curMetas)
       }
       onJoin(key, currentPresence, newPresence)
     })
     this.map(leaves, (key, leftPresence) => {
-      let currentPresence = state[key]
+      const currentPresence = state[key]
       if(!currentPresence){ return }
-      let refsToRemove = leftPresence.metas.map(m => m.phx_ref)
+      const refsToRemove = leftPresence.metas.map(m => m.phx_ref)
       currentPresence.metas = currentPresence.metas.filter(p => {
         return refsToRemove.indexOf(p.phx_ref) < 0
       })
@@ -1337,7 +1336,7 @@ export class Presence {
  * calculated timeout retries, such as exponential backoff.
  *
  * @example
- * let reconnectTimer = new Timer(() => this.connect(), function(tries){
+ * const reconnectTimer = new Timer(() => this.connect(), function(tries){
  *   return [1000, 5000, 10000][tries - 1] || 10000
  * })
  * reconnectTimer.scheduleTimeout() // fires after 1000

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -58,7 +58,7 @@ describe("updating join params", () => {
 
   it("can update the join params", () => {
     let counter = 0
-    let params = function(){ return({value: counter}) }
+    const params = function(){ return({value: counter}) }
 
     channel = new Channel("topic", params, socket)
     const joinPush = channel.joinPush
@@ -826,7 +826,7 @@ describe("push", () => {
   let clock, joinPush
   let socketSpy
 
-  let pushParams = (channel) => {
+  const pushParams = (channel) => {
     return({
       topic: "topic",
       event: "event",

--- a/assets/test/presence_test.js
+++ b/assets/test/presence_test.js
@@ -2,9 +2,9 @@ import assert from "assert"
 
 import {Presence} from "../js/phoenix"
 
-let clone = (obj) => { return JSON.parse(JSON.stringify(obj)) }
+const clone = (obj) => { return JSON.parse(JSON.stringify(obj)) }
 
-let fixtures = {
+const fixtures = {
   joins(){
     return {u1: {metas: [{id: 1, phx_ref: "1.2"}]}}
   },
@@ -20,7 +20,7 @@ let fixtures = {
   }
 }
 
-let channelStub = {
+const channelStub = {
   ref: 1,
   events: {},
 
@@ -35,13 +35,13 @@ let channelStub = {
   }
 }
 
-let listByFirst = (id, {metas: [first, ...rest]}) => first
+const listByFirst = (id, {metas: [first, ...rest]}) => first
 
 describe("syncState", () => {
   it("syncs empty state", () => {
-    let newState = {u1: {metas: [{id: 1, phx_ref: "1"}]}}
+    const newState = {u1: {metas: [{id: 1, phx_ref: "1"}]}}
     let state = {}
-    let stateBefore = clone(state)
+    const stateBefore = clone(state)
     Presence.syncState(state, newState)
     assert.deepEqual(state, stateBefore)
 
@@ -50,17 +50,17 @@ describe("syncState", () => {
   })
 
   it("onJoins new presences and onLeave's left presences", () => {
-    let newState = fixtures.state()
+    const newState = fixtures.state()
     let state = {u4: {metas: [{id: 4, phx_ref: "4"}]}}
-    let joined = {}
-    let left = {}
-    let onJoin = (key, current, newPres) => {
+    const joined = {}
+    const left = {}
+    const onJoin = (key, current, newPres) => {
       joined[key] = {current: current, newPres: newPres}
     }
-    let onLeave = (key, current, leftPres) => {
+    const onLeave = (key, current, leftPres) => {
       left[key] = {current: current, leftPres: leftPres}
     }
-    let stateBefore = clone(state)
+    const stateBefore = clone(state)
     Presence.syncState(state, newState, onJoin, onLeave)
     assert.deepEqual(state, stateBefore)
 
@@ -77,14 +77,14 @@ describe("syncState", () => {
   })
 
   it("onJoins only newly added metas", () => {
-    let newState = {u3: {metas: [{id: 3, phx_ref: "3"}, {id: 3, phx_ref: "3.new"}]}}
+    const newState = {u3: {metas: [{id: 3, phx_ref: "3"}, {id: 3, phx_ref: "3.new"}]}}
     let state = {u3: {metas: [{id: 3, phx_ref: "3"}]}}
-    let joined = {}
-    let left = {}
-    let onJoin = (key, current, newPres) => {
+    const joined = {}
+    const left = {}
+    const onJoin = (key, current, newPres) => {
       joined[key] = {current: current, newPres: newPres}
     }
-    let onLeave = (key, current, leftPres) => {
+    const onLeave = (key, current, leftPres) => {
       left[key] = {current: current, leftPres: leftPres}
     }
     state = Presence.syncState(state, newState, onJoin, onLeave)
@@ -99,7 +99,7 @@ describe("syncState", () => {
 
 describe("syncDiff", () => {
   it("syncs empty state", () => {
-    let joins = {u1: {metas: [{id: 1, phx_ref: "1"}]}}
+    const joins = {u1: {metas: [{id: 1, phx_ref: "1"}]}}
     let state = {}
     Presence.syncDiff(state, {joins: joins, leaves: {}})
     assert.deepEqual(state, {})
@@ -136,7 +136,7 @@ describe("syncDiff", () => {
 
 describe("list", () => {
   it("lists full presence by default", () => {
-    let state = fixtures.state()
+    const state = fixtures.state()
     assert.deepEqual(Presence.list(state), [
       {metas: [{id: 1, phx_ref: "1"}]},
       {metas: [{id: 2, phx_ref: "2"}]},
@@ -145,12 +145,12 @@ describe("list", () => {
   })
 
   it("lists with custom function", () => {
-    let state = {u1: {metas: [
+    const state = {u1: {metas: [
       {id: 1, phx_ref: "1.first"},
       {id: 1, phx_ref: "1.second"}]
     }}
 
-    let listBy = (key, {metas: [first, ...rest]}) => {
+    const listBy = (key, {metas: [first, ...rest]}) => {
       return first
     }
 
@@ -162,10 +162,10 @@ describe("list", () => {
 
 describe("instance", () => {
   it("syncs state and diffs", () => {
-    let presence = new Presence(channelStub)
-    let user1 = {metas: [{id: 1, phx_ref: "1"}]}
-    let user2 = {metas: [{id: 2, phx_ref: "2"}]}
-    let newState = {u1: user1, u2: user2}
+    const presence = new Presence(channelStub)
+    const user1 = {metas: [{id: 1, phx_ref: "1"}]}
+    const user2 = {metas: [{id: 2, phx_ref: "2"}]}
+    const newState = {u1: user1, u2: user2}
 
     channelStub.trigger("presence_state", newState)
     assert.deepEqual(presence.list(listByFirst), [{id: 1, phx_ref: 1},
@@ -177,9 +177,9 @@ describe("instance", () => {
 
 
   it("applies pending diff if state is not yet synced", () => {
-    let presence = new Presence(channelStub)
-    let onJoins = []
-    let onLeaves = []
+    const presence = new Presence(channelStub)
+    const onJoins = []
+    const onLeaves = []
 
     presence.onJoin((id, current, newPres) => {
       onJoins.push({id, current, newPres})
@@ -189,11 +189,11 @@ describe("instance", () => {
     })
 
     // new connection
-    let user1 = {metas: [{id: 1, phx_ref: "1"}]}
-    let user2 = {metas: [{id: 2, phx_ref: "2"}]}
-    let user3 = {metas: [{id: 3, phx_ref: "3"}]}
-    let newState = {u1: user1, u2: user2}
-    let leaves = {u2: user2}
+    const user1 = {metas: [{id: 1, phx_ref: "1"}]}
+    const user2 = {metas: [{id: 2, phx_ref: "2"}]}
+    const user3 = {metas: [{id: 3, phx_ref: "3"}]}
+    const newState = {u1: user1, u2: user2}
+    const leaves = {u2: user2}
 
     channelStub.trigger("presence_diff", {joins: {}, leaves: leaves})
 
@@ -225,12 +225,12 @@ describe("instance", () => {
   })
 
   it("allows custom channel events", () => {
-    let presence = new Presence(channelStub, {events: {
+    const presence = new Presence(channelStub, {events: {
       state: "the_state",
       diff: "the_diff"
     }})
 
-    let user1 = {metas: [{id: 1, phx_ref: "1"}]}
+    const user1 = {metas: [{id: 1, phx_ref: "1"}]}
     channelStub.trigger("the_state", {user1: user1})
     assert.deepEqual(presence.list(listByFirst), [{id: 1, phx_ref: "1"}])
     channelStub.trigger("the_diff", {joins: {}, leaves: {user1: user1}})

--- a/assets/test/serializer.js
+++ b/assets/test/serializer.js
@@ -1,13 +1,13 @@
 
 export const encode = (msg) => {
-  let payload = [
+  const payload = [
     msg.join_ref, msg.ref, msg.topic, msg.event, msg.payload
   ]
   return JSON.stringify(payload)
 }
 
 export const decode = (rawPayload) => {
-  let [join_ref, ref, topic, event, payload] = JSON.parse(rawPayload)
+  const [join_ref, ref, topic, event, payload] = JSON.parse(rawPayload)
 
   return {join_ref, ref, topic, event, payload}
 }

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -155,7 +155,7 @@ describe("connect with WebSocket", () => {
   it("establishes websocket connection with endpoint", () => {
     socket.connect()
 
-    let conn = socket.conn
+    const conn = socket.conn
     assert.ok(conn instanceof WebSocket)
     assert.equal(conn.url, socket.endPointURL())
   })
@@ -189,7 +189,7 @@ describe("connect with WebSocket", () => {
   it("is idempotent", () => {
     socket.connect()
 
-    let conn = socket.conn
+    const conn = socket.conn
 
     socket.connect()
 
@@ -213,7 +213,7 @@ describe("connect with long poll", () => {
   it("establishes long poll connection with endpoint", () => {
     socket.connect()
 
-    let conn = socket.conn
+    const conn = socket.conn
     assert.ok(conn instanceof LongPoll)
     assert.equal(conn.pollEndpoint, "http://example.com/socket/longpoll?vsn=2.0.0")
     assert.equal(conn.timeout, 20000)
@@ -252,7 +252,7 @@ describe("connect with long poll", () => {
   it("is idempotent", () => {
     socket.connect()
 
-    let conn = socket.conn
+    const conn = socket.conn
 
     socket.connect()
 
@@ -795,7 +795,7 @@ describe("custom encoder and decoder", () => {
 
   it("encodes to JSON array by default", () => {
     socket = new Socket("/socket")
-    let payload = {topic: "topic", ref: "2", join_ref: "1", event: "join", payload: {foo: "bar"}}
+    const payload = {topic: "topic", ref: "2", join_ref: "1", event: "join", payload: {foo: "bar"}}
 
     socket.encode(payload, encoded => {
       assert.deepStrictEqual(encoded, '["1","2","topic","join",{"foo":"bar"}]')
@@ -803,7 +803,7 @@ describe("custom encoder and decoder", () => {
   })
 
   it("allows custom encoding when using WebSocket transport", () => {
-    let encoder = (payload, callback) => callback("encode works")
+    const encoder = (payload, callback) => callback("encode works")
     socket = new Socket("/socket", {transport: WebSocket, encode: encoder})
 
     socket.encode({foo: "bar"}, encoded => {
@@ -812,9 +812,9 @@ describe("custom encoder and decoder", () => {
   })
 
   it("forces JSON encoding when using LongPoll transport", () => {
-    let encoder = (payload, callback) => callback("encode works")
+    const encoder = (payload, callback) => callback("encode works")
     socket = new Socket("/socket", {transport: LongPoll, encode: encoder})
-    let payload = {topic: "topic", ref: "2", join_ref: "1", event: "join", payload: {foo: "bar"}}
+    const payload = {topic: "topic", ref: "2", join_ref: "1", event: "join", payload: {foo: "bar"}}
 
     socket.encode(payload, encoded => {
       assert.deepStrictEqual(encoded, '["1","2","topic","join",{"foo":"bar"}]')
@@ -823,7 +823,7 @@ describe("custom encoder and decoder", () => {
 
   it("decodes JSON by default", () => {
     socket = new Socket("/socket")
-    let encoded = '["1","2","topic","join",{"foo":"bar"}]'
+    const encoded = '["1","2","topic","join",{"foo":"bar"}]'
 
     socket.decode(encoded, decoded => {
       assert.deepStrictEqual(decoded, {topic: "topic", ref: "2", join_ref: "1", event: "join", payload: {foo: "bar"}})
@@ -831,7 +831,7 @@ describe("custom encoder and decoder", () => {
   })
 
   it("allows custom decoding when using WebSocket transport", () => {
-    let decoder = (payload, callback) => callback("decode works")
+    const decoder = (payload, callback) => callback("decode works")
     socket = new Socket("/socket", {transport: WebSocket, decode: decoder})
 
     socket.decode("...esoteric format...", decoded => {
@@ -840,9 +840,9 @@ describe("custom encoder and decoder", () => {
   })
 
   it("forces JSON decoding when using LongPoll transport", () => {
-    let decoder = (payload, callback) => callback("decode works")
+    const decoder = (payload, callback) => callback("decode works")
     socket = new Socket("/socket", {transport: LongPoll, decode: decoder})
-    let payload = {topic: "topic", ref: "2", join_ref: "1", event: "join", payload: {foo: "bar"}}
+    const payload = {topic: "topic", ref: "2", join_ref: "1", event: "join", payload: {foo: "bar"}}
 
     socket.decode('["1","2","topic","join",{"foo":"bar"}]', decoded => {
       assert.deepStrictEqual(decoded, payload)

--- a/installer/templates/phx_assets/webpack/socket.js
+++ b/installer/templates/phx_assets/webpack/socket.js
@@ -8,7 +8,7 @@
 // from the params if you are not using authentication.
 import {Socket} from "phoenix"
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+const socket = new Socket("/socket", {params: {token: window.userToken}})
 
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,
@@ -55,7 +55,7 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
+const channel = socket.channel("topic:subtopic", {})
 channel.join()
   .receive("ok", resp => { console.log("Joined successfully", resp) })
   .receive("error", resp => { console.log("Unable to join", resp) })


### PR DESCRIPTION
Hi :wave: 

I noticed that the JavaScript generated for the channel code declared many variable as `let` when `const` would be a bit clearer.

Figured while I did that, might as well fix it everywhere.

This PR converts all the .js code that used `let` but didn't mutate into `const`.