### PR TITLE
Update Dockerfile releases.md

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -202,7 +202,6 @@ COPY lib lib
 RUN mix compile
 
 # build release
-COPY rel rel
 RUN mix release
 
 # prepare release image


### PR DESCRIPTION
The rel directory may not exist, and there was no previous reference to mix release.init either. Since COPY requires the existence of src, it would stop the execution of docker build in the common case of not having a rel dir.