### PR TITLE
improve efficiency of mix phx.gen.secret

### DIFF
--- a/lib/mix/tasks/phx.gen.secret.ex
+++ b/lib/mix/tasks/phx.gen.secret.ex
@@ -25,7 +25,8 @@ defmodule Mix.Tasks.Phx.Gen.Secret do
   end
 
   defp random_string(length) when length > 31 do
-    :crypto.strong_rand_bytes(length) |> Base.encode64 |> binary_part(0, length)
+    num_bytes = trunc(Float.ceil(length * 3 / 4))
+    :crypto.strong_rand_bytes(num_bytes) |> Base.encode64() |> binary_part(0, length)
   end
   defp random_string(_), do: Mix.raise "The secret should be at least 32 characters long"
 


### PR DESCRIPTION
since binaries become at least 4/3 their original size when base 64
encoded, we can improve our efficiency by only generating random bytes
that are 3/4 as long as our required length.

we take the ceiling of the product instead of flooring because otherwise
there would not be enough base 64 characters. rounding would also be
slightly problematic in that the final base 64 character has only 4 and
16 possible values for double and single padded strings, respectively.

oh, and we can't just use `Kernel.ceil/1` or `:erlang.ceil/1` since
those are somewhat new additions to elixir and erlang.

here is a little proof this works:
```
$ iex
Erlang/OTP 22 [erts-10.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]

Interactive Elixir (1.9.1) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Enum.map(1..16_384, fn length -> num_bytes = trunc(Float.ceil(length * 3 / 4)); :crypto.strong_rand_bytes(num_bytes) |> Base.encode64() |> String.replace(~r/[^=]=+$/, "") |> binary_part(0, length) end)
["x", "Oa", "ATF", "asm7", "2AMXn", "TuNd8X", "UBr9bCy", "sEuSs+EG",
 "pnAdvvRD9", "3G0CodN0uu", "Fe5VhNdlE95", "0c38yBYAPJUF", "u8aRWAlnkDwmb",
 "qfK0ky/ETcUEUr", "s/x4w+o/7CBSyWf", "Sq0MK33GXQlaWxTf", "b7Qqev0thaGlG8tbh",
 "GgC/H0jV3LeSRNpx6V", "WJ9OueghKHNaj6ymbhn", "x6y5oIzPKtYJMW0Jf3h5",
 "R8eSZvEld3vIYGJVYcjpa", "hvFUlEzHVgkBvkTT8GbRLY", "QtU9mVrABSbcEI5zfsjzGAS",
 "alZwOLTX7uXHkalrc04aIOsb", "6PhGvi4iYk1OpBUmRfwfOIrts",
 "ZIsEN+h+X1+2pRf/CMHjAkqIY1", "Y6Sg1eHrLS11KA45MvxHJ3UlRr6",
 "rt5RoB16QH6K2x3gPt6tcfl/c868", "KGozghQNSvUM0ehTzPvyXlWEiC6qp",
 "JRPShCpup3J+88RZ8m57lqbMuJxmyb", "MKXNOsL5hbcxM0TpuLYyOV5KL0BLCLG",
 "UFBrJKOlUV4LrYfI0YSslmud9l5vrJ7G", "gKSZf4DpRYx4PvY6TYpzgdPhPcNMN3kGF",
 "0E8tlZQ9sjtN6cVY3wudH/Up+M0nvB/423", "4EsKMdADrJPx9hE8UXTx4ydO99AW/b/G4cy",
 "XUHZa9PL3clrmtiGDk/Gb/GSUOZcqSbjgtV8",
 "U7ZOs9fDRMMTNCL1Wh45miVAjBaIcG8wWF7N4",
 "9UwymeJIwKKjms3HokDDXFx34H6k53ITimctZC",
 "UBK1FMkgNOFPHCMup5F7DCHV7Aj4U8lHVSVJ0RU",
 "Tq33udfeSKs06KDnSFNGLzfpRugJfPgY19TFaNeQ",
 "Xlow7ZjPN+DTIZnqc1yMnFEI8eo7okwew4XxCJDWL",
 "w6blkL0tY87jUWwkU7876kRMeOKZlYu1BEwuf97KMV",
 "RbveURTv1G8e9CFYBYtwHKiKeFqVhjn2FKs7StX/OhY",
 "/PoQX2q63l4tralISCi2ZWeh6WUCQFxgkxTGpBhhykUM",
 "hiMcTbW1VyXZKee2dKU8bD4RbnUWDW7vWeq3xIQ7bRoAq",
 "A4DezeO5zWP8U6h8rwLqJSoOFjJOyk6RfRhWXWFqYY5dSs",
 "6IB1VqBVP56xPBcsY5W/TDYWH2v9fTWfib1qaT4AhvCAOle",
 "qbXVhZxWnZc+8PgK29+PuT0jXp63OO0t1OUX4wHxqaIt0MlU",
 "+60/Kh1PLdlPAsu1tRV7FwlVaWGKkHPrpwnymKPKdr0w9PZw3",
 "Wg3Sx1NYGkky+9Bl0yoUILvfXEYBf64hKpcpcm8x9+xYKxEKt7", ...]
```

we run the function with the addition of
`|> String.replace(~r/[^=]=+$/, "")` to ensure we never include the
character before the padding or the padding itself. since
`binary_part/3` raises an error if an index is out of bounds, this shows
that we always have enough base 64 characters in the string.