### PR TITLE
Fix @spec issue with `Template.template_not_found`

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -145,7 +145,7 @@ defmodule Phoenix.Template do
       By default it raises but can be customized
       to render a particular template.
       """
-      @spec template_not_found(Phoenix.Template.name, map) :: no_return
+      @spec template_not_found(Phoenix.Template.name, map) :: no_return | String.t() | iolist()
       def template_not_found(template, assigns) do
         Template.raise_template_not_found(__MODULE__, template, assigns)
       end


### PR DESCRIPTION
Phoenix.Template.template_not_found is designed to be optionally overridden by the user, but the @spec specifies a return type of `no_return`. This PR adds the possible expected return types.