### PR TITLE
Refactor flash methods from Phoenix.Controller into Phoenix.Controller.Flash

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1273,24 +1273,7 @@ defmodule Phoenix.Controller do
   @doc """
   Fetches the flash storage.
   """
-  def fetch_flash(conn, _opts \\ []) do
-    session_flash = get_session(conn, "phoenix_flash")
-    conn = persist_flash(conn, session_flash || %{})
-
-    register_before_send conn, fn conn ->
-      flash = conn.private.phoenix_flash
-      flash_size = map_size(flash)
-
-      cond do
-        is_nil(session_flash) and flash_size == 0 ->
-          conn
-        flash_size > 0 and conn.status in 300..308 ->
-          put_session(conn, "phoenix_flash", flash)
-        true ->
-          delete_session(conn, "phoenix_flash")
-      end
-    end
-  end
+  defdelegate fetch_flash(conn, opts \\ []), to: Phoenix.Controller.Flash
 
   @doc """
   Persists a value in flash.
@@ -1304,9 +1287,7 @@ defmodule Phoenix.Controller do
       "Welcome Back!"
 
   """
-  def put_flash(conn, key, message) do
-    persist_flash(conn, Map.put(get_flash(conn), flash_key(key), message))
-  end
+  defdelegate put_flash(conn, key, message), to: Phoenix.Controller.Flash
 
   @doc """
   Returns a map of previously set flash messages or an empty map.
@@ -1321,10 +1302,7 @@ defmodule Phoenix.Controller do
       %{"info" => "Welcome Back!"}
 
   """
-  def get_flash(conn) do
-    Map.get(conn.private, :phoenix_flash) ||
-      raise ArgumentError, message: "flash not fetched, call fetch_flash/2"
-  end
+  defdelegate get_flash(conn), to: Phoenix.Controller.Flash
 
   @doc """
   Returns a message from flash by `key`.
@@ -1336,9 +1314,7 @@ defmodule Phoenix.Controller do
       "Welcome Back!"
 
   """
-  def get_flash(conn, key) do
-    get_flash(conn)[flash_key(key)]
-  end
+  defdelegate get_flash(conn, key), to: Phoenix.Controller.Flash
 
   @doc """
   Generates a status message from the template name.
@@ -1364,16 +1340,7 @@ defmodule Phoenix.Controller do
   @doc """
   Clears all flash messages.
   """
-  def clear_flash(conn) do
-    persist_flash(conn, %{})
-  end
-
-  defp flash_key(binary) when is_binary(binary), do: binary
-  defp flash_key(atom) when is_atom(atom), do: Atom.to_string(atom)
-
-  defp persist_flash(conn, value) do
-    put_private(conn, :phoenix_flash, value)
-  end
+  defdelegate clear_flash(conn), to: Phoenix.Controller.Flash
 
   @doc """
   Returns the current request path with its default query parameters:

--- a/lib/phoenix/controller/flash.ex
+++ b/lib/phoenix/controller/flash.ex
@@ -12,8 +12,7 @@ defmodule Phoenix.Controller.Flash do
     conn = persist_flash(conn, found_flash || %{})
 
     register_before_send conn, fn conn ->
-      flash = conn.private[@session_atom]
-        || raise KeyError, key: @session_atom, term: conn.private
+      flash = Map.fetch!(conn.private, @session_atom)
       flash_size = map_size(flash)
 
       cond do
@@ -40,7 +39,7 @@ defmodule Phoenix.Controller.Flash do
   @doc false
   def get_flash(conn) do
     Map.get(conn.private, @session_atom) ||
-      raise ArgumentError, message: "flash not fetched, call fetch_flash/2"
+      raise ArgumentError, "flash not fetched, call fetch_flash/2"
   end
 
   def get_flash(conn, key) do

