### PR TITLE
Add Elixir 1.7 and 1.8 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ elixir:
   - 1.4
   - 1.5
   - 1.6
+  - 1.7
+  - 1.8
 otp_release:
   - 19.3
   - 20.3
@@ -13,6 +15,14 @@ matrix:
       otp_release: 21.0
     - elixir: 1.4
       otp_release: 21.0
+    - elixir: 1.7
+      otp_release: 19.3
+    - elixir: 1.7
+      otp_release: 20.3
+    - elixir: 1.8
+      otp_release: 19.3
+    - elixir: 1.8
+      otp_release: 20.3
 sudo: false
 env:
   global:


### PR DESCRIPTION
To avoid increasing much the build matrix, removed the combinations of new Elixir with older OTP versions.