### PR TITLE
Bump phoenix_html.js to v2.13.3

### DIFF
--- a/installer/templates/phx_static/app.js
+++ b/installer/templates/phx_static/app.js
@@ -1,3 +1,3 @@
 // for phoenix_html support, including form and button helpers
 // copy the following scripts into your javascript bundle:
-// * https://raw.githubusercontent.com/phoenixframework/phoenix_html/v2.10.0/priv/static/phoenix_html.js
+// * https://raw.githubusercontent.com/phoenixframework/phoenix_html/v2.13.3/priv/static/phoenix_html.js

--- a/installer/templates/phx_static/app.js
+++ b/installer/templates/phx_static/app.js
@@ -1,3 +1,3 @@
 // for phoenix_html support, including form and button helpers
 // copy the following scripts into your javascript bundle:
-// * https://raw.githubusercontent.com/phoenixframework/phoenix_html/v2.13.3/priv/static/phoenix_html.js
+// * https://raw.githubusercontent.com/phoenixframework/phoenix_html/master/priv/static/phoenix_html.js


### PR DESCRIPTION
When generating an app with the `--no-webpack` option, delete links don't work with _v2.10.0_ of the mentioned file.