### PR TITLE
Fix Credo issues found in a newly generated app

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -231,8 +231,9 @@ defmodule Phx.New.Generator do
      test: [username: user, password: pass, database: {:literal, ~s|"#{app}_test\#{System.get_env("MIX_TEST_PARTITION")}"|}, hostname: "localhost",
             pool: Ecto.Adapters.SQL.Sandbox],
      test_setup_all: "Ecto.Adapters.SQL.Sandbox.mode(#{inspect module}.Repo, :manual)",
-     test_setup: ":ok = Ecto.Adapters.SQL.Sandbox.checkout(#{inspect module}.Repo)",
-     test_async: "Ecto.Adapters.SQL.Sandbox.mode(#{inspect module}.Repo, {:shared, self()})"]
+     test_alias: "alias Ecto.Adapters.SQL.Sandbox",
+     test_setup: ":ok = Sandbox.checkout(#{inspect module}.Repo)",
+     test_async: "Sandbox.mode(#{inspect module}.Repo, {:shared, self()})"]
   end
 
   defp kw_to_config(kw) do

--- a/installer/templates/phx_ecto/data_case.ex
+++ b/installer/templates/phx_ecto/data_case.ex
@@ -15,6 +15,7 @@ defmodule <%= app_module %>.DataCase do
   """
 
   use ExUnit.CaseTemplate
+  <%= adapter_config[:test_alias] %>
 
   using do
     quote do

--- a/installer/templates/phx_test/support/channel_case.ex
+++ b/installer/templates/phx_test/support/channel_case.ex
@@ -16,6 +16,7 @@ defmodule <%= web_namespace %>.ChannelCase do
   """
 
   use ExUnit.CaseTemplate
+  <%= adapter_config[:test_alias] %>
 
   using do
     quote do

--- a/installer/templates/phx_test/support/conn_case.ex
+++ b/installer/templates/phx_test/support/conn_case.ex
@@ -16,6 +16,7 @@ defmodule <%= web_namespace %>.ConnCase do
   """
 
   use ExUnit.CaseTemplate
+  <%= adapter_config[:test_alias] %>
 
   using do
     quote do

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -324,9 +324,9 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "custom_path/config/prod.secret.exs", [~r/url: database_url/]
       assert_file "custom_path/lib/custom_path/repo.ex", "Ecto.Adapters.Postgres"
 
-      assert_file "custom_path/test/support/conn_case.ex", "Ecto.Adapters.SQL.Sandbox.checkout"
-      assert_file "custom_path/test/support/channel_case.ex", "Ecto.Adapters.SQL.Sandbox.checkout"
-      assert_file "custom_path/test/support/data_case.ex", "Ecto.Adapters.SQL.Sandbox.checkout"
+      assert_file "custom_path/test/support/conn_case.ex", ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.checkout"]
+      assert_file "custom_path/test/support/channel_case.ex", ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.checkout"]
+      assert_file "custom_path/test/support/data_case.ex", ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.checkout"]
     end
   end
 
@@ -341,9 +341,9 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "custom_path/config/prod.secret.exs", [~r/url: database_url/]
       assert_file "custom_path/lib/custom_path/repo.ex", "Ecto.Adapters.MyXQL"
 
-      assert_file "custom_path/test/support/conn_case.ex", "Ecto.Adapters.SQL.Sandbox.mode"
-      assert_file "custom_path/test/support/channel_case.ex", "Ecto.Adapters.SQL.Sandbox.mode"
-      assert_file "custom_path/test/support/data_case.ex", "Ecto.Adapters.SQL.Sandbox.mode"
+      assert_file "custom_path/test/support/conn_case.ex", ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.mode"]
+      assert_file "custom_path/test/support/channel_case.ex", ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.mode"]
+      assert_file "custom_path/test/support/data_case.ex", ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.mode"]
     end
   end
 

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -351,8 +351,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file root_path(app, "config/test.exs"), [~r/username: "postgres"/, ~r/password: "postgres"/, ~r/hostname: "localhost"/]
       assert_file root_path(app, "config/prod.secret.exs"), [~r/url: database_url/]
 
-      assert_file web_path(app, "test/support/conn_case.ex"), "Ecto.Adapters.SQL.Sandbox.checkout"
-      assert_file web_path(app, "test/support/channel_case.ex"), "Ecto.Adapters.SQL.Sandbox.checkout"
+      assert_file web_path(app, "test/support/conn_case.ex"), ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.checkout"]
+      assert_file web_path(app, "test/support/channel_case.ex"), ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.checkout"]
     end
   end
 
@@ -369,8 +369,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file root_path(app, "config/test.exs"), [~r/username: "root"/, ~r/password: ""/]
       assert_file root_path(app, "config/prod.secret.exs"), [~r/url: database_url/]
 
-      assert_file web_path(app, "test/support/conn_case.ex"), "Ecto.Adapters.SQL.Sandbox.checkout"
-      assert_file web_path(app, "test/support/channel_case.ex"), "Ecto.Adapters.SQL.Sandbox.checkout"
+      assert_file web_path(app, "test/support/conn_case.ex"), ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.checkout"]
+      assert_file web_path(app, "test/support/channel_case.ex"), ["alias Ecto.Adapters.SQL.Sandbox", "Sandbox.checkout"]
     end
   end
 


### PR DESCRIPTION
Issues found:

```
  Software Design
┃
┃ [D] ↘ Nested modules could be aliased at the top of the invoking module.
┃       test/support/data_case.ex:34:7 #(Foo.DataCase)
┃ [D] ↘ Nested modules could be aliased at the top of the invoking module.
┃       test/support/data_case.ex:31:11 #(Foo.DataCase)
┃ [D] ↘ Nested modules could be aliased at the top of the invoking module.
┃       test/support/conn_case.ex:35:7 #(FooWeb.ConnCase)
┃ [D] ↘ Nested modules could be aliased at the top of the invoking module.
┃       test/support/conn_case.ex:32:11 #(FooWeb.ConnCase)
┃ [D] ↘ Nested modules could be aliased at the top of the invoking module.
┃       test/support/channel_case.ex:34:7 #(FooWeb.ChannelCase)
┃ [D] ↘ Nested modules could be aliased at the top of the invoking module.
┃       test/support/channel_case.ex:31:11 #(FooWeb.ChannelCase)
```