### PR TITLE
Add trailing_slash option to Phoenix.Router using and match macro

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -554,6 +554,8 @@ defmodule Phoenix.Router do
     * `:assigns` - a map of data to merge into the connection when a route matches
     * `:metadata` - a map of metadata used by the telemetry events and returned by
       `route_info/4`
+    * `:trailing_slash` - a boolean to flag whether or not the helper functions
+      append a trailing slash. Defaults to `false`.
 
   ## Examples
 
@@ -827,6 +829,8 @@ defmodule Phoenix.Router do
     * `:assigns` - a map of data to merge into the connection when a route matches
     * `:log` - the level to log the route dispatching under,
       may be set to false. Defaults to `:debug`
+    * `:trailing_slash` - whether or not the helper functions append a trailing
+      slash. Defaults to `false`.
 
   """
   defmacro scope(options, do: context) do

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -115,14 +115,14 @@ defmodule Phoenix.Router.Helpers do
     catch_all = Enum.map(groups, &defhelper_catch_all/1)
 
     defhelper = quote @anno do
-      defhelper = fn helper, vars, opts, bins, segs ->
+      defhelper = fn helper, vars, opts, bins, segs, trailing_slash? ->
         def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars)) do
           unquote(:"#{helper}_path")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars), [])
         end
 
         def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars), params)
             when is_list(params) or is_map(params) do
-          path(conn_or_endpoint, segments(unquote(segs), params, unquote(bins),
+          path(conn_or_endpoint, segments(unquote(segs), params, unquote(bins), unquote(Macro.escape(trailing_slash?)),
                 {unquote(helper), unquote(Macro.escape(opts)), unquote(Enum.map(vars, &Macro.to_string/1))}))
         end
 
@@ -263,21 +263,25 @@ defmodule Phoenix.Router.Helpers do
       defp to_param(true), do: "true"
       defp to_param(data), do: Phoenix.Param.to_param(data)
 
-      defp segments(segments, [], _reserved, _opts) do
-        segments
+      defp segments(segments, [], _reserved, trailing_slash?, _opts) do
+        maybe_append_slash(segments, trailing_slash?)
       end
 
-      defp segments(segments, query, reserved, _opts) when is_list(query) or is_map(query) do
+      defp segments(segments, query, reserved, trailing_slash?, _opts) when is_list(query) or is_map(query) do
         dict = for {k, v} <- query,
                not ((k = to_string(k)) in reserved),
                do: {k, v}
 
 
         case Conn.Query.encode dict, &to_param/1 do
-          "" -> segments
-          o  -> segments <> "?" <> o
+          "" -> maybe_append_slash(segments, trailing_slash?)
+          o  -> maybe_append_slash(segments, trailing_slash?) <> "?" <> o
         end
       end
+
+      defp maybe_append_slash("/", _), do: "/"
+      defp maybe_append_slash(path, _trailing_slash? = true), do: path <> "/"
+      defp maybe_append_slash(path, _), do: path
     end
 
     Module.create(Module.concat(env.module, Helpers), code, line: env.line, file: env.file)
@@ -291,6 +295,7 @@ defmodule Phoenix.Router.Helpers do
   def defhelper(%Route{} = route, exprs) do
     helper = route.helper
     opts = route.plug_opts
+    trailing_slash? = route.trailing_slash?
 
     {bins, vars} = :lists.unzip(exprs.binding)
     segs = expand_segments(exprs.path)
@@ -301,7 +306,8 @@ defmodule Phoenix.Router.Helpers do
         unquote(Macro.escape(vars)),
         unquote(Macro.escape(opts)),
         unquote(Macro.escape(bins)),
-        unquote(Macro.escape(segs))
+        unquote(Macro.escape(segs)),
+        unquote(Macro.escape(trailing_slash?))
       )
     end
   end

--- a/lib/phoenix/router/route.ex
+++ b/lib/phoenix/router/route.ex
@@ -21,11 +21,12 @@ defmodule Phoenix.Router.Route do
     * `:assigns` - the route info
     * `:pipe_through` - the pipeline names as a list of atoms
     * `:metadata` - general metadata used on telemetry events and route info
-
+    * `:trailing_slash?` - whether or not the helper functions append a trailing slash
   """
 
   defstruct [:verb, :line, :kind, :path, :host, :plug, :plug_opts,
-             :helper, :private, :pipe_through, :assigns, :metadata]
+             :helper, :private, :pipe_through, :assigns, :metadata,
+             :trailing_slash?]
 
   @type t :: %Route{}
 
