### PR TITLE
Explicitly include the layout option when generating render_errors

### DIFF
--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -16,7 +16,7 @@ config :<%= app_name %><%= if namespaced? do %>,
 config :<%= app_name %>, <%= endpoint_module %>,
   url: [host: "localhost"],
   secret_key_base: "<%= secret_key_base %>",
-  render_errors: [view: <%= web_namespace %>.ErrorView, accepts: ~w(<%= if html do %>html <% end %>json)],
+  render_errors: [view: <%= web_namespace %>.ErrorView, accepts: ~w(<%= if html do %>html <% end %>json), layout: false],
   pubsub: [name: <%= app_module %>.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # Configures Elixir's Logger

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
@@ -14,7 +14,7 @@ config :<%= web_app_name %><%= if namespaced? do %>,
 config :<%= web_app_name %>, <%= endpoint_module %>,
   url: [host: "localhost"],
   secret_key_base: "<%= secret_key_base %>",
-  render_errors: [view: <%= web_namespace %>.ErrorView, accepts: ~w(<%= if html do %>html <% end %>json)],
+  render_errors: [view: <%= web_namespace %>.ErrorView, accepts: ~w(<%= if html do %>html <% end %>json), layout: false],
   pubsub: [name: <%= web_namespace %>.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # Import environment specific config. This must remain at the bottom


### PR DESCRIPTION
This will hint to the users that a layout can be provided for error
pages.