### PR TITLE
Allow using a keyword list/map for socket assigns

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -303,19 +303,24 @@ defmodule Phoenix.Socket do
   ## USER API
 
   @doc """
-  Adds a key/value pair to socket assigns.
+  Adds key value pairs to socket assigns.
+
+  A single key value pair may be passed, a keyword list or map
+  of assigns may be provided to be merged into existing socket
+  assigns.
 
   ## Examples
 
-      iex> socket.assigns[:token]
-      nil
-      iex> socket = assign(socket, :token, "bar")
-      iex> socket.assigns[:token]
-      "bar"
-
+  iex> assign(socket, :name, "Elixir")
+  iex> assign(socket, name: "Elixir", logo: "💧")
   """
-  def assign(socket = %Socket{}, key, value) do
-    put_in socket.assigns[key], value
+  def assign(%Socket{} = socket, key, value) do
+    assign(socket, [{key, value}])
+  end
+
+  def assign(%Socket{} = socket, attrs)
+  when is_map(attrs) or is_list(attrs) do
+    %{socket | assigns: Map.merge(socket.assigns, Map.new(attrs))}
   end
 
   @doc """

--- a/test/phoenix/socket/socket_test.exs
+++ b/test/phoenix/socket/socket_test.exs
@@ -37,4 +37,30 @@ defmodule Phoenix.SocketTest do
       assert socket.assigns[:foo] == :bar
     end
   end
+
+  describe "assign/2" do
+    test "assigns a map socket" do
+      socket = %Phoenix.Socket{}
+      assert socket.assigns[:foo] == nil
+      socket = assign(socket, %{foo: :bar, abc: :def})
+      assert socket.assigns[:foo] == :bar
+      assert socket.assigns[:abc] == :def
+    end
+
+    test "merges if values exist" do
+      socket = %Phoenix.Socket{}
+      socket = assign(socket, %{foo: :bar, abc: :def})
+      socket = assign(socket, %{foo: :baz})
+      assert socket.assigns[:foo] == :baz
+      assert socket.assigns[:abc] == :def
+    end
+
+    test "merges keyword lists" do
+      socket = %Phoenix.Socket{}
+      socket = assign(socket, %{foo: :bar, abc: :def})
+      socket = assign(socket, [foo: :baz])
+      assert socket.assigns[:foo] == :baz
+      assert socket.assigns[:abc] == :def
+    end
+  end
 end


### PR DESCRIPTION
This reflects the capabilities of Live View, allow multiple vallues to
be assigned at once.