### PR TITLE
Changes to init callback description to make it easier to read

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -66,8 +66,8 @@ defmodule Phoenix.Endpoint do
 
   For dynamically configuring the endpoint, such as loading data
   from environment variables or configuration files, Phoenix invokes
-  the `init/2` callback on the endpoint, passing a `:supervisor`
-  atom as first argument and the endpoint configuration as second.
+  the `init/2` callback on the endpoint, passing the atom `:supervisor`
+  as the first argument and the endpoint configuration as second.
 
   All of Phoenix configuration, except the Compile-time configuration
   below can be set dynamically from the `c:init/2` callback.


### PR DESCRIPTION
Specifically it makes it more obvious that exactly `:supervisor` is passed instead of potentially some other atom. Use "the" instead of "a" because there can only be one instance of an atom in the system.