### PR TITLE
Phoenix.Token.verify/4 will always return true when provided a max_age lower or equal to 0

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -233,6 +233,8 @@ defmodule Phoenix.Token do
     false
   end
 
+  defp expired?(signed, max_age_secs) when max_age_secs <= 0, do: true
+
   defp expired?(signed, max_age_secs), do: (signed + trunc(max_age_secs * 1000)) < now_ms()
 
   defp now_ms, do: System.system_time(:millisecond)

--- a/test/phoenix/token_test.exs
+++ b/test/phoenix/token_test.exs
@@ -46,6 +46,7 @@ defmodule Phoenix.TokenTest do
     assert Token.verify(conn(), "id", token, max_age: -1000) == {:error, :expired}
     assert Token.verify(conn(), "id", token, max_age: 100) == {:ok, 1}
     assert Token.verify(conn(), "id", token, max_age: -100) == {:error, :expired}
+    assert Token.verify(conn(), "id", token, max_age: 0) == {:error, :expired}
 
     token = Token.sign(conn(), "id", 1)
     assert Token.verify(conn(), "id", token, max_age: 0.1) == {:ok, 1}


### PR DESCRIPTION
Because of the comparison being done in ms if assertions with 0
can sometimes lead to unexpected results

Example:

```
token = Phoenix.Token.sign(Endpoint, @salt, user_id)

assert {:error, :expired} = Phoenix.Token.verify(Endpoint, @salt, token, max_age: 0)
```

Even though this test should always pass, given that the expiration of the token is right now, it can sometimes fail giving it a transient behaviour.