### PR TITLE
Add accept-language to the list of headers that are copied in Phoenix.ConnTest.recycle

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -442,17 +442,17 @@ defmodule Phoenix.ConnTest do
   This emulates behaviour performed by browsers where cookies
   returned in the response are available in following requests.
 
-  By default, only the headers "accept" and "authorization" are
-  recycled. However, a custom set of headers can be specified by
-  passing a list of strings representing its names as the second
-  argument of the function.
+  By default, only the headers "accept", "accept-language", and
+  "authorization" are recycled. However, a custom set of headers
+  can be specified by passing a list of strings representing its
+  names as the second argument of the function.
 
   Note `recycle/1` is automatically invoked when dispatching
   to the endpoint, unless the connection has already been
   recycled.
   """
   @spec recycle(Conn.t, [String.t]) :: Conn.t
-  def recycle(conn, headers \\ ~w(accept authorization)) do
+  def recycle(conn, headers \\ ~w(accept accept-language authorization)) do
     build_conn()
     |> Map.put(:host, conn.host)
     |> Plug.Test.recycle_cookies(conn)

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -151,11 +151,13 @@ defmodule Phoenix.Test.ConnTest do
         build_conn()
         |> get("/")
         |> put_req_header("accept", "text/html")
+        |> put_req_header("accept-language", "ja")
         |> put_req_header("authorization", "Bearer mytoken")
         |> put_req_header("hello", "world")
 
       conn = conn |> recycle()
       assert get_req_header(conn, "accept") == ["text/html"]
+      assert get_req_header(conn, "accept-language") == ["ja"]
       assert get_req_header(conn, "authorization") == ["Bearer mytoken"]
       assert get_req_header(conn, "hello") == []
     end


### PR DESCRIPTION
closes https://github.com/phoenixframework/phoenix/issues/3531

ready for review