### PR TITLE
Enable show_sensitive_data_on_connection_error in config/dev.exs

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -192,7 +192,8 @@ defmodule Phx.New.Generator do
   end
 
   defp db_config(app, module, user, pass) do
-    [dev:  [username: user, password: pass, database: "#{app}_dev", hostname: "localhost"],
+    [dev:  [username: user, password: pass, database: "#{app}_dev", hostname: "localhost",
+            show_sensitive_data_on_connection_error: true],
      test: [username: user, password: pass, database: "#{app}_test", hostname: "localhost",
             pool: Ecto.Adapters.SQL.Sandbox],
      prod: [username: user, password: pass, database: "#{app}_prod"],


### PR DESCRIPTION
This will help developers debug connection errors in development,
improving their getting started experience.