### PR TITLE
Update the documentation for 1.4.1 context location

### DIFF
--- a/guides/phoenix_mix_tasks.md
+++ b/guides/phoenix_mix_tasks.md
@@ -205,8 +205,8 @@ $ mix phx.gen.html Blog Post posts body:string word_count:integer
 * creating test/hello_web/controllers/post_controller_test.exs
 * creating lib/hello/blog/post.ex
 * creating priv/repo/migrations/20170906150129_create_posts.exs
-* creating lib/hello/blog/blog.ex
-* injecting lib/hello/blog/blog.ex
+* creating lib/hello/blog.ex
+* injecting lib/hello/blog.ex
 * creating test/hello/blog/blog_test.exs
 * injecting test/hello/blog/blog_test.exs
 ```
@@ -277,8 +277,8 @@ $ mix phx.gen.html Blog Post posts body:string word_count:integer --no-schema
 * creating lib/hello_web/templates/post/show.html.eex
 * creating lib/hello_web/views/post_view.ex
 * creating test/hello_web/controllers/post_controller_test.exs
-* creating lib/hello/blog/blog.ex
-* injecting lib/hello/blog/blog.ex
+* creating lib/hello/blog.ex
+* injecting lib/hello/blog.ex
 * creating test/hello/blog/blog_test.exs
 * injecting test/hello/blog/blog_test.exs
 ```
@@ -316,8 +316,8 @@ $ mix phx.gen.json Blog Post posts title:string content:string
 * creating lib/hello_web/controllers/fallback_controller.ex
 * creating lib/hello/blog/post.ex
 * creating priv/repo/migrations/20170906153323_create_posts.exs
-* creating lib/hello/blog/blog.ex
-* injecting lib/hello/blog/blog.ex
+* creating lib/hello/blog.ex
+* injecting lib/hello/blog.ex
 * creating test/hello/blog/blog_test.exs
 * injecting test/hello/blog/blog_test.exs
 ```
@@ -388,8 +388,8 @@ $ mix phx.gen.json Blog Post posts title:string content:string --no-schema
 * creating test/hello_web/controllers/post_controller_test.exs
 * creating lib/hello_web/views/changeset_view.ex
 * creating lib/hello_web/controllers/fallback_controller.ex
-* creating lib/hello/blog/blog.ex
-* injecting lib/hello/blog/blog.ex
+* creating lib/hello/blog.ex
+* injecting lib/hello/blog.ex
 * creating test/hello/blog/blog_test.exs
 * injecting test/hello/blog/blog_test.exs
 ```
@@ -408,9 +408,9 @@ Important: If we don't do this, our application won't compile, and we'll get an 
 $ mix phx.server
 Compiling 18 files (.ex)
 
-== Compilation error in file lib/hello/blog/blog.ex ==
-** (CompileError) lib/hello/blog/blog.ex:65: Hello.Blog.Post.__struct__/0 is undefined, cannot expand struct Hello.Blog.Post
-    lib/hello/blog/blog.ex:65: (module)
+== Compilation error in file lib/hello/blog.ex ==
+** (CompileError) lib/hello/blog.ex:65: Hello.Blog.Post.__struct__/0 is undefined, cannot expand struct Hello.Blog.Post
+    lib/hello/blog.ex:65: (module)
     (stdlib) erl_eval.erl:670: :erl_eval.do_apply/6
     (elixir) lib/kernel/parallel_compiler.ex:121: anonymous fn/4 in Kernel.ParallelCompiler.spawn_compilers/1
 ```
@@ -425,8 +425,8 @@ The `mix phx.gen.context` task takes a number of arguments, the module name of t
 $ mix phx.gen.context Accounts User users name:string age:integer
 * creating lib/hello/accounts/user.ex
 * creating priv/repo/migrations/20170906161158_create_users.exs
-* creating lib/hello/accounts/accounts.ex
-* injecting lib/hello/accounts/accounts.ex
+* creating lib/hello/accounts.ex
+* injecting lib/hello/accounts.ex
 * creating test/hello/accounts/accounts_test.exs
 * injecting test/hello/accounts/accounts_test.exs
 ```
@@ -436,8 +436,8 @@ $ mix phx.gen.context Accounts User users name:string age:integer
 ```console
 * creating lib/hello/admin/accounts/user.ex
 * creating priv/repo/migrations/20170906161246_create_users.exs
-* creating lib/hello/admin/accounts/accounts.ex
-* injecting lib/hello/admin/accounts/accounts.ex
+* creating lib/hello/admin/accounts.ex
+* injecting lib/hello/admin/accounts.ex
 * creating test/hello/admin/accounts/accounts_test.exs
 * injecting test/hello/admin/accounts/accounts_test.exs
 ```