@@ -45,15 +46,17 @@ defmodule Phoenix.Router.Route do
   Receives the verb, path, plug, options and helper
   and returns a `Phoenix.Router.Route` struct.
   """
-  @spec build(non_neg_integer, :match | :forward, atom, String.t, String.t | nil, atom, atom, atom | nil, atom, map, map, map) :: t
-  def build(line, kind, verb, path, host, plug, plug_opts, helper, pipe_through, private, assigns, metadata)
+  @spec build(non_neg_integer, :match | :forward, atom, String.t, String.t | nil, atom, atom, atom | nil, atom, map, map, map, boolean) :: t
+  def build(line, kind, verb, path, host, plug, plug_opts, helper, pipe_through, private, assigns, metadata, trailing_slash?)
       when is_atom(verb) and (is_binary(host) or is_nil(host)) and
            is_atom(plug) and (is_binary(helper) or is_nil(helper)) and
            is_list(pipe_through) and is_map(private) and is_map(assigns) and
-           is_map(metadata) and kind in [:match, :forward] do
+           is_map(metadata) and kind in [:match, :forward] and
+           is_boolean(trailing_slash?) do
     %Route{kind: kind, verb: verb, path: path, host: host, private: private,
            plug: plug, plug_opts: plug_opts, helper: helper,
-           pipe_through: pipe_through, assigns: assigns, line: line, metadata: metadata}
+           pipe_through: pipe_through, assigns: assigns, line: line, metadata: metadata,
+           trailing_slash?: trailing_slash?}
   end
 
   @doc """

--- a/lib/phoenix/router/scope.ex
+++ b/lib/phoenix/router/scope.ex
@@ -6,7 +6,7 @@ defmodule Phoenix.Router.Scope do
   @pipes :phoenix_pipeline_scopes
   @top :phoenix_top_scopes
 
-  defstruct path: [], alias: [], as: [], pipes: [], host: nil, private: %{}, assigns: %{}, log: :debug
+  defstruct path: [], alias: [], as: [], pipes: [], host: nil, private: %{}, assigns: %{}, log: :debug, trailing_slash?: false
 
   @doc """
   Initializes the scope.
@@ -26,6 +26,7 @@ defmodule Phoenix.Router.Scope do
     assigns = Keyword.get(opts, :assigns, %{})
     as      = Keyword.get(opts, :as, Phoenix.Naming.resource_name(plug, "Controller"))
     alias?  = Keyword.get(opts, :alias, true)
+    trailing_slash? = Keyword.get(opts, :trailing_slash, get_top(module).trailing_slash?) == true
 
     if to_string(as) == "static"  do
       raise ArgumentError, "`static` is a reserved route prefix generated from #{inspect plug} or `:as` option"
@@ -39,7 +40,7 @@ defmodule Phoenix.Router.Scope do
       |> Keyword.get(:metadata, %{})
       |> Map.put(:log, Keyword.get(opts, :log, log))
 
-    Phoenix.Router.Route.build(line, kind, verb, path, host, alias, plug_opts, as, pipes, private, assigns, metadata)
+    Phoenix.Router.Route.build(line, kind, verb, path, host, alias, plug_opts, as, pipes, private, assigns, metadata, trailing_slash?)
   end
 
   @doc """
@@ -113,7 +114,8 @@ defmodule Phoenix.Router.Scope do
       pipes: top.pipes,
       private: Map.merge(top.private, private),
       assigns: Map.merge(top.assigns, assigns),
-      log: Keyword.get(opts, :log, top.log)
+      log: Keyword.get(opts, :log, top.log),
+      trailing_slash?: Keyword.get(opts, :trailing_slash, top.trailing_slash?) == true
     })
   end
 

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -5,6 +5,8 @@ modules = [
   CommentController,
   FileController,
   ProductController,
+  TrailController,
+  VistaController,
   Admin.MessageController,
   SubPlug
 ]
@@ -50,6 +52,19 @@ defmodule Phoenix.Router.HelpersTest do
     scope "/admin/new", alias: Admin, as: "admin" do
       resources "/messages", MessageController
     end
+
+    scope "/trails", trailing_slash: true do
+      get "/", TrailController, :index
+      get "/open", TrailController, :open, trailing_slash: false
+
+      resources "/vistas", VistaController
+
+      scope "/nested" do
+        get "/path", TrailController, :nested_path
+      end
+    end
+
+    get "/trails/top", TrailController, :top, trailing_slash: true
 
     get "/", PostController, :root, as: :page
     get "/products/:id", ProductController, :show
@@ -204,6 +219,13 @@ defmodule Phoenix.Router.HelpersTest do
       "/posts/file/%3D%3Dd--%2B/%3AO.jpg?xx=%2F%3D%2B%2F"
   end
 