--- a/lib/phoenix/controller/flash.ex
+++ b/lib/phoenix/controller/flash.ex
@@ -1,0 +1,57 @@
+defmodule Phoenix.Controller.Flash do
+  import Plug.Conn
+
+  @moduledoc false
+
+  @session_key "phoenix_flash"
+  @session_atom :phoenix_flash
+
+  @doc false
+  def fetch_flash(conn, _opts \\ []) do
+    found_flash = get_session(conn, @session_key)
+    conn = persist_flash(conn, found_flash || %{})
+
+    register_before_send conn, fn conn ->
+      flash = conn.private[@session_atom]
+        || raise KeyError, key: @session_atom, term: conn.private
+      flash_size = map_size(flash)
+
+      cond do
+        is_nil(found_flash) and flash_size == 0 ->
+          conn
+        flash_size > 0 and conn.status in 300..308 ->
+          put_session(conn, @session_key, flash)
+        true ->
+          delete_session(conn, @session_key)
+      end
+    end
+  end
+
+  @doc false
+  def clear_flash(conn) do
+    persist_flash(conn, %{})
+  end
+
+  @doc false
+  def put_flash(conn, key, message) do
+    persist_flash(conn, Map.put(get_flash(conn), flash_key(key), message))
+  end
+
+  @doc false
+  def get_flash(conn) do
+    Map.get(conn.private, @session_atom) ||
+      raise ArgumentError, message: "flash not fetched, call fetch_flash/2"
+  end
+
+  def get_flash(conn, key) do
+    get_flash(conn)[flash_key(key)]
+  end
+
+  defp persist_flash(conn, value) do
+    put_private(conn, @session_atom, value)
+  end
+
+  defp flash_key(binary) when is_binary(binary), do: binary
+  defp flash_key(atom) when is_atom(atom), do: Atom.to_string(atom)
+
+end

--- a/test/phoenix/controller/flash_test.exs
+++ b/test/phoenix/controller/flash_test.exs
@@ -11,29 +11,29 @@ defmodule Phoenix.Controller.FlashTest do
 
   test "flash is persisted when status is a redirect" do
     for status <- 300..308 do
-      conn = conn(:get, "/") |> with_session |> fetch_flash()
+      conn = conn() |> with_session |> fetch_flash()
                              |> put_flash(:notice, "elixir") |> send_resp(status, "ok")
       assert get_flash(conn, :notice) == "elixir"
       assert get_resp_header(conn, "set-cookie") != []
-      conn = conn(:get, "/") |> recycle_cookies(conn) |> with_session |> fetch_flash()
+      conn = conn() |> recycle_cookies(conn) |> with_session |> fetch_flash()
       assert get_flash(conn, :notice) == "elixir"
     end
   end
 
   test "flash is not persisted when status is not redirect" do
     for status <- [299, 309, 200, 404] do
-      conn = conn(:get, "/") |> with_session |> fetch_flash()
+      conn = conn() |> with_session |> fetch_flash()
                              |> put_flash(:notice, "elixir") |> send_resp(status, "ok")
       assert get_flash(conn, :notice) == "elixir"
       assert get_resp_header(conn, "set-cookie") != []
-      conn = conn(:get, "/") |> recycle_cookies(conn) |> with_session |> fetch_flash()
+      conn = conn() |> recycle_cookies(conn) |> with_session |> fetch_flash()
       assert get_flash(conn, :notice) == nil
     end
   end
 
   test "flash does not write to session when it is empty and no session exists" do
     conn =
-      conn(:get, "/")
+      conn()
       |> with_session()
       |> fetch_flash()
       |> clear_flash()
@@ -44,14 +44,14 @@ defmodule Phoenix.Controller.FlashTest do
 
   test "flash writes to session when it is empty and a previous session exists" do
     persisted_flash_conn =
-      conn(:get, "/")
+      conn()
       |> with_session()
       |> fetch_flash()
       |> put_flash(:info, "existing")
       |> send_resp(302, "ok")
 
     conn =
-      conn(:get, "/")
+      conn()
       |> Plug.Test.recycle_cookies(persisted_flash_conn)
       |> with_session()
       |> fetch_flash()
@@ -63,36 +63,36 @@ defmodule Phoenix.Controller.FlashTest do
 
   test "get_flash/1 raises ArgumentError when flash not previously fetched" do
     assert_raise ArgumentError, fn ->
-      conn(:get, "/") |> with_session |> get_flash()
+      conn() |> with_session |> get_flash()
     end
   end
 
   test "get_flash/1 returns the map of messages" do
-    conn = conn(:get, "/") |> with_session |> fetch_flash([]) |> put_flash(:notice, "hi")
+    conn = conn() |> with_session |> fetch_flash([]) |> put_flash(:notice, "hi")
     assert get_flash(conn) == %{"notice" => "hi"}
   end
 
   test "get_flash/2 returns the message by key" do
-    conn = conn(:get, "/") |> with_session |> fetch_flash([]) |> put_flash(:notice, "hi")
+    conn = conn() |> with_session |> fetch_flash([]) |> put_flash(:notice, "hi")
     assert get_flash(conn, :notice) == "hi"
     assert get_flash(conn, "notice") == "hi"
   end
 
   test "get_flash/2 returns nil for missing key" do
