### PR TITLE
Update documentation to install npm modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ To build the documentation from source:
 
 ```bash
 $ npm install --prefix assets
-$ cd ..
 $ MIX_ENV=docs mix docs
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ To create projects outside of the `installer/` directory, add the latest archive
 To build the documentation from source:
 
 ```bash
-$ cd assets
-$ npm install
+$ npm install --prefix assets
 $ cd ..
 $ MIX_ENV=docs mix docs
 ```
@@ -70,9 +69,8 @@ $ mix archive.build
 ### Building phoenix.js
 
 ```bash
-$ cd assets
-$ npm install
-$ npm run watch
+$ npm install --prefix assets
+$ npm run watch --prefix assets
 ```
 
 ## Important links

--- a/installer/templates/phx_single/README.md
+++ b/installer/templates/phx_single/README.md
@@ -4,7 +4,7 @@ To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`<%= if ecto do %>
   * Create and migrate your database with `mix ecto.setup`<% end %><%= if webpack do %>
-  * Install Node.js dependencies with `cd assets && npm install`<% end %>
+  * Install Node.js dependencies with `npm install --prefix assets`<% end %>
   * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/installer/templates/phx_umbrella/apps/app_name_web/README.md
+++ b/installer/templates/phx_umbrella/apps/app_name_web/README.md
@@ -4,7 +4,7 @@ To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.setup`
-  * Install Node.js dependencies with `cd assets && npm install`
+  * Install Node.js dependencies with `npm install --prefix assets`
   * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/lib/phoenix/endpoint/watcher.ex
+++ b/lib/phoenix/endpoint/watcher.ex
@@ -39,13 +39,13 @@ defmodule Phoenix.Endpoint.Watcher do
       !System.find_executable("node") ->
         Logger.error "Could not start watcher because \"node\" is not available. Your Phoenix " <>
                      "application is still running, however assets won't be compiled. " <>
-                     "You may fix this by installing \"node\" and then running \"cd assets && npm install\"."
+                     "You may fix this by installing \"node\" and then running \"npm install --prefix assets\"."
         exit(:shutdown)
 
       not File.exists?(script_path) ->
         Logger.error "Could not start node watcher because script #{inspect script_path} does not " <>
                      "exist. Your Phoenix application is still running, however assets " <>
-                     "won't be compiled. You may fix this by running \"cd assets && npm install\"."
+                     "won't be compiled. You may fix this by running \"npm install --prefix assets\"."
         exit(:shutdown)
 
       true -> :ok


### PR DESCRIPTION
This PR updates the docs and some of the messages to use `npm install --prefix asset` instead of  `cd assets & npm install`.  (Taken from the documentation of PhoenixLiveView.)

Why is important?, well if you follow the instructions generated on the README.md when you create a new phoenix app,  The user will end on the assets directory without the possibility to run: `mix phx.server` :confused: 

```
  * Install dependencies with `mix deps.get`
  * Create and migrate your database with `mix ecto.setup`
  * Install Node.js dependencies with `cd assets && npm install`
  * Start Phoenix endpoint with `mix phx.server`
```   

So this could be less confusing:

```
  * Install dependencies with `mix deps.get`
  * Create and migrate your database with `mix ecto.setup`
  * Install Node.js dependencies with `npm install --prefix assets`
  * Start Phoenix endpoint with `mix phx.server`
``` 
