### PR TITLE
Support Websocket subprotocols

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -836,8 +836,12 @@ defmodule Phoenix.Endpoint do
     * `:compress` - whether to enable per message compresssion on
       all data frames, defaults to false
 
-    * `:subprotocol` - supported websocket subprotocol.
-      Used for handshake `Sec-WebSocket-Protocol` response header
+    * `:subprotocols` - a list of supported websocket subprotocols.
+      Used for handshake `Sec-WebSocket-Protocol` response header, defaults to nil.
+
+      For example:
+
+          subprotocols: ["sip", "mqtt"]
 
   ## Longpoll configuration
 

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -836,6 +836,9 @@ defmodule Phoenix.Endpoint do
     * `:compress` - whether to enable per message compresssion on
       all data frames, defaults to false
 
+    * `:subprotocol` - supported websocket subprotocol.
+      Used for handshake `Sec-WebSocket-Protocol` response header
+
   ## Longpoll configuration
 
   The following configuration applies only to `:longpoll`:

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -374,8 +374,8 @@ defmodule Phoenix.Socket.Transport do
       [] ->
         conn
 
-      subprotocols_header ->
-        request_subprotocols = subprotocols_header |> hd |> Plug.Conn.Utils.list()
+      [subprotocols_header | _] ->
+        request_subprotocols = subprotocols_header |> Plug.Conn.Utils.list()
         subprotocol = Enum.find(subprotocols, fn elem -> Enum.find(request_subprotocols, &(&1 == elem)) end)
 
         if subprotocol do
@@ -451,13 +451,13 @@ defmodule Phoenix.Socket.Transport do
     To fix this issue, you may either:
 
       1. update websocket: [subprotocols: [..]] to your actual subprotocols
-        in your endpoint socket configuration.
+         in your endpoint socket configuration.
 
       2. check the correctness of the `sec-websocket-protocol` request header
-        sent from the client.
+         sent from the client.
 
       3. remove `websocket` option from your endpoint socket configuration
-      if you don't use Websocket subprotocols.
+         if you don't use Websocket subprotocols.
     """
 
     resp(conn, :forbidden, "")

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -446,7 +446,7 @@ defmodule Phoenix.Socket.Transport do
 
   defp do_check_subprotocols(conn, subprotocols, subprotocols_header) do
     import Plug.Conn
-    request_subprotocols = subprotocols_header |> List.first |> Plug.Conn.Utils.list
+    request_subprotocols = subprotocols_header |> hd |> Plug.Conn.Utils.list
     subprotocol = Enum.find(subprotocols, fn elem -> Enum.find(request_subprotocols, & &1 == elem) end)
 
     if subprotocol do

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -359,6 +359,7 @@ defmodule Phoenix.Socket.Transport do
   Should be called by transports before connecting when appropriate.
   If the sec-websocket-protocol header matches the allowed subprotocol,
   it will put sec-websocket-protocol response header and return the given connection.
+  If no sec-websocket-protocol header was sent it will return the given connection.
 
   Otherwise a 403 Forbidden response will be sent and the connection halted.
   It is a noop if the connection has been halted.
@@ -366,6 +367,7 @@ defmodule Phoenix.Socket.Transport do
   def check_origin(conn, subprotocol)
 
   def check_subprotocol(%Plug.Conn{halted: true} = conn, _subprotocol), do: conn
+  def check_subprotocol(conn, nil), do: conn
 
   def check_subprotocol(conn, subprotocol) do
     import Plug.Conn

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -364,7 +364,7 @@ defmodule Phoenix.Socket.Transport do
   Otherwise a 403 Forbidden response will be sent and the connection halted.
   It is a noop if the connection has been halted.
   """
-  def check_subprotocols(conn, subprotocols \\ nil)
+  def check_subprotocols(conn, subprotocols)
 
   def check_subprotocols(%Plug.Conn{halted: true} = conn, _subprotocols), do: conn
   def check_subprotocols(conn, nil), do: conn

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -354,47 +354,50 @@ defmodule Phoenix.Socket.Transport do
   end
 
   @doc """
-  Checks the Websocket subprotocol request header against the allowed subprotocol.
+  Checks the Websocket subprotocols request header against the allowed subprotocols.
 
   Should be called by transports before connecting when appropriate.
-  If the sec-websocket-protocol header matches the allowed subprotocol,
+  If the sec-websocket-protocol header matches the allowed subprotocols,
   it will put sec-websocket-protocol response header and return the given connection.
   If no sec-websocket-protocol header was sent it will return the given connection.
 
   Otherwise a 403 Forbidden response will be sent and the connection halted.
   It is a noop if the connection has been halted.
   """
-  def check_subprotocol(conn, subprotocol)
+  def check_subprotocols(conn, subprotocols \\ nil)
 
