### PR TITLE
Fix typespec for put_layout

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -489,7 +489,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_layout(Plug.Conn.t, {atom, binary | atom} | binary | false) :: Plug.Conn.t
+  @spec put_layout(Plug.Conn.t, {atom, binary | atom} | atom | binary | false) :: Plug.Conn.t
   def put_layout(%Plug.Conn{state: state} = conn, layout) do
     if state in @unsent do
       do_put_layout(conn, layout)


### PR DESCRIPTION
https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/controller.ex#L509 makes it clear that an atom is a valid layout value, the typespec should reflect that.