### PR TITLE
remove x-headers to headers

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -797,7 +797,7 @@ defmodule Phoenix.Endpoint do
       The valid keys are:
 
         * `:peer_data` - the result of `Plug.Conn.get_peer_data/1`
-        * `:x_headers` - all request headers that have an "x-" prefix
+        * `:headers` - all request headers
         * `:uri` - a `%URI{}` with information from the conn
         * `{:session, session_config}` - the session information from `Plug.Conn`.
           The `session_config` is an exact copy of the arguments given to `Plug.Session`.
@@ -812,7 +812,7 @@ defmodule Phoenix.Endpoint do
 
           socket "/socket", AppWeb.UserSocket,
             websocket: [
-              connect_info: [:peer_data, :x_headers, :uri, session: [store: :cookie]]
+              connect_info: [:peer_data, :headers, :uri, session: [store: :cookie]]
             ]
 
       With arbitrary keywords:

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -219,7 +219,7 @@ defmodule Phoenix.Socket.Transport do
 
     connect_info =
       Enum.map(connect_info, fn
-        key when key in [:peer_data, :uri, :x_headers] ->
+        key when key in [:peer_data, :uri, :headers] ->
           key
 
         {:session, session} ->
@@ -230,7 +230,7 @@ defmodule Phoenix.Socket.Transport do
 
         other ->
           raise ArgumentError,
-                ":connect_info keys are expected to be one of :peer_data, :x_headers, :uri, or {:session, config}, " <>
+                ":connect_info keys are expected to be one of :peer_data, :headers, :uri, or {:session, config}, " <>
                   "optionally followed by custom keyword pairs, got: #{inspect(other)}"
       end)
 
@@ -363,7 +363,7 @@ defmodule Phoenix.Socket.Transport do
   The supported keys are:
 
     * `:peer_data` - the result of `Plug.Conn.get_peer_data/1`
-    * `:x_headers` - a list of all request headers that have an "x-" prefix
+    * `:headers` - a list of all request headers
     * `:uri` - a `%URI{}` derived from the conn
 
   """
@@ -373,8 +373,8 @@ defmodule Phoenix.Socket.Transport do
         :peer_data ->
           {:peer_data, Plug.Conn.get_peer_data(conn)}
 
-        :x_headers ->
-          {:x_headers, fetch_x_headers(conn)}
+        :headers ->
+          {:headers, conn.req_headers}
 
         :uri ->
           {:uri, fetch_uri(conn)}
@@ -397,12 +397,6 @@ defmodule Phoenix.Socket.Transport do
           {key, val}
       end
     end
-  end
-
-  defp fetch_x_headers(conn) do
-    for {header, _} = pair <- conn.req_headers,
-        String.starts_with?(header, "x-"),
-        do: pair
   end
 
   defp fetch_uri(%{host: host, scheme: scheme, query_string: query_string, port: port, request_path: request_path}) do

--- a/test/phoenix/integration/websocket_channels_test.exs
+++ b/test/phoenix/integration/websocket_channels_test.exs
@@ -107,7 +107,7 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
         connect_info
         |> Map.update!(:peer_data, &Map.put(&1, :address, address))
         |> Map.update!(:uri, &Map.from_struct/1)
-        |> Map.update!(:x_headers, &Map.new/1)
+        |> Map.update!(:headers, &Map.new/1)
 
       socket =
         socket
@@ -165,7 +165,7 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
       websocket: [
         check_origin: ["//example.com"],
         timeout: 200,
-        connect_info: [:x_headers, :peer_data, :uri, session: @session_config, signing_salt: "salt"]
+        connect_info: [:headers, :peer_data, :uri, session: @session_config, signing_salt: "salt"]
       ]
 
     plug Plug.Session, @session_config
@@ -241,7 +241,7 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
         refute_receive %Message{event: "new_msg"}
       end
 
-      test "transport x_headers are extracted to the socket connect_info" do
+      test "transport headers are extracted to the socket connect_info" do
         extra_headers = [{"x-application", "Phoenix"}]
         {:ok, sock} =
           WebsocketClient.start_link(
@@ -255,8 +255,8 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
 
         assert_receive %Message{event: "joined",
                                 payload: %{"connect_info" =>
-                                  %{"x_headers" =>
-                                    %{"x-application" => "Phoenix"}}}}
+                                  %{"headers" =>
+                                  %{"connection" => "Upgrade", "host" => "127.0.0.1", "sec-websocket-key" => _, "sec-websocket-version" => "13", "upgrade" => "websocket", "x-application" => "Phoenix"}}}}
       end
 
       test "transport peer_data is extracted to the socket connect_info" do


### PR DESCRIPTION
## What was done
Socket transport will send back the entire list of header insisted limited header name starting by `x-`

## Why was it done
In some case it can be had to have a header starting by `x-`, it's better to let the framework open to any header name for more flexibility. 

