### PR TITLE
Raise error when route name uses `static` in the prefix

### DIFF
--- a/lib/phoenix/router/scope.ex
+++ b/lib/phoenix/router/scope.ex
@@ -27,6 +27,10 @@ defmodule Phoenix.Router.Scope do
     as      = Keyword.get(opts, :as, Phoenix.Naming.resource_name(plug, "Controller"))
     alias?  = Keyword.get(opts, :alias, true)
 
+    if to_string(as) == "static"  do
+      raise ArgumentError, "`static` is a reserved route prefix generated from #{inspect plug} or `:as` option"
+    end
+
     {path, host, alias, as, pipes, private, assigns} =
       join(module, path, plug, alias?, as, private, assigns)
     Phoenix.Router.Route.build(line, kind, verb, path, host, alias, plug_opts, as, pipes, private, assigns)

--- a/test/phoenix/router/scope_test.exs
+++ b/test/phoenix/router/scope_test.exs
@@ -205,4 +205,24 @@ defmodule Phoenix.Router.ScopedRoutingTest do
     assert conn.status == 200
     assert conn.resp_body == "api v1 users show"
   end
+
+  test "raises for reserved prefixes" do
+    assert_raise ArgumentError, ~r/`static` is a reserved route prefix/, fn ->
+      defmodule ErrorRouter do
+        use Phoenix.Router
+        scope "/" do
+          get "/", StaticController, :index
+        end
+      end
+    end
+
+    assert_raise ArgumentError, ~r/`static` is a reserved route prefix/, fn ->
+      defmodule ErrorRouter do
+        use Phoenix.Router
+        scope "/" do
+          get "/", Api.V1.UserController, :show, as: :static
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #3346