### PR TITLE
Improve `change_<schema>` when generating a context.

### DIFF
--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -90,7 +90,10 @@
       iex> change_<%= schema.singular %>(<%= schema.singular %>)
       %Ecto.Changeset{source: %<%= inspect schema.alias %>{}}
 
+      iex> change_<%= schema.singular %>(<%= schema.singular %>, %{field: value})
+      %Ecto.Changeset{source: %<%= inspect schema.alias %>{}}
+
   """
-  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do
-    <%= inspect schema.alias %>.changeset(<%= schema.singular %>, %{})
+  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs \\ %{}) do
+    <%= inspect schema.alias %>.changeset(<%= schema.singular %>, attrs)
   end


### PR DESCRIPTION
By default the schema that is generated defines a `changeset` that accepts a `attr` argument. It seems really strange to me that the `change_` function in the context defaults to always passing `%{}` to `changeset` by default.