### PR TITLE
Fix typespec of socket.id

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -250,7 +250,7 @@ defmodule Phoenix.Socket do
           channel_pid: pid,
           endpoint: atom,
           handler: atom,
-          id: nil,
+          id: String.t | nil,
           joined: boolean,
           ref: term,
           private: %{},


### PR DESCRIPTION
The typespec of Phoenix.Socket lists `id` as `nil`. It should be `String.t` if I see that correctly. 