### PR TITLE
Update css-loader to ^2.1.1

### DIFF
--- a/installer/templates/phx_assets/webpack/package.json
+++ b/installer/templates/phx_assets/webpack/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.0",
     "copy-webpack-plugin": "^4.5.0",
-    "css-loader": "^0.28.10",
+    "css-loader": "^2.1.1",
     "mini-css-extract-plugin": "^0.4.0",
     "optimize-css-assets-webpack-plugin": "^4.0.0",
     "terser-webpack-plugin": "^1.1.0",


### PR DESCRIPTION
I was having a problem in my Phoenix project, that the `@import`'s of my CSS file was not following the given order, so updating `css-loader` to the latest version just fixed it.