### PR TITLE
Update Heroku deployment docs to include container based approach

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -154,40 +154,9 @@ build:
 ```
 
 #### Setup Your app with Dockerfile
-Add `Dockerfile` to your root folder, in this example we used [`bitwalker/alpine-elixir-phoenix:latest`](https://hub.docker.com/r/bitwalker/alpine-elixir-phoenix) as our base image. Here is a sample basic `Dockerfile`:
+Add `Dockerfile` to your root folder. You can follow [container release docs](./releases.md#containers).
 
-```dockerfile
-FROM bitwalker/alpine-elixir-phoenix:latest
-
-ARG SECRET_KEY_BASE
-
-# Set exposed ports
-EXPOSE 5000
-ENV PORT=5000 MIX_ENV=prod
-
-# Cache elixir deps
-ADD mix.exs mix.lock ./
-RUN mix do deps.get, deps.compile
-
-# Same with npm deps
-ADD assets/package.json assets/
-RUN cd assets && \
-    npm install
-
-ADD . .
-
-# Run frontend build, compile, and digest assets
-RUN cd assets/ && \
-    npm run deploy && \
-    cd - && \
-    mix do compile, phx.digest
-
-USER default
-
-CMD ["mix", "phx.server"]
-```
-Now you can push your app to heroku and you can see it starts building the image and deploy it.
-
+Once you have the image definition setup, you can push your app to heroku and you can see it starts building the image and deploy it.
 
 ## Making our Project ready for Heroku
 

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -35,8 +35,7 @@ Let's separate this process into a few steps so we can keep track of where we ar
 - Initialize Git repository
 - Sign up for Heroku
 - Install the Heroku Toolbelt
-- Create the Heroku application
-- Add the Phoenix static buildpack
+- Create and setup Heroku application
 - Make our project ready for Heroku
 - Deploy time!
 - Useful Heroku commands
@@ -69,8 +68,11 @@ Once we have signed up, we can download the correct version of the Heroku Toolbe
 
 The Heroku CLI, part of the Toolbelt, is useful to create Heroku applications, list currently running dynos for an existing application, tail logs or run one-off commands (mix tasks for instance).
 
-## Creating the Heroku Application
+## Create and Setup Heroku Application
+There are two different ways to deploy a Phoenix app on Heroku. We could use Heroku buildpacks or their container stack. The difference between these two approaches is in how we tell Heroku to treat our build. In buildpack case, we need to update our apps configuration on Heroku to use Phoenix/Elixir specific buildpacks instead of trying to automatically detect it. On container approach, we have more control on how we want to setup our app and we can define our container image using `Dockerfile` and `heroku.yml`. We describe both approaches below.
 
+### Using Heroku Buildpacks
+#### Create Application
 Now that we have the Toolbelt installed, let's create the Heroku application. In our project directory, run:
 
 > Note: the first time we use a Heroku command, it may prompt us to log in. If this happens, just enter the email and password you specified during signup.
@@ -103,7 +105,7 @@ elixir_version=1.8.1
 erlang_version=21.2.5
 ```
 
