### PR TITLE
Set correct webpack path for phoenix_live_view in umbrella apps

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -148,6 +148,7 @@ defmodule Phx.New.Generator do
       phoenix_path: phoenix_path,
       phoenix_webpack_path: phoenix_webpack_path(project, dev),
       phoenix_html_webpack_path: phoenix_html_webpack_path(project),
+      phoenix_live_view_webpack_path: phoenix_live_view_webpack_path(project),
       phoenix_static_path: phoenix_static_path(phoenix_path),
       pubsub_server: pubsub_server,
       secret_key_base: random_string(64),
@@ -287,6 +288,11 @@ defmodule Phx.New.Generator do
     do: "../../../deps/phoenix_html"
   defp phoenix_html_webpack_path(%Project{in_umbrella?: false}),
     do: "../deps/phoenix_html"
+
+  defp phoenix_live_view_webpack_path(%Project{in_umbrella?: true}),
+    do: "../../../deps/phoenix_live_view"
+  defp phoenix_live_view_webpack_path(%Project{in_umbrella?: false}),
+    do: "../deps/phoenix_live_view"
 
   # defp phoenix_dep("deps/phoenix"), do: ~s[{:phoenix, "~> #{@phoenix_version}"}]
   defp phoenix_dep("deps/phoenix"), do: ~s[{:phoenix, github: "phoenixframework/phoenix", override: true}]

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "phoenix": "file:<%= phoenix_webpack_path %>"<%= if html do %>,
     "phoenix_html": "file:<%= phoenix_html_webpack_path %>"<% end %><%= if live do %>,
-    "phoenix_live_view": "file:../deps/phoenix_live_view",
+    "phoenix_live_view": "file:<%= phoenix_live_view_webpack_path %>",
     "nprogress": "^0.2.0"<% end %>
   },
   "devDependencies": {

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -312,7 +312,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file web_path(@app, "mix.exs"), &assert(&1 =~ ~r":phoenix_live_view")
 
       assert_file web_path(@app, "assets/package.json"),
-                  ~s["phoenix_live_view": "file:../deps/phoenix_live_view"]
+                  ~s["phoenix_live_view": "file:../../../deps/phoenix_live_view"]
 
       assert_file web_path(@app, "assets/js/app.js"), fn file ->
         assert file =~ ~s[import {LiveSocket} from "phoenix_live_view"]


### PR DESCRIPTION
A quick fix against #3680 relating to the installer generating a `--live` app in an umbrella project.

Currently the Webpack template has a [hard coded reference](https://github.com/phoenixframework/phoenix/pull/3680/files#diff-d1254ba0442b3c34b3011c5e46f2ff17R12) to the live_view assets file path that is specific to a standard Phoenix project structure:
```
"phoenix_live_view": "file:../deps/phoenix_live_view" 
```

This copies how `phoenix_html` is set in the generator by checking whether it's in an umbrella project and inserts the correct file path.