### PR TITLE
Emit telemetry when router fails

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -358,11 +358,15 @@ defmodule Phoenix.Router do
             conn
         rescue
           e in Plug.Conn.WrapperError ->
-            :telemetry.execute([:phoenix, :router_dispatch, :failure], %{}, %{error: e})
+            measurements = %{duration: System.monotonic_time() - start}
+            metadata = %{kind: :error, error: e, stacktrace: System.stacktrace()}
+            :telemetry.execute([:phoenix, :router_dispatch, :failure], measurements, metadata)
             Plug.Conn.WrapperError.reraise(e)
         catch
           :error, reason ->
-            :telemetry.execute([:phoenix, :router_dispatch, :failure], %{}, %{error: reason})
+            measurements = %{duration: System.monotonic_time() - start}
+            metadata = %{kind: :error, error: reason, stacktrace: System.stacktrace()}
+            :telemetry.execute([:phoenix, :router_dispatch, :failure], measurements, metadata)
             Plug.Conn.WrapperError.reraise(piped_conn, :error, reason, System.stacktrace())
         end
     end

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -358,9 +358,11 @@ defmodule Phoenix.Router do
             conn
         rescue
           e in Plug.Conn.WrapperError ->
+            :telemetry.execute([:phoenix, :router_dispatch, :failure], %{}, %{error: e})
             Plug.Conn.WrapperError.reraise(e)
         catch
           :error, reason ->
+            :telemetry.execute([:phoenix, :router_dispatch, :failure], %{}, %{error: reason})
             Plug.Conn.WrapperError.reraise(piped_conn, :error, reason, System.stacktrace())
         end
     end


### PR DESCRIPTION
We're attempting to add tracing support for phoenix based on telemetry. Currently, if the router throws we have no way to capture the stack trace/error or finish the trace. I've added telemetry events for failures based on the discussion here: https://github.com/beam-telemetry/telemetry/issues/57.

This PR is incomplete and does not send the correct metadata, provide any testing, or include the necessary documentation improvements. I intend to add those things but I wanted to ensure that this was a desirable feature before I did all of that. In particular, I'm not sure what the correct metadata should be in these scenarios. The error and stack trace is ideal but I'm not sure it's always possible to supply that.

Let me know what you think.