### PR TITLE
Minor improvements to Channels docs page

### DIFF
--- a/guides/channels.md
+++ b/guides/channels.md
@@ -262,7 +262,7 @@ Save the file and your browser should auto refresh, thanks to the Phoenix live r
 In `lib/hello_web/templates/page/index.html.eex`, we'll replace the existing code with a container to hold our chat messages, and an input field to send them:
 
 ```html
-<div id="messages"></div>
+<div id="messages" role="log" aria-live="polite"></div>
 <input id="chat-input" type="text"></input>
 ```
 

--- a/guides/channels.md
+++ b/guides/channels.md
@@ -304,7 +304,7 @@ chatInput.addEventListener("keypress", event => {
 })
 
 channel.on("new_msg", payload => {
-  let messageItem = document.createElement("li")
+  let messageItem = document.createElement("p")
   messageItem.innerText = `[${Date()}] ${payload.body}`
   messagesContainer.appendChild(messageItem)
 })

--- a/guides/channels.md
+++ b/guides/channels.md
@@ -275,7 +275,7 @@ let chatInput         = document.querySelector("#chat-input")
 let messagesContainer = document.querySelector("#messages")
 
 chatInput.addEventListener("keypress", event => {
-  if(event.keyCode === 13){
+  if(event.key === 'Enter'){
     channel.push("new_msg", {body: chatInput.value})
     chatInput.value = ""
   }
@@ -297,7 +297,7 @@ let chatInput         = document.querySelector("#chat-input")
 let messagesContainer = document.querySelector("#messages")
 
 chatInput.addEventListener("keypress", event => {
-  if(event.keyCode === 13){
+  if(event.key === 'Enter'){
     channel.push("new_msg", {body: chatInput.value})
     chatInput.value = ""
   }


### PR DESCRIPTION
I noticed some minor flaws while learning about Channels. 

- The js examples use [keyCode, which is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode). I've updated the examples to use [key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) instead. 
- `li` elements are not valid children outside of ol/ul/menu elements ([src](https://html.spec.whatwg.org/multipage/grouping-content.html#the-li-element)). I've replaced the `li` with a `p` tag, which matches the referenced [phoenix chat example implementation](https://github.com/chrismccord/phoenix_chat_example/blob/master/web/static/js/app.js#L51).
- Lastly, I added some [aria live region attributes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions) for some very preliminary accessibility. This sort of feature would require a lot more work, but having some basic a11y functionality in the docs can hopefully provide a good start for developers.