### PR TITLE
resources/4 accepts alias option but not listed in the doc

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -569,6 +569,7 @@ defmodule Phoenix.Router do
       is automatically derived from the controller name, i.e. `UserController` will
       have name `"user"`
     * `:as` - configures the named helper exclusively
+    * `:alias` - an alias (atom) containing the controller scope
     * `:singleton` - defines routes for a singleton resource that is looked up by
       the client without referencing an ID. Read below for more information
 


### PR DESCRIPTION
I found that `resources/4` accepts `:alias` option and [tested here](https://github.com/phoenixframework/phoenix/blob/2c586b7d45e0d7fa5cb1b640dc2b624b04afbff9/test/phoenix/router/resources_test.exs#L48) but not mentioned in the document. Please tell me if I'm missing something.