### PR TITLE
Handle 'Accept: ' header with missing value as '*/*'

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1272,6 +1272,12 @@ defmodule Phoenix.Controller do
     end
   end
 
+  # If the accept header is empty, we treat it as */* and
+  # we use the first format specified in the accepts list.
+  defp parse_header_accept(conn, [], [], [first|_]) do
+    put_format(conn, first)
+  end
+
   defp parse_header_accept(conn, [], acc, accepted) do
     acc
     |> Enum.sort()

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -355,6 +355,16 @@ defmodule Phoenix.Controller.ControllerTest do
       assert conn.params["_format"] == nil
     end
 
+    test "treats empty accept header as any" do
+      conn = accepts with_accept(""), ~w(html)
+      assert get_format(conn) == "html"
+      assert conn.params["_format"] == nil
+
+      conn = accepts with_accept(" "), ~w(json)
+      assert get_format(conn) == "json"
+      assert conn.params["_format"] == nil
+    end
+
     test "ignores invalid media types" do
       conn = accepts with_accept("foo/bar, bar baz, application/json"), ~w(html json)
       assert get_format(conn) == "json"


### PR DESCRIPTION
Requests to phoenix which contain an accept header with an empty value (eg: `Accept: `) cause `Phoenix.NotAcceptableError` to be raised. There seems to be no way to handle this through changes to the `config :mime, :types` setting.

This change allows such headers to be handled as "any" (`*/*`).