### PR TITLE
Fixing spelling error

### DIFF
--- a/installer/templates/phx_test/live/page_live_test.exs
+++ b/installer/templates/phx_test/live/page_live_test.exs
@@ -4,8 +4,8 @@ defmodule <%= web_namespace %>.PageLiveTest do
   import Phoenix.LiveViewTest
 
   test "disconnected and connected render", %{conn: conn} do
-    {:ok, page_live, disconneted_html} = live(conn, "/")
-    assert disconneted_html =~ "Welcome to Phoenix!"
+    {:ok, page_live, disconnected_html} = live(conn, "/")
+    assert disconnected_html =~ "Welcome to Phoenix!"
     assert render(page_live) =~ "Welcome to Phoenix!"
   end
 end


### PR DESCRIPTION
This fixes a spelling error in the generated page_live_test.exs