### PR TITLE
Correct the pathname referred to in the documentation.

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -60,7 +60,7 @@ Release created at _build/dev/rel/my_app!
 
 You can start the release by calling `_build/dev/rel/my_app/bin/my_app start`, where you have to replace `my_app` by your current application name. If you do so, your application should start but you will notice your web server does not actually run! That's because we need to tell Phoenix to start the web servers. When using `mix phx.server`, the `phx.server` command does that for us, but in a release we don't have Mix (which is a *build* tool), so we have to do it ourselves.
 
-Open up `config/prod.secret.exs` and you should find a section about "Using releases" with a configuration to set. Go ahead and uncomment that line or manually add the line below, adapted to your application names:
+Open up `config/prod.exs` and you should find a section about "Using releases" with a configuration to set. Go ahead and uncomment that line or manually add the line below, adapted to your application names:
 
 ```elixir
 config :my_app, MyApp.Endpoint, server: true


### PR DESCRIPTION
The guide for releases suggest a code change to uncomment the following line in  config/prod.secret.exs:
```elixir
config :my_app, MyApp.Endpoint, server: true
```

However, it is actually in config/prod.exs.

elixir version: 1.9.0
phx version: 1.4.9

Overall the documentation worked really well and I was able to run the release. 👍

## Question:
Should the edit be made in config/prod.exs or should that line show up in config/prod/secret.exs when phoenix scaffolds a new app?

I ask this question because further down the documentation [#Runtime configuration](https://github.com/MichaelDimmitt/phoenix/blob/master/guides/deployment/releases.md#runtime-configuration) suggests that you should copy the config/prod/secret.exs into config/releases.exs