### PR TITLE
Improved phx.routes umbrella error message

### DIFF
--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -38,14 +38,20 @@ defmodule Mix.Tasks.Phx.Routes do
 
   defp router(nil, base) do
     if Mix.Project.umbrella?() do
-      Mix.raise "umbrella applications require an explicit router to be given to phx.routes"
+      Mix.raise """
+      umbrella applications require an explicit router to be given to phx.routes, for example:
+
+        $ mix phx.routes MyAppWeb.Router
+      """
     end
     web_router = web_mod(base, "Router")
     old_router = app_mod(base, "Router")
 
     loaded(web_router) || loaded(old_router) || Mix.raise """
     no router found at #{inspect web_router} or #{inspect old_router}.
-    An explicit router module may be given to phx.routes.
+    An explicit router module may be given to phx.routes, for example:
+
+      $ mix phx.routes MyAppWeb.Router
     """
   end
   defp router(router_name, _base) do


### PR DESCRIPTION
Hey 👋 & Happy New Year 🎆 

I Ran the `phx.routes` mix task the other day on an umbrella project and I was greeted by the following error message

```
** (Mix) umbrella applications require an explicit router to be given to phx.routes
```

It's not clear how one should specify the router, a file path or a module name so I added an example to make it clear. The new error message as follows:

```
** (Mix) umbrella applications require an explicit router to be given to phx.routes, for example:

  $ mix phx.routes MyAppWeb.Router
```

This is well documented but thought this might save someone a bit of confusion.

We could also iterate through the apps and see if any of them have defined a router module with the default naming conventions and list them to make the error even more useful, something like this:

```
** (Mix) umbrella applications require an explicit router to be given to phx.routes, for example:

  $ mix phx.routes MyAppWeb.Router

Found these routers:

  MyAppWeb.Router
  MyAppApi.Router
```

This PR just includes the improved error message without the router discovery part. I'd be happy to work on that if you think it would make a nice addition.

Hope this is all ok 👍 

Thanks,
Ville