### PR TITLE
Do not overwrite `:http` configuration in `prod.secret.exs`

### DIFF
--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -25,11 +25,11 @@ config :logger, level: :info
 #       ...
 #       url: [host: "example.com", port: 443],
 #       https: [
-#         :inet6,
 #         port: 443,
 #         cipher_suite: :strong,
 #         keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
-#         certfile: System.get_env("SOME_APP_SSL_CERT_PATH")
+#         certfile: System.get_env("SOME_APP_SSL_CERT_PATH"),
+#         transport_options: [socket_opts: [:inet6]]
 #       ]
 #
 # The `cipher_suite` is set to `:strong` to support only the

--- a/installer/templates/phx_single/config/prod.secret.exs
+++ b/installer/templates/phx_single/config/prod.secret.exs
@@ -12,7 +12,10 @@ secret_key_base =
     """
 
 config :<%= app_name %>, <%= endpoint_module %>,
-  http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
+  http: [
+    port: String.to_integer(System.get_env("PORT") || "4000"),
+    transport_options: [socket_opts: [:inet6]]
+  ],
   secret_key_base: secret_key_base
 
 # ## Using releases (Elixir v1.9+)

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
@@ -20,11 +20,11 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
 #       ...
 #       url: [host: "example.com", port: 443],
 #       https: [
-#         :inet6,
 #         port: 443,
 #         cipher_suite: :strong,
 #         keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
-#         certfile: System.get_env("SOME_APP_SSL_CERT_PATH")
+#         certfile: System.get_env("SOME_APP_SSL_CERT_PATH"),
+#         transport_options: [socket_opts: [:inet6]]
 #       ]
 #
 # The `cipher_suite` is set to `:strong` to support only the

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/prod.secret.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/prod.secret.exs
@@ -6,7 +6,10 @@ secret_key_base =
     """
 
 config :<%= web_app_name %>, <%= endpoint_module %>,
-  http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
+  http: [
+    port: String.to_integer(System.get_env("PORT") || "4000"),
+    transport_options: [socket_opts: [:inet6]]
+  ],
   secret_key_base: secret_key_base
 
 # ## Using releases (Elixir v1.9+)

--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -13,9 +13,19 @@ defmodule Phoenix.Integration.EndpointTest do
     render_errors: [accepts: ~w(html json)])
   Application.put_env(:endpoint_int, DevEndpoint,
       http: [port: "4808"], debug_errors: true, drainer: false)
-  Application.put_env(:endpoint_int, ProdInet6Endpoint,
-    http: [port: "4809", transport_options: [socket_opts: [:inet6]]],
-    url: [host: "example.com"], server: true)
+
+  if hd(Application.spec(:plug_cowboy, :vsn)) == ?1 do
+    # Cowboy v1
+    Application.put_env(:endpoint_int, ProdInet6Endpoint,
+      http: [{:port, "4809"}, :inet6],
+      url: [host: "example.com"], server: true)
+  else
+    # Cowboy v2
+    Application.put_env(:endpoint_int, ProdInet6Endpoint,
+      http: [port: "4809", transport_options: [socket_opts: [:inet6]]],
+      url: [host: "example.com"],
+      server: true)
+  end
 
   defmodule Router do
     @moduledoc """

--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -14,7 +14,7 @@ defmodule Phoenix.Integration.EndpointTest do
   Application.put_env(:endpoint_int, DevEndpoint,
       http: [port: "4808"], debug_errors: true, drainer: false)
   Application.put_env(:endpoint_int, ProdInet6Endpoint,
-    http: [{:port, "4809"}, :inet6],
+    http: [port: "4809", transport_options: [socket_opts: [:inet6]]],
     url: [host: "example.com"], server: true)
 
   defmodule Router do


### PR DESCRIPTION
Currently, default (generated by the installer) `prod.secret.exs` overwrites existing `:http` config (#3549).

Default `prod.secret.exs`:

```elixir
config :demo_app, DemoAppWeb.Endpoint,
  http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
  secret_key_base: secret_key_base
```

The Config deep merges keyword lists only and `[:inet6, port: ...]` is a regular list so Config overwrites `:http` value. This behavior could be inconvenient (and maybe even confusing) if you have SSL or custom dispatch configuration in `config.exs` or `prod.exs`.

After some digging in Phoenix, Plug.Cowboy, Cowboy, and Ranch the only solution I've managed to find is to set `:inet6` inside `endpoint_config[:http][:transport_options][:socket_opts]` instead of `endpoint_config[:http]`.

Fixes #3549.