### PR TITLE
Use phoenix_html.js installed by mix

### DIFF
--- a/installer/templates/phx_static/app.js
+++ b/installer/templates/phx_static/app.js
@@ -1,3 +1,3 @@
 // for phoenix_html support, including form and button helpers
 // copy the following scripts into your javascript bundle:
-// * https://raw.githubusercontent.com/phoenixframework/phoenix_html/master/priv/static/phoenix_html.js
+// * deps/phoenix_html/priv/static/phoenix_html.js


### PR DESCRIPTION
Recently, notice a [PR](https://github.com/phoenixframework/phoenix/pull/3609) which bump the version of `phoenix_html.js`.

But, always giving the point which points to the newest version of phoenix_html.js maybe not a good idea. Assume such a situation:
+ a user `mix phx.new` a project with `phoenix 1.4.11` in 2021 (this is an extreme case, I know)
+ mainstream of phoenix has already ugraded to `phoenix 2.0.0`, and `phoenix_html` isn't compatible with `phoenix 1.4.11`

After reading the comments,  the user get the script at `https://raw.githubusercontent.com/phoenixframework/phoenix_html/master/priv/static/phoenix_html.js`, but that version of script is not working with his app.

Because of that, using a path relative to the the directory installed by Mix maybe a better solution - version of `phoenix_html`  is defined in `mix.exs`, it is impossible to encounter above situation.

