### PR TITLE
Fix `Phoenix.Controller.current_url`

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1438,7 +1438,7 @@ defmodule Phoenix.Controller do
   See `current_url/2` to override the default parameters.
   """
   def current_url(%Plug.Conn{} = conn) do
-    router_module(conn).url(conn) <> current_path(conn)
+    Module.concat(router_module(conn), "Helpers").url(conn) <> current_path(conn)
   end
 
   @doc ~S"""
@@ -1485,7 +1485,7 @@ defmodule Phoenix.Controller do
   host, etc, you may use `put_router_url/2`.
   """
   def current_url(%Plug.Conn{} = conn, %{} = params) do
-    router_module(conn).url(conn) <> current_path(conn, params)
+    Module.concat(router_module(conn), "Helpers").url(conn) <> current_path(conn, params)
   end
 
   @doc false

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -601,13 +601,19 @@ defmodule Phoenix.Controller.ControllerTest do
   end
 
   describe "path and url generation" do
-    def url(_), do: "https://www.example.com"
+    defmodule PhoenixEndpoint do
+      def url(_), do: "https://www.example.com"
+    end
+
+    defmodule PhoenixRouter.Helpers do
+      def url(_), do: "https://www.example.com"
+    end
 
     def build_conn_for_path(path) do
       conn(:get, path)
       |> fetch_query_params()
-      |> put_private(:phoenix_endpoint, __MODULE__)
-      |> put_private(:phoenix_router, __MODULE__)
+      |> put_private(:phoenix_endpoint, PhoenixEndpoint)
+      |> put_private(:phoenix_router, PhoenixRouter)
     end
 
     test "current_path/1 uses the conn's query params" do


### PR DESCRIPTION
There seems to be a small bug in the latest release - the `current_url` helper throws an undefined function error because it's trying to call `ExampleWeb.Router.url\1` instead of `ExampleWeb.Router.Helpers.url\1`.

I've proposed a fix here using `Module.concat`. I've also updated the tests to use mock `Endpoint` and `Router` modules that more closely follow the structure of those found in Phoenix projects in order to prevent a recurrence.

_Edit_: forgot to include steps to repro the original bug:

- Generate a new empty app using v1.4.4
- Add a line to `ExampleWeb.PageController.index`:
```
    IO.inspect(current_url(conn))
```
- Visit the page and see the error

Thanks for reading!