### PR TITLE
utilize [name] in webpack.config.js

### DIFF
--- a/installer/templates/phx_assets/webpack/webpack.config.js
+++ b/installer/templates/phx_assets/webpack/webpack.config.js
@@ -13,10 +13,10 @@ module.exports = (env, options) => ({
     ]
   },
   entry: {
-    './js/app.js': ['./js/app.js'].concat(glob.sync('./vendor/**/*.js'))
+    'app': ['./js/app.js'].concat(glob.sync('./vendor/**/*.js'))
   },
   output: {
-    filename: 'app.js',
+    filename: '[name].js',
     path: path.resolve(__dirname, '../priv/static/js')
   },
   stats: {
@@ -38,7 +38,7 @@ module.exports = (env, options) => ({
     ]
   },
   plugins: [
-    new MiniCssExtractPlugin({ filename: '../css/app.css' }),
+    new MiniCssExtractPlugin({ filename: '../css/[name].css' }),
     new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
   ]
 });


### PR DESCRIPTION
spent hours in webpack land as I wanted to output a separate css file.. :/

using [name] is step 1. - that enables one to have multiple entries and thus outputs..

I propose a doc PR later perhaps something like this
```
  entry: {
    'app': ['./js/app.js'].concat(glob.sync('./vendor/**/*.js'))
    // above will output app.js and app.css(if any css is imported in the js files)
    // in the appropriate priv/static folders (js/css)
    //
    // add entry if you want to build more separate js/css files eg:
    //
    // 'app': ['./js/app.js'].concat(glob.sync('./vendor/**/*.js')),
    // 'example': ['./js/other.js']
    //
    // which additionally will output example.js and example.css(if any css is imported in the js files)
  },

```
though I'm uncertain of how verbose/detailed/specific we want to be..