+  test "top-level named routes with trailing slashes" do
+    assert Helpers.trail_path(__MODULE__, :top) == "/trails/top/"
+    assert Helpers.trail_path(__MODULE__, :top, id: 5) == "/trails/top/?id=5"
+    assert Helpers.trail_path(__MODULE__, :top, %{"id" => "foo"}) == "/trails/top/?id=foo"
+    assert Helpers.trail_path(__MODULE__, :top, %{"id" => "foo bar"}) == "/trails/top/?id=foo+bar"
+  end
+
   test "resources generates named routes for :index, :edit, :show, :new" do
     assert Helpers.user_path(__MODULE__, :index, []) == "/users"
     assert Helpers.user_path(__MODULE__, :index) == "/users"
@@ -351,6 +373,48 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.admin_message_path(__MODULE__, :index) == "/admin/new/messages"
     assert Helpers.admin_message_path(__MODULE__, :show, 1, []) == "/admin/new/messages/1"
     assert Helpers.admin_message_path(__MODULE__, :show, 1) == "/admin/new/messages/1"
+  end
+
+  test "scoped route helpers generated with trailing slashes" do
+    assert Helpers.trail_path(__MODULE__, :index) == "/trails/"
+    assert Helpers.trail_path(__MODULE__, :index, id: 5) == "/trails/?id=5"
+    assert Helpers.trail_path(__MODULE__, :index, %{"id" => "foo"}) == "/trails/?id=foo"
+    assert Helpers.trail_path(__MODULE__, :index, %{"id" => "foo bar"}) == "/trails/?id=foo+bar"
+  end
+
+  test "scoped route helpers generated with trailing slashes overridden" do
+    assert Helpers.trail_path(__MODULE__, :open) == "/trails/open"
+    assert Helpers.trail_path(__MODULE__, :open, id: 5) == "/trails/open?id=5"
+    assert Helpers.trail_path(__MODULE__, :open, %{"id" => "foo"}) == "/trails/open?id=foo"
+    assert Helpers.trail_path(__MODULE__, :open, %{"id" => "foo bar"}) == "/trails/open?id=foo+bar"
+  end
+
+  test "scoped route helpers generated with trailing slashes for resource" do
+    assert Helpers.vista_path(__MODULE__, :index) == "/trails/vistas/"
+    assert Helpers.vista_path(__MODULE__, :index, []) == "/trails/vistas/"
+    assert Helpers.vista_path(__MODULE__, :index, id: 5) == "/trails/vistas/?id=5"
+    assert Helpers.vista_path(__MODULE__, :index, %{"id" => "foo"}) == "/trails/vistas/?id=foo"
+
+    assert Helpers.vista_path(__MODULE__, :new) == "/trails/vistas/new/"
+    assert Helpers.vista_path(__MODULE__, :new, []) == "/trails/vistas/new/"
+    assert Helpers.vista_path(__MODULE__, :create) == "/trails/vistas/"
+    assert Helpers.vista_path(__MODULE__, :create, []) == "/trails/vistas/"
+    assert Helpers.vista_path(__MODULE__, :show, 2) == "/trails/vistas/2/"
+    assert Helpers.vista_path(__MODULE__, :show, 2, []) == "/trails/vistas/2/"
+    assert Helpers.vista_path(__MODULE__, :edit, 2) == "/trails/vistas/2/edit/"
+    assert Helpers.vista_path(__MODULE__, :edit, 2, []) == "/trails/vistas/2/edit/"
+    assert Helpers.vista_path(__MODULE__, :update, 2) == "/trails/vistas/2/"
+    assert Helpers.vista_path(__MODULE__, :update, 2, []) == "/trails/vistas/2/"
+    assert Helpers.vista_path(__MODULE__, :delete, 2) == "/trails/vistas/2/"
+    assert Helpers.vista_path(__MODULE__, :delete, 2, []) == "/trails/vistas/2/"
+  end
+
+  test "scoped route helpers generated within scoped routes with trailing slashes" do
+    assert Helpers.trail_path(__MODULE__, :nested_path) == "/trails/nested/path/"
+    assert Helpers.trail_path(__MODULE__, :nested_path, []) == "/trails/nested/path/"
+    assert Helpers.trail_path(__MODULE__, :nested_path, [id: 5]) == "/trails/nested/path/?id=5"
+    assert Helpers.trail_path(__MODULE__, :nested_path, %{"id" => "foo"}) == "/trails/nested/path/?id=foo"
+    assert Helpers.trail_path(__MODULE__, :nested_path, %{"id" => "foo bar"}) == "/trails/nested/path/?id=foo+bar"
   end
 
   test "can pass an {m, f, a} tuple as a plug argument" do

--- a/test/phoenix/router/route_test.exs
+++ b/test/phoenix/router/route_test.exs
@@ -11,7 +11,7 @@ defmodule Phoenix.Router.RouteTest do
   end
 
   test "builds a route based on verb, path, plug, plug options and helper" do
