### PR TITLE
Patch webpack config to load app.js after vendor js

### DIFF
--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = (env, options) => ({
     ]
   },
   entry: {
-    './js/app.js': ['./js/app.js'].concat(glob.sync('./vendor/**/*.js'))
+    './js/app.js': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
   },
   output: {
     filename: 'app.js',


### PR DESCRIPTION
The goal of this PR is to update the default Webpack config to load `./js/app.js` last so that it can be exported by the entry point as an output library.

**Issue**

Webpack output can not reliably be exposed as a library with the default config.

**Root Cause**

Webpack entry point returns last `./vendor/js` library when present instead of `./js/app.js`.

**The Fix**

Update default Webpack config to swap entry load order so `./js/app.js` loads last.

**Details**

Before getting started, I must disclose that I am not a Webpack expert! The extent of my knowledge is yesterday while upgrading a phoenix app from v1.3 -> v1.4 and replacing brunch with it, exposing this issue. 😄 

When using the default Webpack config, the entry section has `./js/app.js` first and then concats all contents of `./vendor/js` after it:

```javascript
   entry: {
     './js/app.js': ['./js/app.js'].concat(glob.sync('./vendor/**/*.js'))
   },
```

If we decide to export something from `./js/app.js` and expose it to the browser for explicit execution, we can make a modification to the output config like so:

```javascript
export var App = {
  run: function() {
    console.log("PhxWebpackExample.App - NOOP");
  }
}
```

So far, the issue remains hidden. The JS will be properly exported and available for use:

<img width="1454" alt="Screen Shot 2019-06-07 at 10 10 07 AM" src="https://user-images.githubusercontent.com/22482/59119507-9bf11800-8918-11e9-9b03-7607a2bf6bfb.png">

However, once we add some minified JS to `./vendor/js` our exposed code runs in to problems:

<img width="1454" alt="Screen Shot 2019-06-07 at 10 12 52 AM" src="https://user-images.githubusercontent.com/22482/59119523-a6131680-8918-11e9-9723-e20938ed524c.png">

What is happening? From what I understand in the [Webpack documentation](https://webpack.js.org/configuration/output#outputlibrary) (1), the output library receives the return value from the entry point. Once we add libraries in `./vendor/js` then it would receive whatever library loads last.

To ensure that `./js/app.js` remains the return value, reordering the default config value resolves this issue:

```javascript
  entry: {
      './js/app.js': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
  },
```

<img width="1454" alt="Screen Shot 2019-06-07 at 10 14 39 AM" src="https://user-images.githubusercontent.com/22482/59119531-ac08f780-8918-11e9-8ba3-ef826bcce0be.png">

An example project with the code samples that highlights the issue is [available here](https://github.com/yellow5/phx_webpack_example) (2) along with various commands + logs in [this gist](https://gist.github.com/yellow5/a8ca58a416f55e9279a7b5aed7c0e8e7) (3).

(1) https://webpack.js.org/configuration/output#outputlibrary
(2) https://github.com/yellow5/phx_webpack_example
(3) https://gist.github.com/yellow5/a8ca58a416f55e9279a7b5aed7c0e8e7