### PR TITLE
Updated `channel_case` sandbox documentation.

### DIFF
--- a/installer/templates/phx_ecto/data_case.ex
+++ b/installer/templates/phx_ecto/data_case.ex
@@ -10,8 +10,8 @@ defmodule <%= app_module %>.DataCase do
   we enable the SQL sandbox, so changes done to the database
   are reverted at the end of every test. If you are using
   PostgreSQL, you can even run database tests asynchronously
-  by setting `use <%= web_namespace %>.DataCase, async: true`, although
-  this option is not recommendded for other databases.
+  by setting `use <%= app_module %>.DataCase, async: true`, although
+  this option is not recommended for other databases.
   """
 
   use ExUnit.CaseTemplate

--- a/installer/templates/phx_test/support/channel_case.ex
+++ b/installer/templates/phx_test/support/channel_case.ex
@@ -8,9 +8,11 @@ defmodule <%= web_namespace %>.ChannelCase do
   to build common data structures and query the data layer.
 
   Finally, if the test case interacts with the database,
-  it cannot be async. For this reason, every test runs
-  inside a transaction which is reset at the beginning
-  of the test unless the test case is marked as async.
+  we enable the SQL sandbox, so changes done to the database
+  are reverted at the end of every test. If you are using
+  PostgreSQL, you can even run database tests asynchronously
+  by setting `use <%= web_namespace %>.ChannelCase, async: true`, although
+  this option is not recommended for other databases.
   """
 
   use ExUnit.CaseTemplate

--- a/installer/templates/phx_test/support/conn_case.ex
+++ b/installer/templates/phx_test/support/conn_case.ex
@@ -12,7 +12,7 @@ defmodule <%= web_namespace %>.ConnCase do
   are reverted at the end of every test. If you are using
   PostgreSQL, you can even run database tests asynchronously
   by setting `use <%= web_namespace %>.ConnCase, async: true`, although
-  this option is not recommendded for other databases.
+  this option is not recommended for other databases.
   """
 
   use ExUnit.CaseTemplate


### PR DESCRIPTION
The intent of this PR is to improve the generated documentation in the installer with respect to async testing of PostgreSQL databases:

*  `channel_case.ex` template was missed as part of phoenixframework#3577 .
*  `data_case.ex` template incorrectly referenced `web_namespace` instead of `app_module`.
* fixed a typo in `conn_case.ex` template.
