### PR TITLE
Use hex in mix local.phx

### DIFF
--- a/installer/lib/mix/tasks/local.phx.ex
+++ b/installer/lib/mix/tasks/local.phx.ex
@@ -1,7 +1,6 @@
 defmodule Mix.Tasks.Local.Phx do
   use Mix.Task
 
-  @url "https://github.com/phoenixframework/archives/raw/master/phx_new.ez"
   @shortdoc "Updates the Phoenix project generator locally"
 
   @moduledoc """
@@ -9,9 +8,13 @@ defmodule Mix.Tasks.Local.Phx do
 
       mix local.phx
 
-  Accepts the same command line options as `archive.install`.
+  Accepts the same command line options as `archive.install hex phx_new`.
+
+  *Note: Older versions of this task (up to and including 1.4.0) do not fetch
+  the latest version from hex.  If your phx_new archive is older than 1.4, it's
+  necessary to call `mix archive.install hex phx_new` manually at least once.*
   """
   def run(args) do
-    Mix.Task.run "archive.install", [@url | args]
+    Mix.Task.run("archive.install", ["hex", "phx_new" | args])
   end
 end


### PR DESCRIPTION
Following from [this Stack Overflow question](https://stackoverflow.com/questions/56743592/why-does-running-local-phx-downgrade-the-phoenix-archive) and a [closed issue](https://github.com/phoenixframework/archives/issues/2) on the archives repository, it is not clear from the `mix local.phx` docs that the command is no longer supported, and effectively downgrades to 1.3.2.

I deprecated the task, added a warning, and made the version that will be installed explicit, so that it's visible from the task output.

```
$ mix local.phx
WARNING: mix local.phx is no longer supported, use: mix archive.install hex phx_new
Are you sure you want to install "https://github.com/phoenixframework/archives/raw/master/phx_new-1.3.4.ez"? [Yn]
```