--- a/guides/testing/testing.md
+++ b/guides/testing/testing.md
@@ -443,8 +443,8 @@ $ mix phx.gen.html Users User users name:string email:string bio:string number_o
 * creating test/hello_web/controllers/user_controller_test.exs
 * creating lib/hello/users/user.ex
 * creating priv/repo/migrations/20180904210841_create_users.exs
-* creating lib/hello/users/users.ex
-* injecting lib/hello/users/users.ex
+* creating lib/hello/users.ex
+* injecting lib/hello/users.ex
 * creating test/hello/users/users_test.exs
 * injecting test/hello/users/users_test.exs
 

--- a/guides/testing/testing_controllers.md
+++ b/guides/testing/testing_controllers.md
@@ -35,8 +35,8 @@ $ mix phx.gen.context Accounts User users name:string email:string:unique passwo
 
 * creating lib/hello/accounts/user.ex
 * creating priv/repo/migrations/20170913155721_create_users.exs
-* creating lib/hello/accounts/accounts.ex
-* injecting lib/hello/accounts/accounts.ex
+* creating lib/hello/accounts.ex
+* injecting lib/hello/accounts.ex
 * creating test/hello/accounts/accounts_test.exs
 * injecting test/hello/accounts/accounts_test.exs
 
@@ -401,7 +401,7 @@ end
 
 We want a HTTP status code of 404 to notify the requester that this resource was not found, as well as an accompanying error message. Notice that we use [`text_response/2`](https://hexdocs.pm/phoenix/Phoenix.ConnTest.html#text_response/2) instead of [`json_response/2`](https://hexdocs.pm/phoenix/Phoenix.ConnTest.html#json_response/2) to assert that the status code is 404 and the response body matches the accompanying error message. You can run this test now to see what happens. You should see that an `Ecto.NoResultsError` is thrown, because there is no such user in the database.
 
-Our controller action needs to handle the error thrown by Ecto. We have two choices here. By default, this will be handled by the [phoenix_ecto](https://github.com/phoenixframework/phoenix_ecto) library, returning a 404. However if we want to show a custom error message, we can create a new `get_user/1` function that does not throw an Ecto error. For this example, we'll take the second path and implement a new `get_user/1` function in the file `lib/hello/accounts/accounts.ex`, just before the `get_user!/1` function:
+Our controller action needs to handle the error thrown by Ecto. We have two choices here. By default, this will be handled by the [phoenix_ecto](https://github.com/phoenixframework/phoenix_ecto) library, returning a 404. However if we want to show a custom error message, we can create a new `get_user/1` function that does not throw an Ecto error. For this example, we'll take the second path and implement a new `get_user/1` function in the file `lib/hello/accounts.ex`, just before the `get_user!/1` function:
 
 ```elixir
 @doc """

--- a/guides/testing/testing_schemas.md
+++ b/guides/testing/testing_schemas.md
@@ -476,8 +476,8 @@ bio:string number_of_pets:integer
 * creating test/hello_web/controllers/user_controller_test.exs
 * creating lib/hello/accounts/user.ex
 * creating priv/repo/migrations/20180906212909_create_users.exs
-* creating lib/hello/accounts/accounts.ex
-* injecting lib/hello/accounts/accounts.ex
+* creating lib/hello/accounts.ex
+* injecting lib/hello/accounts.ex
 * creating test/hello/accounts/accounts_test.exs
 * injecting test/hello/accounts/accounts_test.exs
 

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
 
   Overall, this generator will add the following files to `lib/your_app`:
 
-    * a context module in `accounts/accounts.ex`, serving as the API boundary
+    * a context module in `accounts.ex`, serving as the API boundary
     * a schema in `accounts/user.ex`, with a `users` table
 
   A migration file for the repository and test files for the context

--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
 
   Overall, this generator will add the following files to `lib/`:
 
-    * a context module in `lib/app/accounts/accounts.ex` for the accounts API
+    * a context module in `lib/app/accounts.ex` for the accounts API
     * a schema in `lib/app/accounts/user.ex`, with an `users` table
     * a view in `lib/app_web/views/user_view.ex`
     * a controller in `lib/app_web/controllers/user_controller.ex`

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
 
   Overall, this generator will add the following files to `lib/`:
 
-    * a context module in `lib/app/accounts/accounts.ex` for the accounts API
+    * a context module in `lib/app/accounts.ex` for the accounts API
     * a schema in `lib/app/accounts/user.ex`, with an `users` table
     * a view in `lib/app_web/views/user_view.ex`
     * a controller in `lib/app_web/controllers/user_controller.ex`


### PR DESCRIPTION
1bf9ec3ee6c97bb3847669a74f2d8debd3648dc3 dropped special convention for context locations, but guides and documentation weren't properly updated.

This commit fixes some (hopefully all) of the outdated file names in the documentation.

cc @chrismccord 