### PR TITLE
Only install required dependencies in Dockerfile

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -154,7 +154,7 @@ Here is an example Docker file to run at the root of your application covering a
 # FROM elixir:1.9.0-alpine as build
 
 # install build dependencies
-RUN apk add --update git build-base nodejs yarn python
+RUN apk add --update build-base nodejs npm
 
 # prepare build dir
 RUN mkdir /app


### PR DESCRIPTION
The assets compilation script now requires `npm` instead of `yarn` so we need to install it first.
Removed `python` and `git` because they are not needed in most deployments.
`build-base` is preserved because `gcc` is often needed.