### PR TITLE
Fix rejoining channels after explicit reconnect

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -939,12 +939,20 @@ export class Socket {
   }
 
   teardown(callback, code, reason){
-    if(this.conn){
-      this.conn.onclose = function(){} // noop
+    if(this.conn) {
       if(code){ this.conn.close(code, reason || "") } else { this.conn.close() }
-      this.conn = null
     }
-    callback && callback()
+
+    // Force connection cleanup and callback to the next event loop. This is
+    // necessary for `conn.close()` to finish and trigger all necesary
+    // callbacks.
+    setTimeout(() => {
+      if(this.conn){
+        this.conn.onclose = function(){} // noop
+        this.conn = null
+      }
+      callback && callback()
+    })
   }
 
   onConnClose(event){

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -263,19 +263,22 @@ describe("with transports", done =>{
       socket = new Socket("/socket")
     })
 
-    it("removes existing connection", () => {
+    it("removes existing connection", done => {
       socket.connect()
-      socket.disconnect()
-
-      assert.equal(socket.conn, null)
+      socket.disconnect(() => {
+        assert.equal(socket.conn, null)
+        done()
+      })
     })
 
-    it("calls callback", () => {
+    it("calls callback", done => {
       let count = 0
       socket.connect()
-      socket.disconnect(() => count++)
-
-      assert.equal(count, 1)
+      socket.disconnect(() => {
+        count++
+        assert.equal(count, 1)
+        done()
+      })
     })
 
     it("calls connection close callback", () => {
@@ -630,14 +633,13 @@ describe("with transports", done =>{
       assert.ok(spy.calledOnce)
     })
 
-    it('does not schedule reconnectTimer timeout if normal close after explicit disconnect', () => {
+    it('does not schedule reconnectTimer timeout if normal close after explicit disconnect', done => {
       const spy = sinon.spy(socket.reconnectTimer, 'scheduleTimeout')
 
-      const event = { code: 1000 }
-
-      socket.disconnect()
-
-      assert.ok(spy.notCalled)
+      socket.disconnect(() => {
+        assert.ok(spy.notCalled)
+        done()
+      })
     })
 
     it('schedules reconnectTimer timeout if not normal close', () => {
@@ -650,17 +652,19 @@ describe("with transports", done =>{
       assert.ok(spy.calledOnce)
     })
 
-    it('schedules reconnectTimer timeout if connection cannot be made after a previous clean disconnect', () => {
+    it('schedules reconnectTimer timeout if connection cannot be made after a previous clean disconnect', done => {
       const spy = sinon.spy(socket.reconnectTimer, 'scheduleTimeout')
 
-      socket.disconnect();
-      socket.connect();
+      socket.disconnect(() => {
+        socket.connect();
 
-      const event = { code: 1001 }
+        const event = { code: 1001 }
 
-      socket.onConnClose(event)
+        socket.onConnClose(event)
 
-      assert.ok(spy.calledOnce)
+        assert.ok(spy.calledOnce)
+        done()
+      })
     })
 
     it("triggers onClose callback", () => {


### PR DESCRIPTION
Previously when a socket which had channels open was explicitly reconnected (`socket.disconnect(() => socket.connect())` then the existing channels were not rejoined.

This was because `onConnClose` was not called. This was due to a timing issue in `teardown` function. This function called close on connection and also cleaned up onclose listener on the connection object. The close however happened in the next event loop by which time the onclose listener was already removed.

The channels stayed in `joined` state even though socket was disconnected. On reconnect `joined` channels were not rejoined.

Fixes #3458