### PR TITLE
Optimize syncDiff and syncState

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -154,29 +154,26 @@
  *
  * ### Handling individual presence join and leave events
  *
- * The `presence.onJoin` and `presence.onLeave` callbacks can be used to
- * react to individual presences joining and leaving the app. For example:
+ * The `presence.onChange` callback can be used to react to individual
+ * presences joining and leaving the app. onChange can only be used when
+ * deprecated onJoin and onLeave functions are not used.
+ * For example:
  *
  * ```javascript
  * let presence = new Presence(channel)
  *
  * // detect if user has joined for the 1st time or from another tab/device
- * presence.onJoin((id, current, newPres) => {
- *   if(!current){
- *     console.log("user has entered for the first time", newPres)
+ * presence.onChange((id, oldPresence, newPresence) => {
+ *   if(!oldPresence){
+ *     console.log("user has entered for the first time", newPresence)
+ *   } else if (newPresence.metas.length === 0){
+ *     console.log("user has left from all devices", newPresence)
  *   } else {
- *     console.log("user additional presence", newPres)
+ *     console.log("old presence", oldPresence");
+ *     console.log("new presence", newPresence");
  *   }
  * })
  *
- * // detect if user has left from all tabs/devices, or is still present
- * presence.onLeave((id, current, leftPres) => {
- *   if(current.metas.length === 0){
- *     console.log("user has left from all devices", leftPres)
- *   } else {
- *     console.log("user left from a device", leftPres)
- *   }
- * })
  * // receive presence data from server
  * presence.onSync(() => {
  *   displayUsers(presence.list())
@@ -1284,39 +1281,62 @@ export class Presence {
     this.channel = channel
     this.joinRef = null
     this.caller = {
-      onJoin: function(){},
-      onLeave: function(){},
+      onChange: null,
+      onJoin: null,
+      onLeave: null,
       onSync: function(){}
     }
 
     this.channel.on(events.state, newState => {
-      let {onJoin, onLeave, onSync} = this.caller
+      let {onChange, onJoin, onLeave, onSync} = this.caller
 
       this.joinRef = this.channel.joinRef()
-      this.state = Presence.syncState(this.state, newState, onJoin, onLeave)
+      if (onJoin || onLeave) {
+        Presence.syncState(this.state, newState, onJoin, onLeave)
+      } else {
+        Presence.synchronizeState(this.state, newState, onChange)
+      }
 
       this.pendingDiffs.forEach(diff => {
-        this.state = Presence.syncDiff(this.state, diff, onJoin, onLeave)
+        if (onJoin || onLeave) {
+          Presence.syncDiff(this.state, diff, onJoin, onLeave)
+        } else {
+          Presence.synchronizeDiff(this.state, diff, onChange)
+        }
       })
       this.pendingDiffs = []
       onSync()
     })
 
     this.channel.on(events.diff, diff => {
-      let {onJoin, onLeave, onSync} = this.caller
+      let {onChange, onJoin, onLeave, onSync} = this.caller
 
       if(this.inPendingSyncState()){
         this.pendingDiffs.push(diff)
       } else {
-        this.state = Presence.syncDiff(this.state, diff, onJoin, onLeave)
+        if (onJoin || onLeave) {
+          Presence.syncDiff(this.state, diff, onJoin, onLeave)
+        } else {
+          Presence.synchronizeDiff(this.state, diff, onChange)
+        }
         onSync()
       }
     })
   }
 
-  onJoin(callback){ this.caller.onJoin = callback }
+  // @deprecated Please use onChange instead
+  onJoin(callback){
+    console && console.warn && console.warn('onJoin is deprecated, use onChange instead')
+    this.caller.onJoin = callback
+  }
 
-  onLeave(callback){ this.caller.onLeave = callback }
+  // @deprecated Please use onChange instead
+  onLeave(callback){
+    console && console.warn && console.warn('onLeave is deprecated, use onChange instead')
+    this.caller.onLeave = callback
+  }
+
+  onChange(callback){ this.caller.onChange = callback }
 
   onSync(callback){ this.caller.onSync = callback }
 
@@ -1329,12 +1349,65 @@ export class Presence {
   // lower-level public static API
 
   /**
+   * Used to sync the list of presences on the server with the client's state.
+   * An optional `onChange` callback can be provided to react to changes in the
+   * client's local presences across disconnects and reconnects with the
+   * server.
+   *
+   * onChange callback will be invoked with three arguments:
+   * 1. key - presence key (e.g. user-5)
+   * 2. oldPresence - presence object before the sync
+   * 3. newPresence - presence object after the sync
+   *
+   * **NOTE**: This function mutates the state object that is passed to this
+   * function as the first argument.
+   *
+   * @returns {Presence}
+   */
+  static synchronizeState(state, newState, onChange){
+    let joins = {}
+    let leaves = {}
+
+    this.map(state, (key, presence) => {
+      if(!newState[key]){
+        leaves[key] = presence
+      }
+    })
+    this.map(newState, (key, newPresence) => {
+      let currentPresence = state[key]
+      if(currentPresence){
+        let newRefs = newPresence.metas.map(m => m.phx_ref)
+        let curRefs = currentPresence.metas.map(m => m.phx_ref)
+        let joinedMetas = newPresence.metas.filter(m => curRefs.indexOf(m.phx_ref) < 0)
+        let leftMetas = currentPresence.metas.filter(m => newRefs.indexOf(m.phx_ref) < 0)
+        if(joinedMetas.length > 0){
+          joins[key] = newPresence
+          joins[key].metas = joinedMetas
+        }
+        if(leftMetas.length > 0){
+          if(joinedMetas.length > 0){
+            leaves[key] = {metas: leftMetas}
+          } else {
+            leaves[key] = newPresence;
+            leaves[key].metas = leftMetas
+          }
+        }
+      } else {
+        joins[key] = newPresence
+      }
+    })
+    return this.synchronizeDiff(state, {joins: joins, leaves: leaves}, onChange)
+  }
+
+  /**
    * Used to sync the list of presences on the server
    * with the client's state. An optional `onJoin` and `onLeave` callback can
    * be provided to react to changes in the client's local presences across
    * disconnects and reconnects with the server.
    *
    * @returns {Presence}
+   *
+   * @deprecated Use synchronizeState function instead
    */
   static syncState(currentState, newState, onJoin, onLeave){
     let state = this.clone(currentState)
@@ -1370,12 +1443,77 @@ export class Presence {
 
   /**
    *
+   * Used to sync a diff of presence join and leave events from the server, as
+   * they happen. Like `syncState`, `syncDiff` accepts optional `onChange`
+   * callback to react to a user joining or leaving from a device.
+   *
+   * onChange callback will be invoked with three arguments:
+   * 1. key - presence key (e.g. user-5)
+   * 2. oldPresence - presence object before the sync
+   * 3. newPresence - presence object after the sync
+   *
+   * **NOTE**: This function mutates the state object that is passed to this
+   * function as the first argument.
+   *
+   * @returns {Presence}
+   */
+  static synchronizeDiff(state, {joins, leaves}, onChange){
+    const changes = {}
+    this.map(joins, (key, newPresence) => {
+      changes[key] = {joinedMetas: newPresence.metas, leftMetas: [], update: newPresence}
+    })
+    this.map(leaves, (key, leftPresence) => {
+      if (changes[key]) {
+        changes[key].leftMetas = leftPresence.metas;
+      } else {
+        changes[key] = {joinedMetas: [], leftMetas: leftPresence.metas, update: leftPresence}
+      }
+    })
+
+    this.map(changes, (key, {joinedMetas, leftMetas, update}) => {
+      const joinedRefs = joinedMetas.map(m => m.phx_ref)
+      const refsToRemove = leftMetas.map(m => m.phx_ref)
+      const oldPresence = state[key];
+
+      const newPresence = {metas: oldPresence ? oldPresence.metas : []};
+      newPresence.metas = newPresence.metas
+        .filter(m => joinedRefs.indexOf(m.phx_ref) === -1)
+        .concat(joinedMetas)
+        .filter(p => refsToRemove.indexOf(p.phx_ref) === -1)
+
+      Object.keys(update).forEach(key => {
+        // metas is already handled above separately
+        if (key !== "metas") newPresence[key] = update[key];
+      })
+
+      if (newPresence.metas.length === 0) {
+        // Delete the presence from the state when the metas are empty
+        delete state[key]
+      } else {
+        // Update the old presence with the new presence in one atomic
+        // operation
+        state[key] = newPresence;
+      }
+
+      // Only notify onChange when there were any changes. If there were
+      // changes but the old metas and new betas are still empty then there's
+      // no reason to notify onChange callback.
+      if (onChange) onChange(key, oldPresence, newPresence)
+    });
+
+    return state;
+  }
+
+  /**
+   *
    * Used to sync a diff of presence join and leave
    * events from the server, as they happen. Like `syncState`, `syncDiff`
    * accepts optional `onJoin` and `onLeave` callbacks to react to a user
    * joining or leaving from a device.
    *
    * @returns {Presence}
+   *
+   * @deprecated Use synchronizeDiff function instead
    */
   static syncDiff(currentState, {joins, leaves}, onJoin, onLeave){
     let state = this.clone(currentState)

--- a/assets/test/presence_test.js
+++ b/assets/test/presence_test.js
@@ -37,6 +37,65 @@ let channelStub = {
 
 let listByFirst = (id, {metas: [first, ...rest]}) => first
 
+describe("synchronizeState", () => {
+  it("syncs empty state", () => {
+    let newState = {u1: {metas: [{id: 1, phx_ref: "1"}]}}
+    let state = {}
+    Presence.synchronizeState(state, newState)
+    assert.deepEqual(state, newState)
+  })
+
+  it("invokes onChange on joins and leaves", () => {
+    let newState = fixtures.state()
+    let state = {u4: {metas: [{id: 4, phx_ref: "4"}]}}
+    let changes = {}
+
+    let onChange = (key, oldPresence, newPresence) => {
+      changes[key] = {oldPresence: oldPresence, newPresence: newPresence}
+    }
+
+    Presence.synchronizeState(state, newState, onChange)
+    assert.deepEqual(state, newState)
+
+    assert.deepEqual(changes, {
+      u1: {oldPresence: null, newPresence: {metas: [{id: 1, phx_ref: "1"}]}},
+      u2: {oldPresence: null, newPresence: {metas: [{id: 2, phx_ref: "2"}]}},
+      u3: {oldPresence: null, newPresence: {metas: [{id: 3, phx_ref: "3"}]}},
+      u4: {oldPresence: {metas: [{id: 4, phx_ref: "4"}]}, newPresence: {metas: []}}
+    })
+  })
+
+  it('has metas for presences after state sync due to server restart', () => {
+    // State prior to server disconnect, id: 1 is joined to presence
+    let state = {
+      u1: {metas: [{id: 1, phx_ref: "1"}]}
+    };
+
+    // New state from new server instance with id: 1 still joined, but with new phx_ref
+    let newState = {
+      u1: {metas: [{id: 1, phx_ref: "2"}]}
+    };
+
+    let changes = {}
+    let onChange = (key, oldPresence, newPresence) => {
+      changes[key] = {oldPresence: oldPresence, newPresence: newPresence}
+    }
+
+    Presence.synchronizeState(state, newState, onChange);
+
+    assert.deepEqual(state, {
+      u1: {metas: [{id: 1, phx_ref: "2"}]}
+    });
+
+    assert.deepEqual(changes, {
+      u1: {
+        oldPresence: {metas: [{id: 1, phx_ref: "1"}]},
+        newPresence: {metas: [{id: 1, phx_ref: "2"}]}
+      }
+    });
+  });
+})
+
 describe("syncState", () => {
   it("syncs empty state", () => {
     let newState = {u1: {metas: [{id: 1, phx_ref: "1"}]}}
@@ -97,6 +156,113 @@ describe("syncState", () => {
   })
 })
 
+describe("synchronizeDiff", () => {
+  it("syncs empty state", () => {
+    let joins = {u1: {metas: [{id: 1, phx_ref: "1"}]}}
+    let state = {}
+
+    const returnedState = Presence.synchronizeDiff(state, {joins: joins, leaves: {}})
+    assert.deepEqual(state, joins)
+    assert.deepEqual(state, returnedState)
+  })
+
+  it("removes presence when meta is empty and adds additional meta", () => {
+    let state = fixtures.state()
+    Presence.synchronizeDiff(state, {joins: fixtures.joins(), leaves: fixtures.leaves()})
+
+    assert.deepEqual(state, {
+      u1: {metas: [{id: 1, phx_ref: "1"}, {id: 1, phx_ref: "1.2"}]},
+      u3: {metas: [{id: 3, phx_ref: "3"}]}
+    })
+  })
+
+  it("removes meta while leaving key if other metas exist", () => {
+    let state = {
+      u1: {metas: [{id: 1, phx_ref: "1"}, {id: 1, phx_ref: "1.2"}]}
+    }
+    Presence.synchronizeDiff(state, {joins: {}, leaves: {u1: {metas: [{id: 1, phx_ref: "1"}]}}})
+
+    assert.deepEqual(state, {
+      u1: {metas: [{id: 1, phx_ref: "1.2"}]},
+    })
+  })
+
+  it("calls onChange function on update", done => {
+    let state = {}
+    let update1 = {
+      joins: {u1: {metas: [{id: 1, phx_ref: 1}, {id: 2, phx_ref: 2}]}},
+      leaves: {}
+    }
+    let update2 = {
+      joins: {u1: {metas: [{id: 1, phx_ref_prev: 1, phx_ref: 1.1}]}},
+      leaves: {u1: {metas: [{id: 1, phx_ref: 1}]}}
+    }
+
+    let stateAfterUpdate1 = {metas: [{id: 1, phx_ref: 1}, {id: 2, phx_ref: 2}]}
+    let expectedFinalState = {metas: [{id: 2, phx_ref: 2}, {id: 1, phx_ref: 1.1, phx_ref_prev: 1}]}
+
+    let onChange = (key, oldPresence, newPresence) => {
+      assert.deepEqual(key, "u1");
+      assert.deepEqual(oldPresence, stateAfterUpdate1)
+      assert.deepEqual(newPresence, expectedFinalState)
+      done();
+    };
+
+    Presence.synchronizeDiff(state, update1)
+    Presence.synchronizeDiff(state, update2, onChange)
+  });
+
+  it("calls onChange function on leave", done => {
+    let state = {}
+    let update1 = {
+      joins: {u1: {metas: [{id: 1, phx_ref: 1}, {id: 2, phx_ref: 2}]}},
+      leaves: {}
+    }
+    let update2 = {
+      joins: {},
+      leaves: {u1: {metas: [{id: 1, phx_ref: 1}]}}
+    }
+
+    let stateAfterUpdate1 = {metas: [{id: 1, phx_ref: 1}, {id: 2, phx_ref: 2}]}
+    let expectedFinalState = {metas: [{id: 2, phx_ref: 2}]}
+
+    let onChange = (key, oldPresence, newPresence) => {
+      assert.deepEqual(key, "u1");
+      assert.deepEqual(oldPresence, stateAfterUpdate1)
+      assert.deepEqual(newPresence, expectedFinalState)
+      done();
+    };
+
+    Presence.synchronizeDiff(state, update1)
+    Presence.synchronizeDiff(state, update2, onChange)
+  });
+
+  it("calls onChange with latest custom state", done => {
+    let state = {}
+    let update1 = {
+      joins: {u1: {foo: 'bar', metas: [{id: 1, phx_ref: 1}]}},
+      leaves: {}
+    }
+    let update2 = {
+      joins: {u1: {foo: 'baz', metas: [{id: 1, phx_ref_prev: 1, phx_ref: 1.1}]}},
+      leaves: {u1: {foo: 'bar', metas: [{id: 1, phx_ref: 1}]}}
+    }
+
+    let stateAfterUpdate1 = {foo: 'bar', metas: [{id: 1, phx_ref: 1}]}
+    let expectedFinalState = {foo: 'baz', metas: [{id: 1, phx_ref: 1.1, phx_ref_prev: 1}]}
+
+    let onChange = (key, oldPresence, newPresence) => {
+      assert.deepEqual(key, "u1");
+      assert.deepEqual(oldPresence, stateAfterUpdate1)
+      assert.deepEqual(newPresence, expectedFinalState)
+      done();
+    };
+
+    Presence.synchronizeDiff(state, update1)
+    Presence.synchronizeDiff(state, update2, onChange)
+  });
+})
+
 describe("syncDiff", () => {
   it("syncs empty state", () => {
     let joins = {u1: {metas: [{id: 1, phx_ref: "1"}]}}
@@ -132,7 +298,6 @@ describe("syncDiff", () => {
     })
   })
 })
-
 
 describe("list", () => {
   it("lists full presence by default", () => {
@@ -178,14 +343,10 @@ describe("instance", () => {
 
   it("applies pending diff if state is not yet synced", () => {
     let presence = new Presence(channelStub)
-    let onJoins = []
-    let onLeaves = []
+    let onChanges = []
 
-    presence.onJoin((id, current, newPres) => {
-      onJoins.push({id, current, newPres})
-    })
-    presence.onLeave((id, current, leftPres) => {
-      onLeaves.push({id, current, leftPres})
+    presence.onChange((id, oldPresence, newPresence) => {
+      onChanges.push({id, oldPresence, newPresence})
     })
 
     // new connection
@@ -201,16 +362,14 @@ describe("instance", () => {
     assert.deepEqual(presence.pendingDiffs, [{joins: {}, leaves: leaves}])
 
     channelStub.trigger("presence_state", newState)
-    assert.deepEqual(onLeaves, [
-      {id: "u2", current: {metas: []}, leftPres: {metas: [{id: 2, phx_ref: "2"}]}}
+    assert.deepEqual(onChanges, [
+      {id: "u1", oldPresence: undefined, newPresence: user1},
+      {id: "u2", oldPresence: undefined, newPresence: user2},
+      {id: "u2", oldPresence: user2, newPresence: {metas: []}}
     ])
 
     assert.deepEqual(presence.list(listByFirst), [{id: 1, phx_ref: "1"}])
     assert.deepEqual(presence.pendingDiffs, [])
-    assert.deepEqual(onJoins, [
-      {id: "u1", current: undefined, newPres: {metas: [{id: 1, phx_ref: "1"}]}},
-      {id: "u2", current: undefined, newPres: {metas: [{id: 2, phx_ref: "2"}]}}
-    ])
 
     // disconnect and reconnect
     assert.equal(presence.inPendingSyncState(), false)


### PR DESCRIPTION
Syncing presences was very slow due to using clone(). For channels that have couple of thousand of users where users are joining/leaving and we also have updates, clone() used almost all the CPU.

onJoin and onLeave callbacks were merged into one onChange callback. This is because previous onJoin and onLeave callbacks were very confusing and this way we don't have to use the the clone function. Previously onJoin and onLeave both were called with 3 arguments: key, currentPresence and newPresence/leftPresence. The currentPresence however was the same value as before the update for onJoin, but updated presence (joins/leaves processed) for onLeave. So in onJoin case we get the state before the changes and in onLeave case we get the state after all the changes.

Also the old onJoin newPresence variables included metas that were in leaves payload which made it hard to detect a join vs an update.

New onChange callback includes the previous presence (state before the updates) and new presence (state after the updates) which makes it much easier to process changes and see what has happened.

onJoin and onLeave are still in the API because of backwards compatibility but they're marked as deprecated.

This addresses both #3509 and #3475


Site with 3K users, before:
![Screen Shot 2019-08-05 at 18 29 39](https://user-images.githubusercontent.com/3438/62479151-7320be00-b7b5-11e9-9a18-c67cc100d4ab.png)

and after:
![Screen Shot 2019-08-05 at 18 26 20](https://user-images.githubusercontent.com/3438/62479160-76b44500-b7b5-11e9-8915-6757fe6c5899.png)

@josevalim @chrismccord opinions?

**UPDATE 2020/02/06**: We were able to get to over 22K users in one channel in production env with this code. Just to clarify, we render only 100 most important users, others are only synced but not shown.