-  def check_subprotocol(%Plug.Conn{halted: true} = conn, _subprotocol), do: conn
-  def check_subprotocol(conn, nil), do: conn
+  def check_subprotocols(%Plug.Conn{halted: true} = conn, _subprotocols), do: conn
+  def check_subprotocols(conn, nil), do: conn
 
-  def check_subprotocol(conn, subprotocol) do
+  def check_subprotocols(conn, subprotocols) when is_list(subprotocols) do
     import Plug.Conn
-    subprotocols = get_req_header(conn, "sec-websocket-protocol")
+    request_subprotocols =
+      conn
+      |> get_req_header("sec-websocket-protocol")
+      |> List.first
+      |> Plug.Conn.Utils.list
+    subprotocol = Enum.find(subprotocols, fn elem -> Enum.find(request_subprotocols, & &1 == elem) end)
 
-    case Enum.member?(subprotocols, subprotocol) do
-      true ->
-        put_resp_header(conn, "sec-websocket-protocol", subprotocol)
+    if subprotocol do
+      put_resp_header(conn, "sec-websocket-protocol", subprotocol)
+    else
+      Logger.error """
+      Could not check Websocket subprotocols for Phoenix.Socket transport.
 
-      false ->
-        Logger.error """
-        Could not check Websocket subprotocol for Phoenix.Socket transport.
+      Subprotocols of the request: #{inspect(request_subprotocols)}
+      Expected subprotocols: #{inspect(subprotocols)}
 
-        Subprotocols of the request: #{inspect(subprotocols)}
-        Expected subprotocol: #{inspect(subprotocol)}
+      This happens when you are attempting a socket connection to
+      a different subprotocols than the one configured in your endpoint.
+      To fix this issue, you may either:
 
-        This happens when you are attempting a socket connection to
-        a different subprotocol than the one configured in your endpoint.
-        To fix this issue, you may either:
+        1. update websocket: [subprotocols: ...] to your actual subprotocols
+           in your endpoint socket configuration.
 
-          1. update websocket: [subprotocol: ...] to your actual subprotocol
-             in your endpoint socket configuration.
-
-          2. check the correctness of the `sec-websocket-protocol` request header
-             sent from the client.
-        """
-        conn |> resp(:forbidden, "") |> halt()
+        2. check the correctness of the `sec-websocket-protocol` request header
+           sent from the client.
+      """
+      conn |> resp(:forbidden, "") |> halt()
     end
   end
 

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -392,7 +392,7 @@ defmodule Phoenix.Socket.Transport do
              in your endpoint socket configuration.
 
           2. check the correctness of the `sec-websocket-protocol` request header
-             sends from the client.
+             sent from the client.
         """
         conn |> resp(:forbidden, "") |> halt()
     end

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -391,7 +391,7 @@ defmodule Phoenix.Socket.Transport do
       a different subprotocols than the one configured in your endpoint.
       To fix this issue, you may either:
 
-        1. update websocket: [subprotocols: ...] to your actual subprotocols
+        1. update websocket: [subprotocols: [..]] to your actual subprotocols
            in your endpoint socket configuration.
 
         2. check the correctness of the `sec-websocket-protocol` request header
@@ -399,6 +399,27 @@ defmodule Phoenix.Socket.Transport do
       """
       conn |> resp(:forbidden, "") |> halt()
     end
+
+  end
+
+  def check_subprotocols(conn, subprotocols) do
+    import Plug.Conn
+    Logger.error """
+    Could not check Websocket subprotocols for Phoenix.Socket transport.
+
+    Expected subprotocols should be a list.
+    Passed expected subprotocols: #{inspect(subprotocols)}
+
+    This happens when you incorrectly configured supported subprotocols.
+    To fix this issue, you may either:
+
+      1. update websocket: [subprotocols: [..]] to your actual subprotocols
+         in your endpoint socket configuration.
+
+      2. remove `websocket` option from your endpoint socket configuration
+         if you don't use Websocket subprotocols.
+    """
+    conn |> resp(:forbidden, "") |> halt()
   end
 
   @doc """

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -393,7 +393,9 @@ defmodule Phoenix.Socket.Transport do
       2. remove `websocket` option from your endpoint socket configuration
          if you don't use Websocket subprotocols.
     """
-    conn |> resp(:forbidden, "") |> halt()
+    resp(conn, :forbidden, "")
+    |> send_resp()
+    |> halt()
   end
 
   @doc """
@@ -466,7 +468,9 @@ defmodule Phoenix.Socket.Transport do
         2. check the correctness of the `sec-websocket-protocol` request header
           sent from the client.
       """
