### PR TITLE
Remove COPY rel rel command from Dockerfile example

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -202,7 +202,6 @@ COPY lib lib
 RUN mix compile
 
 # build release
-COPY rel rel
 RUN mix release
 
 # prepare release image

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -201,7 +201,8 @@ COPY priv priv
 COPY lib lib
 RUN mix compile
 
-# build release
+# build release (uncomment COPY if rel/ exists)
+# COPY rel rel
 RUN mix release
 
 # prepare release image


### PR DESCRIPTION
This has never worked for me, and I've always had to remove it
when setting up phoenix dockerfiles.  There is no "rel" directory
in the phoenix project root, so it has nothing to copy, so it crashes.

Here is someone else that had to remove it:
https://stackoverflow.com/questions/58163103/how-do-i-run-elixir-phoenix-docker-in-production-mode-using-example-from-phoenix

Did this refer to something used in older versions?