### PR TITLE
Update pubsub to 2.0-dev for new umbrella apps

### DIFF
--- a/installer/templates/phx_umbrella/apps/app_name/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/mix.exs
@@ -36,11 +36,11 @@ defmodule <%= app_module %>.MixProject do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
-      {:phoenix_pubsub, "~> 2.0"}<%= if ecto do %>,
+      {:phoenix_pubsub, "~> 2.0-dev", github: "phoenixframework/phoenix_pubsub"}<%= if ecto do %>,
       {:ecto_sql, "~> 3.1"},
       {:<%= adapter_app %>, ">= 0.0.0"},
-      {:jason, "~> 1.0"}
-    <% end %>]
+      {:jason, "~> 1.0"}<% end %>
+    ]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.<%= if ecto do %>

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -89,7 +89,10 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file app_path(@app, "lib/#{@app}/application.ex"), ~r/defmodule PhxUmb.Application do/
       assert_file app_path(@app, "lib/#{@app}/application.ex"), ~r/PhxUmb.Repo/
       assert_file app_path(@app, "lib/#{@app}.ex"), ~r/defmodule PhxUmb do/
-      assert_file app_path(@app, "mix.exs"), ~r/mod: {PhxUmb.Application, \[\]}/
+      assert_file app_path(@app, "mix.exs"), fn file ->
+        assert file =~ "mod: {PhxUmb.Application, []}"
+        assert file =~ "{:phoenix_pubsub, \"~> 2.0-dev\", github: \"phoenixframework/phoenix_pubsub\"}"
+      end
       assert_file app_path(@app, "test/test_helper.exs")
 
       assert_file web_path(@app, "lib/#{@app}_web/application.ex"), ~r/defmodule PhxUmbWeb.Application do/


### PR DESCRIPTION
* Fixes "dependencies have diverged" error (:phoenix requires :phoenix_pubsub 2.0-dev)
* Moves the closing bracket for the deps list to a new line to fix formatting