### PR TITLE
Enabling recycle of custom headers

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -463,17 +463,22 @@ defmodule Phoenix.ConnTest do
   This emulates behaviour performed by browsers where cookies
   returned in the response are available in following requests.
 
+  By default, only the headers "accept" and "authorization" are
+  recycled. However, a custom set of headers can be specified by
+  passing a list of strings representing its names as the second
+  argument of the function.
+
   Note `recycle/1` is automatically invoked when dispatching
   to the endpoint, unless the connection has already been
   recycled.
   """
-  @spec recycle(Conn.t) :: Conn.t
-  def recycle(conn) do
+  @spec recycle(Conn.t, [String.t]) :: Conn.t
+  def recycle(conn, headers \\ ~w(accept authorization)) do
     build_conn()
     |> Map.put(:host, conn.host)
     |> Plug.Test.recycle_cookies(conn)
     |> Plug.Test.put_peer_data(Plug.Conn.get_peer_data(conn))
-    |> copy_headers(conn.req_headers, ~w(accept authorization))
+    |> copy_headers(conn.req_headers, headers)
   end
 
   defp copy_headers(conn, headers, copy) do

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -197,6 +197,22 @@ defmodule Phoenix.Test.ConnTest do
     end
   end
 
+  describe "recycle/2" do
+    test "custom request headers are persisted" do
+      conn =
+        build_conn()
+        |> get("/")
+        |> put_req_header("accept", "text/html")
+        |> put_req_header("hello", "world")
+        |> put_req_header("foo", "bar")
+
+      conn = conn |> recycle(~w(hello accept))
+      assert get_req_header(conn, "accept") == ["text/html"]
+      assert get_req_header(conn, "hello") == ["world"]
+      assert get_req_header(conn, "foo") == []
+    end
+  end
+
   test "ensure_recycled/1" do
     conn =
       build_conn()


### PR DESCRIPTION
Adding a new argument to specify which headers will be persisted after recycling the connection. By default we keep the existing behavior, so only `accept` and `authorization` are persisted. 