### PR TITLE
Added a link to another 3rd party Channel client: GodotPhoenixChannels

### DIFF
--- a/guides/channels.md
+++ b/guides/channels.md
@@ -178,6 +178,8 @@ Phoenix ships with a JavaScript client that is available when generating a new P
   - [dn-phoenix](https://github.com/jfis/dn-phoenix)
 + Elixir
   - [phoenix_gen_socket_client](https://github.com/Aircloak/phoenix_gen_socket_client)
++ GDScript (Godot Game Engine)
+  - [GodotPhoenixChannels)(https://github.com/alfredbaudisch/GodotPhoenixChannels)
 
 ## Tying it all together
 Let's tie all these ideas together by building a simple chat application. After [generating a new Phoenix application](https://hexdocs.pm/phoenix/up_and_running.html) we'll see that the endpoint is already set up for us in `lib/hello_web/endpoint.ex`:


### PR DESCRIPTION
Brand new Phoenix Channels client for the open-source Godot Game Engine https://godotengine.org, implemented in GDScript (Godot's Python like language).

This client implements almost every aspect of the official JS client (right now only push buffers are missing, other than that, everything else is there).

Although Godot is not a game engine as popular as Unity, it has been growing since its latest release, specially between open-source enthusiasts, and since it has built-in WebSocket support, I felt it had a natural fit for Phoenix Channels. Also last month the engine got [a grant](https://godotengine.org/article/godot-engine-awarded-50000-mozilla-open-source-support-program) from the Mozilla Foundation, which will help turn it into an even better "web-ready" platform, and again, I see a fit with Phoenix Channels here.