### PR TITLE
Fix typo in Live index template

### DIFF
--- a/priv/templates/phx.gen.live/index.html.leex
+++ b/priv/templates/phx.gen.live/index.html.leex
@@ -19,7 +19,7 @@
   </thead>
   <tbody id="<%= schema.plural %>">
     <%%= for <%= schema.singular %> <- @<%= schema.plural %> do %>
-      <tr id="<%= schema.singular %>-<%%= post.id %>">
+      <tr id="<%= schema.singular %>-<%%= <%= schema.singular %>.id %>">
 <%= for {k, _} <- schema.attrs do %>        <td><%%= <%= schema.singular %>.<%= k %> %></td>
 <% end %>
         <td>


### PR DESCRIPTION
This change fixes a typo error in the template generated by LiveView.

I found the issue while testing the new `phx.gen.live` generator.