### PR TITLE
Camelize --web option to generators

### DIFF
--- a/lib/mix/phoenix/schema.ex
+++ b/lib/mix/phoenix/schema.ex
@@ -73,7 +73,7 @@ defmodule Mix.Phoenix.Schema do
     uniques   = uniques(cli_attrs)
     {assocs, attrs} = partition_attrs_and_assocs(module, attrs(cli_attrs))
     types = types(attrs)
-    web_namespace = opts[:web]
+    web_namespace = opts[:web] && Phoenix.Naming.camelize(opts[:web])
     web_path = web_namespace && Phoenix.Naming.underscore(web_namespace)
     embedded? = Keyword.get(opts, :embedded, false)
     generate? = Keyword.get(opts, :schema, true)


### PR DESCRIPTION
It’s not clear if `--web` to generators takes a module or directory name. Both

```bash
$ mix phx.gen.html Sales User users --web Sales
```
```bash
$ mix phx.gen.html Sales User users --web sales
```

feel equally valid. However, passing `sales` generates module names like

```elixir
MyAppWeb.:"Elixir.sales.User"Controller
```

which won’t compile.

Instead of raising on bad input, accept both forms by normalising to camel case first.