### PR TITLE
Fix error handling when joining a channel using LongPoll

### DIFF
--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -87,7 +87,7 @@ defmodule Phoenix.Transports.LongPoll do
 
     receive do
       {:ok, ^ref} -> :ok
-      {:error, ^ref} -> :unauthorized
+      {:error, ^ref} -> :ok
     after
       opts[:window_ms] -> :request_timeout
     end


### PR DESCRIPTION
This fixes #3590

With **WebSocket** (OK behaviour):
**Given**: I have a channel that returns `{:error, :channel_disabled}` on join
**When**: User joins the channel with WebSocket transport
**Then**: `channel.join(...).receive('error')` is triggered where we can handle the error and decide if we want to reconnect or not.

With **LongPoll** (NOT OK behaviour):
**Given**: I have a channel that returns `{:error, :channel_disabled}` on join
**When**: User joins the channel with LongPoll transport
**Then**: `channel.join(...).receive('error')` is never triggered (NOT OK). Instead the whole transport reconnects to the PubSub. In our case we return an error again and so it basically starts reconnection loop.

This happened because `LongPoll` returned 401 whenever channel returned
something that was not `{:ok, socket}`. phoenix.js [ajax request][1] has:
```
      if(!resp || resp.status !== 200){
        this.onerror(resp && resp.status)
        this.closeAndRetry()
      }
```
This basically means that when it got 401 then it called
`closeAndRetry` on the whole transport.

`LongPoll` now returns 200 even if the join failed. This way we don't
trigger closeAndRetry. The actual error message is still received by
polling. `phoenix.js` now successfully triggers the join error callback
like with WebSocket.

[1]: https://github.com/phoenixframework/phoenix/blob/bf395cbeafae0f212e8c96c99c173d0bdb278f58/assets/js/phoenix.js#L1164-L1169