### PR TITLE
Add option to not define default layout and view

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -162,9 +162,7 @@ defmodule Phoenix.Controller do
   connection-agnostic and typically invoked from your views.
   """
   defmacro __using__(opts) do
-    {put_default_views, opts} = Keyword.pop(opts, :put_default_views, true)
-
-    quote bind_quoted: [put_default_views: put_default_views, opts: opts] do
+    quote bind_quoted: [opts: opts] do
       import Phoenix.Controller
 
       # TODO v2: No longer automatically import dependencies
@@ -172,7 +170,7 @@ defmodule Phoenix.Controller do
 
       use Phoenix.Controller.Pipeline, opts
 
-      if put_default_views do
+      if opts[:put_default_views] do
         plug :put_new_layout, {Phoenix.Controller.__layout__(__MODULE__, opts), :app}
         plug :put_new_view, Phoenix.Controller.__view__(__MODULE__)
       end

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -41,6 +41,9 @@ defmodule Phoenix.Controller do
     * `:log` - the level to log. When false, disables controller
       logging
 
+    * `:put_default_views` - controls whether the default view
+      and layout should be set or not
+
   ## Connection
 
   A controller by default provides many convenience functions for
@@ -159,7 +162,9 @@ defmodule Phoenix.Controller do
   connection-agnostic and typically invoked from your views.
   """
   defmacro __using__(opts) do
-    quote bind_quoted: [opts: opts] do
+    {put_default_views, opts} = Keyword.pop(opts, :put_default_views, true)
+
+    quote bind_quoted: [put_default_views: put_default_views, opts: opts] do
       import Phoenix.Controller
 
       # TODO v2: No longer automatically import dependencies
@@ -167,8 +172,10 @@ defmodule Phoenix.Controller do
 
       use Phoenix.Controller.Pipeline, opts
 
-      plug :put_new_layout, {Phoenix.Controller.__layout__(__MODULE__, opts), :app}
-      plug :put_new_view, Phoenix.Controller.__view__(__MODULE__)
+      if put_default_views do
+        plug :put_new_layout, {Phoenix.Controller.__layout__(__MODULE__, opts), :app}
+        plug :put_new_view, Phoenix.Controller.__view__(__MODULE__)
+      end
     end
   end
 

--- a/test/phoenix/controller/pipeline_test.exs
+++ b/test/phoenix/controller/pipeline_test.exs
@@ -44,6 +44,12 @@ defmodule Phoenix.Controller.PipelineTest do
     end
   end
 
+  defmodule NoViewsController do
+    use Phoenix.Controller, set_views: false
+
+    def show(conn, _), do: conn
+  end
+
   defmodule FallbackFunctionController do
     use Phoenix.Controller
 
@@ -91,6 +97,7 @@ defmodule Phoenix.Controller.PipelineTest do
 
     defp put_assign(conn, _), do: assign(conn, :value_before_action, :a_value)
   end
+
   def init(opts), do: opts
   def call(conn, :not_a_conn), do: Plug.Conn.send_resp(conn, 200, "fallback")
   def call(_conn, :bad_fallback), do: :bad_fallback
@@ -123,6 +130,15 @@ defmodule Phoenix.Controller.PipelineTest do
            |> put_view(Hello)
            |> put_layout(false)
            |> MyController.call(:create)
+    assert view_module(conn) == Hello
+    assert layout(conn) == false
+  end
+
+  test "does not set default view/layout" do
+    conn = stack_conn()
+           |> NoViewsController.call(:show)
+           |> put_new_view(Hello)
+
     assert view_module(conn) == Hello
     assert layout(conn) == false
   end


### PR DESCRIPTION
This can be useful for applications that want to control the defaults on their own, for example I use different naming scheme where instead of `MyAppWeb.FooController` each controllers is named as `MyAppWeb.Controllers.Foo` and the views are named `MyApp.Views.Foo`, which is suits more into overall naming scheme after file path.