### PR TITLE
No joined-check for channel broadcasts

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -494,16 +494,14 @@ defmodule Phoenix.Channel do
       :ok
 
   """
-  def broadcast(socket, event, message) do
-    %{pubsub_server: pubsub_server, topic: topic} = assert_joined!(socket)
+  def broadcast(%Socket{pubsub_server: pubsub_server, topic: topic}, event, message) do
     Server.broadcast(pubsub_server, topic, event, message)
   end
 
   @doc """
   Same as `broadcast/3`, but raises if broadcast fails.
   """
-  def broadcast!(socket, event, message) do
-    %{pubsub_server: pubsub_server, topic: topic} = assert_joined!(socket)
+  def broadcast!(%Socket{pubsub_server: pubsub_server, topic: topic}, event, message) do
     Server.broadcast!(pubsub_server, topic, event, message)
   end
 

--- a/test/phoenix/channel_test.exs
+++ b/test/phoenix/channel_test.exs
@@ -95,7 +95,7 @@ defmodule Phoenix.Channel.ChannelTest do
     }
   end
 
-  test "broadcasts when not joined" do
+  test "`broadcast_from`s when not joined" do
     socket = %Phoenix.Socket{joined: false}
 
     assert_raise RuntimeError, ~r"join", fn ->
@@ -104,14 +104,6 @@ defmodule Phoenix.Channel.ChannelTest do
 
     assert_raise RuntimeError, ~r"join", fn ->
       broadcast_from!(socket, "event", %{key: :val})
-    end
-
-    assert_raise RuntimeError, ~r"join", fn ->
-      broadcast(socket, "event", %{key: :val})
-    end
-
-    assert_raise RuntimeError, ~r"join", fn ->
-      broadcast!(socket, "event", %{key: :val})
     end
   end
 


### PR DESCRIPTION
Making `broadcast/3` and `broadcast!/3` check whether socket is joined seems superfluous because: 
* messages are sent to sockets subscribed to a topic, that are retrieved from an ETS table, implying that these sockets are already joined
* [`assert_joined!/1`](https://github.com/phoenixframework/phoenix/blob/v1.4.9/lib/phoenix/channel.ex#L589) only checks the input socket's `:joined` status, but only the `:topic` and `:pubsub_server` is used from it, and the retrieved sockets won't get checked for joined status (at least not in the `broadcast/3` functions)

The check has been added in [commit](https://github.com/phoenixframework/phoenix/commit/ac3e96963e81b76fa417fa2029334094d379be77), and it is clear that `broadcast/3` was implemented via `broadcast_from/4` before, that did joined-checking, and it indeed needs it. I assume that during refactoring, this was mechanically carried over. 

There was one failing test, but removed it as well as a corollary of the above logic.

I could be wrong, and in that case, I'm sorry for taking your time.