### PR TITLE
Fixed default config for new projects so that live_reload works on views again

### DIFF
--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -51,7 +51,7 @@ config :<%= app_name %>, <%= endpoint_module %>,
     patterns: [
       ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
       ~r"priv/gettext/.*(po)$",
-      ~r"lib/<%= lib_web_name %>/{live,views}/.*(ex)$",
+      ~r"lib/<%= lib_web_name %>/(live|views)/.*(ex)$",
       ~r"lib/<%= lib_web_name %>/templates/.*(eex)$"
     ]
   ]<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -49,7 +49,7 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
     patterns: [
       ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",
       ~r"priv/gettext/.*(po)$",
-      ~r"lib/<%= web_app_name %>/{live,views}/.*(ex)$",
+      ~r"lib/<%= web_app_name %>/(live|views)/.*(ex)$",
       ~r"lib/<%= web_app_name %>/templates/.*(eex)$"
     ]
   ]<% end %>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -93,7 +93,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/assets/.babelrc", "env"
       assert_file "phx_blog/config/dev.exs", fn file ->
         assert file =~ "watchers: [\n    node:"
-        assert file =~ "lib/phx_blog_web/{live,views}/.*(ex)"
+        assert file =~ "lib/phx_blog_web/(live|views)/.*(ex)"
         assert file =~ "lib/phx_blog_web/templates/.*(eex)"
       end
       assert_file "phx_blog/assets/static/favicon.ico"

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file root_path(@app, "config/dev.exs"), fn file ->
         assert file =~ ~r{watchers: \[\s+node:}
         assert file =~ "cd: Path.expand(\"../apps/phx_umb_web/assets\", __DIR__)"
-        assert file =~ "lib/#{@app}_web/{live,views}/.*(ex)"
+        assert file =~ "lib/#{@app}_web/(live|views)/.*(ex)"
         assert file =~ "lib/#{@app}_web/templates/.*(eex)"
       end
 


### PR DESCRIPTION
A while ago the default `dev.exs` config was changed to begin incorporating Phoenix Live View, but a shell style glob `{live,views}` was added instead of a regex `(live|views)`, thus breaking the live reload of views in a new project.