### PR TITLE
Add default argument for change_* in controller and context's template

### DIFF
--- a/priv/templates/phx.gen.context/access_no_schema.ex
+++ b/priv/templates/phx.gen.context/access_no_schema.ex
@@ -84,6 +84,6 @@
       %Todo{...}
 
   """
-  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do
+  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %> \\ %<%= inspect schema.alias %>{}) do
     raise "TODO"
   end

--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -91,6 +91,6 @@
       %Ecto.Changeset{source: %<%= inspect schema.alias %>{}}
 
   """
-  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do
+  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %> \\ %<%= inspect schema.alias %>{}) do
     <%= inspect schema.alias %>.changeset(<%= schema.singular %>, %{})
   end

--- a/priv/templates/phx.gen.html/controller.ex
+++ b/priv/templates/phx.gen.html/controller.ex
@@ -2,7 +2,6 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   use <%= inspect context.web_module %>, :controller
 
   alias <%= inspect context.module %>
-  alias <%= inspect schema.module %>
 
   def index(conn, _params) do
     <%= schema.plural %> = <%= inspect context.alias %>.list_<%= schema.plural %>()
@@ -10,7 +9,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def new(conn, _params) do
-    changeset = <%= inspect context.alias %>.change_<%= schema.singular %>(%<%= inspect schema.alias %>{})
+    changeset = <%= inspect context.alias %>.change_<%= schema.singular %>()
     render(conn, "new.html", changeset: changeset)
   end
 


### PR DESCRIPTION
Why?

A Context is responsible for abstracting away all backend details, so
schema related things should be placed in it.

If the schema related things is leaked to controller, the controller
is not schema-agnostic anymore.

Before this commit:
```
// file post_controller.ex
alias XX.Posts
alias XX.Posts.Post
changeset = Posts.change_post(%Post{})
```

After this commit:
```
// file post_controller.ex
alias XX.Posts
changeset = Posts.change_post()
```

Schema related things is hidden under context. Awesome! right?