### PR TITLE
Add `--auto-install` flag to phx.new generator

### DIFF
--- a/installer/lib/phx_new/dependency_installer.ex
+++ b/installer/lib/phx_new/dependency_installer.ex
@@ -1,0 +1,62 @@
+defmodule Phx.New.DependencyInstaller do
+  @moduledoc false
+  alias Phx.New.{Project}
+
+  def install_webpack(install?, project, relative_app_path) do
+    assets_path = Path.join(project.web_path || project.project_path, "assets")
+    webpack_config = Path.join(assets_path, "webpack.config.js")
+
+    maybe_cmd(project, "cd #{relative_app_path.(assets_path)} && npm install && node node_modules/webpack/bin/webpack.js --mode development",
+              File.exists?(webpack_config), install? && System.find_executable("npm"))
+  end
+
+  def install_mix(project, install?) do
+    maybe_cmd(project, "mix deps.get", true, install? && hex_available?())
+  end
+
+  def compile(project, mix_step) do
+    compile =
+        case mix_step do
+          [] -> Task.async(fn -> rebar_available?() && cmd(project, "mix deps.compile") end)
+          _  -> Task.async(fn -> :ok end)
+        end
+    Task.await(compile, :infinity)
+  end
+
+  defp hex_available? do
+    Code.ensure_loaded?(Hex)
+  end
+
+  defp rebar_available? do
+    Mix.Rebar.rebar_cmd(:rebar) && Mix.Rebar.rebar_cmd(:rebar3)
+  end
+
+  defp maybe_cmd(project, cmd, should_run?, can_run?) do
+    cond do
+      should_run? && can_run? ->
+        cmd(project, cmd)
+      should_run? ->
+        ["$ #{cmd}"]
+      true ->
+        []
+    end
+  end
+
+  defp cmd(%Project{} = project, cmd) do
+    Mix.shell.info [:green, "* running ", :reset, cmd]
+    case Mix.shell.cmd(cmd, cmd_opts(project)) do
+      0 ->
+        []
+      _ ->
+        ["$ #{cmd}"]
+    end
+  end
+
+  defp cmd_opts(%Project{} = project) do
+    if Project.verbose?(project) do
+      []
+    else
+      [quiet: true]
+    end
+  end
+end

--- a/installer/lib/phx_new/project.ex
+++ b/installer/lib/phx_new/project.ex
@@ -47,6 +47,10 @@ defmodule Phx.New.Project do
     Keyword.get(opts, :verbose, false)
   end
 
+  def auto_install?(%Project{opts: opts}) do
+    Keyword.get(opts, :auto_install, false)
+  end
+
   def join_path(%Project{} = project, location, path)
       when location in [:project, :app, :web] do
 

--- a/installer/test/mix_helper.exs
+++ b/installer/test/mix_helper.exs
@@ -8,6 +8,13 @@ defmodule Phoenix.LiveReloader do
   def call(conn, _), do: conn
 end
 
+# Mock installing so we don't install dependencies for testing
+defmodule Phx.New.DependencyInstaller do
+  def install_webpack(_install?, _project, _relative_app_path), do: ["$ cd assets && npm install && node node_modules/webpack/bin/webpack.js --mode development"]
+  def install_mix(_project, _install?), do: ["$ mix deps.get"]
+  def compile(_project, _mix_step), do: :ok
+end
+
 defmodule MixHelper do
   import ExUnit.Assertions
   import ExUnit.CaptureIO

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -160,7 +160,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
   test "new without defaults" do
     in_tmp "new without defaults", fn ->
-      Mix.Tasks.Phx.New.run([@app_name, "--no-html", "--no-webpack", "--no-ecto"])
+      Mix.Tasks.Phx.New.run([@app_name, "--no-html", "--no-webpack", "--no-ecto", "--auto-install"])
 
       # No webpack
       refute File.read!("phx_blog/.gitignore") |> String.contains?("/assets/node_modules/")
@@ -223,6 +223,9 @@ defmodule Mix.Tasks.Phx.NewTest do
                   &refute(&1 =~ ~r"Phoenix.LiveReloader.Socket")
       assert_file "phx_blog/lib/phx_blog_web/views/error_view.ex", ~r".json"
       assert_file "phx_blog/lib/phx_blog_web/router.ex", &refute(&1 =~ ~r"pipeline :browser")
+
+      # Auto install
+      refute_received {:mix_shell, :yes?, ["\nFetch and install dependencies?"]}
     end
   end
 


### PR DESCRIPTION
Usage example: `mix phx.new phx_blog --auto-install`

This optional flag causes it to fetch and install dependencies without prompting the user.

---

I nearly always want to install the mix and npm dependencies for a newly generated Phoenix app. This flag allows the user to indicate they would like the dependencies installed automatically. This allows you to generate Phoenix apps "unattended". For example,

```
mix phx.new phx_blog --auto-install ; cd phx_blog ; mix ecto.create ; mix phx.server
```
