### PR TITLE
Ignore directory created by elixir language server

### DIFF
--- a/installer/templates/phx_single/gitignore
+++ b/installer/templates/phx_single/gitignore
@@ -32,3 +32,6 @@ npm-debug.log
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+
+# Ignore directory created by elixir language server
+/.elixir_ls/


### PR DESCRIPTION
It's not strictly phoenix issue but this directory is annoying for me. And I imagine that I'm not the only person using this extension