### PR TITLE
Optimize resource assigning in Phoenix.View

### DIFF
--- a/lib/phoenix/view.ex
+++ b/lib/phoenix/view.ex
@@ -388,7 +388,12 @@ defmodule Phoenix.View do
   defp to_map(assigns) when is_list(assigns), do: :maps.from_list(assigns)
 
   defp assign_resource(assigns, view, resource) do
-    as = Map.get(assigns, :as) || view.__resource__
+    as =
+      case assigns do
+        %{as: as} -> as
+        _ -> view.__resource__
+      end
+
     Map.put(assigns, as, resource)
   end
 


### PR DESCRIPTION
When profiling a heavy loaded Phoenix application that in some cases calls Phoenix.View.assign_resource/3 many times this change makes the function be 25% faster.

The downside is that it changes `as: nil` behaviour. I suppose it is not a documented behaviour and we better get a speedup.