### PR TITLE
Fixed template example field name

### DIFF
--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -88,7 +88,7 @@
   ## Examples
 
       iex> change_<%= schema.singular %>(<%= schema.singular %>)
-      %Ecto.Changeset{source: %<%= inspect schema.alias %>{}}
+      %Ecto.Changeset{data: %<%= inspect schema.alias %>{}}
 
   """
   def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do


### PR DESCRIPTION
Minor problem I found while trying to doctest a context.

A little side-question: from what I see, doctesting a context is not supported out-of-the-box, so should I bother doing it or not?