### PR TITLE
Build sourcemaps by default in dev

### DIFF
--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -4,11 +4,12 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const devMode = process.env.NODE_ENV !== 'production'
 
 module.exports = (env, options) => ({
   optimization: {
     minimizer: [
-      new TerserPlugin({ cache: true, parallel: true, sourceMap: false }),
+      new TerserPlugin({ cache: true, parallel: true, sourceMap: devMode }),
       new OptimizeCSSAssetsPlugin({})
     ]
   },
@@ -19,9 +20,7 @@ module.exports = (env, options) => ({
     filename: 'app.js',
     path: path.resolve(__dirname, '../priv/static/js')
   },
-  stats: {
-    colors: !/^win/i.test(process.platform)
-  },
+  devtool: devMode ? 'source-map' : undefined,
   module: {
     rules: [
       {
@@ -33,7 +32,15 @@ module.exports = (env, options) => ({
       },
       {
         test: /\.css$/,
-        use: [MiniCssExtractPlugin.loader, 'css-loader']
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: devMode
+            }
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
Thanks for all of the amazing work on Pheonix! Great framework.

I can't see any reason why we wouldn't want to enable source map generation by default. What do you think?