### PR TITLE
Added null reference check on resetHeartbeat() on phoenix.js

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -847,7 +847,7 @@ export class Socket {
    * @private
    */
 
-  resetHeartbeat(){ if(this.conn.skipHeartbeat){ return }
+  resetHeartbeat(){ if(this.conn && this.conn.skipHeartbeat){ return }
     this.pendingHeartbeatRef = null
     clearInterval(this.heartbeatTimer)
     this.heartbeatTimer = setInterval(() => this.sendHeartbeat(), this.heartbeatIntervalMs)


### PR DESCRIPTION
While running phoenix.js on react-native, we were getting a few of these in production:

```
#4 TypeError: null is not an object (evaluating 'this.conn.skipHeartbeat')
```

Adding a null reference check before evaluating that fixed the issue. 