### PR TITLE
Fixing mix ecto.drop documentation typo

### DIFF
--- a/guides/phoenix_mix_tasks.md
+++ b/guides/phoenix_mix_tasks.md
@@ -661,7 +661,7 @@ $ mix ecto.create
 
 To fix this, we can change the password in the environment specific configuration file. For the development environment the password used can be found at the bottom of the `config/dev.exs` file.
 
-#### `ecto.drop`
+### `mix ecto.drop`
 
 This task will drop the database specified in our repo. By default it will look for the repo named after our application (the one generated with our app unless we opted out of ecto). It will not prompt us to check if we're sure we want to drop the db, so do exercise caution.
 


### PR DESCRIPTION
Fixing mix ecto.drop documentation typo