### PR TITLE
Add `defer` to default blueprint script

### DIFF
--- a/installer/templates/phx_web/templates/layout/app.html.eex
+++ b/installer/templates/phx_web/templates/layout/app.html.eex
@@ -7,6 +7,7 @@
     <title><%= app_module %> · Phoenix Framework</title>
     <link rel="stylesheet" href="<%%= Routes.static_path(@conn, "/css/app.css") %>"/>
     <%%= csrf_meta_tag() %>
+    <script defer type="text/javascript" src="<%%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
   <body>
     <header>
@@ -26,6 +27,5 @@
       <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
       <%%= render @view_module, @view_template, assigns %>
     </main>
-    <script type="text/javascript" src="<%%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>


### PR DESCRIPTION
`defer` is an easy, well supported attribute we can provide in our blueprints to start loading scripts much earlier.  `defer` basically says, go to network but don't execute until `domInteractive` (once HTML is parsed and loaded).  Currently with the `js` file at the end of the body tag, it goes to network and executes only until after the HTML is parsed and loaded.

97% browser support: 

https://caniuse.com/#feat=script-defer

## Before (last tick at bottom of performance timeline)
<img width="396" alt="Screen Shot 2020-01-20 at 8 02 00 PM" src="https://user-images.githubusercontent.com/7374640/72774513-c057e700-3bbf-11ea-946b-793642a1578e.png">

## After (second tick at same time as css is fetched)
<img width="309" alt="Screen Shot 2020-01-20 at 8 00 05 PM" src="https://user-images.githubusercontent.com/7374640/72774514-c057e700-3bbf-11ea-8ab9-8cf406d408ad.png">
