### PR TITLE
Instrument controller calls with Telemetry

### DIFF
--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -24,7 +24,7 @@ defmodule Phoenix.Controller.Pipeline do
                       |> Map.put(:phoenix_action, action))
 
         start = System.monotonic_time()
-        :telemetry.execute([:phoenix, :controller, :call, :start], %{}, %{
+        :telemetry.execute([:phoenix, :controller, :call, :start], %{time: System.system_time()}, %{
           conn: conn,
           controller: __MODULE__,
           action: action

--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -35,7 +35,7 @@ defmodule Phoenix.Controller.Pipeline do
         end
         stop = System.monotonic_time()
         :telemetry.execute([:phoenix, :controller, :call, :stop], %{
-          time: stop - start
+          duration: stop - start
         }, %{
           conn: conn,
           controller: __MODULE__,

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Phoenix.MixProject do
     [
       {:plug, "~> 1.7"},
       {:phoenix_pubsub, "~> 1.1"},
+      {:telemetry, "~> 0.4.0"},
 
       # Optional deps
       {:plug_cowboy, "~> 1.0 or ~> 2.0", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -17,5 +17,6 @@
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
+  "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
   "websocket_client": {:git, "https://github.com/jeremyong/websocket_client.git", "9a6f65d05ebf2725d62fb19262b21f1805a59fbf", []},
 }

--- a/test/phoenix/controller/pipeline_test.exs
+++ b/test/phoenix/controller/pipeline_test.exs
@@ -213,13 +213,18 @@ defmodule Phoenix.Controller.PipelineTest do
     MyController.call(stack_conn(), :show)
 
     assert_receive {:event, :start, measurements, metadata}
-    assert measurements == %{}
+    assert map_size(measurements) == 1
+    assert %{time: time} = measurements
+    assert is_integer(time)
+    assert map_size(metadata) == 3
     assert %{controller: MyController, action: :show, conn: conn} = metadata
     assert conn.private.stack == []
 
     assert_receive {:event, :stop, measurements, metadata}
+    assert map_size(measurements) == 1
     assert %{duration: duration} = measurements
     assert is_integer(duration)
+    assert map_size(metadata) == 3
     assert %{controller: MyController, action: :show, conn: conn} = metadata
     assert conn.private.stack == [:action, :before2, :before1]
   end

--- a/test/phoenix/controller/pipeline_test.exs
+++ b/test/phoenix/controller/pipeline_test.exs
@@ -218,8 +218,8 @@ defmodule Phoenix.Controller.PipelineTest do
     assert conn.private.stack == []
 
     assert_receive {:event, :stop, measurements, metadata}
-    assert %{time: time} = measurements
-    assert is_integer(time)
+    assert %{duration: duration} = measurements
+    assert is_integer(duration)
     assert %{controller: MyController, action: :show, conn: conn} = metadata
     assert conn.private.stack == [:action, :before2, :before1]
   end


### PR DESCRIPTION
This is a first attempt at integrating Telemetry with Phoenix. There are two events emitted, before and after the controller is called, to make it consistent with the existing instrumenters API. The `stop` event carries the total time it took to execute the pipeline. Both events include the same metadata, controller name, action, and conn. 

I have a few questions I hope more experienced contributors will help me answer 😄 

**Endpoint:** is it safe to assume that endpoint is always present in the controller's conn? I thought that it might be quite useful to include it in the event metadata.

**Implementation:** I'm not sure if it's fine to keep it as is, or maybe it would be cleaner to implement it as an instrumenter? 🤔 

**Time measurement name:** I used generic "time", although I'm not sure I like it. Other candidates I thought about are "latency", "response_time", or "processing_time", although none of them is technically correct because more code is invoked before the pipeline is called.

Tell me what you think about it! 🙂 

#### TODO

- [ ] docs

/cc @bryannaegele @binaryseed