### PR TITLE
Fix file path formatting

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -533,7 +533,7 @@ defmodule HelloWeb.SessionView do
 end
 ```
 
-Next, add a new template in `lib/hello_web/templates/session/new.html.eex:`
+Next, add a new template in `lib/hello_web/templates/session/new.html.eex`:
 
 ```eex
 <h1>Sign in</h1>

--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -525,7 +525,7 @@ We used `resources` to generate a set of routes under the `"/session"` path. Thi
 
 We defined an `authenticate_user/2` plug in the router which simply uses `Plug.Conn.get_session/2` to check for a `:user_id` in the session. If we find one, it means a user has previously authenticated, and we call into `Hello.Accounts.get_user!/1` to place our `:current_user` into the connection assigns. If we don't have a session, we add a flash error message, redirect to the homepage, and we use `Plug.Conn.halt/1` to halt further plugs downstream from being invoked. We won't use this new plug quite yet, but it will be ready and waiting as we add authenticated routes in just a moment.
 
-Lastly, we need `SessionView` to render a template for our login form. Create a new file in `lib/hello_web/views/session_view.ex:`
+Lastly, we need `SessionView` to render a template for our login form. Create a new file in `lib/hello_web/views/session_view.ex`:
 
 ```elixir
 defmodule HelloWeb.SessionView do


### PR DESCRIPTION
Adjustment for file path code highlighting in Contexts Guide.

We have:
... `lib/hello_web/views/session_view.ex:`
... `lib/hello_web/templates/session/new.html.eex:`

We wish
... `lib/hello_web/views/session_view.ex`:
... `lib/hello_web/templates/session/new.html.eex`: