### PR TITLE
Allow custom websocket transports instead of forcing Phoenix.Transpor…

### DIFF
--- a/lib/phoenix/endpoint/cowboy_websocket.ex
+++ b/lib/phoenix/endpoint/cowboy_websocket.ex
@@ -13,7 +13,7 @@ defmodule Phoenix.Endpoint.CowboyWebSocket do
     conn = @connection.conn(req, transport)
 
     try do
-      case Phoenix.Transports.WebSocket.connect(conn, endpoint, handler, opts) do
+      case module.connect(conn, endpoint, handler, opts) do
         {:ok, %Plug.Conn{adapter: {@connection, req}} = conn, args} ->
           timeout = Keyword.fetch!(opts, :timeout)
           req = copy_resp_headers(conn, req)


### PR DESCRIPTION
On previous releases (1.3), it was allowed to define custom transports in the config as defined by

```
{"/socket", Phoenix.Endpoint.CowboyWebSocket, {App.Custom.WebSocket, {App.Endpoint, App.UserSocket, [...]}}}
```

Even if `App.Custom.Websocket` is defined, it's currently being forced to use `Phoenix.Transports.Websocket` unlike previous builds prior 1.4