### PR TITLE
Add template patterns to error messages?

### DIFF
--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -116,7 +116,7 @@ defmodule Phoenix.Template do
     def message(exception) do
       "Could not render #{inspect exception.template} for #{inspect exception.module}, "
         <> "please define a matching clause for render/2 or define a template at "
-        <> "#{inspect Path.relative_to_cwd(exception.root) <> "/" <> exception.pattern}. "
+        <> "#{inspect Path.join(Path.relative_to_cwd(exception.root), exception.pattern)}. "
         <> available_templates(exception.available)
         <> "\nAssigns:\n\n"
         <> inspect(exception.assigns)

--- a/lib/phoenix/template.ex
+++ b/lib/phoenix/template.ex
@@ -116,7 +116,7 @@ defmodule Phoenix.Template do
     def message(exception) do
       "Could not render #{inspect exception.template} for #{inspect exception.module}, "
         <> "please define a matching clause for render/2 or define a template at "
-        <> "#{inspect Path.relative_to_cwd exception.root}. "
+        <> "#{inspect Path.relative_to_cwd(exception.root) <> "/" <> exception.pattern}. "
         <> available_templates(exception.available)
         <> "\nAssigns:\n\n"
         <> inspect(exception.assigns)


### PR DESCRIPTION
Patterns don't currently appear in `Phoenix.Template.UndefinedError` messages. Would this be appropriate?

```
** (Phoenix.Template.UndefinedError) Could not render "doesnotexist" for
MyAppWeb.PageView,  please define a matching clause for render/2 or define a template
at "lib/testing_web/templates/page/*". The following templates were compiled:

* index.html
```