### PR TITLE
Fix Dockerfile build dependency

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -154,7 +154,7 @@ Here is an example Docker file to run at the root of your application covering a
 # FROM elixir:1.9.0-alpine as build
 
 # install build dependencies
-RUN apk add --update git build-base nodejs yarn python
+RUN apk add --update git build-base npm yarn python
 
 # prepare build dir
 RUN mkdir /app


### PR DESCRIPTION
The current nodejs dependency does not include npm for some reason. Following the current instructions will cause a failure. There is no need to keep nodejs as it is a dependency of npm.