### PR TITLE
 Add set_allow_snapshot_isolation: :on to config/test.exs for MSSQL

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -221,7 +221,14 @@ defmodule Phx.New.Generator do
   end
 
   defp get_ecto_adapter("mssql", app, module) do
-    {:tds, Ecto.Adapters.Tds, db_config(app, module, "sa", "some!Password")}
+    config =
+      app
+      |> db_config(module, "sa", "some!Password")
+      |> Keyword.update!(:test, fn test_settings ->
+        test_settings ++ [set_allow_snapshot_isolation: :on]
+      end)
+
+    {:tds, Ecto.Adapters.Tds, config}
   end
   defp get_ecto_adapter("mysql", app, module) do
     {:myxql, Ecto.Adapters.MyXQL, db_config(app, module, "root", "")}

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -487,7 +487,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "custom_path/mix.exs", ":tds"
       assert_file "custom_path/config/dev.exs", [~r/username: "sa"/, ~r/password: "some!Password"/]
-      assert_file "custom_path/config/test.exs", [~r/username: "sa"/, ~r/password: "some!Password"/]
+      assert_file "custom_path/config/test.exs", [~r/username: "sa"/, ~r/password: "some!Password"/, ~r/set_allow_snapshot_isolation: :on/]
       assert_file "custom_path/config/prod.secret.exs", [~r/url: database_url/]
       assert_file "custom_path/lib/custom_path/repo.ex", "Ecto.Adapters.Tds"
 


### PR DESCRIPTION
This automatically adds the `set_allow_snapshot_isolation: :on` setting to new phoenix apps using MSSQL databases. This setting makes MSSQL compatible with Ecto's SQL sandbox and allows the
user to run their database-backed tests concurrently.