### PR TITLE
Add missing floki package for phx.new --live

### DIFF
--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -41,7 +41,8 @@ defmodule <%= app_module %>.MixProject do
       {:phoenix_ecto, "~> 4.1"},
       {:ecto_sql, "~> 3.1"},
       {<%= inspect adapter_app %>, ">= 0.0.0"},<% end %><%= if html do %><%= if live do %>
-      {:phoenix_live_view, "~> 0.8.1"},<% end %>
+      {:phoenix_live_view, "~> 0.8.1"},
+      {:floki, ">= 0.0.0", only: :test},<% end %>
       {:phoenix_html, "~> 2.11"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},<% end %><%= if gettext do %>
       {:gettext, "~> 0.11"},<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
@@ -39,7 +39,8 @@ defmodule <%= web_namespace %>.MixProject do
     [
       <%= phoenix_dep %>,<%= if ecto do %>
       {:phoenix_ecto, "~> 4.0"},<% end %><%= if html do %><%= if live do %>
-      {:phoenix_live_view, "~> 0.8.1"},<% end %>
+      {:phoenix_live_view, "~> 0.8.1"},
+      {:floki, ">= 0.0.0", only: :test},<% end %>
       {:phoenix_html, "~> 2.11"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},<% end %><%= if gettext do %>
       {:gettext, "~> 0.11"},<% end %><%= if app_name != web_app_name do %>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -140,6 +140,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       refute_file "phx_blog/lib/phx_blog_web/live/page_live_view.ex"
       refute_file "phx_blog/assets/js/live.js"
       assert_file "phx_blog/mix.exs", &refute(&1 =~ ~r":phoenix_live_view")
+      assert_file "phx_blog/mix.exs", &refute(&1 =~ ~r":floki")
       assert_file "phx_blog/assets/package.json",
                   &refute(&1 =~ ~s["phoenix_live_view": "file:../deps/phoenix_live_view"])
 
@@ -284,6 +285,7 @@ defmodule Mix.Tasks.Phx.NewTest do
     in_tmp "new with live", fn ->
       Mix.Tasks.Phx.New.run([@app_name, "--live"])
       assert_file "phx_blog/mix.exs", &assert(&1 =~ ~r":phoenix_live_view")
+      assert_file "phx_blog/mix.exs", &assert(&1 =~ ~r":floki")
 
       refute_file "phx_blog/lib/phx_blog_web/controllers/page_controller.ex"
 

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -244,6 +244,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       # No LiveView (in web_path)
       assert_file web_path(@app, "mix.exs"), &refute(&1 =~ ~r":phoenix_live_view")
+      assert_file web_path(@app, "mix.exs"), &refute(&1 =~ ~r":floki")
       refute File.exists?(web_path(@app, "lib/#{@app}_web/templates/page/hero.html.leex"))
 
       refute_file web_path(@app, "assets/js/live.js")
@@ -310,6 +311,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       end
 
       assert_file web_path(@app, "mix.exs"), &assert(&1 =~ ~r":phoenix_live_view")
+      assert_file web_path(@app, "mix.exs"), &assert(&1 =~ ~r":floki")
 
       assert_file web_path(@app, "assets/package.json"),
                   ~s["phoenix_live_view": "file:../deps/phoenix_live_view"]


### PR DESCRIPTION
The floki package is missing when generating a new phoenix project with the option --live.

Without this package you will get the following error when running `mix test:

```
...
** (UndefinedFunctionError) function Floki.parse_document/1 is undefined (module Floki is not available)
...
```