### PR TITLE
Improve code formatting consistency in guides (and additional guides fixes)

### DIFF
--- a/guides/adding_pages.md
+++ b/guides/adding_pages.md
@@ -200,7 +200,9 @@ Now that we've got the route, controller, view, and template, we should be able 
 
 There are a couple of interesting things to notice about what we just did. We didn't need to stop and re-start the server while we made these changes. Yes, Phoenix has hot code reloading! Also, even though our `index.html.eex` file consisted of only a single `div` tag, the page we get is a full HTML document. Our index template is rendered into the application layout - `lib/hello_web/templates/layout/app.html.eex`. If you open it, you'll see a line that looks like this:
 
-    <%= render(@view_module, @view_template, assigns) %>
+```html
+<%= render(@view_module, @view_template, assigns) %>
+```
 
 which is what renders our template into the layout before the HTML is sent off to the browser.
 

--- a/guides/adding_pages.md
+++ b/guides/adding_pages.md
@@ -269,7 +269,7 @@ And this is what the template should look like:
 </div>
 ```
 
-Our messenger appears as `@messenger`. In this case, this is not a module attribute. It is special bit of metaprogrammed syntax which stands in for `assigns.messenger`. The result is much nicer on the eyes and much easier to work with in a template.
+Our messenger appears as `@messenger`. In this case, this is not a module attribute. It is a special bit of metaprogrammed syntax which stands in for `assigns.messenger`. The result is much nicer on the eyes and much easier to work with in a template.
 
 We're done. If you point your browser here: [http://localhost:4000/hello/Frank](http://localhost:4000/hello/Frank), you should see a page that looks like this:
 

--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -39,7 +39,7 @@ As long as we change the action name in the `PageController` to `test` as well, 
 
 ```elixir
 defmodule HelloWeb.PageController do
-  . . .
+  ...
 
   def test(conn, _params) do
     render(conn, "index.html")
@@ -65,7 +65,7 @@ The second parameter is `params`. Not surprisingly, this is a map which holds an
 
 ```elixir
 defmodule HelloWeb.HelloController do
-  . . .
+  ...
 
   def show(conn, %{"messenger" => messenger}) do
     render(conn, "show.html", messenger: messenger)
@@ -93,7 +93,7 @@ To do this we modify the `index` action as follows:
 
 ```elixir
 defmodule HelloWeb.PageController do
-  . . .
+  ...
   def index(conn, _params) do
     conn
     |> put_flash(:info, "Welcome to Phoenix, from flash info!")
@@ -234,7 +234,7 @@ defmodule HelloWeb.PageController do
   use HelloWeb, :controller
 
   plug :assign_welcome_message, "Hi!" when action in [:index, :show]
-. . .
+...
 ```
 
 ### Sending responses directly
@@ -353,7 +353,7 @@ end
 ```
 What it doesn't have is an alternative template for rendering text. Let's add one at `lib/hello_web/templates/page/index.text.eex`. Here is our example `index.text.eex` template.
 
-```elixir
+```html
 OMG, this is actually some text.
 ```
 
@@ -369,7 +369,7 @@ defmodule HelloWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
   end
-. . .
+...
 ```
 
 We also need to tell the controller to render a template with the same format as the one returned by `Phoenix.Controller.get_format/1`. We do that by substituting the name of the template "index.html" with the atom version `:index`.
@@ -392,7 +392,7 @@ end
 
 And let's add a bit to our text template.
 
-```elixir
+```html
 OMG, this is actually some text. <%= @message %>
 ```
 
@@ -468,10 +468,10 @@ In order to try out `redirect/2`, let's create a new route in `lib/hello_web/rou
 ```elixir
 defmodule HelloWeb.Router do
   use HelloWeb, :router
-  . . .
+  ...
 
   scope "/", HelloWeb do
-    . . .
+    ...
     get "/", PageController, :index
   end
 
@@ -479,7 +479,7 @@ defmodule HelloWeb.Router do
   scope "/", HelloWeb do
     get "/redirect_test", PageController, :redirect_test, as: :redirect_test
   end
-  . . .
+  ...
 end
 ```
 
@@ -644,6 +644,7 @@ end
 If we call this plug as part of the plug pipeline any downstream plugs will still be processed. If we want to prevent downstream plugs from being processed in the event of the 404 response we can simply call `Plug.Conn.halt/1`.
 
 ```elixir
+    ...
     case Blog.get_post(conn.params["id"]) do
       {:ok, post} ->
         assign(conn, :post, post)
@@ -657,24 +658,24 @@ If we call this plug as part of the plug pipeline any downstream plugs will stil
 It's important to note that `halt/1` simply sets the `:halted` key on `Plug.Conn.t` to `true`.  This is enough to prevent downstream plugs from being invoked but it will not stop the execution of code locally. As such
 
 ```elixir
-  conn
-  |> send_resp(404, "Not found")
-  |> halt()
+conn
+|> send_resp(404, "Not found")
+|> halt()
 ```
 
 ... is functionally equivalent to...
 
 ```elixir
-  conn
-  |> halt()
-  |> send_resp(404, "Not found")
+conn
+|> halt()
+|> send_resp(404, "Not found")
 ```
 
 It's also important to note that halting will only stop the plug pipeline from continuing. Function plugs will still execute unless their implementation checks for the `:halted` value.
 
-```
-  def post_authorization_plug(%{halted: true} = conn, _), do: conn
-  def post_authorization_plug(conn, _) do
-  . . .
-  end
+```elixir
+def post_authorization_plug(%{halted: true} = conn, _), do: conn
+def post_authorization_plug(conn, _) do
+  ...
+end
 ```

--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -188,11 +188,11 @@ Changesets define a pipeline of transformations our data needs to undergo before
 Let's take a closer look at our default changeset function.
 
 ```elixir
-  def changeset(%User{} = user, attrs) do
-    user
-    |> cast(attrs, [:name, :email, :bio, :number_of_pets])
-    |> validate_required([:name, :email, :bio, :number_of_pets])
-  end
+def changeset(%User{} = user, attrs) do
+  user
+  |> cast(attrs, [:name, :email, :bio, :number_of_pets])
+  |> validate_required([:name, :email, :bio, :number_of_pets])
+end
 ```
 
 Right now, we have two transformations in our pipeline. In the first call, we invoke `Ecto.Changeset`'s `cast/3`, passing in our external parameters and marking which fields are required for validation.
