### PR TITLE
Context.function_count/1 accounts for both def and defdelegate

### DIFF
--- a/lib/mix/phoenix/context.ex
+++ b/lib/mix/phoenix/context.ex
@@ -61,6 +61,7 @@ defmodule Mix.Phoenix.Context do
       |> Code.string_to_quoted!()
       |> Macro.postwalk(0, fn
         {:def, _, _} = node, count -> {node, count + 1}
+        {:defdelegate, _, _} = node, count -> {node, count + 1}
         node, count -> {node, count}
       end)
 

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -249,8 +249,8 @@ defmodule Mix.Tasks.Phx.Gen.Context do
 
       Mix.shell.info """
       You are generating into an existing context.
-      The #{inspect context.module} context currently has #{function_count} functions and \
-      #{file_count} files in its directory.
+      The #{inspect context.module} context currently has #{function_count} function(s) and \
+      #{file_count} file(s) in its directory.
 
         * It's OK to have multiple resources in the same context as \
           long as they are closely related

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -249,8 +249,8 @@ defmodule Mix.Tasks.Phx.Gen.Context do
 
       Mix.shell.info """
       You are generating into an existing context.
-      The #{inspect context.module} context currently has #{function_count} function(s) and \
-      #{file_count} file(s) in its directory.
+      The #{inspect context.module} context currently has #{function_count} functions and \
+      #{file_count} files in its directory.
 
         * It's OK to have multiple resources in the same context as \
           long as they are closely related


### PR DESCRIPTION
This PR will allow `Context.function_count/1` to count both `def` and `defdelegate` functions.

Currently the `Context.function_count/1` function returns the number of `def` functions in the Context file.
I usually change the context file to contain only/mostly `defdelegate` functions which are delegated to modules under `context_folder/api/module_name.ex`. The prompt I get in the terminal about the number of functions I have in the Context file is always inaccurate due to this issue. It's a minor issue and might not be popular, but I'd thought I'd create this PR to scratch my own itch since it was just a one-liner.