### PR TITLE
Add Elixir Slack link in the help column of the initial default page

### DIFF
--- a/installer/templates/phx_web/templates/page/index.html.eex
+++ b/installer/templates/phx_web/templates/page/index.html.eex
@@ -30,6 +30,9 @@
       <li>
         <a href="https://twitter.com/elixirphoenix">Twitter @elixirphoenix</a>
       </li>
+      <li>
+        <a href="https://elixir-slackin.herokuapp.com/">Elixir on Slack</a>
+      </li>
     </ul>
   </article>
 </section>


### PR DESCRIPTION
Considering that the Elixir community on Slack has now more than 20k members, it's one of the best places to find help. Adding it to Phoenix initial default page should bring even more members to the community.