### PR TITLE
Fix devMode in webpack.config.js

### DIFF
--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -4,49 +4,52 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const devMode = process.env.NODE_ENV !== 'production'
 
-module.exports = (env, options) => ({
-  optimization: {
-    minimizer: [
-      new TerserPlugin({ cache: true, parallel: true, sourceMap: devMode }),
-      new OptimizeCSSAssetsPlugin({})
-    ]
-  },
-  entry: {
-    'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
-  },
-  output: {
-    filename: '[name].js',
-    path: path.resolve(__dirname, '../priv/static/js'),
-    publicPath: '/js/'
-  },
-  devtool: devMode ? 'source-map' : undefined,
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader'
-        }
-      },
-      {
-        test: /\.css$/,
-        use: [
-          MiniCssExtractPlugin.loader,
-          {
-            loader: 'css-loader',
-            options: {
-              sourceMap: devMode
-            }
+module.exports = (env, options) => {
+  const devMode = options.mode !== 'production';
+
+  return {
+    optimization: {
+      minimizer: [
+        new TerserPlugin({ cache: true, parallel: true, sourceMap: devMode }),
+        new OptimizeCSSAssetsPlugin({})
+      ]
+    },
+    entry: {
+      'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
+    },
+    output: {
+      filename: '[name].js',
+      path: path.resolve(__dirname, '../priv/static/js'),
+      publicPath: '/js/'
+    },
+    devtool: devMode ? 'source-map' : undefined,
+    module: {
+      rules: [
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          use: {
+            loader: 'babel-loader'
           }
-        ]
-      }
+        },
+        {
+          test: /\.css$/,
+          use: [
+            MiniCssExtractPlugin.loader,
+            {
+              loader: 'css-loader',
+              options: {
+                sourceMap: devMode
+              }
+            }
+          ]
+        }
+      ]
+    },
+    plugins: [
+      new MiniCssExtractPlugin({ filename: '../css/app.css' }),
+      new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
     ]
-  },
-  plugins: [
-    new MiniCssExtractPlugin({ filename: '../css/app.css' }),
-    new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
-  ]
-});
+  }
+};


### PR DESCRIPTION
When using `webpack --mode production`, webpack does not set `NODE_ENV` within the build script itself [(see docs)](https://webpack.js.org/guides/production/#specify-the-mode). The result is that `devMode` will always be true in the current `webpack.config.js`, even when running the `deploy` script.

This PR checks the `options.mode` property to set `devMode`. A common alternative is to set `"deploy": "env NODE_ENV=production webpack --mode production"` in `package.json`, but I think this method is cleaner and removes cross-platform concerns about how to set environment variables.