### PR TITLE
Allow disabling logger via application configuration

### DIFF
--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -44,7 +44,9 @@ defmodule Phoenix do
       :erlang.system_flag(:backtrace_depth, stacktrace_depth)
     end
 
-    Phoenix.Logger.install()
+    if Application.fetch_env!(:phoenix, :logger) do
+      Phoenix.Logger.install()
+    end
 
     children = [
       # Code reloading must be serial across all Phoenix apps

--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -24,6 +24,13 @@ defmodule Phoenix.Logger do
   With the configuration above, Phoenix will filter all parameters,
   except those that match exactly `id` or `order`. If a kept parameter
   matches, all parameters nested under that one will also be kept.
+
+  ## Disabling
+
+  When you are using custom logging system it is not always desirable to enable
+  `#{inspect __MODULE__}` by default. You can always disable this in general by:
+
+      config :phoenix, :logger, false
   """
 
   require Logger

--- a/mix.exs
+++ b/mix.exs
@@ -44,6 +44,7 @@ defmodule Phoenix.MixProject do
       mod: {Phoenix, []},
       extra_applications: [:logger, :eex, :crypto],
       env: [
+        logger: true,
         stacktrace_depth: nil,
         template_engines: [],
         format_encoders: [],


### PR DESCRIPTION
Elixir's `Logger` is very constraining library and some people (like me)
prefer to use different approaches (like `logger` or `lager`) which
(among other things) allow for much more detailed log levels and
structured logging. If someone use such logging library then
`Phoenix.Logger` can generate needless noise in logs. This change allows
to disable this module by such users.