### PR TITLE
Update package.json to get latest js dependencies

### DIFF
--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -13,12 +13,12 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.0",
-    "copy-webpack-plugin": "^4.5.0",
-    "css-loader": "^2.1.1",
-    "mini-css-extract-plugin": "^0.4.0",
+    "copy-webpack-plugin": "^5.1.1",
+    "css-loader": "^3.4.2",
+    "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
-    "terser-webpack-plugin": "^1.1.0",
-    "webpack": "4.4.0",
+    "terser-webpack-plugin": "^2.3.2",
+    "webpack": "4.41.5",
     "webpack-cli": "^3.3.2"
   }
 }


### PR DESCRIPTION
This is a PR to update version constraints in `package.json`. Fixes #3654 

As mentioned in #3654 there are breaking changes in the dependencies. We should verify that they are not an issue.

I have tested that `mix phx.server` runs as normal, and that the webpack compilation runs without errors. I haven't done a detailed testing of the compilation of individual files, channels or liveview etc.