### PR TITLE
Fix Cowboy WebSocket error handling

### DIFF
--- a/lib/phoenix/endpoint/cowboy_websocket.ex
+++ b/lib/phoenix/endpoint/cowboy_websocket.ex
@@ -21,7 +21,7 @@ defmodule Phoenix.Endpoint.CowboyWebSocket do
           req = Cowboy2Handler.copy_resp_headers(conn, req)
           {:upgrade, :protocol, __MODULE__, req, {handler, args, timeout}}
 
-        {:error, %Plug.Conn{adapter: {@connection, req} = conn}} ->
+        {:error, %Plug.Conn{adapter: {@connection, req}} = conn} ->
           {:shutdown, Cowboy2Handler.copy_resp_headers(conn, req), :no_state}
       end
     catch


### PR DESCRIPTION
`conn` is wrongly nested in pattern match, causing exceptions when passed to `Cowboy2Handler.copy_resp_headers/2`.

Fixes failing tests in  #3474, #3490, #3491 and #3495.