### PR TITLE
Return iodata instead binary in Socket.Serializer behaviour

### DIFF
--- a/lib/phoenix/socket/serializer.ex
+++ b/lib/phoenix/socket/serializer.ex
@@ -12,15 +12,15 @@ defmodule Phoenix.Socket.Serializer do
   Encodes a `Phoenix.Socket.Broadcast` struct to fastlane format.
   """
   @callback fastlane!(Phoenix.Socket.Broadcast.t()) ::
-              {:socket_push, :text, String.t()}
-              | {:socket_push, :binary, binary()}
+              {:socket_push, :text, iodata()}
+              | {:socket_push, :binary, iodata()}
 
   @doc """
   Encodes `Phoenix.Socket.Message` and `Phoenix.Socket.Reply` structs to push format.
   """
   @callback encode!(Phoenix.Socket.Message.t() | Phoenix.Socket.Reply.t()) ::
-              {:socket_push, :text, String.t()}
-              | {:socket_push, :binary, binary()}
+              {:socket_push, :text, iodata()}
+              | {:socket_push, :binary, iodata()}
 
   @doc """
   Decodes iodata into `Phoenix.Socket.Message` struct.


### PR DESCRIPTION
Fix of the mismatch between the types described in the `Phoenix.Socket.Serializer` behaviour and implemented in serializers [`Phoenix.Socket.V2.JSONSerializer`](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/socket/serializers/v2_json_serializer.ex#L21) and [`Phoenix.Socket.V1.JSONSerializer`](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/socket/serializers/v1_json_serializer.ex#L36).