### PR TITLE
Adding option to disable `Router.Helpers` docs to `use Phoenix.Router`

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -246,16 +246,18 @@ defmodule Phoenix.Router do
   @http_methods [:get, :post, :put, :patch, :delete, :options, :connect, :trace, :head]
 
   @doc false
-  defmacro __using__(_) do
+  defmacro __using__(opts) do
     quote do
-      unquote(prelude())
+      unquote(prelude(opts))
       unquote(defs())
       unquote(match_dispatch())
     end
   end
 
-  defp prelude() do
+  defp prelude(opts) do
     quote do
+      @helpers_docs Keyword.get(unquote(opts), :helpers_docs, true)
+
       Module.register_attribute __MODULE__, :phoenix_routes, accumulate: true
       @phoenix_forwards %{}
 
@@ -396,7 +398,9 @@ defmodule Phoenix.Router do
     routes = env.module |> Module.get_attribute(:phoenix_routes) |> Enum.reverse
     routes_with_exprs = Enum.map(routes, &{&1, Route.exprs(&1)})
 
-    Helpers.define(env, routes_with_exprs)
+    helpers_docs = Module.get_attribute(env.module, :helpers_docs)
+
+    Helpers.define(env, routes_with_exprs, docs: helpers_docs)
     {matches, _} = Enum.map_reduce(routes_with_exprs, %{}, &build_match/2)
 
     checks =

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -256,7 +256,7 @@ defmodule Phoenix.Router do
 
   defp prelude(opts) do
     quote do
-      @helpers_docs Keyword.get(unquote(opts), :helpers_docs, true)
+      @helpers_moduledoc Keyword.get(unquote(opts), :helpers_moduledoc, true)
 
       Module.register_attribute __MODULE__, :phoenix_routes, accumulate: true
       @phoenix_forwards %{}
@@ -398,9 +398,9 @@ defmodule Phoenix.Router do
     routes = env.module |> Module.get_attribute(:phoenix_routes) |> Enum.reverse
     routes_with_exprs = Enum.map(routes, &{&1, Route.exprs(&1)})
 
-    helpers_docs = Module.get_attribute(env.module, :helpers_docs)
+    helpers_moduledoc = Module.get_attribute(env.module, :helpers_moduledoc)
 
-    Helpers.define(env, routes_with_exprs, docs: helpers_docs)
+    Helpers.define(env, routes_with_exprs, docs: helpers_moduledoc)
     {matches, _} = Enum.map_reduce(routes_with_exprs, %{}, &build_match/2)
 
     checks =

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -101,7 +101,7 @@ defmodule Phoenix.Router.Helpers do
   @doc """
   Generates the helper module for the given environment and routes.
   """
-  def define(env, routes) do
+  def define(env, routes, opts \\ []) do
     # Ignore any route without helper or forwards.
     routes =
       Enum.filter(routes, fn {route, _exprs} ->
@@ -171,6 +171,8 @@ defmodule Phoenix.Router.Helpers do
       end
     end
 
+    docs = Keyword.get(opts, :docs, true)
+
     # It is in general bad practice to generate large chunks of code
     # inside quoted expressions. However, we can get away with this
     # here for two reasons:
@@ -181,7 +183,7 @@ defmodule Phoenix.Router.Helpers do
     #   per helper module anyway.
     #
     code = quote do
-      @moduledoc """
+      @moduledoc unquote(docs) && """
       Module with named helpers generated from #{inspect unquote(env.module)}.
       """
       unquote(defhelper)
@@ -189,21 +191,21 @@ defmodule Phoenix.Router.Helpers do
       unquote_splicing(impls)
       unquote_splicing(catch_all)
 
-      @doc """
+      @doc unquote(docs) && """
       Generates the path information including any necessary prefix.
       """
       def path(data, path) do
         Phoenix.Router.Helpers.path(unquote(env.module), data, path)
       end
 
-      @doc """
+      @doc unquote(docs) && """
       Generates the connection/endpoint base URL without any path information.
       """
       def url(data) do
         Phoenix.Router.Helpers.url(unquote(env.module), data)
       end
 
-      @doc """
+      @doc unquote(docs) && """
       Generates path to a static asset given its file path.
       """
       def static_path(%Conn{private: private} = conn, path) do
@@ -218,7 +220,7 @@ defmodule Phoenix.Router.Helpers do
         endpoint.static_path(path)
       end
 
-      @doc """
+      @doc unquote(docs) && """
       Generates url to a static asset given its file path.
       """
       def static_url(%Conn{private: private}, path) do
@@ -237,7 +239,7 @@ defmodule Phoenix.Router.Helpers do
         endpoint.static_url <> endpoint.static_path(path)
       end
 
-      @doc """
+      @doc unquote(docs) && """
       Generates an integrity hash to a static asset given its file path.
       """
       def static_integrity(%Conn{private: %{phoenix_endpoint: endpoint}}, path) do

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -191,21 +191,21 @@ defmodule Phoenix.Router.Helpers do
       unquote_splicing(impls)
       unquote_splicing(catch_all)
 
-      @doc unquote(docs) && """
+      @doc """
       Generates the path information including any necessary prefix.
       """
       def path(data, path) do
         Phoenix.Router.Helpers.path(unquote(env.module), data, path)
       end
 
-      @doc unquote(docs) && """
+      @doc """
       Generates the connection/endpoint base URL without any path information.
       """
       def url(data) do
         Phoenix.Router.Helpers.url(unquote(env.module), data)
       end
 
-      @doc unquote(docs) && """
+      @doc """
       Generates path to a static asset given its file path.
       """
       def static_path(%Conn{private: private} = conn, path) do
@@ -220,7 +220,7 @@ defmodule Phoenix.Router.Helpers do
         endpoint.static_path(path)
       end
 
-      @doc unquote(docs) && """
+      @doc """
       Generates url to a static asset given its file path.
       """
       def static_url(%Conn{private: private}, path) do
@@ -239,7 +239,7 @@ defmodule Phoenix.Router.Helpers do
         endpoint.static_url <> endpoint.static_path(path)
       end
 
-      @doc unquote(docs) && """
+      @doc """
       Generates an integrity hash to a static asset given its file path.
       """
       def static_integrity(%Conn{private: %{phoenix_endpoint: endpoint}}, path) do


### PR DESCRIPTION
You said a PR for this was welcome on the issue #3579, so here it is. 

I am still trying to figure out how to test it, since I can't use `Code.fetch_docs/1` on in memory modules. Tried to do the same it's done on [docs tests on elixir repo](https://github.com/kelvinst/elixir/blob/642a794ace79f8098187034f75455bf95de1e7fc/lib/elixir/test/elixir/kernel/docs_test.exs#L99-L121), but the `write_beam` function just writes the beam for the given module, and if I do that for the router, it will save the beam for it, but not for the helper that's defined altogheter.

Any idea? Maybe there is a way to get the helper from it to save its beam, IDK.