### PR TITLE
Dockerfile: Ensure "COPY priv" is before "npm deploy" and "mix phx.digest"

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -193,11 +193,11 @@ RUN mix deps.compile
 
 # build assets
 COPY assets assets
+COPY priv priv
 RUN cd assets && npm install && npm run deploy
 RUN mix phx.digest
 
 # build project
-COPY priv priv
 COPY lib lib
 RUN mix compile
 


### PR DESCRIPTION
- The steps `npm deploy` and `mix phx.digest` generate new Javascript
  and a `cache_manifest.json` file inside the build docker container.
- The `COPY priv priv` copies the priv directory from the working
  directory outside docker to the build docker container.  This also
  contains the `cache_manifest.json`.

Therefore:

If you have ever played around with releases outside of docker, the
`COPY priv priv` command will overwrite the cache_manifest.json you just
built inside docker with whatever is in your working directory, which
is older.  It will give the appearance of any javascript changes you
make not being updated even if you build new docker containers.