-## Adding the Phoenix Static Buildpack
+#### Adding the Phoenix Static Buildpack
 
 We need to compile static assets for a successful Phoenix deployment. The [Phoenix static buildpack](https://github.com/gjaldon/heroku-buildpack-phoenix-static) can take care of that for us, so let's add it now.
 
@@ -127,6 +129,65 @@ web: mix phx.server
 ```
 
 Heroku will recognize this file and use the command to start your application, ensuring that it also starts the Phoenix server.
+
+### Using Container Stack
+#### Create Heroku application
+Set the stack of your app to `container`, this allows us to use `Dockerfile` to define our app setup.
+```console
+$ heroku create
+Creating app... done, ⬢ mysterious-meadow-6277
+$ heroku stack:set container
+```
+Add a new `heroku.yml` file to your root folder. In this file you can define addons used by your app, how to build the image and what configs are passed to the image. You can learn more about Heroku's `heroku.yml` options [here](https://devcenter.heroku.com/articles/build-docker-images-heroku-yml). Here is a sample:
+```yaml
+setup:
+  addons:
+    - plan: heroku-postgresql
+      as: DATABASE
+build:
+  docker:
+    web: Dockerfile
+  config:
+    MIX_ENV: prod
+    SECRET_KEY_BASE: $SECRET_KEY_BASE
+    DATBASE_URL: $DATABASE_URL
+```
+
+#### Setup Your app with Dockerfile
+Add `Dockerfile` to your root folder, in this example we used [`bitwalker/alpine-elixir-phoenix:latest`](https://hub.docker.com/r/bitwalker/alpine-elixir-phoenix) as our base image. Here is a sample basic `Dockerfile`:
+
+```dockerfile
+FROM bitwalker/alpine-elixir-phoenix:latest
+
+ARG SECRET_KEY_BASE
+
+# Set exposed ports
+EXPOSE 5000
+ENV PORT=5000 MIX_ENV=prod
+
+# Cache elixir deps
+ADD mix.exs mix.lock ./
+RUN mix do deps.get, deps.compile
+
+# Same with npm deps
+ADD assets/package.json assets/
+RUN cd assets && \
+    npm install
+
+ADD . .
+
+# Run frontend build, compile, and digest assets
+RUN cd assets/ && \
+    npm run deploy && \
+    cd - && \
+    mix do compile, phx.digest
+
+USER default
+
+CMD ["mix", "phx.server"]
+```
+Now you can push your app to heroku and you can see it starts building the image and deploy it.
+
 
 ## Making our Project ready for Heroku
 

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -23,7 +23,7 @@ Once that is done, you can assemble a release by going through all of the steps 
 
 First set the environment variables:
 
-```
+```console
 $ mix phx.gen.secret
 REALLY_LONG_SECRET
 $ export SECRET_KEY_BASE=REALLY_LONG_SECRET
@@ -32,7 +32,7 @@ $ export DATABASE_URL=ecto://USER:PASS@HOST/database
 
 Then load dependencies to compile code and assets:
 
-```
+```console
 # Initial setup
 $ mix deps.get --only prod
 $ MIX_ENV=prod mix compile
@@ -44,7 +44,7 @@ $ mix phx.digest
 
 And now run `mix release`:
 
-```
+```console
 $ MIX_ENV=prod mix release
 Generated my_app app
 * assembling my_app-0.1.0 on MIX_ENV=prod
@@ -68,7 +68,7 @@ config :my_app, MyApp.Endpoint, server: true
 
 Now assemble the release once again:
 
-```
+```console
 $ MIX_ENV=prod mix release
 Generated my_app app
 * assembling my_app-0.1.0 on MIX_ENV=prod
@@ -98,7 +98,7 @@ However, in many cases, we don't want to set the values for `SECRET_KEY_BASE` an
 
 Now if you assemble another release, you should see this:
 
-```
+```console
 $ MIX_ENV=prod mix release
 Generated my_app app
 * assembling my_app-0.1.0 on MIX_ENV=prod
@@ -133,7 +133,7 @@ defmodule MyApp.Release do
   defp repos do
     Application.fetch_env!(@app, :ecto_repos)
   end
-  
+
   defp load_app do
     Application.load(@app)
   end
@@ -144,7 +144,7 @@ Where you replace the first two lines by your application names.
 
 Now you can assemble a new release with `MIX_ENV=prod mix release` and you can invoke any code, including the functions in the module above, by calling the `eval` command:
 
-```
+```console
 $ _build/prod/rel/my_app/bin/my_app eval "MyApp.Release.migrate"
 ```
 
@@ -168,7 +168,7 @@ Elixir releases work well with container technologies, such as Docker. The idea 
 
 Here is an example Docker file to run at the root of your application covering all of the steps above:
 
-```
+```docker
 FROM elixir:1.9.0-alpine AS build
 
 # install build dependencies


### PR DESCRIPTION
# Problem
Heroku's setup using buildpacks can get little tricky at times and is not very flexible. For example adding `ImageMagick` to our Heroku setup can get really complicated.

# Alternative Solution
Heroku also [offers `container` stack](https://devcenter.heroku.com/articles/build-docker-images-heroku-yml) which can be used to deploy apps using docker containers. In this way, we need to add a `Dockerfile` to define our image and whats needed to be built, then use `heroku.yml` to tell heroku how to run our image and what needs to be passed to it (think of it as `docker-compose`)

# Change
This PR updates the docs to also describe how we can build a container based app on heroku and set it up with phoenix.