### PR TITLE
Allow the app configuration to specify a custom migration module for the generated migration code.

### DIFF
--- a/lib/mix/phoenix/schema.ex
+++ b/lib/mix/phoenix/schema.ex
@@ -77,7 +77,6 @@ defmodule Mix.Phoenix.Schema do
     web_path = web_namespace && Phoenix.Naming.underscore(web_namespace)
     embedded? = Keyword.get(opts, :embedded, false)
     generate? = Keyword.get(opts, :schema, true)
-    migration_module = migration_module()
 
     singular =
       module
@@ -125,7 +124,7 @@ defmodule Mix.Phoenix.Schema do
       sample_id: sample_id(opts),
       context_app: ctx_app,
       generate?: generate?,
-      migration_module: migration_module}
+      migration_module: migration_module()}
   end
 
   @doc """
@@ -347,18 +346,10 @@ defmodule Mix.Phoenix.Schema do
     |> String.replace("/", "_")
   end
 
-@doc """
-  Looks in the application configuration file for a custom migration module to use when generating the migration file.
-  
-  ## Example
-    config :ecto_sql, migration_module: MyApplication.CustomMigrationModule
-  If a custom migration module is not defined in the configuration, returns the default Ecto.Migration
-  """
-  defp migration_module() do
-    case Application.get_env(:ecto_sql, :migration_module) do
-      nil -> Ecto.Migration
+  defp migration_module do
+    case Application.get_env(:ecto_sql, :migration_module, Ecto.Migration) do
       migration_module when is_atom(migration_module) -> migration_module
-      other -> raise "Expect :migration_module to be a module, got: #{inspect(other)}"
+      other -> Mix.raise "Expected :migration_module to be a module, got: #{inspect(other)}"
     end
   end
 end

--- a/lib/mix/phoenix/schema.ex
+++ b/lib/mix/phoenix/schema.ex
@@ -30,7 +30,8 @@ defmodule Mix.Phoenix.Schema do
             web_path: nil,
             web_namespace: nil,
             context_app: nil,
-            route_helper: nil
+            route_helper: nil,
+            migration_module: nil
 
   @valid_types [
     :integer,
@@ -76,6 +77,7 @@ defmodule Mix.Phoenix.Schema do
     web_path = web_namespace && Phoenix.Naming.underscore(web_namespace)
     embedded? = Keyword.get(opts, :embedded, false)
     generate? = Keyword.get(opts, :schema, true)
+    migration_module = migration_module()
 
     singular =
       module
@@ -122,7 +124,8 @@ defmodule Mix.Phoenix.Schema do
       route_helper: route_helper(web_path, singular),
       sample_id: sample_id(opts),
       context_app: ctx_app,
-      generate?: generate?}
+      generate?: generate?,
+      migration_module: migration_module}
   end
 
   @doc """
@@ -342,5 +345,20 @@ defmodule Mix.Phoenix.Schema do
     "#{web_path}_#{singular}"
     |> String.trim_leading("_")
     |> String.replace("/", "_")
+  end
+
+@doc """
+  Looks in the application configuration file for a custom migration module to use when generating the migration file.
+  
+  ## Example
+    config :ecto_sql, migration_module: MyApplication.CustomMigrationModule
+  If a custom migration module is not defined in the configuration, returns the default Ecto.Migration
+  """
+  defp migration_module() do
+    case Application.get_env(:ecto_sql, :migration_module) do
+      nil -> Ecto.Migration
+      migration_module when is_atom(migration_module) -> migration_module
+      other -> raise "Expect :migration_module to be a module, got: #{inspect(other)}"
+    end
   end
 end

--- a/priv/templates/phx.gen.schema/migration.exs
+++ b/priv/templates/phx.gen.schema/migration.exs
@@ -1,5 +1,5 @@
 defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.table) %> do
-  use Ecto.Migration
+  use <%=  inspect schema.migration_module %>
 
   def change do
     create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %>) do

--- a/priv/templates/phx.gen.schema/migration.exs
+++ b/priv/templates/phx.gen.schema/migration.exs
@@ -1,5 +1,5 @@
 defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.table) %> do
-  use <%=  inspect schema.migration_module %>
+  use <%= inspect schema.migration_module %>
 
   def change do
     create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %>) do

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -268,6 +268,22 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
         end
       end
     end
+
+    in_tmp_project "uses defaults from generators configuration (binary_id) with Migration Module set", fn ->
+      with_generator_env [binary_id: true], fn ->
+        Application.put_env(:ecto_sql, :migration_module, MyCustomApp.MigrationModule)
+        Gen.Schema.run(~w(Blog.Post posts))
+        Application.delete_env(:ecto_sql, :migration_module)
+
+        assert [migration] = Path.wildcard("priv/repo/migrations/*_create_posts.exs")
+
+        assert_file migration, fn file ->
+          assert file =~ "use MyCustomApp.MigrationModule"
+          assert file =~ "create table(:posts, primary_key: false) do"
+          assert file =~ "add :id, :binary_id, primary_key: true"
+        end
+      end
+    end
   end
 
   test "generates schema without extra line break", config do

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -268,20 +268,23 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
         end
       end
     end
+  end
 
-    in_tmp_project "uses defaults from generators configuration (binary_id) with Migration Module set", fn ->
-      with_generator_env [binary_id: true], fn ->
+  test "generates migrations with a custom migration module", config do
+    in_tmp_project config.test, fn ->
+      try do
         Application.put_env(:ecto_sql, :migration_module, MyCustomApp.MigrationModule)
-        Gen.Schema.run(~w(Blog.Post posts))
-        Application.delete_env(:ecto_sql, :migration_module)
-
+  
+        Gen.Schema.run(~w(Blog.Post posts))        
+  
         assert [migration] = Path.wildcard("priv/repo/migrations/*_create_posts.exs")
-
+  
         assert_file migration, fn file ->
           assert file =~ "use MyCustomApp.MigrationModule"
-          assert file =~ "create table(:posts, primary_key: false) do"
-          assert file =~ "add :id, :binary_id, primary_key: true"
+          assert file =~ "create table(:posts) do"
         end
+      after
+        Application.delete_env(:ecto_sql, :migration_module)
       end
     end
   end


### PR DESCRIPTION
If the current app configuration specifies a custom migration module the generated migration code will use that rather than the default
  Ecto.Migration
     config :ecto_sql, migration_module: MyApplication.CustomMigrationModule

cf.  https://github.com/elixir-ecto/ecto_sql/pull/76

I think I have all the bases covered, if not please advise and I will correct.

Thank you!