### PR TITLE
Update phx.local docs to indicate deprecated status

### DIFF
--- a/installer/lib/mix/tasks/local.phx.ex
+++ b/installer/lib/mix/tasks/local.phx.ex
@@ -9,9 +9,9 @@ defmodule Mix.Tasks.Local.Phx do
 
       mix local.phx
 
-  Accepts the same command line options as `archive.install`.
+  Accepts the same command line options as `archive.install`. `phx.local` is no longer supported after 1.3. To update the Phoenix project generator, please use `mix archive.install hex phx_new` instead.
   """
   def run(args) do
-    Mix.Task.run "archive.install", [@url | args]
+    Mix.Task.run("archive.install", [@url | args])
   end
 end


### PR DESCRIPTION
Running `mix phx.local` is not supported after version 1.3. https://github.com/phoenixframework/archives/issues/2