-    route = build(1, :match, :get, "/foo/:bar", nil, Hello, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"}, %{log: :debug})
+    route = build(1, :match, :get, "/foo/:bar", nil, Hello, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"}, %{log: :debug}, true)
     assert route.kind == :match
     assert route.verb == :get
     assert route.path == "/foo/:bar"
@@ -24,31 +24,32 @@ defmodule Phoenix.Router.RouteTest do
     assert route.private == %{foo: "bar"}
     assert route.assigns == %{bar: "baz"}
     assert route.metadata == %{log: :debug}
+    assert route.trailing_slash? == true
   end
 
   test "builds expressions based on the route" do
-    exprs = build(1, :match, :get, "/foo/:bar", nil, Hello, :world, "hello_world", [], %{}, %{}, %{}) |> exprs
+    exprs = build(1, :match, :get, "/foo/:bar", nil, Hello, :world, "hello_world", [], %{}, %{}, %{}, false) |> exprs
     assert exprs.verb_match == "GET"
     assert exprs.path == ["foo", {:bar, [], nil}]
     assert exprs.binding == [{"bar", {:bar, [], nil}}]
     assert Macro.to_string(exprs.host) == "_"
 
-    exprs = build(1, :match, :get, "/", "foo.", Hello, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"}, %{}) |> exprs
+    exprs = build(1, :match, :get, "/", "foo.", Hello, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"}, %{}, false) |> exprs
     assert Macro.to_string(exprs.host) == "\"foo.\" <> _"
 
-    exprs = build(1, :match, :get, "/", "foo.com", Hello, :world, "hello_world", [], %{foo: "bar"}, %{bar: "baz"}, %{}) |> exprs
+    exprs = build(1, :match, :get, "/", "foo.com", Hello, :world, "hello_world", [], %{foo: "bar"}, %{bar: "baz"}, %{}, false) |> exprs
     assert Macro.to_string(exprs.host) == "\"foo.com\""
   end
 
   test "builds a catch-all verb_match for match routes" do
-    route = build(1, :match, :*, "/foo/:bar", nil, __MODULE__, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"}, %{})
+    route = build(1, :match, :*, "/foo/:bar", nil, __MODULE__, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"}, %{}, false)
     assert route.verb == :*
     assert route.kind == :match
     assert exprs(route).verb_match == {:_verb, [], nil}
   end
 
   test "builds a catch-all verb_match for forwarded routes" do
-    route = build(1, :forward, :*, "/foo/:bar", nil, __MODULE__, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"}, %{})
+    route = build(1, :forward, :*, "/foo/:bar", nil, __MODULE__, :world, "hello_world", [:foo, :bar], %{foo: "bar"}, %{bar: "baz"}, %{}, false)
     assert route.verb == :*
     assert route.kind == :forward
     assert exprs(route).verb_match == {:_verb, [], nil}
@@ -68,10 +69,10 @@ defmodule Phoenix.Router.RouteTest do
     opts = %{a: ~r/foo/}
     escaped_opts = Macro.escape(opts)
 
-    route = build(1, :match, :*, "/foo", nil, __MODULE__, opts, "hello_world", [], %{}, %{}, %{})
+    route = build(1, :match, :*, "/foo", nil, __MODULE__, opts, "hello_world", [], %{}, %{}, %{}, false)
     assert {__MODULE__, escaped_opts} == exprs(route).dispatch
 
-    fwd_route = build(1, :forward, :*, "/foo", nil, __MODULE__, opts, "hello_world", [], %{}, %{}, %{})
+    fwd_route = build(1, :forward, :*, "/foo", nil, __MODULE__, opts, "hello_world", [], %{}, %{}, %{}, false)
     assert {_, {:{}, _, [_, __MODULE__, ^escaped_opts]}} = exprs(fwd_route).dispatch
   end
 end


### PR DESCRIPTION
This PR adds a `:trailing_slash` option to Phoenix.Router that can be used to modify the generated helper functions:

1. You can define it globally when using Phoenix.Router:

```elixir
defmodule MyAppWeb.Router do
  use Phoenix.Router, trailing_slash: true
end
```

This will cause all generated `*_path` and `*_url` functions to append a trailing slash to the router paths.

2. You can define it per-route, like so:

```elixir
defmodule MyAppWeb.Router do
  use Phoenix.Router

  scope "/", MyAppWeb do
    get("/posts", PostController, :index)
    get("/users", UserController, :index, trailing_slash: true)
  end
end
```

```elixir
alias MyAppWeb.Router.Helpers, as: Routes

Routes.post_path(MyAppWeb.Endpoint, :index) # => "/posts"
Routes.user_path(MyAppWeb.Endpoint, :index) # => "/users/"
```

**Caveats**

This currently has no impact on calls (through the helpers) to `endpoint.url()`.  I'm not sure if this is a problem, and/or what the best solution might be, to ensure we avoid duplicating slashes somewhere in the path.

Closes #3573 