### PR TITLE
Updated phoenixjs disconnect documentation.

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -799,9 +799,13 @@ export class Socket {
   }
 
   /**
-   * @param {Function} callback
-   * @param {integer} code
-   * @param {string} reason
+   * Disconnects the socket
+   *
+   * See https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes for valid status codes.
+   *
+   * @param {Function} callback - Optional callback which is called after socket is disconnected.
+   * @param {integer} code - A status code for disconnection (Optional).
+   * @param {string} reason - A textual description of the reason to disconnect. (Optional)
    */
   disconnect(callback, code, reason){
     this.closeWasClean = true


### PR DESCRIPTION
I recently had to supply socket.disconnect with a code for disconnecting and couldn't easily find any documentation. I added a link to the relevant part of the javascript socket documentation where you find codes with descriptions.