### PR TITLE
Add publicPath to Webpack config

### DIFF
--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = (env, options) => ({
   },
   output: {
     filename: 'app.js',
-    path: path.resolve(__dirname, '../priv/static/js')
+    path: path.resolve(__dirname, '../priv/static/js'),
+    publicPath: "/js/"
   },
   devtool: devMode ? 'source-map' : undefined,
   module: {

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -14,10 +14,10 @@ module.exports = (env, options) => ({
     ]
   },
   entry: {
-    './js/app.js': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
+    'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
   },
   output: {
-    filename: 'app.js',
+    filename: '[name].js',
     path: path.resolve(__dirname, '../priv/static/js'),
     publicPath: "/js/"
   },

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = (env, options) => ({
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, '../priv/static/js'),
-    publicPath: "/js/"
+    publicPath: '/js/'
   },
   devtool: devMode ? 'source-map' : undefined,
   module: {


### PR DESCRIPTION
# Problem
Some JS libraries generate chunk files when Webpack is running, and the current config leads to 404 errors when these chunks are referenced in the compiled JS. For example, the [Monaco Editor](https://microsoft.github.io/monaco-editor/) library generates chunks for service workers and languages.

# Solution
By adding setting `publicPath: '/js/'` to the Webpack config's output, these chunks can be successfully imported. With the updated config, the chunked filenames are generated as `[name].js`. The entry key has been changed to `app`, which produces an `app.js` file in the `priv/static/js` directory.

With the Monaco library imported with the new Webpack config, there are now dozens of files in the js directory:

```
# priv/static/js
...
52.js
53.js
54.js
55.js
56.js
57.js
58.js
59.js
6.js
60.js
61.js
62.js
63.js
7.js
8.js
9.js
app.js
css.worker.js
editor.worker.js
html.worker.js
json.worker.js
ts.worker.js
```