### PR TITLE
Add `mix setup` to generated apps

### DIFF
--- a/installer/templates/phx_single/README.md
+++ b/installer/templates/phx_single/README.md
@@ -2,9 +2,7 @@
 
 To start your Phoenix server:
 
-  * Install dependencies with `mix deps.get`<%= if ecto do %>
-  * Create and migrate your database with `mix ecto.setup`<% end %><%= if webpack do %>
-  * Install Node.js dependencies with `npm install --prefix assets`<% end %>
+  * Setup the project with `mix setup`
   * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -12,8 +12,8 @@ defmodule <%= app_module %>.MixProject do
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: [:phoenix<%= if gettext do %>, :gettext<% end %>] ++ Mix.compilers(),
-      start_permanent: Mix.env() == :prod,<%= if ecto do %>
-      aliases: aliases(),<% end %>
+      start_permanent: Mix.env() == :prod,
+      aliases: aliases(),
       deps: deps()
     ]
   end
@@ -52,19 +52,20 @@ defmodule <%= app_module %>.MixProject do
       {:jason, "~> 1.0"},
       {:plug_cowboy, "~> 2.0"}
     ]
-  end<%= if ecto do %>
+  end
 
   # Aliases are shortcuts or tasks specific to the current project.
-  # For example, to create, migrate and run the seeds file at once:
+  # For example, to install project dependencies and perform other setup tasks, run:
   #
-  #     $ mix ecto.setup
+  #     $ mix setup
   #
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
+      setup: ["deps.get"<%= if ecto do %>, "ecto.setup"<% end %><%= if webpack do %>, "cmd npm install --prefix assets"<% end %>]<%= if ecto do %>,
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]<% end %>
     ]
-  end<% end %>
+  end
 end

--- a/installer/templates/phx_umbrella/apps/app_name/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/mix.exs
@@ -43,17 +43,15 @@ defmodule <%= app_module %>.MixProject do
     ]
   end
 
-  # Aliases are shortcuts or tasks specific to the current project.<%= if ecto do %>
-  # For example, to create, migrate and run the seeds file at once:
-  #
-  #     $ mix ecto.setup<% end %>
+  # Aliases are shortcuts or tasks specific to the current project.
   #
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
-    [<%= if ecto do %>
+    [
+      setup: ["deps.get"<%= if ecto do %>, "ecto.setup"<% end %>]<%= if ecto do %>,
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test"]
-    <% end %>]
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]<% end %>
+    ]
   end
 end

--- a/installer/templates/phx_umbrella/apps/app_name_web/README.md
+++ b/installer/templates/phx_umbrella/apps/app_name_web/README.md
@@ -2,9 +2,7 @@
 
 To start your Phoenix server:
 
-  * Install dependencies with `mix deps.get`
-  * Create and migrate your database with `mix ecto.setup`
-  * Install Node.js dependencies with `npm install --prefix assets`
+  * Setup the project with `mix setup`
   * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.

--- a/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
@@ -53,11 +53,13 @@ defmodule <%= web_namespace %>.MixProject do
     ]
   end
 
-  # Aliases are shortcuts or tasks specific to the current project.<%= if ecto do %>
-  # For example, we extend the test task to create and migrate the database.<% end %>
+  # Aliases are shortcuts or tasks specific to the current project.
   #
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
-    [<%= if ecto do %>test: ["ecto.create --quiet", "ecto.migrate", "test"]<% end %>]
+    [
+      setup: ["deps.get"<%= if webpack do %>, "cmd npm install --prefix assets"<% end %>]<%= if ecto do %>,
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]<% end %>
+    ]
   end
 end

--- a/installer/templates/phx_umbrella/mix.exs
+++ b/installer/templates/phx_umbrella/mix.exs
@@ -6,7 +6,8 @@ defmodule <%= root_app_module %>.MixProject do
       apps_path: "apps",
       version: "0.1.0",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      aliases: aliases()
     ]
   end
 
@@ -21,8 +22,24 @@ defmodule <%= root_app_module %>.MixProject do
   # Type "mix help deps" for more examples and options.
   #
   # Dependencies listed here are available only for this project
-  # and cannot be accessed from applications inside the apps folder
+  # and cannot be accessed from applications inside the apps/ folder.
   defp deps do
     []
+  end
+
+  # Aliases are shortcuts or tasks specific to the current project.
+  # For example, to install project dependencies and perform other setup tasks, run:
+  #
+  #     $ mix setup
+  #
+  # See the documentation for `Mix` for more info on aliases.
+  #
+  # Aliases listed here are available only for this project
+  # and cannot be accessed from applications inside the apps/ folder.
+  defp aliases do
+    [
+      # run `mix setup` in all child apps
+      setup: ["cmd mix setup"]
+    ]
   end
 end


### PR DESCRIPTION
I'd like to propose that newly generated Phoenix apps have a `mix setup`
task (an alias) that sets up developer's environment: fetching mix
dependencies, preparing the database, installing npm deps, etc. This
way, instead of copy-pasting various commands from the README, there's
just one command to remember: `mix setup`. This also serves a good
starting point for developers to put their project-specific setup steps.

This is inspired by: https://github.com/github/scripts-to-rule-them-all.

I've used this pattern over the years on many projects, here are some OSS examples:

- https://github.com/hexpm/hexpm/blob/e52e883ec5360a674f604fed7b54d6c48c431687/mix.exs#L77
- https://github.com/hexpm/diff/blob/d86d1f2f61ffce9f2d69df5125781935487e3f19/mix.exs#L66
- https://github.com/elixir-lang/ex_doc/blob/v0.21.3/mix.exs#L40

Here's how this would look like:

    defp aliases() do
      [
        setup: ["deps.get", "ecto.setup", "cmd npm install --prefix assets"],
        "ecto.setup": ...,
        ...
      ]
    end

(Originally posted at https://groups.google.com/forum/#!topic/phoenix-core/s-Ws0gbzXIM.)

===

There's one caveat: the running commands are without a tty so there are
no progress bars, colors, etc which might be considered worse experience
than running these commands manually today. For me running just one
command by far outweight that downside.

This is a proof-of-concept, if you'd like to pursue this I'm happy to
finish this up including documenting and testing it!