### PR TITLE
Fix documentation generated in prod.exs

### DIFF
--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -22,7 +22,7 @@ config :logger, level: :info
 # To get SSL working, you will need to add the `https` key
 # to the previous section and set your `:url` port to 443:
 #
-#     config :<%= app_name %>, <%= endpoint_module %>,
+#     config :<%= web_app_name %>, <%= endpoint_module %>,
 #       ...
 #       url: [host: "example.com", port: 443],
 #       https: [
@@ -46,7 +46,7 @@ config :logger, level: :info
 # We also recommend setting `force_ssl` in your endpoint, ensuring
 # no data is ever sent via http, always redirecting to https:
 #
-#     config :<%= app_name %>, <%= endpoint_module %>,
+#     config :<%= web_app_name %>, <%= endpoint_module %>,
 #       force_ssl: [hsts: true]
 #
 # Check `Plug.SSL` for all available options in `force_ssl`.
@@ -61,7 +61,7 @@ config :logger, level: :info
 # Alternatively, you can configure exactly which server to
 # start per endpoint:
 #
-#     config :<%= app_name %>, <%= endpoint_module %>, server: true
+#     config :<%= web_app_name %>, <%= endpoint_module %>, server: true
 #
 # Note you can't rely on `System.get_env/1` when using releases.
 # See the releases documentation accordingly.

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
@@ -23,7 +23,7 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
 # To get SSL working, you will need to add the `https` key
 # to the previous section and set your `:url` port to 443:
 #
-#     config :<%= app_name %>, <%= endpoint_module %>,
+#     config :<%= web_app_name %>, <%= endpoint_module %>,
 #       ...
 #       url: [host: "example.com", port: 443],
 #       https: [
@@ -47,7 +47,7 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
 # We also recommend setting `force_ssl` in your endpoint, ensuring
 # no data is ever sent via http, always redirecting to https:
 #
-#     config :<%= app_name %>, <%= endpoint_module %>,
+#     config :<%= web_app_name %>, <%= endpoint_module %>,
 #       force_ssl: [hsts: true]
 #
 # Check `Plug.SSL` for all available options in `force_ssl`.
@@ -62,7 +62,7 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
 # Alternatively, you can configure exactly which server to
 # start per endpoint:
 #
-#     config :<%= app_name %>, <%= endpoint_module %>, server: true
+#     config :<%= web_app_name %>, <%= endpoint_module %>, server: true
 #
 # Note you can't rely on `System.get_env/1` when using releases.
 # See the releases documentation accordingly.


### PR DESCRIPTION
When running `phx.new` with the `--umbrella` flag, the comments generated in the web app's `/config/prod.exs` have a small bug in that they refer to the `:app_name` instead of `:web_app_name`.

E.g. 
`awesome_umbrella/apps/awesome_web/config/prod.exs` has:
`config :awesome_web, AwesomeWeb.Endpoint,`
yet the comments in that file have 3 references to
`#     config :awesome, AwesomeWeb.Endpoint,`

For non-umbrella projects, the output is correct as `app_name` and `web_app_name` have the same value, however I still think it's more correct to use `web_app_name`.

Hope this is helpful! 😃 

