### PR TITLE
Replace Map.get with Keyword.get inside generated DataCase errors_on function

### DIFF
--- a/installer/templates/phx_ecto/data_case.ex
+++ b/installer/templates/phx_ecto/data_case.ex
@@ -46,7 +46,7 @@ defmodule <%= app_module %>.DataCase do
   def errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
       Regex.replace(~r"%{(\w+)}", message, fn _, key ->
-        opts |> Map.get(String.to_existing_atom(key), key) |> to_string()
+        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
       end)
     end)
   end


### PR DESCRIPTION
The generated `errors_on` function inside DataCase uses `Map.get`, but `opts` is a keyword list.

Right now, the `errors_on` function from `master` causes an error, like:

```
(BadMapError) expected a map, got: [count: 3, validation: :length, kind: :min, type: :string]
```

This is related to the recently merged #3204 PR.