-    conn = conn(:get, "/") |> with_session |> fetch_flash([])
+    conn = conn() |> with_session |> fetch_flash([])
     assert get_flash(conn, :notice) == nil
     assert get_flash(conn, "notice") == nil
   end
 
   test "put_flash/3 raises ArgumentError when flash not previously fetched" do
     assert_raise ArgumentError, fn ->
-      conn(:get, "/") |> with_session |> put_flash(:error, "boom!")
+      conn() |> with_session |> put_flash(:error, "boom!")
     end
   end
 
   test "put_flash/3 adds the key/message pair to the flash" do
     conn =
-      conn(:get, "/")
+      conn()
       |> with_session
       |> fetch_flash([])
       |> put_flash(:error, "oh noes!")
@@ -106,7 +106,7 @@ defmodule Phoenix.Controller.FlashTest do
 
   test "clear_flash/1 clears the flash messages" do
     conn =
-      conn(:get, "/")
+      conn()
       |> with_session
       |> fetch_flash([])
       |> put_flash(:error, "oh noes!")
@@ -119,7 +119,12 @@ defmodule Phoenix.Controller.FlashTest do
 
   test "fetch_flash/2 raises ArgumentError when session not previously fetched" do
     assert_raise ArgumentError, fn ->
-      conn(:get, "/") |> fetch_flash([])
+      conn() |> fetch_flash([])
     end
   end
+
+  defp conn() do
+    conn(:get, "/")
+  end
+
 end

--- a/test/phoenix/controller/flash_test.exs
+++ b/test/phoenix/controller/flash_test.exs
@@ -15,7 +15,7 @@ defmodule Phoenix.Controller.FlashTest do
                              |> put_flash(:notice, "elixir") |> send_resp(status, "ok")
       assert get_flash(conn, :notice) == "elixir"
       assert get_resp_header(conn, "set-cookie") != []
-      conn = conn() |> recycle_cookies(conn) |> with_session |> fetch_flash()
+      conn = conn(recycle_cookies: conn) |> with_session |> fetch_flash()
       assert get_flash(conn, :notice) == "elixir"
     end
   end
@@ -26,7 +26,7 @@ defmodule Phoenix.Controller.FlashTest do
                              |> put_flash(:notice, "elixir") |> send_resp(status, "ok")
       assert get_flash(conn, :notice) == "elixir"
       assert get_resp_header(conn, "set-cookie") != []
-      conn = conn() |> recycle_cookies(conn) |> with_session |> fetch_flash()
+      conn = conn(recycle_cookies: conn) |> with_session |> fetch_flash()
       assert get_flash(conn, :notice) == nil
     end
   end
@@ -51,8 +51,7 @@ defmodule Phoenix.Controller.FlashTest do
       |> send_resp(302, "ok")
 
     conn =
-      conn()
-      |> Plug.Test.recycle_cookies(persisted_flash_conn)
+      conn(recycle_cookies: persisted_flash_conn)
       |> with_session()
       |> fetch_flash()
       |> clear_flash()
@@ -123,8 +122,13 @@ defmodule Phoenix.Controller.FlashTest do
     end
   end
 
-  defp conn() do
-    conn(:get, "/")
+  defp conn(opts \\ []) do
+    conn = conn(:get, "/")
+
+    case opts[:recycle_cookies] do
+      nil -> conn
+      old_conn -> conn |> recycle_cookies(old_conn)
+    end
   end
 
 end

--- a/test/phoenix/controller/flash_test.exs
+++ b/test/phoenix/controller/flash_test.exs
@@ -11,22 +11,22 @@ defmodule Phoenix.Controller.FlashTest do
 
   test "flash is persisted when status is a redirect" do
     for status <- 300..308 do
-      conn = conn() |> with_session |> fetch_flash()
+      conn = conn() |> fetch_flash()
                              |> put_flash(:notice, "elixir") |> send_resp(status, "ok")
       assert get_flash(conn, :notice) == "elixir"
       assert get_resp_header(conn, "set-cookie") != []
-      conn = conn(recycle_cookies: conn) |> with_session |> fetch_flash()
+      conn = conn(recycle_cookies: conn) |> fetch_flash()
       assert get_flash(conn, :notice) == "elixir"
     end
   end
 
   test "flash is not persisted when status is not redirect" do
     for status <- [299, 309, 200, 404] do
-      conn = conn() |> with_session |> fetch_flash()
+      conn = conn() |> fetch_flash()
                              |> put_flash(:notice, "elixir") |> send_resp(status, "ok")
       assert get_flash(conn, :notice) == "elixir"
       assert get_resp_header(conn, "set-cookie") != []
