### PR TITLE
Listen on 127.0.0.1 by default

### DIFF
--- a/installer/templates/phx_single/config/prod.secret.exs
+++ b/installer/templates/phx_single/config/prod.secret.exs
@@ -13,5 +13,5 @@ secret_key_base =
     """
 
 config :<%= app_name %>, <%= endpoint_module %>,
-  http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
+  http: [:inet6, ip: {127, 0, 0, 1}, port: String.to_integer(System.get_env("PORT") || "4000")],
   secret_key_base: secret_key_base


### PR DESCRIPTION
Listening on all interfaces by default may inadvertently overexpose a webservice to a network. 

I haven't seen previous issues about this, and since this is a small change, I figured I would start discussion with a PR. 