### PR TITLE
Document phx.server alternative

### DIFF
--- a/lib/mix/tasks/phx.server.ex
+++ b/lib/mix/tasks/phx.server.ex
@@ -6,6 +6,9 @@ defmodule Mix.Tasks.Phx.Server do
   @moduledoc """
   Starts the application by configuring all endpoints servers to run.
 
+  Note: to start the endpoint without using this mix task you must set
+  `server: true` in your `Phoenix.Endpoint` configuration.
+
   ## Command line options
 
   This task accepts the same command-line arguments as `run`.


### PR DESCRIPTION
Document that setting `server: true` in your endpoint configuration will allow you to start your Phoenix Endpoint server without using the `mix phx.server` task. Document this in a place that a user will likely find it, in the mix task that they need to use (by default) to start their server.