### PR TITLE
Use non-deprecated socket/3 in guide

### DIFF
--- a/guides/testing/testing_channels.md
+++ b/guides/testing/testing_channels.md
@@ -81,7 +81,7 @@ First off, is the setup block:
 ```elixir
 setup do
   {:ok, _, socket} =
-    socket("user_id", %{some: :assign})
+    socket(UserSocket, "user_id", %{some: :assign})
     |> subscribe_and_join(RoomChannel, "room:lobby")
 
   {:ok, socket: socket}


### PR DESCRIPTION
socket/2 is deprecated, see: https://github.com/phoenixframework/phoenix/blob/v1.4.12/lib/phoenix/test/channel_test.ex#L240