### PR TITLE
Replace includes with indexOf in phoenix.js

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -1013,7 +1013,7 @@ export class Socket {
   off(refs) {
     for(let key in this.stateChangeCallbacks){
       this.stateChangeCallbacks[key] = this.stateChangeCallbacks[key].filter(([ref]) => {
-        return !refs.includes(ref)
+        return refs.indexOf(ref) === -1
       })
     }
   }


### PR DESCRIPTION
Sadly we have to support IE11 which does not support [Array.prototype.includes()
](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes). The fix itself it quite simple: instead of includes we can use indexOf.