### PR TITLE
Docs: further clarify heroku config settings

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -175,6 +175,16 @@ url: [scheme: "https", host: "mysterious-meadow-6277.herokuapp.com", port: 443],
 force_ssl: [rewrite_on: [:x_forwarded_proto]],
 ```
 
+Also, regardless if you are using distillery or mix releases, the buildpack requires that you set `server: true` so the prod.exs configuration should appear something like this.
+
+```elixir
+config :hello, Hello.Endpoint,
+  server: true,
+  http: [:inet6, port: String.to_integer(System.get_env("PORT") || "4000")],
+  url: [scheme: "https", host: "mysterious-meadow-6277.herokuapp.com", port: 443],
+  force_ssl: [rewrite_on: [:x_forwarded_proto]]
+```
+
 Then open up your `config/prod.secret.exs` and uncomment the `# ssl: true,` line in your repository configuration. It will look like this:
 
 ```elixir


### PR DESCRIPTION
I did my first Heroku deploy this week and had a heck of a time with the buildpack configuration for Phoenix 1.14.10 and wanted to be sure others who follow get up and running with ease :)

I've got a 100% functional Elixir app on heroku [now](https://elixirprimes.herokuapp.com/) w/ the prod [config](https://github.com/toranb/elixir-primes-demo/blob/master/config/prod.exs#L12-L17) shown in this PR so I know it works today with the very latest Phoenix. Related [discussion](https://github.com/HashNuke/heroku-buildpack-elixir/issues/161) on the buildpack github for anyone interested.