### PR TITLE
Include releases.md in generated docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -133,6 +133,7 @@ defmodule Phoenix.MixProject do
       "guides/testing/testing_channels.md",
 
       "guides/deployment/deployment.md",
+      "guides/deployment/releases.md",
       "guides/deployment/heroku.md"
       ]
   end


### PR DESCRIPTION
Currently https://hexdocs.pm/phoenix/releases.html is a 404. 

Closes #3465 