### PR TITLE
Update project tagline to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![phoenix logo](https://raw.githubusercontent.com/phoenixframework/phoenix/master/priv/static/phoenix.png)
 > ### Productive. Reliable. Fast.
-> A productive web framework that does not compromise speed and maintainability.
+> A productive web framework that does not compromise speed or maintainability.
 
 [![Build Status](https://api.travis-ci.org/phoenixframework/phoenix.svg?branch=master)](https://travis-ci.org/phoenixframework/phoenix)
 [![Inline docs](http://inch-ci.org/github/phoenixframework/phoenix.svg)](http://inch-ci.org/github/phoenixframework/phoenix)

--- a/guides/views.md
+++ b/guides/views.md
@@ -75,7 +75,7 @@ Let's open up the `lib/hello_web/templates/page/index.html.eex` and locate this 
 ```html
 <section class="phx-hero">
   <h1><%= gettext "Welcome to %{name}!", name: "Phoenix" %></h1>
-  <p>A productive web framework that<br/>does not compromise speed and maintainability.</p>
+  <p>A productive web framework that<br/>does not compromise speed or maintainability.</p>
 </section>
 ```
 
@@ -84,7 +84,7 @@ Then let's add a line with a link back to the same page. (The objective is to se
 ```html
 <section class="phx-hero">
   <h1><%= gettext "Welcome to %{name}!", name: "Phoenix" %></h1>
-  <p>A productive web framework that<br/>does not compromise speed and maintainability.</p>
+  <p>A productive web framework that<br/>does not compromise speed or maintainability.</p>
   <p><a href="<%= Routes.page_path(@conn, :index) %>">Link back to this page</a></p>
 </section>
 ```

--- a/installer/templates/phx_web/templates/page/index.html.eex
+++ b/installer/templates/phx_web/templates/page/index.html.eex
@@ -1,6 +1,6 @@
 <section class="phx-hero">
   <h1><%%= gettext "Welcome to %{name}!", name: "Phoenix" %></h1>
-  <p>A productive web framework that<br/>does not compromise speed and maintainability.</p>
+  <p>A productive web framework that<br/>does not compromise speed or maintainability.</p>
 </section>
 
 <section class="row">

--- a/lib/mix/tasks/phx.ex
+++ b/lib/mix/tasks/phx.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Phx do
     Application.ensure_all_started(:phoenix)
     Mix.shell.info "Phoenix v#{Application.spec(:phoenix, :vsn)}"
     Mix.shell.info "Productive. Reliable. Fast."
-    Mix.shell.info "A productive web framework that does not compromise speed and maintainability."
+    Mix.shell.info "A productive web framework that does not compromise speed or maintainability."
     Mix.shell.info "\nAvailable tasks:\n"
     Mix.Tasks.Help.run(["--search", "phx."])
   end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Phoenix.MixProject do
       homepage_url: "http://www.phoenixframework.org",
       description: """
       Productive. Reliable. Fast. A productive web framework that
-      does not compromise speed and maintainability.
+      does not compromise speed or maintainability.
       """
     ]
   end


### PR DESCRIPTION
This is a super nitpick, but [my friend](https://github.com/jalcine) dared me to open a PR, so here it is.

The project tagline currently reads:

> A productive web framework that does not compromise speed and maintainability.

While this may technically be true, it translates to the following logic:

```
(doesCompromiseSpeed && doesCompromiseMaintainability) === false
```

The issue with this is that since only one of the conditions needs to be `false`, it could be interpreted along the lines of:

> Other frameworks compromise both speed and maintainability, but Phoenix only compromises one of them.

Thus, I think it'd be better to change the "and" to an "or," so that it's clear that Phoenix does not compromise either speed _or_ maintainability. In other words:

```
(doesCompromiseSpeed || doesCompromiseMaintainability) === false
```