### PR TITLE
Update phx_live template

### DIFF
--- a/installer/templates/phx_live/templates/layout/root.html.leex
+++ b/installer/templates/phx_live/templates/layout/root.html.leex
@@ -4,9 +4,10 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <%%= csrf_meta_tag() %>
     <%%= live_title_tag assigns[:page_title] || "<%= app_module %>", suffix: " · Phoenix Framework" %>
     <link rel="stylesheet" href="<%%= Routes.static_path(@conn, "/css/app.css") %>"/>
-    <%%= csrf_meta_tag() %>
+    <script defer type="text/javascript" src="<%%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
   <body>
     <header>
@@ -22,7 +23,6 @@
       </section>
     </header>
     <%%= @inner_content %>
-    <script type="text/javascript" src="<%%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </body>
 </html>
 


### PR DESCRIPTION
Update live template to reflect phx_web template changes in this commit:

https://github.com/phoenixframework/phoenix/commit/3948cf297d1072d9e6a5bae52a4a61687d8a6fbb

Also moved `csrf_meta_tag()` up to be adjacent to other meta tags.