### PR TITLE
Move context test to mirror placement in lib

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -61,8 +61,8 @@ username:string:unique
 * creating priv/repo/migrations/20170629175236_create_users.exs
 * creating lib/hello/accounts.ex
 * injecting lib/hello/accounts.ex
-* creating test/hello/accounts/accounts_test.exs
-* injecting test/hello/accounts/accounts_test.exs
+* creating test/hello/accounts_test.exs
+* injecting test/hello/accounts_test.exs
 
 Add the resource to your browser scope in lib/hello_web/router.ex:
 
@@ -258,7 +258,7 @@ email:string:unique user_id:references:users
 * creating lib/hello/accounts/credential.ex
 * creating priv/repo/migrations/20170629180555_create_credentials.exs
 * injecting lib/hello/accounts.ex
-* injecting test/hello/accounts/accounts_test.exs
+* injecting test/hello/accounts_test.exs
 
 Remember to update your repository by running migrations:
 

--- a/lib/mix/phoenix/context.ex
+++ b/lib/mix/phoenix/context.ex
@@ -31,7 +31,7 @@ defmodule Mix.Phoenix.Context do
     dir       = Mix.Phoenix.context_lib_path(ctx_app, basedir)
     file      = dir <> ".ex"
     test_dir  = Mix.Phoenix.context_test_path(ctx_app, basedir)
-    test_file = Path.join([test_dir, basename <> "_test.exs"])
+    test_file = test_dir <> "_test.exs"
     generate? = Keyword.get(opts, :context, true)
 
     %Context{

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -36,7 +36,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
 
       assert String.ends_with?(context.dir, "lib/phoenix/blog")
       assert String.ends_with?(context.file, "lib/phoenix/blog.ex")
-      assert String.ends_with?(context.test_file, "test/phoenix/blog/blog_test.exs")
+      assert String.ends_with?(context.test_file, "test/phoenix/blog_test.exs")
       assert String.ends_with?(context.schema.file, "lib/phoenix/blog/post.ex")
     end
   end
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
 
       assert String.ends_with?(context.dir, "lib/phoenix/site/blog")
       assert String.ends_with?(context.file, "lib/phoenix/site/blog.ex")
-      assert String.ends_with?(context.test_file, "test/phoenix/site/blog/blog_test.exs")
+      assert String.ends_with?(context.test_file, "test/phoenix/site/blog_test.exs")
       assert String.ends_with?(context.schema.file, "lib/phoenix/site/blog/post.ex")
     end
   end
@@ -139,7 +139,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
         assert file =~ "def change_post"
       end
 
-      assert_file "test/phoenix/blog/blog_test.exs", fn file ->
+      assert_file "test/phoenix/blog_test.exs", fn file ->
         assert file =~ "use Phoenix.DataCase"
         assert file =~ "describe \"posts\" do"
         assert file =~ "def post_fixture(attrs \\\\ %{})"
@@ -164,7 +164,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
         assert file =~ "field :title, :string"
       end
 
-      assert_file "test/phoenix/blog/blog_test.exs", fn file ->
+      assert_file "test/phoenix/blog_test.exs", fn file ->
         assert file =~ "use Phoenix.DataCase"
         assert file =~ "describe \"comments\" do"
         assert file =~ "def comment_fixture(attrs \\\\ %{})"
@@ -203,7 +203,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
         assert file =~ "raise \"TODO\""
       end
 
-      assert_file "test/phoenix/blog/blog_test.exs", fn file ->
+      assert_file "test/phoenix/blog_test.exs", fn file ->
         assert file =~ "use Phoenix.DataCase"
         assert file =~ "describe \"posts\" do"
         assert file =~ "def post_fixture(attrs \\\\ %{})"

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
 
       assert_file "lib/phoenix/blog/post.ex"
       assert_file "lib/phoenix/blog.ex"
-      assert_file "test/phoenix/blog/blog_test.exs", fn file ->
+      assert_file "test/phoenix/blog_test.exs", fn file ->
         assert file =~ "alarm: ~T[15:01:01]"
         assert file =~ "alarm_usec: ~T[15:01:01.000000]"
         assert file =~ "announcement_date: ~D[2010-04-17]"

--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
       assert_file "lib/phoenix/blog/post.ex"
       assert_file "lib/phoenix/blog.ex"
 
-      assert_file "test/phoenix/blog/blog_test.exs", fn file ->
+      assert_file "test/phoenix/blog_test.exs", fn file ->
         assert file =~ "use Phoenix.DataCase"
       end
 


### PR DESCRIPTION
When `phx.gen` creates a new context, it creates the context and puts it as a sibling to a directory by the same name containing the generated schema: `mix phx.gen.html Accounts User ...` generates both `lib/my_app/accounts.ex` and `lib/my_app/accounts/user.ex`.

The generated tests do not follow the same structure—the tests are both generated under `test/my_app/accounts/`.

The inconsistency for the Context between `lib` and `test` make it difficult to configure tools such as [projectionist.vim](https://github.com/tpope/vim-projectionist) which may rely on a mirrored structure to intuit which test maps to which file.

This PR attempts to move the context's test up a directory so that both `lib` and `test` are in sync.