### PR TITLE
deployment guide: Application.load -> ensure_all_started

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -150,7 +150,17 @@ $ _build/dev/rel/my_app/bin/my_app eval "MyApp.Release.migrate"
 
 And that's it!
 
-You can use this approach to create any custom command to run in production. In this case, we used `load_app`, which calls `Application.load/1` to load the current application without starting it. However, you may want to write a custom command that starts the whole application. In such cases, `Application.ensure_all_started/1` must be used. Keep in mind starting the application will start all processes for the current application, including the Phoenix endpoint.
+You can use this approach to create any custom command to run in production. In this case, we used `load_app`, which calls `Application.load/1` to load the current application without starting it. However, you may want to write a custom command that starts the whole application. In such cases, `Application.ensure_all_started/1` must be used. Keep in mind starting the application will start all processes for the current application, including the Phoenix endpoint. This can be circumvented by changing your supervision tree to not start certain children under certain conditions. For example, in the release commands file you could do:
+
+```elixir
+defp start_app do
+  load_app()
+  Application.put_env(@app, :minimal, true)
+  Application.ensure_all_started(@app)
+end
+```
+
+And then in your application you check `Application.get_env(@app, :minimal)` and start only part of the children when it is set.
 
 ## Containers
 

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -135,7 +135,7 @@ defmodule MyApp.Release do
   end
   
   defp load_app do
-    Application.ensure_all_started(@app)
+    Application.load(@app)
   end
 end
 ```
@@ -149,6 +149,8 @@ $ _build/dev/rel/my_app/bin/my_app eval "MyApp.Release.migrate"
 ```
 
 And that's it!
+
+You can use this approach to create any custom command to run in production. In this case, we used `load_app`, which calls `Application.load/1` to load the current application without starting it. However, you may want to write a custom command that starts the whole application. In such cases, `Application.ensure_all_started/1` must be used. Keep in mind starting the application will start all processes for the current application, including the Phoenix endpoint.
 
 ## Containers
 

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -135,7 +135,7 @@ defmodule MyApp.Release do
   end
   
   defp load_app do
-    Application.load(@app)
+    Application.ensure_all_started(@app)
   end
 end
 ```


### PR DESCRIPTION
I loved to see this documentation, but I ran into a snag. My postgrex configuration has `ssl: true`, so the `:ssl` app is required for the connection. When I followed this guide, I got:

```
** (EXIT from #PID<0.165.0>) an exception was raised:
    ** (RuntimeError) SSL connection can not be established because `:ssl` application is not started,
you can add it to `extra_application` in your `mix.exs`:

  def application do
    [extra_applications: [:ssl]]
  end

        (postgrex) lib/postgrex.ex:538: Postgrex.ensure_deps_started!/1
        (postgrex) lib/postgrex.ex:480: Postgrex.child_spec/1
        (ecto_sql) lib/ecto/adapters/sql.ex:462: Ecto.Adapters.SQL.init/3
        (ecto) lib/ecto/repo/supervisor.ex:162: Ecto.Repo.Supervisor.init/1
        (stdlib) supervisor.erl:295: :supervisor.init/1
        (stdlib) gen_server.erl:374: :gen_server.init_it/2
        (stdlib) gen_server.erl:342: :gen_server.init_it/6
        (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

In the #elixir-lang channel, _gamache_ helped me with the solution: `Application.ensure_all_started/1` is needed. Perhaps we should use this in the docs so others don't get bit by the same issue?

Thanks!!!