### PR TITLE
Adds two options to the generated error_tag helper.

### DIFF
--- a/installer/templates/phx_web/views/error_helpers.ex
+++ b/installer/templates/phx_web/views/error_helpers.ex
@@ -7,11 +7,16 @@ defmodule <%= web_namespace %>.ErrorHelpers do
 
   @doc """
   Generates tag for inlined form input errors.
+
+  Options:
+  tag: Atom, the content_tag name. Default :span
+  class: String, An html class attribute. Default "help-block"
   """
-  def error_tag(form, field) do
+  def error_tag(form, field, options \\ []) do
+    tag = Keyword.get(options, :tag, :span)
+    klass = Keyword.get(options, :class, "help-block")
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
-      content_tag(:span, translate_error(error),
-        class: "help-block",
+      content_tag(tag, translate_error(error), class: klass, 
         data: [phx_error_for: input_id(form, field)]
       )
     end)


### PR DESCRIPTION
The options add a way to specify the content_tag's name and class.

example. 
`<%= error_tag f, :some_field, class: "text-red-400 error", tag: :div %>`