### PR TITLE
Include install dependencies step in Release documentation

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -37,6 +37,9 @@ Then load dependencies to compile code and assets:
 $ mix deps.get --only prod
 $ MIX_ENV=prod mix compile
 
+# Install / update  JavaScript dependencies
+$ npm install --prefix ./assets
+
 # Compile assets
 $ npm run deploy --prefix ./assets
 $ mix phx.digest


### PR DESCRIPTION
<3 <3 Ya'll are awesome thank you for everything <3 <3

When walking through the process of building a release for the first time, we've
seen a few people copy these steps out and expect them to run.

On a new server they fail, as `npm install` is not listed.

This causes a "webpack not found" error, which can be confusing (especially to
those without experience with JavaScript and its build process).