### PR TITLE
Added ability to filter out endpoint logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /_build
+/cover
 /deps
 /doc
 /tmp


### PR DESCRIPTION
The purpose of this change is to introduce the ability to filter out logs for endpoints (configured by the user). This is useful for reducing the noise in logs when using tools like Prometheus and exposing a `/metrics` endpoint that needs to be scraped every 5 seconds or if using Kubernetes and K8s needs to hit a `/health` endpoint.