### PR TITLE
Update heroku.md add parentheses for raise

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -146,7 +146,7 @@ First, let's make sure our secret key is loaded from Heroku's environment variab
 config :hello, HelloWeb.Endpoint,
   url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json",
-  secret_key_base: System.get_env("SECRET_KEY_BASE") || raise "missing SECRET_KEY_BASE env var"
+  secret_key_base: System.get_env("SECRET_KEY_BASE") || raise("missing SECRET_KEY_BASE env var")
 ```
 
 Then, we'll add the production database configuration to `config/prod.exs`:


### PR DESCRIPTION
in case 
`secret_key_base: System.get_env("SECRET_KEY_BASE") || raise "missing SECRET_KEY_BASE env var" `

is not the last argument eg.

```
config :app, AppWeb.Endpoint,
  url: [host: "localhost"],
  secret_key_base: System.get_env("SECRET_KEY_BASE") || raise "missing SECRET_KEY_BASE env var",
  render_errors: [view: AppWeb.ErrorView, accepts: ~w(html json)],
  pubsub: [name: App.PubSub, adapter: Phoenix.PubSub.PG2]

```
the raise lacking parentheses will cause a CompileError (elixir 1.7.1)
** (CompileError) config/config.exs:13: invalid call "missing SECRET_KEY_BASE env var"

adding parentheses avoids issue.