### PR TITLE
Fix typos

### DIFF
--- a/guides/endpoint.md
+++ b/guides/endpoint.md
@@ -166,7 +166,7 @@ In these examples, the `rewrite_on:` key specifies the HTTP header used by a rev
 
 ### HSTS
 
-HSTS or "strict-transport-security" is a mechanism that allows a website to declare itself as only accessible via a secure connection (HTTPS). It was introduced to prevent man-in-the-middle attacks that strip SSL/TLS. It causes web browers to redirect from HTTP to HTTPS and refuse to connect unless the connection uses SSL/TLS.
+HSTS or "strict-transport-security" is a mechanism that allows a website to declare itself as only accessible via a secure connection (HTTPS). It was introduced to prevent man-in-the-middle attacks that strip SSL/TLS. It causes web browsers to redirect from HTTP to HTTPS and refuse to connect unless the connection uses SSL/TLS.
 
 With `force_ssl: :hsts` set the `Strict-Transport-Security` header is set with a max age that defines the length of time the policy is valid for. Modern web browsers will respond to this by redirecting from HTTP to HTTPS for the standard case but it does have other consequenses. [RFC6797](https://tools.ietf.org/html/rfc6797) which defines HSTS also specifies **that the browser should keep track of the policy of a host and apply it until it expires.** It also specifies that **traffic on any port other than 80 is assumed to be encrypted** as per the policy.
 

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -106,7 +106,7 @@ defmodule Phoenix.Socket do
   The server may send messages or replies back. For messages, the
   ref uniquely identifies the message. For replies, the ref matches
   the original message. Both data-types also include a join_ref that
-  uniquely identifes the currently joined channel.
+  uniquely identifies the currently joined channel.
 
   The `Phoenix.Socket` implementation may also send special messages
   and replies:

--- a/test/mix/tasks/phx.digest_test.exs
+++ b/test/mix/tasks/phx.digest_test.exs
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Phx.DigestTest do
   end
 
   @input_path "input_path"
-  test "uses the input path as output path when no outputh path is given" do
+  test "uses the input path as output path when no output path is given" do
     in_tmp @input_path, fn ->
       File.mkdir_p!(@input_path)
       Mix.Tasks.Phx.Digest.run([@input_path, "--no-deps-check"])

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -585,7 +585,7 @@ defmodule Phoenix.Controller.ControllerTest do
     assert Phoenix.Controller.__view__(MyApp.Admin.UserController) == MyApp.Admin.UserView
   end
 
-  test "__layout__ returns the layout modoule based on controller module" do
+  test "__layout__ returns the layout module based on controller module" do
     assert Phoenix.Controller.__layout__(UserController, []) ==
            LayoutView
     assert Phoenix.Controller.__layout__(MyApp.UserController, []) ==


### PR DESCRIPTION
Just some typo fixing around the code base

Used this guy [here](https://github.com/samuelpordeus/typo_killer) to find them 🙂 