### PR TITLE
Document compress option

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -922,6 +922,9 @@ defmodule Phoenix.Endpoint do
 
     * `:max_frame_size` - the maximum allowed frame size in bytes.
       Supported from Cowboy 2.3 onwards, defaults to "infinity"
+      
+    * `:compress` - whether to enable per message compresssion on
+      all data frames, defaults to false
 
   ## Longpoll configuration
 


### PR DESCRIPTION
This adds documentation for the compress option. There is already an example for it which shows it can be used. I tested it all still works well.