### PR TITLE
Initializes Git in Phx.New task

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.Phx.New do
   @switches [dev: :boolean, webpack: :boolean, ecto: :boolean,
              app: :string, module: :string, web_module: :string,
              database: :string, binary_id: :boolean, html: :boolean,
-             umbrella: :boolean]
+             umbrella: :boolean, git: :boolean]
 
   def run([version]) when version in ~w(-v --version) do
     Mix.shell.info "Phoenix v#{@version}"
@@ -121,7 +121,18 @@ defmodule Mix.Tasks.Phx.New do
     |> Generator.put_binding()
     |> validate_project()
     |> generator.generate()
+    |> init_git(opts)
     |> prompt_to_install_deps(generator)
+  end
+
+  defp init_git(%Project{} = project, opts) do
+    initialize? = Keyword.get(opts, :git, true)
+
+    maybe_cd(project.project_path, fn ->
+      maybe_cmd("git init", initialize?, true)
+    end)
+
+    project
   end
 
   defp validate_project(%Project{opts: opts} = project) do

--- a/test/mix/tasks/phx.new_test.exs
+++ b/test/mix/tasks/phx.new_test.exs
@@ -72,6 +72,9 @@ defmodule Mix.Tasks.Phx.NewTest do
           # Ensure /priv static files are copied
           assert File.exists?("priv/static/js/phoenix.js")
 
+          # Ensure /.git path exists
+          assert File.exists?(".git/")
+
           # We can run tests too, starting the app.
           assert capture_io(fn ->
             capture_io(:user, fn ->


### PR DESCRIPTION
Based on the Rails framework, when `rails new app` is issued it gets created with git already initialized.

This PR attempts to replicate that behaviour.

I've also made the option of skipping the initialization of `git` entirely by passing `--no-git` as an argument