### PR TITLE
Fix trivial ui issue in generated index.html.eex template

### DIFF
--- a/priv/templates/phx.gen.html/index.html.eex
+++ b/priv/templates/phx.gen.html/index.html.eex
@@ -14,9 +14,9 @@
 <%= for {k, _} <- schema.attrs do %>      <td><%%= <%= schema.singular %>.<%= k %> %></td>
 <% end %>
       <td>
-        <%%= link "Show", to: Routes.<%= schema.route_helper %>_path(@conn, :show, <%= schema.singular %>) %>
-        <%%= link "Edit", to: Routes.<%= schema.route_helper %>_path(@conn, :edit, <%= schema.singular %>) %>
-        <%%= link "Delete", to: Routes.<%= schema.route_helper %>_path(@conn, :delete, <%= schema.singular %>), method: :delete, data: [confirm: "Are you sure?"] %>
+        <span><%%= link "Show", to: Routes.<%= schema.route_helper %>_path(@conn, :show, <%= schema.singular %>) %></span>
+        <span><%%= link "Edit", to: Routes.<%= schema.route_helper %>_path(@conn, :edit, <%= schema.singular %>) %></span>
+        <span><%%= link "Delete", to: Routes.<%= schema.route_helper %>_path(@conn, :delete, <%= schema.singular %>), method: :delete, data: [confirm: "Are you sure?"] %></span>
       </td>
     </tr>
 <%% end %>


### PR DESCRIPTION
The links "Show", "Edit" and "Delete" are sticked together. Wrap them with span to add a little space in between.

Note that the same is done in the "show" template:
https://github.com/phoenixframework/phoenix/blob/master/priv/templates/phx.gen.html/show.html.eex#L12