### PR TITLE
Add link to live_dashboard in root layout

### DIFF
--- a/installer/templates/phx_live/templates/layout/root.html.leex
+++ b/installer/templates/phx_live/templates/layout/root.html.leex
@@ -13,7 +13,8 @@
       <section class="container">
         <nav role="navigation">
           <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
+            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if live and dashboard do %>
+            <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li><% end %>
           </ul>
         </nav>
         <a href="https://phoenixframework.org/" class="phx-logo">

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -341,6 +341,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/lib/phx_blog_web/templates/layout/root.html.leex", fn file ->
         assert file =~ ~s|<%= live_title_tag assigns[:page_title]|
+        assert file =~ ~s|<%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home)|
       end
 
       assert_file "phx_blog/lib/phx_blog_web/live/page_live.html.leex", fn file ->
@@ -377,6 +378,19 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~ ~s[live "/", PageLive]
         refute file =~ ~s[plug :fetch_flash]
         refute file =~ ~s[PageController]
+      end
+    end
+  end
+
+  test "new with live without dashboard" do
+    in_tmp "new with live without dashboard", fn ->
+      Mix.Tasks.Phx.New.run([@app_name, "--live", "--no-dashboard"])
+
+      assert_file "phx_blog/mix.exs", &refute(&1 =~ ~r":phoenix_live_dashboard")
+
+      # No Dashboard
+      assert_file "phx_blog/lib/phx_blog_web/templates/layout/root.html.leex", fn file ->
+        refute file =~ ~s|<%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home)|
       end
     end
   end


### PR DESCRIPTION
Nothing fancy: <img width="111" alt="Screen Shot 2020-03-27 at 1 18 58 PM" src="https://user-images.githubusercontent.com/168677/77798544-54b34f80-7030-11ea-93ce-6396db6dc64d.png">

// @chrismccord 
