### PR TITLE
phoenix.js: Document that passing params to connect() is deprecated

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -773,6 +773,9 @@ export class Socket {
   /**
    *
    * @param {Object} params - The params to send when connecting, for example `{user_id: userToken}`
+   *
+   * Passing params to connect is deprecated; pass them in the Socket constructor instead:
+   * `new Socket("/socket", {params: {user_id: userToken}})`.
    */
   connect(params){
     if(params){


### PR DESCRIPTION
From the [documentation](https://hexdocs.pm/phoenix/js/index.html#socketconnect) it was not clear that passing params into `Socket.connect()` is deprecated, only in runtime this will show on the JS console.