### PR TITLE
Inline assigns to map transformation in Phoenix.View

### DIFF
--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -384,6 +384,8 @@ defmodule Phoenix.View do
     render view, template, assign_resource(assigns, view, resource)
   end
 
+  @compile {:inline, [to_map: 1]}
+
   defp to_map(assigns) when is_map(assigns), do: assigns
   defp to_map(assigns) when is_list(assigns), do: :maps.from_list(assigns)
 


### PR DESCRIPTION
This makes heavily nested rendering ~8% faster.