### PR TITLE
Add CheckRepoReady plug to generated phoenix applications

### DIFF
--- a/guides/errors.md
+++ b/guides/errors.md
@@ -72,7 +72,7 @@ defmodule Phoenix.Router do
 end
 ```
 
-Plug provides a protocol called `Plug.Exception` specifically for adding a status to exception structs.
+Plug provides a protocol called `Plug.Exception` where we are able to customize the status and add actions that exception structs can returns on the debug error page.
 
 If we wanted to supply a status of 404 for an `Ecto.NoResultsError`, we could do it by defining an implementation for the `Plug.Exception` protocol like this:
 
@@ -83,3 +83,20 @@ end
 ```
 
 Note that this is just an example: Phoenix [already does this](https://github.com/phoenixframework/phoenix_ecto/blob/master/lib/phoenix_ecto/plug.ex) for `Ecto.NoResultsError`, so you don't have to.
+
+#### Actions
+
+Actions are functions that can be triggered by the error page, it is basically a list of maps defining a `label` and a `handler` to be executed.
+It is rendered in the error page as a collection of buttons and follows the format of: `[%{label: String.t(), handler: {module(), function :: atom(), args :: []}}]`.
+
+If we wanted to return some actions for an `Ecto.NoResultsError` we would implement `Plug.Exception` like this:
+
+```elixir
+defimpl Plug.Exception, for: Ecto.NoResultsError do
+  def status(_exception), do: 404
+  def actions(_exception), do: [%{
+      label: "Run seeds",
+      handler: {Code, :eval_file, "priv/repo/seeds.exs"}
+    }]
+end
+```

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -38,7 +38,7 @@ defmodule <%= app_module %>.MixProject do
   defp deps do
     [
       <%= phoenix_dep %>,<%= if ecto do %>
-      {:phoenix_ecto, "~> 4.0"},
+      {:phoenix_ecto, "~> 4.1"},
       {:ecto_sql, "~> 3.1"},
       {<%= inspect adapter_app %>, ">= 0.0.0"},<% end %><%= if html do %>
       {:phoenix_html, "~> 2.11"},

--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -20,7 +20,8 @@ defmodule <%= endpoint_module %> do
   if code_reloading? do<%= if html do %>
     socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
     plug Phoenix.LiveReloader<% end %>
-    plug Phoenix.CodeReloader
+    plug Phoenix.CodeReloader<%= if ecto do %>
+    plug Phoenix.Ecto.CheckRepoStatus, otp_app: :<%= web_app_name %><% end %>
   end
 
   plug Plug.RequestId

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -133,6 +133,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/test/support/data_case.ex", ~r"defmodule PhxBlog.DataCase"
       assert_file "phx_blog/lib/phx_blog_web.ex", ~r"defmodule PhxBlogWeb"
       assert_file "phx_blog/priv/repo/migrations/.formatter.exs", ~r"import_deps: \[:ecto_sql\]"
+      assert_file "phx_blog/lib/phx_blog_web/endpoint.ex", ~r"plug Phoenix.Ecto.CheckRepoStatus, otp_app: :phx_blog"
 
       # Install dependencies?
       assert_received {:mix_shell, :yes?, ["\nFetch and install dependencies?"]}
@@ -178,6 +179,9 @@ defmodule Mix.Tasks.Phx.NewTest do
       # No Ecto
       config = ~r/config :phx_blog, PhxBlog.Repo,/
       refute File.exists?("phx_blog/lib/phx_blog/repo.ex")
+      assert_file "phx_blog/lib/phx_blog_web/endpoint.ex", fn file ->
+        refute file =~ "plug Phoenix.Ecto.CheckRepoStatus, otp_app: :phx_blog"
+      end
 
       # No gettext
       refute_file "phx_blog/lib/phx_blog_web/gettext.ex"


### PR DESCRIPTION
Adds the `CheckRepoReady` plug to default generated phoenix applications which checks whether the application's repos have the storage created or have pending migrations.

For that, we had to bump the minimum version of `phoenix_ecto` on the generated applications to `4.1` as to get the release with the changes in phoenixframework/phoenix_ecto#122 and then add the plug to the generated application's `endpoint.ex`.

### Next steps

- Once we have a release of the changes in elixir-ecto/ecto_sql#164, we should also bump the version of `ecto_sql` on the phoenix generated applications, so, for now, the check for whether the storage is created will not work (only the check for pending migrations)

- Once we have a release of the changes in elixir-plug/plug#876, we should bump the version of `plug` in [elixir-plug/plug-cowboy](https://github.com/elixir-plug/plug_cowboy/blob/master/mix.exs#L35) as to 

### Changes not in the scope of this PR that can be other PR

- Add a little bit of info about the `actions/1` function in `Plug.Exception` (elixir-plug/plug#876) in [guides/errors.md](guides/errors.md)

### TODO

- [x] Add tests (done [here](https://github.com/phoenixframework/phoenix/compare/c8ddd35541d26a5dbad807f95d4109e30fa3be9b..6168dacc4536e4ed9ccbef51b198dceae4481d53))

cc @josevalim 