### PR TITLE
Prevent duplicate channel instantiation in phoenix.js

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -362,7 +362,7 @@ class Push {
  */
 export class Channel {
   constructor(topic, params, socket) {
-    if (socket.channels.find((c) => c.topic === topic)) {
+    if (socket.channels.find(c => c.topic === topic)) {
       throw new Error(`tried to instantiate the same channel twice. Try using a different topic`)
     }
 

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -362,6 +362,10 @@ class Push {
  */
 export class Channel {
   constructor(topic, params, socket) {
+    if (socket.channels.find((c) => c.topic === topic)) {
+      throw new Error(`tried to instantiate the same channel twice. Try using a different topic`)
+    }
+
     this.state       = CHANNEL_STATES.closed
     this.topic       = topic
     this.params      = closure(params || {})
@@ -920,8 +924,13 @@ export class Socket {
    * @returns {Channel}
    */
   channel(topic, chanParams = {}){
-    let chan = new Channel(topic, chanParams, this)
-    this.channels.push(chan)
+    let chan = this.channels.find(c => c.topic === topic);
+
+    if(!chan){
+      chan = new Channel(topic, chanParams, this)
+      this.channels.push(chan)
+    }
+
     return chan
   }
 

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -13,7 +13,7 @@ const defaultTimeout = 10000
 
 describe("constructor", () => {
   beforeEach(() => {
-    socket = { timeout: 1234 }
+    socket = new Socket("/socket", { timeout: 1234 })
   })
 
   it("sets defaults", () => {
@@ -49,11 +49,15 @@ describe("constructor", () => {
     assert.equal(joinPush.timeout, 1234)
   })
 
+  it("throws if instantiating the same channel twice", () => {
+    socket.channel("topic", {one: "two"})
+    assert.throws(() => new Channel("topic", function(){ return({one: "two"}) }, socket), /^Error: tried to instantiate the same channel twice/)
+  })
 })
 
 describe("updating join params", () => {
   beforeEach(() => {
-    socket = { timeout: 1234 }
+    socket = new Socket("/socket", { timeout: 1234 })
   })
 
   it("can update the join params", () => {

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -391,6 +391,21 @@ describe("channel", () => {
     const [foundChannel] = socket.channels
     assert.deepStrictEqual(foundChannel, channel)
   })
+
+  it("doesn't add duplicated channel if already exists", () => {
+    assert.equal(socket.channels.length, 0)
+
+     channel = socket.channel("topic", {one: "two"})
+
+     assert.equal(socket.channels.length, 1)
+
+     channel = socket.channel("topic", {two: "three"})
+
+     assert.equal(socket.channels.length, 1)
+
+     const [foundChannel] = socket.channels
+    assert.deepStrictEqual(foundChannel, channel)
+  })
 })
 
 describe("remove", () => {

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -395,13 +395,11 @@ describe("channel", () => {
   it("doesn't add duplicated channel if already exists", () => {
     assert.equal(socket.channels.length, 0)
 
-     channel = socket.channel("topic", {one: "two"})
+    channel = socket.channel("topic", {one: "two"})
+    assert.equal(socket.channels.length, 1)
 
-     assert.equal(socket.channels.length, 1)
-
-     channel = socket.channel("topic", {two: "three"})
-
-     assert.equal(socket.channels.length, 1)
+    channel = socket.channel("topic", {two: "three"})
+    assert.equal(socket.channels.length, 1)
 
      const [foundChannel] = socket.channels
     assert.deepStrictEqual(foundChannel, channel)

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -401,7 +401,7 @@ describe("channel", () => {
     channel = socket.channel("topic", {two: "three"})
     assert.equal(socket.channels.length, 1)
 
-     const [foundChannel] = socket.channels
+    const [foundChannel] = socket.channels
     assert.deepStrictEqual(foundChannel, channel)
   })
 })


### PR DESCRIPTION
Fixes #3171 

This PR covers the following scenarios:

1 - When using `socket.channel("topic")` twice, returning the channel itself, gracefully, as [mentioned here](https://github.com/phoenixframework/phoenix/issues/3171#issuecomment-445841298).

2 - When trying to instantiate a channel within the same socket for the same topic, (e.g. `new Channel`), raising an error to prevent duplicate binding and blocking a duplicate channel on client-side as [requested here](https://github.com/phoenixframework/phoenix/issues/3171#issuecomment-445843240)

In this case, a duplicate join is no longer possible as `channel.joinedOnce` prevents a channel from being joined twice, while topic "2" covers cases where two different channels with the same topic are instantiated.

Hope this helps! :-)
