### PR TITLE
Update doc for `get_flash/2`

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1414,7 +1414,7 @@ defmodule Phoenix.Controller do
   end
 
   @doc """
-  Returns a message from flash by `key`.
+  Returns a message from flash by `key` (or `nil` if no message is available for `key`).
 
   ## Examples
 


### PR DESCRIPTION
Specify that `nil` is returned if there is no message for `key`