### PR TITLE
websocket, add protocol header option to connect_info

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -733,6 +733,7 @@ export class Socket {
     this.ref                  = 0
     this.timeout              = opts.timeout || DEFAULT_TIMEOUT
     this.transport            = opts.transport || global.WebSocket || LongPoll
+    this.transport_protocol   = opts.transport_protocol || null
     this.defaultEncoder       = Serializer.encode
     this.defaultDecoder       = Serializer.decode
     this.closeWasClean        = false
@@ -831,7 +832,11 @@ export class Socket {
     }
     if(this.conn){ return }
     this.closeWasClean = false
-    this.conn = new this.transport(this.endPointURL())
+    if ( this.transport_protocol ) {
+      this.conn = new this.transport(this.endPointURL(), this.transport_protocol )
+    } else {
+      this.conn = new this.transport(this.endPointURL() )
+    }
     this.conn.binaryType = this.binaryType
     this.conn.timeout    = this.longpollerTimeout
     this.conn.onopen     = () => this.onConnOpen()

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -219,7 +219,7 @@ defmodule Phoenix.Socket.Transport do
 
     connect_info =
       Enum.map(connect_info, fn
-        key when key in [:peer_data, :uri, :x_headers] ->
+        key when key in [:peer_data, :uri, :x_headers, :protocol ] ->
           key
 
         {:session, session} ->
@@ -378,6 +378,9 @@ defmodule Phoenix.Socket.Transport do
 
         :uri ->
           {:uri, fetch_uri(conn)}
+
+        :protocol ->
+          { :protocol, Plug.Conn.get_req_header( conn, "sec-websocket-protocol" ) }
 
         {:session, {key, store, store_config}} ->
           conn = Plug.Conn.fetch_cookies(conn)


### PR DESCRIPTION
Background: sec-websocket-protocol is a header that can be set by the second arg to Websocket

This patch adds:
- an option (transport_protocol) to phoenix.js Socket that becomes arg2 to Websocket
- Websocket will set sec-websocket-protocol header when provided
- socket/transport.ex: validate_config will now accept :protocol
- socket/transport.ex: connect_info will include :protocol taken from req_headers when configured

The JS option is not relevant to LongPoll, though there is no coded defense that prohibits it.