@@ -210,7 +210,7 @@ Hello.User
 
 Next, let's build a changeset from our schema with an empty `User` struct, and an empty map of parameters.
 
-```console
+```elixir
 iex> changeset = User.changeset(%User{}, %{})
 
 #Ecto.Changeset<action: nil, changes: %{},
@@ -223,14 +223,14 @@ iex> changeset = User.changeset(%User{}, %{})
 
 Once we have a changeset, we can check it if it is valid.
 
-```console
+```elixir
 iex> changeset.valid?
 false
 ```
 
 Since this one is not valid, we can ask it what the errors are.
 
-```console
+```elixir
 iex> changeset.errors
 [name: {"can't be blank", [validation: :required]},
  email: {"can't be blank", [validation: :required]},
@@ -268,7 +268,7 @@ What happens if we pass a key/value pair that is in neither defined in the schem
 
 Inside our existing IEx shell, let's create a `params` map with valid values plus an extra `random_key: "random value"`.
 
-```console
+```elixir
 iex> params = %{name: "Joe Example", email: "joe@example.com", bio: "An example to all", number_of_pets: 5, random_key: "random value"}
 %{email: "joe@example.com", name: "Joe Example", bio: "An example to all",
 number_of_pets: 5, random_key: "random value"}
@@ -276,7 +276,7 @@ number_of_pets: 5, random_key: "random value"}
 
 Next, let's use our new `params` map to create another changeset.
 
-```console
+```elixir
 iex> changeset = User.changeset(%User{}, params)
 #Ecto.Changeset<action: nil,
  changes: %{bio: "An example to all", email: "joe@example.com",
@@ -286,14 +286,14 @@ iex> changeset = User.changeset(%User{}, params)
 
 Our new changeset is valid.
 
-```console
+```elixir
 iex> changeset.valid?
 true
 ```
 
 We can also check the changeset's changes - the map we get after all of the transformations are complete.
 
-```console
+```elixir
 iex(9)> changeset.changes
 %{bio: "An example to all", email: "joe@example.com", name: "Joe Example",
   number_of_pets: 5}
@@ -306,18 +306,18 @@ We can validate more than just whether a field is required or not. Let's take a 
 What if we had a requirement that all biographies in our system must be at least two characters long? We can do this easily by adding another transformation to the pipeline in our changeset which validates the length of the `bio` field.
 
 ```elixir
-  def changeset(%User{} = user, attrs) do
-    user
-    |> cast(attrs, [:name, :email, :bio, :number_of_pets])
-    |> validate_required([:name, :email, :bio, :number_of_pets])
-    |> validate_length(:bio, min: 2)
-  end
+def changeset(%User{} = user, attrs) do
+  user
+  |> cast(attrs, [:name, :email, :bio, :number_of_pets])
+  |> validate_required([:name, :email, :bio, :number_of_pets])
+  |> validate_length(:bio, min: 2)
+end
 ```
 
 Now, if we try to cast data containing a value of "A" for our user's bio, we should see the failed validation in the changeset's errors.
 
 
-```console
+```elixir
 iex> changeset = User.changeset(%User{}, %{bio: "A"})
 iex> changeset.errors[:bio]
 {"should be at least %{count} character(s)",
@@ -327,31 +327,31 @@ iex> changeset.errors[:bio]
 If we also have a requirement for the maximum length that a bio can have, we can simply add another validation.
 
 ```elixir
-  def changeset(%User{} = user, attrs) do
-    user
-    |> cast(attrs, [:name, :email, :bio, :number_of_pets])
-    |> validate_required([:name, :email, :bio, :number_of_pets])
-    |> validate_length(:bio, min: 2)
-    |> validate_length(:bio, max: 140)
-  end
+def changeset(%User{} = user, attrs) do
+  user
+  |> cast(attrs, [:name, :email, :bio, :number_of_pets])
+  |> validate_required([:name, :email, :bio, :number_of_pets])
+  |> validate_length(:bio, min: 2)
+  |> validate_length(:bio, max: 140)
+end
 ```
 
 Let's say we want to perform at least some rudimentary format validation on the `email` field. All we want to check for is the presence of the "@". The `validate_format/3` function is just what we need.
 
 ```elixir
-  def changeset(%User{} = user, attrs) do
-    user
-    |> cast(attrs, [:name, :email, :bio, :number_of_pets])
-    |> validate_required([:name, :email, :bio, :number_of_pets])
-    |> validate_length(:bio, min: 2)
-    |> validate_length(:bio, max: 140)
-    |> validate_format(:email, ~r/@/)
-  end
+def changeset(%User{} = user, attrs) do
+  user
+  |> cast(attrs, [:name, :email, :bio, :number_of_pets])
+  |> validate_required([:name, :email, :bio, :number_of_pets])
+  |> validate_length(:bio, min: 2)
+  |> validate_length(:bio, max: 140)
+  |> validate_format(:email, ~r/@/)
+end
 ```
 
 If we try to cast a user with an email of "example.com", we should see an error message like the following.
 
-```console
+```elixir
 iex> changeset = User.changeset(%User{}, %{email: "example.com"})
 iex> changeset.errors[:email]
 {"has invalid format", [validation: :format]}
@@ -365,7 +365,7 @@ We've talked a lot about migrations and data-storage, but we haven't yet persist
 
 Let's head back over to IEx with `iex -S mix`, and insert a couple of users into the database.
 
-```console
+```elixir
 iex> alias Hello.{Repo, User}
 [Hello.Repo, Hello.User]
 iex> Repo.insert(%User{email: "user1@example.com"})
@@ -389,7 +389,7 @@ INSERT INTO "users" ("email","inserted_at","updated_at") VALUES ($1,$2,$3) RETUR
 
 We started by aliasing our `User` and `Repo` modules for easy access. Next, we called `Repo.insert/1` and passed a user struct. Since we're in the `dev` environment, we can see the debug logs for the query our Repo performed when inserting the underlying `%User{}` data. We received a 2-tuple back with `{:ok, %User{}}`, which lets us know the insertion was successful. With a couple of users inserted, let's fetch them back out of the repo.
 
-```console
+```elixir
 iex> Repo.all(User)
 [debug] QUERY OK source="users" db=2.7ms
 SELECT u0."id", u0."bio", u0."email", u0."name", u0."number_of_pets", u0."inserted_at", u0."updated_at" FROM "users" AS u0 []
@@ -405,7 +405,7 @@ SELECT u0."id", u0."bio", u0."email", u0."name", u0."number_of_pets", u0."insert
 
 That was easy! `Repo.all/1` takes a data source, our `User` schema in this case, and translates that to an underlying SQL query against our database. After it fetches the data, the Repo then uses our Ecto schema to map the database values back into Elixir data-structures according to our `User` schema. We're not just limited to basic querying – Ecto includes a full-fledged query DSL for advanced SQL generation. In addition to a natural Elixir DSL, Ecto's query engine gives us multiple great features, such as SQL injection protection and compile-time optimization of queries. Let's try it out.
 
-```console
+```elixir
 iex> import Ecto.Query
 Ecto.Query
 
@@ -417,7 +417,7 @@ SELECT u0."email" FROM "users" AS u0 []
 
 First, we imported `Ecto.Query`, which imports the `from` macro of Ecto's Query DSL. Next, we built a query which selects all the email addresses in our users table. Let's try another example.
 
-```console
+```elixir
 iex)> Repo.one(from u in User, where: ilike(u.email, "%1%"),
                                select: count(u.id))
 [debug] QUERY OK source="users" db=1.6ms SELECT count(u0."id") FROM "users" AS u0 WHERE (u0."email" ILIKE '%1%') []
