### PR TITLE
Allow using `put_new_layout` and `put_new_view` in controller pipeline

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -167,6 +167,13 @@ defmodule Phoenix.Controller do
 
       use Phoenix.Controller.Pipeline, opts
 
+      @before_compile Phoenix.Controller
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(_env) do
+    quote do
       plug :put_new_layout, {Phoenix.Controller.__layout__(__MODULE__, opts), :app}
       plug :put_new_view, Phoenix.Controller.__view__(__MODULE__)
     end


### PR DESCRIPTION
Earlier the layout and view were first things done within the pipeline, this caused problems when someone (like me) wanted to set the default template on their own (I am using custom naming scheme in form of `MyApp.Controllers.Foo` and view is named `MyApp.Views.Foo`). As Phoenix.Controller.Pipeline isn't public in any way I couldn't omit `use Phoenix.Controller` and I was forced to use `put_layout` and `put_view` which have nasty behaviour that it always overwrite the layout and view, this meant that I couldn't longer define layout/view higher in the Plug pipeline. This change put the layout/view definition as the last thing in the pipeline, which allows to define them within controller pipeline using `put_new_layout` and `put_new_view` functions.