### PR TITLE
Standardize Endpoint Telemetry events

### DIFF
--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -37,7 +37,6 @@ defmodule <%= endpoint_module %> do
   end
 
   plug Plug.RequestId
-  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],


### PR DESCRIPTION
This isn't complete yet (needs docs/tests updated) and would be a breaking change as written, but I wanted to open a discussion about whether this is a better way to handle this telemetry than what we're currently doing, and how we might move forward.

## Guiding Principles

* `Plug.Telemetry` doesn't offer a consistent way to ensure that there is always a `:start` and either a `:stop` or `:failure` event. This is important for consistent metrics and distributed tracing integration, as described in [this issue](https://github.com/beam-telemetry/telemetry/issues/57).
* In my opinion, `Phoenix.Endpoint` measurements should account for all the time that the `Endpoint` and any downstream code is executing (which includes sending the response, handling errors, etc.). `Plug.Telemetry` measures the duration between when that Plug is called and just before the response begins to be sent.
* Generating a `Plug.Telemetry` into the user's application code with that is namespaced as `phoenix.endpoint` feels weird to me, because it's in _their_ codebase, but it's documented in Phoenix itself. For example, if I change the prefix in my own `Endpoint` module or delete the plug altogether, it can no longer be easily consumed by other libraries. By comparison, if `phoenix.endpoint.stop` is emitted from Phoenix code as in this proposal, a drop-in library can just know how to consume it without any configuration and, for example, send that data to some vendor's APM solution.
* Users can still use `Plug.Telemetry` if they want to, but it will be clear to them that the event prefixes will be completely up to them and in no way related to Phoenix, since they added them by themselves.

## Problems to be Resolved

* Applications generated with the existing default `Plug.Telemetry` plug would end up having duplicated events unless they removed it from their `Endpoint` module. I would consider that a breaking change. We could obviously solve that by using a different name, but IMO this name is the correct name for this particular event, so I'm curious to hear what others would propose as a solution.
* The measurements and metadata are the same as the existing event, but now it's measuring a different thing, so the durations will seem to increase. This is also a breaking change because people who care about metrics will see a non-trivial "increase in latency" which is really just accounting for all the time spent between the `before_send` hooks fire and the actual end of the request. Again, this could be solved by naming the metric something else, but I'm not sure what else to call it.
* I didn't propose that we have any way to put a different prefix on the metric. We could consider putting the user's `MyAppWeb.Endpoint` module in the metadata to better support multiple Phoenix apps in an umbrella, but wasn't sure that was desired in addition to the `Plug.Conn` struct, and it would be an additive change to the existing metadata for this event.

/cc @bryannaegele @binaryseed @tsloughter