@@ -426,7 +426,7 @@ iex)> Repo.one(from u in User, where: ilike(u.email, "%1%"),
 
 Now we're starting to get a taste of Ecto's rich querying capabilities. We used `Repo.one/1` to fetch the count of all users with an email address containing "1", and received the expected count in return. This just scratches the surface of Ecto's query interface, and much more is supported such as sub-querying, interval queries, and advanced select statements. For example, let's build a query to fetch a map of all user id's to their email addresses.
 
-```console
+```elixir
 iex> Repo.all(from u in User, select: %{u.id => u.email})
 [debug] QUERY OK source="users" db=0.9ms
 SELECT u0."id", u0."email" FROM "users" AS u0 []
@@ -447,7 +447,7 @@ Phoenix applications are configured to use PostgreSQL by default, but what if we
 
 If we are about to create a new application, configuring our application to use MySQL is easy. We can simply pass the `--database mysql` flag to `phx.new` and everything will be configured correctly.
 
-```
+```console
 $ mix phx.new hello_phoenix --database mysql
 
 ```
@@ -459,7 +459,7 @@ To switch adapters, we need to remove the Postgrex dependency and add a new one 
 
 Let's open up our `mix.exs` file and do that now.
 
-```
+```elixir
 defmodule HelloPhoenix.MixProject do
   use Mix.Project
 
@@ -485,7 +485,7 @@ end
 
 Next, we need to configure our new adapter. Let's open up our `config/dev.exs` file and do that.
 
-```
+```elixir
 config :hello_phoenix, HelloPhoenix.Repo,
 username: "root",
 password: "",
@@ -498,20 +498,20 @@ The last change is to open up `lib/hello_phoenix/repo.ex` and make sure to set t
 
 Now all we need to do is fetch our new dependency, and we'll be ready to go.
 
-```
+```console
 $ mix do deps.get, compile
 ```
 
 With our new adapter installed and configured, we're ready to create our database.
 
-```
+```console
 $ mix ecto.create
 ```
 
 The database for HelloPhoenix.repo has been created.
 We're also ready to run any migrations, or do anything else with Ecto that we might choose.
 
-```
+```console
 $ mix ecto.migrate
 [info] == Running HelloPhoenix.Repo.Migrations.CreateUser.change/0 forward
 [info] create table users

--- a/guides/endpoint.md
+++ b/guides/endpoint.md
@@ -7,7 +7,7 @@ Phoenix applications start the HelloWeb.Endpoint as a supervised process. By def
 defmodule Hello.Application do
   use Application
   def start(_type, _args) do
-    #...
+    ...
 
     children = [
       supervisor(HelloWeb.Endpoint, []),
@@ -39,7 +39,9 @@ use Phoenix.Endpoint, otp_app: :hello
 Next the endpoint declares a socket on the "/socket" URI. "/socket" requests will be handled by the `HelloWeb.UserSocket` module which is declared elsewhere in our application. Here we are just declaring that such a connection will exist.
 
 ```elixir
-socket "/socket", HelloWeb.UserSocket
+socket "/socket", HelloWeb.UserSocket,
+  websocket: true,
+  longpoll: false
 ```
 
 Next comes a series of plugs that are relevant to all requests in our application. We can customize some of the features, for example, enabling `gzip: true` when deploying to production to gzip the static files.
@@ -48,7 +50,9 @@ Static files are served from `priv/static` before any part of our request makes 
 
 ```elixir
 plug Plug.Static,
-  at: "/", from: :hello, gzip: false,
+  at: "/",
+  from: :hello,
+  gzip: false,
   only: ~w(css fonts images js favicon.ico robots.txt)
 ```
 If code reloading is enabled, a socket will be used to communicate to the browser that the page needs to be reloaded when code is changed on the server. This feature is enabled by default in the development environment. This is configured using `config :hello, HelloWeb.Endpoint, code_reloader: true`.
@@ -105,12 +109,14 @@ config :hello, HelloWeb.Endpoint,
   http: [port: {:system, "PORT"}],
   url: [host: "example.com"],
   cache_static_manifest: "priv/static/cache_manifest.json",
-  https: [port: 443,
-          otp_app: :hello,
-          keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
-          certfile: System.get_env("SOME_APP_SSL_CERT_PATH"),
-          cacertfile: System.get_env("INTERMEDIATE_CERTFILE_PATH") # OPTIONAL Key for intermediate certificates
-          ]
+  https: [
+    port: 443,
+    otp_app: :hello,
+    keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
+    certfile: System.get_env("SOME_APP_SSL_CERT_PATH"),
+    # OPTIONAL Key for intermediate certificates:
+    cacertfile: System.get_env("INTERMEDIATE_CERTFILE_PATH")
+  ]
 
 ```
 
@@ -131,13 +137,13 @@ With your self-signed certificate, your development configuration in `config/dev
 
 ```elixir
 config :my_app, MyApp.Endpoint,
-       # ...
-       https: [
-         port: 4001,
-         cipher_suite: :strong,
-         keyfile: "priv/cert/selfsigned_key.pem",
-         certfile: "priv/cert/selfsigned.pem"
-       ]
+  ...
+  https: [
+    port: 4001,
+    cipher_suite: :strong,
+    keyfile: "priv/cert/selfsigned_key.pem",
+    certfile: "priv/cert/selfsigned.pem"
+  ]
 ```
 
 This can replace your `http` configuration, or you can run HTTP and HTTPS servers on different ports.

--- a/guides/endpoint.md
+++ b/guides/endpoint.md
@@ -33,13 +33,13 @@ end
 The first call inside of our Endpoint module is the `use Phoenix.Endpoint` macro with the `otp_app`. The `otp_app` is used for the configuration. This defines several functions on the `HelloWeb.Endpoint` module, including the `start_link` function which is called in the supervision tree.
 
 ```elixir
-  use Phoenix.Endpoint, otp_app: :hello
+use Phoenix.Endpoint, otp_app: :hello
 ```
 
 Next the endpoint declares a socket on the "/socket" URI. "/socket" requests will be handled by the `HelloWeb.UserSocket` module which is declared elsewhere in our application. Here we are just declaring that such a connection will exist.
 
 ```elixir
-  socket "/socket", HelloWeb.UserSocket
+socket "/socket", HelloWeb.UserSocket
 ```
 
 Next comes a series of plugs that are relevant to all requests in our application. We can customize some of the features, for example, enabling `gzip: true` when deploying to production to gzip the static files.
@@ -47,40 +47,40 @@ Next comes a series of plugs that are relevant to all requests in our applicatio
 Static files are served from `priv/static` before any part of our request makes it to a router.
 
 ```elixir
-  plug Plug.Static,
-    at: "/", from: :hello, gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+plug Plug.Static,
+  at: "/", from: :hello, gzip: false,
+  only: ~w(css fonts images js favicon.ico robots.txt)
 ```
 If code reloading is enabled, a socket will be used to communicate to the browser that the page needs to be reloaded when code is changed on the server. This feature is enabled by default in the development environment. This is configured using `config :hello, HelloWeb.Endpoint, code_reloader: true`.
 
 ```elixir
-  if code_reloading? do
-    socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
-    plug Phoenix.LiveReloader
-    plug Phoenix.CodeReloader
-  end
+if code_reloading? do
+  socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
+  plug Phoenix.LiveReloader
+  plug Phoenix.CodeReloader
+end
 ```
 
 [Plug.RequestId](https://hexdocs.pm/plug/Plug.RequestId.html) generates a unique id for each request and [Plug.Logger](https://hexdocs.pm/plug/Plug.Logger.html) logs the request path, status code and request time by default.
 
 ```elixir
-  plug Plug.RequestId
-  plug Plug.Logger
+plug Plug.RequestId
+plug Plug.Logger
 ```
 
 [Plug.Session](https://hexdocs.pm/plug/Plug.Session.html) handles the session cookies and session stores.
 
 ```elixir
-  plug Plug.Session,
-    store: :cookie,
-    key: "_hello_key",
-    signing_salt: "change_me"
+plug Plug.Session,
+  store: :cookie,
+  key: "_hello_key",
+  signing_salt: "change_me"
 ```
 
 By default the last plug in the endpoint is the router. The router matches a path to a particular controller action or plug. The router is covered in the [Routing Guide](routing.html).
 
 ```elixir
-  plug HelloWeb.Router
+plug HelloWeb.Router
 ```
 
 The endpoint can be customized to add additional plugs, to allow HTTP basic authentication, CORS, subdomain routing and more.

--- a/guides/introduction/community.md
+++ b/guides/introduction/community.md
@@ -10,4 +10,4 @@ There are a number of places to connect with community members at all experience
 * Ask or answer questions about Phoenix on [Elixir Forum](https://elixirforum.com/c/phoenix-forum) or [Stack Overflow](http://stackoverflow.com/questions/tagged/phoenix-framework).
 * To discuss new features in the framework, email the [phoenix-core mailing list](https://groups.google.com/group/phoenix-core).
 * Follow the Phoenix Framework on [Twitter](https://twitter.com/elixirphoenix).
-* The source for these guides is [on GitHub](https://github.com/phoenixframework/phoenix_guides). To help improve the guides, please report an [issue](https://github.com/phoenixframework/phoenix_guides/issues) or open a [pull request](https://github.com/phoenixframework/phoenix_guides/pulls).
+* The source for these guides is [on GitHub](https://github.com/phoenixframework/phoenix/tree/master/guides). To help improve the guides, please report an [issue](https://github.com/phoenixframework/phoenix/issues) or open a [pull request](https://github.com/phoenixframework/phoenix/pulls).

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -88,7 +88,7 @@ PostgreSQL is a relational database server. Phoenix configures applications to u
 
 When we work with Ecto schemas in these guides, we will use PostgreSQL and the Postgrex adapter for it. In order to follow along with the examples, we should install PostgreSQL. The PostgreSQL wiki has [installation guides](https://wiki.postgresql.org/wiki/Detailed_installation_guides) for a number of different systems.
 
-Postgrex is a direct Phoenix dependency, and it will be automatically installed along with the rest of our dependencies as we start our app.
+Postgrex is a direct Phoenix dependency, and it will be automatically installed along with the rest of our dependencies as we start building our app.
 
 ### inotify-tools (for linux users)
 

--- a/guides/introduction/overview.md
+++ b/guides/introduction/overview.md
@@ -47,7 +47,7 @@ Phoenix is made up of a number of distinct parts, each with its own purpose and 
 
 ## Phoenix Layers
 
-We just covered the internal parts that make up Phoenix, but its important to remember Phoenix itself is actually the top layer of a multi-layer system designed to be modular and flexible. The other layers include Cowboy, Plug, and Ecto.
+We just covered the internal parts that make up Phoenix, but it's important to remember Phoenix itself is actually the top layer of a multi-layer system designed to be modular and flexible. The other layers include Cowboy, Plug, and Ecto.
 
 ### Cowboy
 

--- a/guides/presence.md
+++ b/guides/presence.md
@@ -22,11 +22,11 @@ You're all set! See the Phoenix.Presence docs for more details:
 http://hexdocs.pm/phoenix/Phoenix.Presence.html
 ```
 
-If we open up the `hello_web/channels/presence.ex` file, we will see the following line:
+If we open up the `lib/hello_web/channels/presence.ex` file, we will see the following line:
 
 ```elixir
-  use Phoenix.Presence, otp_app: :hello,
-                        pubsub_server: Hello.PubSub
+use Phoenix.Presence, otp_app: :hello,
+                      pubsub_server: Hello.PubSub
 ```
 
 This sets up the module for presence, defining the functions we require for tracking presences. As mentioned in the generator task, we should add this module to our supervision tree in
@@ -34,7 +34,7 @@ This sets up the module for presence, defining the functions we require for trac
 
 ```elixir
 children = [
-  # ...
+  ...
   HelloWeb.Presence,
 ]
 ```
@@ -64,9 +64,9 @@ end
 We also need to change our connect function to take a `user_id` from the params and assign it on the socket. In production you may want to use `Phoenix.Token` if you have real users that are authenticated.
 
 ```elixir
-  def connect(params, socket) do
-    {:ok, assign(socket, :user_id, params["user_id"])}
-  end
+def connect(params, socket) do
+  {:ok, assign(socket, :user_id, params["user_id"])}
+end
 ```
 
 Next, we will create the channel that we'll communicate presence over. After a user joins we can push the list of presences down the channel and then track the connection. We can also provide a map of additional information to track.
@@ -133,7 +133,7 @@ channel.join()
 
 We can ensure this is working by opening 3 browser tabs. If we navigate to <http://localhost:4000/?name=Alice> on two browser tabs and <http://localhost:4000/?name=Bob> then we should see:
 
-```
+```console
 Alice (count: 2)
 Bob (count: 1)
 ```

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -68,13 +68,13 @@ Define this route at the bottom of the `scope "/", HelloWeb do` block in the rou
 get "/", RootController, :index
 ```
 
-Then run `$ mix compile` at the root of your project.
+Then run `mix compile` at the root of your project.
 
 ## Examining Routes
 
 Phoenix provides a great tool for investigating routes in an application, the mix task `phx.routes`.
 
-Let's see how this works. Go to the root of a newly-generated Phoenix application and run `$ mix phx.routes`. (If you haven't already done so, you'll need to run `$ mix do deps.get, compile` before running the `routes` task.) You should see something like the following, generated from the only route we currently have:
+Let's see how this works. Go to the root of a newly-generated Phoenix application and run `mix phx.routes`. (If you haven't already done so, you'll need to run `mix do deps.get, compile` before running the `routes` task.) You should see something like the following, generated from the only route we currently have:
 
 ```console
 $ mix phx.routes
@@ -100,7 +100,7 @@ end
 ```
 For this purpose, it doesn't matter that we don't actually have a `HelloWeb.UserController`.
 
-Then go to the root of your project, and run `$ mix phx.routes`
+Then go to the root of your project, and run `mix phx.routes`
 
 You should see something like the following:
 
@@ -136,7 +136,7 @@ Let's say we have a read-only posts resource. We could define it like this:
 resources "/posts", PostController, only: [:index, :show]
 ```
 
-Running `$ mix phx.routes` shows that we now only have the routes to the index and show actions defined.
+Running `mix phx.routes` shows that we now only have the routes to the index and show actions defined.
 
 ```elixir
 post_path  GET     /posts      HelloWeb.PostController :index
@@ -149,7 +149,7 @@ Similarly, if we have a comments resource, and we don't want to provide a route 
 resources "/comments", CommentController, except: [:delete]
 ```
 
-Running `$ mix phx.routes` now shows that we have all the routes except the DELETE request to the delete action.
+Running `mix phx.routes` now shows that we have all the routes except the DELETE request to the delete action.
 
 ```elixir
 comment_path  GET    /comments           HelloWeb.CommentController :index
@@ -240,7 +240,7 @@ end
 
 Path helpers are functions which are dynamically defined on the `Router.Helpers` module for an individual application. For us, that is `HelloWeb.Router.Helpers`. Their names are derived from the name of the controller used in the route definition. Our controller is `HelloWeb.PageController`, and `page_path` is the function which will return the path to the root of our application.
 
-That's a mouthful. Let's see it in action. Run `$ iex -S mix` at the root of the project. When we call the `page_path` function on our router helpers with the `Endpoint` or connection and action as arguments, it returns the path to us.
+That's a mouthful. Let's see it in action. Run `iex -S mix` at the root of the project. When we call the `page_path` function on our router helpers with the `Endpoint` or connection and action as arguments, it returns the path to us.
 
 ```elixir
 iex> HelloWeb.Router.Helpers.page_path(HelloWeb.Endpoint, :index)
@@ -313,7 +313,7 @@ resources "/users", UserController do
   resources "/posts", PostController
 end
 ```
-When we run `$ mix phx.routes` now, in addition to the routes we saw for `users` above, we get the following set of routes:
+When we run `mix phx.routes` now, in addition to the routes we saw for `users` above, we get the following set of routes:
 
 ```elixir
 . . .
@@ -387,7 +387,7 @@ end
 
 Note also, that the way this scope is currently defined, we need to fully qualify our controller name, `HelloWeb.Admin.ReviewController`. We'll fix that in a minute.
 
-Running `$ mix phx.routes` again, in addition to the previous set of routes we get the following:
+Running `mix phx.routes` again, in addition to the previous set of routes we get the following:
 
 ```elixir
 . . .
@@ -416,7 +416,7 @@ scope "/admin" do
 end
 ```
 
-and we run `$ mix phx.routes`, we get this output:
+and we run `mix phx.routes`, we get this output:
 
 ```elixir
 . . .
@@ -454,7 +454,7 @@ scope "/admin", as: :admin do
 end
 ```
 
-`$ mix phx.routes` now shows us we have what we are looking for.
+`mix phx.routes` now shows us we have what we are looking for.
 
 ```elixir
 . . .
@@ -477,7 +477,7 @@ admin_review_path  PATCH   /admin/reviews/:id              HelloWeb.Admin.Review
 admin_review_path  DELETE  /admin/reviews/:id              HelloWeb.Admin.ReviewController :delete
 ```
 
-The path helpers now return what we want them to as well. Run `$ iex -S mix` and give it a try yourself.
+The path helpers now return what we want them to as well. Run `iex -S mix` and give it a try yourself.
 
 ```elixir
 iex(1)> HelloWeb.Router.Helpers.review_path(HelloWeb.Endpoint, :index)
@@ -499,7 +499,7 @@ scope "/admin", as: :admin do
 end
 ```
 
-Here's what `$ mix phx.routes` tells us:
+Here's what `mix phx.routes` tells us:
 
 ```elixir
 . . .
@@ -541,7 +541,7 @@ scope "/admin", HelloWeb.Admin, as: :admin do
 end
 ```
 
-Now run `$ mix phx.routes` again and you can see that we get the same result as above when we qualified each controller name individually.
+Now run `mix phx.routes` again and you can see that we get the same result as above when we qualified each controller name individually.
 
 This doesn't just apply to nested routes, we can even nest all of the routes for our application inside a scope that simply has an alias for the name of our Phoenix app, and eliminate the duplication of our application name in our controller names.
 
@@ -561,7 +561,7 @@ defmodule HelloWeb.Router do
 end
 ```
 
-Again `$ mix phx.routes` tells us that all of our controllers now have the correct, fully-qualified names.
+Again `mix phx.routes` tells us that all of our controllers now have the correct, fully-qualified names.
 
 ```elixir
  image_path  GET     /images            HelloWeb.ImageController :index
@@ -597,7 +597,7 @@ scope "/api", HelloWeb.Api, as: :api do
 end
 ```
 
-`$ mix phx.routes` tells us that we have the routes we're looking for.
+`mix phx.routes` tells us that we have the routes we're looking for.
 
 ```elixir
  api_v1_image_path  GET     /api/v1/images            HelloWeb.Api.V1.ImageController :index
@@ -650,7 +650,7 @@ defmodule HelloWeb.Router do
   . . .
 end
 ```
-And when we run `$ mix phx.routes`, we see the following output.
+And when we run `mix phx.routes`, we see the following output.
 
 ```elixir
 user_path  GET     /users           HelloWeb.UserController :index

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -687,11 +687,11 @@ Endpoints organize all the plugs common to every request, and apply them before 
 
 - [Plug.Static](https://hexdocs.pm/plug/Plug.Static.html) - serves static assets. Since this plug comes before the logger, serving of static assets is not logged
 
+- [Phoenix.CodeReloader](https://hexdocs.pm/phoenix/Phoenix.CodeReloader.html) - a plug that enables code reloading for all entries in the web directory. It is configured directly in the Phoenix application
+
 - [Plug.RequestId](https://hexdocs.pm/plug/Plug.RequestId.html) - generates a unique request id for each request.
 
 - [Plug.Logger](https://hexdocs.pm/plug/Plug.Logger.html) - logs incoming requests
-
-- [Phoenix.CodeReloader](https://hexdocs.pm/phoenix/Phoenix.CodeReloader.html) - a plug that enables code reloading for all entries in the web directory. It is configured directly in the Phoenix application
 
 - [Plug.Parsers](https://hexdocs.pm/plug/Plug.Parsers.html) - parses the request body when a known parser is available. By default parsers parse urlencoded, multipart and json (with `jason`). The request body is left untouched when the request content-type cannot be parsed
 

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -41,7 +41,7 @@ Scopes have their own section in this guide, so we won't spend time on the `scop
 Inside the scope block, however, we have our first actual route:
 
 ```elixir
-  get "/", PageController, :index
+get "/", PageController, :index
 ```
 
 `get` is a Phoenix macro which expands out to define one clause of the `match/5` function. It corresponds to the HTTP verb GET. Similar macros exist for other HTTP verbs including POST, PUT, PATCH, DELETE, OPTIONS, CONNECT, TRACE and HEAD.
@@ -51,7 +51,7 @@ The first argument to these macros is the path. Here, it is the root of the appl
 If this were the only route in our router module, the clause of the `match/5` function would look like this after the macro is expanded:
 
 ```elixir
-  def match(:get, "/", PageController, :index, [])
+def match(:get, "/", PageController, :index, [])
 ```
 
 The body of the `match/5` function sets up the connection and invokes the matched controller action.
@@ -203,7 +203,7 @@ This means that the plugs in the `authenticate_user` and `ensure_admin` pipeline
 The `opts` that are passed to the `init/1` callback of a Plug can be passed as a 3rd argument. For example, maybe the background job page lets you set the name of your application to be displayed on the page. This could be passed with:
 
 ```elixir
-  forward "/jobs", BackgroundJob.Plug, name: "Hello Phoenix"
+forward "/jobs", BackgroundJob.Plug, name: "Hello Phoenix"
 ```
 
 There is a fourth `router_opts` argument that can be passed. These options are outlined in the `Phoenix.Router.scope/2` documentation.

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -171,10 +171,10 @@ The `Phoenix.Router.forward/4` macro can be used to send all requests that start
 defmodule HelloWeb.Router do
   use HelloWeb, :router
 
-  #...
+  ...
 
   scope "/", HelloWeb do
-    #...
+    ...
   end
 
   forward "/jobs", BackgroundJob.Plug
@@ -189,7 +189,7 @@ We can even use the `forward/4` macro in a pipeline. If we wanted to ensure that
 defmodule HelloWeb.Router do
   use HelloWeb, :router
 
-  #...
+  ...
 
   scope "/" do
     pipe_through [:authenticate_user, :ensure_admin]
@@ -316,7 +316,7 @@ end
 When we run `mix phx.routes` now, in addition to the routes we saw for `users` above, we get the following set of routes:
 
 ```elixir
-. . .
+...
 user_post_path  GET     /users/:user_id/posts           HelloWeb.PostController :index
 user_post_path  GET     /users/:user_id/posts/:id/edit  HelloWeb.PostController :edit
 user_post_path  GET     /users/:user_id/posts/new       HelloWeb.PostController :new
@@ -363,7 +363,7 @@ The paths to the user facing reviews would look like a standard resource.
 /reviews
 /reviews/1234
 /reviews/1234/edit
-. . .
+...
 ```
 
 The admin review paths could be prefixed with `/admin`.
@@ -372,7 +372,7 @@ The admin review paths could be prefixed with `/admin`.
 /admin/reviews
 /admin/reviews/1234
 /admin/reviews/1234/edit
-. . .
+...
 ```
 
 We accomplish this with a scoped route that sets a path option to `/admin` like this one. For now, let's not nest this scope inside of any other scopes (like the `scope "/", HelloWeb do` one provided for us in a new app).
@@ -390,7 +390,7 @@ Note also, that the way this scope is currently defined, we need to fully qualif
 Running `mix phx.routes` again, in addition to the previous set of routes we get the following:
 
 ```elixir
-. . .
+...
 review_path  GET     /admin/reviews           HelloWeb.Admin.ReviewController :index
 review_path  GET     /admin/reviews/:id/edit  HelloWeb.Admin.ReviewController :edit
 review_path  GET     /admin/reviews/new       HelloWeb.Admin.ReviewController :new
@@ -406,9 +406,9 @@ This looks good, but there is a problem here. Remember that we wanted both user 
 ```elixir
 scope "/", HelloWeb do
   pipe_through :browser
-  . . .
+  ...
   resources "/reviews", ReviewController
-  . . .
+  ...
 end
 
 scope "/admin" do
@@ -419,7 +419,7 @@ end
 and we run `mix phx.routes`, we get this output:
 
 ```elixir
-. . .
+...
 review_path  GET     /reviews                 HelloWeb.ReviewController :index
 review_path  GET     /reviews/:id/edit        HelloWeb.ReviewController :edit
 review_path  GET     /reviews/new             HelloWeb.ReviewController :new
@@ -428,7 +428,7 @@ review_path  POST    /reviews                 HelloWeb.ReviewController :create
 review_path  PATCH   /reviews/:id             HelloWeb.ReviewController :update
              PUT     /reviews/:id             HelloWeb.ReviewController :update
 review_path  DELETE  /reviews/:id             HelloWeb.ReviewController :delete
-. . .
+...
 review_path  GET     /admin/reviews           HelloWeb.Admin.ReviewController :index
 review_path  GET     /admin/reviews/:id/edit  HelloWeb.Admin.ReviewController :edit
 review_path  GET     /admin/reviews/new       HelloWeb.Admin.ReviewController :new
@@ -444,9 +444,9 @@ The actual routes we get all look right, except for the path helper `review_path
 ```elixir
 scope "/", HelloWeb do
   pipe_through :browser
-  . . .
+  ...
   resources "/reviews", ReviewController
-  . . .
+  ...
 end
 
 scope "/admin", as: :admin do
@@ -457,7 +457,7 @@ end
 `mix phx.routes` now shows us we have what we are looking for.
 
 ```elixir
-. . .
+...
       review_path  GET     /reviews                        HelloWeb.ReviewController :index
       review_path  GET     /reviews/:id/edit               HelloWeb.ReviewController :edit
       review_path  GET     /reviews/new                    HelloWeb.ReviewController :new
@@ -466,7 +466,7 @@ end
       review_path  PATCH   /reviews/:id                    HelloWeb.ReviewController :update
                    PUT     /reviews/:id                    HelloWeb.ReviewController :update
       review_path  DELETE  /reviews/:id                    HelloWeb.ReviewController :delete
-. . .
+...
 admin_review_path  GET     /admin/reviews                  HelloWeb.Admin.ReviewController :index
 admin_review_path  GET     /admin/reviews/:id/edit         HelloWeb.Admin.ReviewController :edit
 admin_review_path  GET     /admin/reviews/new              HelloWeb.Admin.ReviewController :new
@@ -502,7 +502,7 @@ end
 Here's what `mix phx.routes` tells us:
 
 ```elixir
-. . .
+...
  admin_image_path  GET     /admin/images            HelloWeb.Admin.ImageController :index
  admin_image_path  GET     /admin/images/:id/edit   HelloWeb.Admin.ImageController :edit
  admin_image_path  GET     /admin/images/new        HelloWeb.Admin.ImageController :new
@@ -635,7 +635,7 @@ This router is perfectly fine with two scopes defined for the same path.
 ```elixir
 defmodule HelloWeb.Router do
   use Phoenix.Router
-  . . .
+  ...
   scope "/", HelloWeb do
     pipe_through :browser
 
@@ -647,7 +647,7 @@ defmodule HelloWeb.Router do
 
     resources "/posts", PostController
   end
-  . . .
+  ...
 end
 ```
 And when we run `mix phx.routes`, we see the following output.

--- a/guides/up_and_running.md
+++ b/guides/up_and_running.md
@@ -14,7 +14,7 @@ We can run `mix phx.new` from any directory in order to bootstrap our Phoenix ap
 $ mix phx.new hello
 ```
 
-> A note about [webpack](https://webpack.js.org/) before we begin: Phoenix will use webpack for asset management by default. Webpacks' dependencies are installed via the node package manager, not mix. Phoenix will prompt us to install them at the end of the `mix phx.new` task. If we say "no" at that point, and if we don't install those dependencies later with `npm install`, our application will raise errors when we try to start it, and our assets may not load properly. If we don't want to use webpack at all, we can simply pass `--no-webpack` to `mix phx.new`.
+> A note about [webpack](https://webpack.js.org/) before we begin: Phoenix will use webpack for asset management by default. Webpack's dependencies are installed via the node package manager, not mix. Phoenix will prompt us to install them at the end of the `mix phx.new` task. If we say "no" at that point, and if we don't install those dependencies later with `npm install`, our application will raise errors when we try to start it, and our assets may not load properly. If we don't want to use webpack at all, we can simply pass `--no-webpack` to `mix phx.new`.
 
 > A note about [Ecto](https://hexdocs.pm/phoenix/ecto.html): Ecto allows our Phoenix application to communicate with a data store, such as PostgreSQL or MongoDB. If our application will not require this component we can skip this dependency by passing the `--no-ecto` flag to `mix phx.new`. This flag may also be combined with `--no-webpack` to create a skeleton application.
 

--- a/guides/up_and_running.md
+++ b/guides/up_and_running.md
@@ -63,11 +63,13 @@ Phoenix assumes that our PostgreSQL database will have a `postgres` user account
 
 Ok, let's give it a try. First, we'll `cd` into the `hello/` directory we've just created:
 
-    $ cd hello
+```console
+$ cd hello
+```
 
 Now we'll create our database:
 
-```
+```console
 $ mix ecto.create
 Compiling 13 files (.ex)
 Generated hello app

--- a/guides/up_and_running.md
+++ b/guides/up_and_running.md
@@ -59,7 +59,7 @@ You can also run your app inside IEx (Interactive Elixir) as:
 
 Once our dependencies are installed, the task will prompt us to change into our project directory and start our application.
 
-Phoenix assumes that our PostgreSQL database will have a `postgres` user account with the correct permissions and a password of "postgres". If that isn't the case, please see the [`Mix Tasks Guide`](phoenix_mix_tasks.html#ecto-specific-mix-tasks) to learn more about the `mix ecto.create` task.
+Phoenix assumes that our PostgreSQL database will have a `postgres` user account with the correct permissions and a password of "postgres". If that isn't the case, please see the [Mix Tasks Guide](phoenix_mix_tasks.html#ecto-specific-mix-tasks) to learn more about the `mix ecto.create` task.
 
 Ok, let's give it a try. First, we'll `cd` into the `hello/` directory we've just created:
 

--- a/guides/views.md
+++ b/guides/views.md
@@ -28,7 +28,7 @@ Let's open up our application layout template, `lib/hello_web/templates/layout/a
 
 to call a `title/0` function, like this.
 
-```elixir
+```html
 <title><%= title() %></title>
 ```
 
@@ -61,7 +61,7 @@ end
 ```
 
 Now if you fire up the server with `mix phx.server` and visit `http://localhost:4000`, you should see the following text below your layout header instead of the main template page:
-```
+```console
 rendering with assigns [:conn, :view_module, :view_template]
 ```
 
@@ -125,7 +125,7 @@ This is the message: <%= message() %>
 
 This doesn't correspond to any action in our controller, but we'll exercise it in an `iex` session. At the root of our project, we can run `iex -S mix`, and then explicitly render our template.
 
-```console
+```elixir
 iex(1)> Phoenix.View.render(HelloWeb.PageView, "test.html", %{})
   {:safe, [["" | "This is the message: "] | "Hello from the view!"]}
 ```
@@ -140,7 +140,7 @@ This is the message: <%= message() %>
 
 Note the `@` in the top line. Now if we change our function call, we see a different rendering after recompiling `PageView` module.
 
-```console
+```elixir
 iex(2)> r HelloWeb.PageView
 warning: redefining module HelloWeb.PageView (current version loaded from _build/dev/lib/hello/ebin/Elixir.HelloWeb.PageView.beam)
   lib/hello_web/views/page_view.ex:1
@@ -154,7 +154,7 @@ iex(3)> Phoenix.View.render(HelloWeb.PageView, "test.html", message: "Assigns ha
  ```
 Let's test out the HTML escaping, just for fun.
 
-```console
+```elixir
 iex(4)> Phoenix.View.render(HelloWeb.PageView, "test.html", message: "<script>badThings();</script>")
 {:safe,
   [[[["" | "I came from assigns: "] |
@@ -164,11 +164,11 @@ iex(4)> Phoenix.View.render(HelloWeb.PageView, "test.html", message: "<script>ba
 
 If we need only the rendered string, without the whole tuple, we can use the `render_to_iodata/3`.
 
- ```console
- iex(5)> Phoenix.View.render_to_iodata(HelloWeb.PageView, "test.html", message: "Assigns has an @.")
- [[[["" | "I came from assigns: "] | "Assigns has an @."] |
-   "\nThis is the message: "] | "Hello from the view!"]
-  ```
+```elixir
+iex(5)> Phoenix.View.render_to_iodata(HelloWeb.PageView, "test.html", message: "Assigns has an @.")
+[[[["" | "I came from assigns: "] | "Assigns has an @."] |
+  "\nThis is the message: "] | "Hello from the view!"]
+```
 
 ### A Word About Layouts
 
@@ -319,26 +319,26 @@ end
 In the view we see our `render/2` function pattern matching on `"index.json"`, `"show.json"`, and `"page.json"`. In our controller `show/2` function, `render(conn, "show.json", page: page)` will pattern match on the matching name and extension in the view's `render/2` functions. In other words, `render(conn, "index.json", pages: pages)` will call `render("index.json", %{pages: pages})`. The `render_many/3` function takes the data we want to respond with (`pages`), a `View`, and a string to pattern match on the `render/2` function defined on `View`. It will map over each item in `pages`, and pass the item to the `render/2` function in `View` matching the file string. `render_one/3` follows, the same signature, ultimately using the `render/2` matching `page.json` to specify what each `page` looks like. The `render/2` matching `"index.json"` will respond with JSON as you would expect:
 
 ```javascript
-  {
-    "data": [
-      {
-       "title": "foo"
-      },
-      {
-       "title": "bar"
-      },
-   ]
-  }
+{
+  "data": [
+    {
+     "title": "foo"
+    },
+    {
+     "title": "bar"
+    },
+ ]
+}
 ```
 
 And the `render/2` matching `"show.json"`:
 
 ```javascript
-  {
-    "data": {
-      "title": "foo"
-    }
+{
+  "data": {
+    "title": "foo"
   }
+}
 ```
 
 It's useful to build our views like this so they can be composable. Imagine a situation where our `Page` has a `has_many` relationship with `Author`, and depending on the request, we may want to send back `author` data with the `page`. We can easily accomplish this with a new `render/2`:
@@ -363,8 +363,8 @@ end
 The name used in assigns is determined from the view. For example the `PageView` will use `%{page: page}` and the `AuthorView` will use `%{author: author}`. This can be overridden with the `as` option. Let's assume that the author view uses `%{writer: writer}` instead of `%{author: author}`:
 
 ```elixir
-  def render("page_with_authors.json", %{page: page}) do
-    %{title: page.title,
-      authors: render_many(page.authors, AuthorView, "author.json", as: :writer)}
-  end
+def render("page_with_authors.json", %{page: page}) do
+  %{title: page.title,
+    authors: render_many(page.authors, AuthorView, "author.json", as: :writer)}
+end
 ```


### PR DESCRIPTION
- Prefer unintended code blocks
- Consistently use `...` for indicating other code present (instead of `. . .` or `#...`)
- Use `elixir` code fence for `iex>` blocks with output
- Update some of outdated code / information
- Fix typos

If this looks good I will do another run through remaining guides some other time.