### PR TITLE
 prohibit context creation with the same name as the application

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -91,7 +91,7 @@ defmodule Mix.Phoenix do
 
   """
   def inflect(singular) do
-    base       = Mix.Phoenix.base
+    base       = Mix.Phoenix.base()
     web_module = base |> web_module() |> inspect()
     scoped     = Phoenix.Naming.camelize(singular)
     path       = Phoenix.Naming.underscore(scoped)

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -208,6 +208,8 @@ defmodule Mix.Tasks.Phx.Gen.Context do
         raise_with_help "Expected the schema, #{inspect schema}, to be a valid module name"
       context == schema ->
         raise_with_help "The context and schema should have different names"
+      context == Mix.Phoenix.base() ->
+        raise_with_help "Cannot generate context #{context} because it has the same name as the application"
       true ->
         args
     end

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -210,6 +210,8 @@ defmodule Mix.Tasks.Phx.Gen.Context do
         raise_with_help "The context and schema should have different names"
       context == Mix.Phoenix.base() ->
         raise_with_help "Cannot generate context #{context} because it has the same name as the application"
+      schema == Mix.Phoenix.base() ->
+        raise_with_help "Cannot generate schema #{schema} because it has the same name as the application"
       true ->
         args
     end

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -108,6 +108,10 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
         Gen.Context.run(~w(Phoenix Post blogs))
       end
 
+      assert_raise Mix.Error, ~r/Cannot generate schema Phoenix because it has the same name as the application/, fn ->
+        Gen.Context.run(~w(Blog Phoenix blogs))
+      end
+
       assert_raise Mix.Error, ~r/Invalid arguments/, fn ->
         Gen.Context.run(~w(Blog.Post posts))
       end

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -104,6 +104,10 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
         Gen.Context.run(~w(Blog Blog blogs))
       end
 
+      assert_raise Mix.Error, ~r/Cannot generate context Phoenix because it has the same name as the application/, fn ->
+        Gen.Context.run(~w(Phoenix Post blogs))
+      end
+
       assert_raise Mix.Error, ~r/Invalid arguments/, fn ->
         Gen.Context.run(~w(Blog.Post posts))
       end


### PR DESCRIPTION
closes #3260