-      conn = conn(recycle_cookies: conn) |> with_session |> fetch_flash()
+      conn = conn(recycle_cookies: conn) |> fetch_flash()
       assert get_flash(conn, :notice) == nil
     end
   end
@@ -34,7 +34,6 @@ defmodule Phoenix.Controller.FlashTest do
   test "flash does not write to session when it is empty and no session exists" do
     conn =
       conn()
-      |> with_session()
       |> fetch_flash()
       |> clear_flash()
       |> send_resp(302, "ok")
@@ -45,14 +44,12 @@ defmodule Phoenix.Controller.FlashTest do
   test "flash writes to session when it is empty and a previous session exists" do
     persisted_flash_conn =
       conn()
-      |> with_session()
       |> fetch_flash()
       |> put_flash(:info, "existing")
       |> send_resp(302, "ok")
 
     conn =
       conn(recycle_cookies: persisted_flash_conn)
-      |> with_session()
       |> fetch_flash()
       |> clear_flash()
       |> send_resp(200, "ok")
@@ -62,37 +59,36 @@ defmodule Phoenix.Controller.FlashTest do
 
   test "get_flash/1 raises ArgumentError when flash not previously fetched" do
     assert_raise ArgumentError, fn ->
-      conn() |> with_session |> get_flash()
+      conn() |> get_flash()
     end
   end
 
   test "get_flash/1 returns the map of messages" do
-    conn = conn() |> with_session |> fetch_flash([]) |> put_flash(:notice, "hi")
+    conn = conn() |> fetch_flash([]) |> put_flash(:notice, "hi")
     assert get_flash(conn) == %{"notice" => "hi"}
   end
 
   test "get_flash/2 returns the message by key" do
-    conn = conn() |> with_session |> fetch_flash([]) |> put_flash(:notice, "hi")
+    conn = conn() |> fetch_flash([]) |> put_flash(:notice, "hi")
     assert get_flash(conn, :notice) == "hi"
     assert get_flash(conn, "notice") == "hi"
   end
 
   test "get_flash/2 returns nil for missing key" do
-    conn = conn() |> with_session |> fetch_flash([])
+    conn = conn() |> fetch_flash([])
     assert get_flash(conn, :notice) == nil
     assert get_flash(conn, "notice") == nil
   end
 
   test "put_flash/3 raises ArgumentError when flash not previously fetched" do
     assert_raise ArgumentError, fn ->
-      conn() |> with_session |> put_flash(:error, "boom!")
+      conn() |> put_flash(:error, "boom!")
     end
   end
 
   test "put_flash/3 adds the key/message pair to the flash" do
     conn =
       conn()
-      |> with_session
       |> fetch_flash([])
       |> put_flash(:error, "oh noes!")
       |> put_flash(:notice, "false alarm!")
@@ -106,7 +102,6 @@ defmodule Phoenix.Controller.FlashTest do
   test "clear_flash/1 clears the flash messages" do
     conn =
       conn()
-      |> with_session
       |> fetch_flash([])
       |> put_flash(:error, "oh noes!")
       |> put_flash(:notice, "false alarm!")
@@ -118,17 +113,20 @@ defmodule Phoenix.Controller.FlashTest do
 
   test "fetch_flash/2 raises ArgumentError when session not previously fetched" do
     assert_raise ArgumentError, fn ->
-      conn() |> fetch_flash([])
+      conn(:get, "/") |> fetch_flash([])
     end
   end
 
   defp conn(opts \\ []) do
     conn = conn(:get, "/")
 
-    case opts[:recycle_cookies] do
+    conn = case opts[:recycle_cookies] do
       nil -> conn
       old_conn -> conn |> recycle_cookies(old_conn)
     end
+
+    conn
+    |> with_session()
   end
 
 end


### PR DESCRIPTION
Based on a conversation here:

https://groups.google.com/forum/#!searchin/phoenix-core/liveview%7Csort:date/phoenix-core/61kVmWkF6QI/70BFY0zFCAAJ

The proposed step forward for getting `--live` (and eventually `--no-live`) integrated into phoenix directly.

```
1. phx.new --live flag (it will be opt-in on v1.5 while we figure things out but probably enabled by default on v1.6)
2. phx.new.live generators
3. Bring the functionality in LiveView.Flash to Phoenix so we can get rid of one plug
```

It was suggested to start with #3

Once released, then I can help remove that code from phoenix_live_view and update the documentation to remove the need for the second flash plug.

@josevalim if I have mis-understood, let me know.

