### PR TITLE
Moving paragraph in ecto documentation

### DIFF
--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -126,6 +126,8 @@ defmodule Hello.Repo do
 end
 ```
 
+It begins by configuring our `otp_app` name and repo module. Then it sets the adapter – Postgres, in our case. It also sets our login credentials. Of course, you can change these to match your actual credentials if they are different.
+
 Our repo has three main tasks - to bring in all the common query functions from `Ecto.Repo`, to set the `otp_app` name equal to our application name, and to configure our database adapter. We'll talk more about how to use the Repo in a bit.
 
 When `phx.new` generated our application, it included some basic repo configuration as well. Let's look at `config/dev.exs`.
@@ -141,8 +143,6 @@ config :hello, Hello.Repo,
   pool_size: 10
 ...
 ```
-
-It begins by configuring our `otp_app` name and repo module. Then it sets the adapter – Postgres, in our case. It also sets our login credentials. Of course, you can change these to match your actual credentials if they are different.
 
 We also have similar configuration in `config/test.exs` and `config/prod.secret.exs` which can also be changed to match your actual credentials.
 


### PR DESCRIPTION
Moving the paragraph in the ecto documentation to describe the code block immediately above it. The current placement is below a different code block, which initially confused me. I feel that the new placement reads better.