### PR TITLE
 Fix rollback/2 in releases guide

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -118,20 +118,24 @@ defmodule MyApp.Release do
   @app :my_app
 
   def migrate do
+    load_app()
+
     for repo <- repos() do
       {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
     end
   end
 
   def rollback(repo, version) do
-    for r <- repos(), r == repo do
-      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
-    end
+    load_app()
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
   end
 
   defp repos do
-    Application.load(@app)
     Application.fetch_env!(@app, :ecto_repos)
+  end
+  
+  defp load_app do
+    Application.load(@app)
   end
 end
 ```

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -124,7 +124,9 @@ defmodule MyApp.Release do
   end
 
   def rollback(repo, version) do
-    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+    for r <- repos(), r == repo do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+    end
   end
 
   defp repos do


### PR DESCRIPTION
Load the configured `@app` (by calling `repos/0`) before attempting the rollback, similar to `migrate/0`. 

Otherwise the following error gets raised:

```
** (RuntimeError) connect raised KeyError exception: key :database not found. The exception details are hidden, as they may contain sensitive data such as database credentials. You may set :show_sensitive_data_on_connection_error to true when starting your connection if you wish to see all of the details
    (elixir) lib/keyword.ex:393: Keyword.fetch!/2
    (postgrex) lib/postgrex/protocol.ex:92: Postgrex.Protocol.connect/1
    (db_connection) lib/db_connection/connection.ex:69: DBConnection.Connection.connect/2
    (connection) lib/connection.ex:622: Connection.enter_connect/5
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: nil

```