### PR TITLE
Colorize webpack output

### DIFF
--- a/guides/errors.md
+++ b/guides/errors.md
@@ -35,7 +35,7 @@ config :hello, HelloWeb.Endpoint,
   debug_errors: false,
   code_reloader: true,
   cache_static_lookup: false,
-  watchers: [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development", "--watch-stdin",
+  watchers: [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development", "--watch-stdin", "--color",
                     cd: Path.expand("../assets", __DIR__)]]
 ```
 

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -17,6 +17,7 @@ config :<%= app_name %>, <%= endpoint_module %>,
       "--mode",
       "development",
       "--watch-stdin",
+      "--color",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]<% else %>[]<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -21,6 +21,7 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
       "--mode",
       "development",
       "--watch-stdin",
+      "--color",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]<% else %>[]<% end %>

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -181,14 +181,14 @@ defmodule Phoenix.Endpoint do
       You can configure it to whatever build tool or command you want:
 
           [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development",
-              "--watch-stdin"]]
+              "--watch-stdin", "--color"]]
 
       The `:cd` option can be used on a watcher to override the folder from
       which the watcher will run. By default this will be the project's root:
       `File.cwd!()`
 
           [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development",
-              "--watch-stdin"], cd: "my_frontend"]
+              "--watch-stdin", "--color"], cd: "my_frontend"]
 
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of


### PR DESCRIPTION
Hi!

This is a simple addition that enables colorized output for `Webpack` by default.

Screenshot `after` change for the newly generated project.

<img width="872" alt="image" src="https://user-images.githubusercontent.com/1043784/55151209-afe60400-5188-11e9-9fd2-62134b70941d.png">

I am sorry but I’m not quite familiar with the process of working with Phoenix framework versions.
Could you help me and point files/locations where I should write a message in the release notes and how can I add a message to the upgrade guide for existing Phoenix apps.

Thank you!