-      conn |> resp(:forbidden, "") |> halt()
+      resp(conn, :forbidden, "")
+      |> send_resp()
+      |> halt()
     end
   end
 

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -364,7 +364,7 @@ defmodule Phoenix.Socket.Transport do
   Otherwise a 403 Forbidden response will be sent and the connection halted.
   It is a noop if the connection has been halted.
   """
-  def check_origin(conn, subprotocol)
+  def check_subprotocol(conn, subprotocol)
 
   def check_subprotocol(%Plug.Conn{halted: true} = conn, _subprotocol), do: conn
   def check_subprotocol(conn, nil), do: conn

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -19,7 +19,7 @@ defmodule Phoenix.Transports.WebSocket do
     |> Transport.transport_log(opts[:transport_log])
     |> Transport.force_ssl(handler, endpoint, opts)
     |> Transport.check_origin(handler, endpoint, opts)
-    |> Transport.check_subprotocol(opts[:subprotocol])
+    |> Transport.check_subprotocols(opts[:subprotocols])
     |> case do
       %{halted: true} = conn ->
         {:error, conn}

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -19,6 +19,7 @@ defmodule Phoenix.Transports.WebSocket do
     |> Transport.transport_log(opts[:transport_log])
     |> Transport.force_ssl(handler, endpoint, opts)
     |> Transport.check_origin(handler, endpoint, opts)
+    |> Transport.check_subprotocol(opts[:subprotocol])
     |> case do
       %{halted: true} = conn ->
         {:error, conn}

--- a/test/phoenix/socket/transport_test.exs
+++ b/test/phoenix/socket/transport_test.exs
@@ -178,6 +178,43 @@ defmodule Phoenix.Socket.TransportTest do
     end
   end
 
+  ## Check subprotocols
+
+  describe "check_subprotocols/2" do
+    defp check_subprotocols(expected, passed) do
+      conn = conn(:get, "/") |> put_req_header("sec-websocket-protocol", Enum.join(passed, ", "))
+      Transport.check_subprotocols(conn, expected)
+    end
+
+    test "does not check subprotocols if not passed expected" do
+      refute check_subprotocols(nil, ["sip"]).halted
+    end
+
+    test "does not check subprotocols if conn is halted" do
+      halted_conn = conn(:get, "/") |> halt()
+      conn = Transport.check_subprotocols(halted_conn, ["sip"])
+      assert conn == halted_conn
+    end
+
+    test "returns first matched subprotocol" do
+      conn = check_subprotocols(["sip", "mqtt"], ["sip", "mqtt"])
+      refute conn.halted
+      assert get_resp_header(conn, "sec-websocket-protocol") == ["sip"]
+    end
+
+    test "halt if expected and passed subprotocols don't match" do
+      conn = check_subprotocols(["sip"], ["mqtt"])
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "halt if expected subprotocols passed in the wrong format" do
+      conn = check_subprotocols("sip", ["mqtt"])
+      assert conn.halted
+      assert conn.status == 403
+    end
+  end
+
   describe "force_ssl/4" do
     test "forces SSL" do
       # Halts


### PR DESCRIPTION
In the WebSockets standard, there is a feature to pass supported subprotocols.

To do this, the client passes the list of supported subprotocols in `Sec-WebSocket-Protocol` header of the upgrade request. eq: `Sec-Websocket-Protocol: v12.stomp, mqtt`.

The server selects a supported protocol and returns it in the same header `Sec-Websocket-Protocol: mqtt`, then the handshake is successful.

If the server does not return the header, then we get a handshake error, like that:
```javascript
WebSocket connection to 'ws://localhost:4000/socket/websocket' failed:
Error during WebSocket handshake: Sent non-empty 'Sec-WebSocket-Protocol' 
header but no response was received`
```
More details in rfc : https://tools.ietf.org/html/rfc6455#section-1.9

Many protocols require the explicit indication of the sub-protocol when implementing over WebSockets.
For example: 
 - SIP over WebSockets requires `sip` subprotocol: https://tools.ietf.org/html/rfc7118#section-4.1
- SOAP over WebSockets requires `sip` subprotocol: https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-SWSB/%5bMS-SWSB%5d.pdf

Cowboy allows us to modify the `init` callback to implement this logic.
Example: https://ninenines.eu/docs/en/cowboy/2.1/guide/ws_handlers

In Phoenix, this can be implemented using [сustom dispatch options](https://hexdocs.pm/phoenix/Phoenix.Endpoint.CowboyAdapter.html#content).
```elixir 
  http: [
    dispatch: [
      {:_, [
        {"/socket/websocket", MyAppWeb.Endpoint.Cowboy2CustomHandler, {MyAppWeb.Endpoint, []}},
        {:_, Phoenix.Endpoint.Cowboy2Handler, {MyAppWeb.Endpoint, []}}
      ]}
    ]
  ],
```

But this is a tricky and complicated way requiring the support own cowboy handler.

This PR adds simple WebSockets subprotocol support by passing `subprotocol` option to `Phoenix.Endpoint.socket/3`

Example: 
```elixir
  socket "/socket", MyAppWeb.UserSocket,
    websocket: [subprotocol: "sip"],
    longpoll: false
```