### PR TITLE
Take paths into account for `%URI{}`'s passed to `put_router_url/2`

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -27,7 +27,7 @@ defmodule Phoenix.Router.Helpers do
   end
 
   def url(_router, %URI{} = uri) do
-    URI.to_string(%URI{uri | path: nil})
+    URI.to_string(uri)
   end
 
   def url(_router, endpoint) when is_atom(endpoint) do

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -130,7 +130,19 @@ defmodule Phoenix.Router.Helpers do
 
         def unquote(:"#{helper}_url")(conn_or_endpoint, unquote(opts), unquote_splicing(vars), params)
             when is_list(params) or is_map(params) do
-          url(conn_or_endpoint) <> unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote_splicing(vars), params)
+
+          url_prefix =
+            case conn_or_endpoint do
+              # When a `%URI{}` struct is passed, we call `url/1` with removed
+              # path because the path helper is also using the path value.
+              %URI{} = uri ->
+                url(%URI{uri | path: nil})
+
+              conn_or_endpoint ->
+                url(conn_or_endpoint)
+            end
+
+          url_prefix <> unquote(:"#{helper}_path")(conn_or_endpoint, unquote(opts), unquote_splicing(vars), params)
         end
       end
     end

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -411,6 +411,15 @@ defmodule Phoenix.Router.HelpersTest do
       url <> "/admin/new/messages/1"
   end
 
+  test "phoenix_router_url set to string with path results in urls with that path" do
+    url = "https://phoenixframework.org/path"
+    conn = Phoenix.Controller.put_router_url(conn_with_endpoint(), url)
+
+    assert Helpers.url(conn) == url
+    assert Helpers.admin_message_url(conn, :show, 1) ==
+      url <> "/admin/new/messages/1"
+  end
+
   test "phoenix_router_url with URI takes precedence over endpoint" do
     uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123}
     conn = Phoenix.Controller.put_router_url(conn_with_endpoint(), uri)

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -412,12 +412,21 @@ defmodule Phoenix.Router.HelpersTest do
   end
 
   test "phoenix_router_url with URI takes precedence over endpoint" do
-    uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123, path: "/path"}
+    uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123}
     conn = Phoenix.Controller.put_router_url(conn_with_endpoint(), uri)
 
     assert Helpers.url(conn) == "https://phoenixframework.org:123"
     assert Helpers.admin_message_url(conn, :show, 1) ==
       "https://phoenixframework.org:123/admin/new/messages/1"
+  end
+
+  test "phoenix_router_url set to URI with path results in urls with that path" do
+    uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123, path: "/path"}
+    conn = Phoenix.Controller.put_router_url(conn_with_endpoint(), uri)
+
+    assert Helpers.url(conn) == "https://phoenixframework.org:123/path"
+    assert Helpers.admin_message_url(conn, :show, 1) ==
+      "https://phoenixframework.org:123/path/admin/new/messages/1"
   end
 
   test "helpers module generates a path helper" do


### PR DESCRIPTION
Following #3181 (and the discussion with @josevalim), this PR is an attempt to re-use the path component from `%URI{}` structs set using the `put_router_url/2` helper function. Currently the path is nillified right before route urls are being generated even if a path is present inside the struct.