### PR TITLE
Enable to use send_download without encode

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -884,7 +884,7 @@ defmodule Phoenix.Controller do
       Defaults to none
     * `:offset` - the bytes to offset when reading. Defaults to `0`
     * `:length` - the total bytes to read. Defaults to `:all`
-    * `:encode` - encode filename using `URI.encode_www_form/1`.
+    * `:encode` - encodes the filename using `URI.encode_www_form/1`.
       Defaults to `true`. When `false`, disables encoding. If you
       disable encoding, you need to guarantee there are no special
       characters in the filename, such as quotes, newlines, etc.

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -884,7 +884,9 @@ defmodule Phoenix.Controller do
       Defaults to none
     * `:offset` - the bytes to offset when reading. Defaults to `0`
     * `:length` - the total bytes to read. Defaults to `:all`
-    * `:encode` - encode filename using URI.encode_www_form. Defaults to `nil`
+    * `:encode` - encode filename using URI.encode_www_form.
+      Defaults to `nil`. Any value different of `false` will apply
+      the encode
 
   ## Examples
 

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -885,8 +885,10 @@ defmodule Phoenix.Controller do
     * `:offset` - the bytes to offset when reading. Defaults to `0`
     * `:length` - the total bytes to read. Defaults to `:all`
     * `:encode` - encode filename using `URI.encode_www_form/1`.
-      Defaults to `true`. When `false`, disables encoding. Disable
-      encoding may cause security implications.
+      Defaults to `true`. When `false`, disables encoding. If you
+      disable encoding, you need to guarantee there are no special
+      characters in the filename, such as quotes, newlines, etc.
+      Otherwise you can expose your application to security attacks
 
   ## Examples
 

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -884,9 +884,9 @@ defmodule Phoenix.Controller do
       Defaults to none
     * `:offset` - the bytes to offset when reading. Defaults to `0`
     * `:length` - the total bytes to read. Defaults to `:all`
-    * `:encode` - encode filename using URI.encode_www_form.
-      Defaults to `nil`. Any value different of `false` will apply
-      the encode
+    * `:encode` - encode filename using `URI.encode_www_form/1`.
+      Defaults to `true`. When `false`, disables encoding. Disable
+      encoding may cause security implications.
 
   ## Examples
 

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -934,7 +934,7 @@ defmodule Phoenix.Controller do
   end
 
   defp encode_filename(filename, encode) when encode == false, do: filename
-  defp encode_filename(filename, encode), do: URI.encode_www_form(filename)
+  defp encode_filename(filename, _encode), do: URI.encode_www_form(filename)
 
   defp ajax?(conn) do
     case get_req_header(conn, "x-requested-with") do

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -928,15 +928,15 @@ defmodule Phoenix.Controller do
 
   defp prepare_send_download(conn, filename, opts) do
     content_type = opts[:content_type] || MIME.from_path(filename)
-    encoded_filename = encode_filename(filename, opts[:encode])
+    encoded_filename = encode_filename(filename, Keyword.get(opts, :encode, true))
     warn_if_ajax(conn)
     conn
     |> put_resp_content_type(content_type, opts[:charset])
     |> put_resp_header("content-disposition", ~s[attachment; filename="#{encoded_filename}"])
   end
 
-  defp encode_filename(filename, encode) when encode == false, do: filename
-  defp encode_filename(filename, _encode), do: URI.encode_www_form(filename)
+  defp encode_filename(filename, false), do: filename
+  defp encode_filename(filename, true), do: URI.encode_www_form(filename)
 
   defp ajax?(conn) do
     case get_req_header(conn, "x-requested-with") do

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -884,6 +884,7 @@ defmodule Phoenix.Controller do
       Defaults to none
     * `:offset` - the bytes to offset when reading. Defaults to `0`
     * `:length` - the total bytes to read. Defaults to `:all`
+    * `:encode` - encode filename using URI.encode_www_form. Defaults to `nil`
 
   ## Examples
 
@@ -925,12 +926,15 @@ defmodule Phoenix.Controller do
 
   defp prepare_send_download(conn, filename, opts) do
     content_type = opts[:content_type] || MIME.from_path(filename)
-    encoded_filename = URI.encode_www_form(filename)
+    encoded_filename = encode_filename(filename, opts[:encode])
     warn_if_ajax(conn)
     conn
     |> put_resp_content_type(content_type, opts[:charset])
     |> put_resp_header("content-disposition", ~s[attachment; filename="#{encoded_filename}"])
   end
+
+  defp encode_filename(filename, encode) when encode == false, do: filename
+  defp encode_filename(filename, encode), do: URI.encode_www_form(filename)
 
   defp ajax?(conn) do
     case get_req_header(conn, "x-requested-with") do

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -402,6 +402,17 @@ defmodule Phoenix.Controller.ControllerTest do
              "world"
     end
 
+    test "sends file for download with custom :filename and :encode false" do
+      conn = send_download(conn(:get, "/"), {:file, @hello_txt}, filename: "dev's hello world.json", encode: false)
+      assert conn.status == 200
+      assert get_resp_header(conn, "content-disposition") ==
+             ["attachment; filename=\"dev's hello world.json\""]
+      assert get_resp_header(conn, "content-type") ==
+             ["application/json"]
+      assert conn.resp_body ==
+             "world"
+    end
+
     test "sends file for download with custom :content_type and :charset" do
       conn = send_download(conn(:get, "/"), {:file, @hello_txt}, content_type: "application/json", charset: "utf8")
       assert conn.status == 200


### PR DESCRIPTION
- Motivation
I was creating a system the enable users to download files with a
variety of names the put spaces and other characters. When downloading
this kind of file names like `my custom report.xlsx` was returning
`my+custom+report.xlsx`. Esthetically it is ugly to users and they need to edit it to download with the correct nam

- Solution
I created the possibility to send option `encode`, the default value of
the option is nil, and it only avoid the encode_www_form if it was
passed as `false`

- Issue: #3343