### PR TITLE
Comment out ellipses in code examples

### DIFF
--- a/guides/channels.md
+++ b/guides/channels.md
@@ -187,7 +187,7 @@ defmodule HelloWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :hello
 
   socket "/socket", HelloWeb.UserSocket
-  # ...
+  ...
 end
 ```
 
@@ -199,7 +199,7 @@ defmodule HelloWeb.UserSocket do
 
   ## Channels
   channel "room:*", HelloWeb.RoomChannel
-  # ...
+  ...
 ```
 
 Now, whenever a client sends a message whose topic starts with `"room:"`, it will be routed to our RoomChannel. Next, we'll define a `HelloWeb.RoomChannel` module to manage our chat room messages.
@@ -377,7 +377,7 @@ Let's say we have an authentication plug in our app called `OurAuth`. When `OurA
 
 ```elixir
 pipeline :browser do
-  # ...
+  ...
   plug OurAuth
   plug :put_user_token
 end

--- a/guides/channels.md
+++ b/guides/channels.md
@@ -187,7 +187,7 @@ defmodule HelloWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :hello
 
   socket "/socket", HelloWeb.UserSocket
-  ...
+  # ...
 end
 ```
 
@@ -199,7 +199,7 @@ defmodule HelloWeb.UserSocket do
 
   ## Channels
   channel "room:*", HelloWeb.RoomChannel
-  ...
+  # ...
 ```
 
 Now, whenever a client sends a message whose topic starts with `"room:"`, it will be routed to our RoomChannel. Next, we'll define a `HelloWeb.RoomChannel` module to manage our chat room messages.
@@ -236,7 +236,7 @@ We can use that library to connect to our socket and join our channel, we just n
 
 ```javascript
 // assets/js/socket.js
-...
+// ...
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
@@ -251,7 +251,7 @@ export default socket
 After that, we need to make sure `assets/js/socket.js` gets imported into our application JavaScript file. To do that, uncomment the last line in `assets/js/app.js`.
 
 ```javascript
-...
+// ...
 import socket from "./socket"
 ```
 
@@ -267,7 +267,7 @@ In `lib/hello_web/templates/page/index.html.eex`, we'll replace the existing cod
 Now let's add a couple of event listeners to `assets/js/socket.js`:
 
 ```javascript
-...
+// ...
 let channel           = socket.channel("room:lobby", {})
 let chatInput         = document.querySelector("#chat-input")
 let messagesContainer = document.querySelector("#messages")
@@ -289,7 +289,7 @@ export default socket
 All we had to do is detect that enter was pressed and then `push` an event over the channel with the message body. We named the event `"new_msg"`. With this in place, let's handle the other piece of a chat application where we listen for new messages and append them to our messages container.
 
 ```javascript
-...
+// ...
 let channel           = socket.channel("room:lobby", {})
 let chatInput         = document.querySelector("#chat-input")
 let messagesContainer = document.querySelector("#messages")
@@ -377,7 +377,7 @@ Let's say we have an authentication plug in our app called `OurAuth`. When `OurA
 
 ```elixir
 pipeline :browser do
-  ...
+  # ...
   plug OurAuth
   plug :put_user_token
 end


### PR DESCRIPTION
In the Channels guide, some of the ellipses in code examples breaks the syntax highlighting -- [Issue #3331](https://github.com/phoenixframework/phoenix/issues/3331). I've simply commented them out in both Elixir and JS.

Example Before:
<img width="754" alt="Screen Shot 2019-03-24 at 8 33 17 PM" src="https://user-images.githubusercontent.com/10692362/54889752-31315400-4e74-11e9-896b-a0726e9dbc0f.png">

After:
<img width="757" alt="Screen Shot 2019-03-24 at 8 34 57 PM" src="https://user-images.githubusercontent.com/10692362/54889782-52924000-4e74-11e9-874d-4b36763f0e11.png">


I wanted to try and generate the hex docs to make sure they are looking correct there as well but had some trouble. I followed these instructions from the README.md:
>To build the documentation from source:
>```bash
>$ cd assets
>$ npm install
>$ cd ..
>$ MIX_ENV=docs mix docs
>```

But was seeing this output:
```
$ MIX_ENV=docs mix docs
Compiling 76 files (.ex)
warning: redefining module Mix.Tasks.Phx.New.Ecto (current version loaded from /Users/llowder/.mix/archives/phx_new-1.4.2/phx_new-1.4.2/ebin/Elixir.Mix.Tasks.Phx.New.Ecto.beam)
  installer/lib/mix/tasks/phx.new.ecto.ex:1

warning: redefining module Mix.Tasks.Phx.New (current version loaded from /Users/llowder/.mix/archives/phx_new-1.4.2/phx_new-1.4.2/ebin/Elixir.Mix.Tasks.Phx.New.beam)
  installer/lib/mix/tasks/phx.new.ex:1

warning: redefining module Phx.New.Single (current version loaded from /Users/llowder/.mix/archives/phx_new-1.4.2/phx_new-1.4.2/ebin/Elixir.Phx.New.Single.beam)
  installer/lib/phx_new/single.ex:1


== Compilation error in file installer/lib/phx_new/single.ex ==
** (File.Error) could not read file "/private/var/folders/b0/5_kh51jj0s7gb2hl047p7gn00000gn/T/mix-local-installer-fetcher-6cTWig/deps/phx_new/templates/phx_assets/app.css": no such file or directory
    (elixir) lib/file.ex:353: File.read!/1
    lib/phx_new/generator.ex:30: anonymous fn/4 in Phx.New.Generator."MACRO-__before_compile__"/2
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    lib/phx_new/generator.ex:26: anonymous fn/3 in Phx.New.Generator."MACRO-__before_compile__"/2
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    expanding macro: Phx.New.Generator.__before_compile__/1
    installer/lib/phx_new/single.ex:1: Phx.New.Single (module)
```

Please let me know if I should open an issue for that, but I imagine I'm just missing something simple. 