### PR TITLE
Fix dashboard installer, closes #3740, closes #3751

### DIFF
--- a/installer/templates/phx_live/templates/layout/root.html.leex
+++ b/installer/templates/phx_live/templates/layout/root.html.leex
@@ -13,7 +13,7 @@
       <section class="container">
         <nav role="navigation">
           <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if live and dashboard do %>
+            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if dashboard do %>
             <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li><% end %>
           </ul>
         </nav>

--- a/installer/templates/phx_live/templates/layout/root.html.leex
+++ b/installer/templates/phx_live/templates/layout/root.html.leex
@@ -13,8 +13,8 @@
       <section class="container">
         <nav role="navigation">
           <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if dashboard do %>
-            <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li><% end %>
+            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if dashboard do %><%%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
+            <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li><%% end %><% end %>
           </ul>
         </nav>
         <a href="https://phoenixframework.org/" class="phx-logo">

--- a/installer/templates/phx_live/templates/layout/root.html.leex
+++ b/installer/templates/phx_live/templates/layout/root.html.leex
@@ -13,8 +13,10 @@
       <section class="container">
         <nav role="navigation">
           <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if dashboard do %><%%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
-            <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li><%% end %><% end %>
+            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
+            <%= if dashboard do %><%%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
+              <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li>
+            <%% end %><% end %>
           </ul>
         </nav>
         <a href="https://phoenixframework.org/" class="phx-logo">

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -42,10 +42,10 @@ defmodule <%= app_module %>.MixProject do
       {:ecto_sql, "~> 3.4"},
       {<%= inspect adapter_app %>, ">= 0.0.0"},<% end %><%= if html do %><%= if live do %>
       {:phoenix_live_view, "~> 0.11.0"},
-      {:floki, ">= 0.0.0", only: :test},<% end %><%= if dashboard do %>
-      {:phoenix_live_dashboard, github: "phoenixframework/phoenix_live_dashboard"},<% end %>
+      {:floki, ">= 0.0.0", only: :test},<% end %>
       {:phoenix_html, "~> 2.11"},
-      {:phoenix_live_reload, "~> 1.2", only: :dev},<% end %>
+      {:phoenix_live_reload, "~> 1.2", only: :dev},<% end %><%= if dashboard do %>
+      {:phoenix_live_dashboard, github: "phoenixframework/phoenix_live_dashboard"},<% end %>
       {:telemetry_metrics, "~> 0.4"},
       {:telemetry_poller, "~> 0.4"},<%= if gettext do %>
       {:gettext, "~> 0.11"},<% end %>

--- a/installer/templates/phx_web/router.ex
+++ b/installer/templates/phx_web/router.ex
@@ -37,7 +37,7 @@ defmodule <%= web_namespace %>.Router do
   # If your application does not have an admins-only section yet,
   # you can use Plug.BasicAuth to set up some basic authentication
   # as long as you are also using SSL (which you should anyway).
-  if Mix.env() == :dev do
+  if Mix.env() in [:dev, :test] do
     import Phoenix.LiveDashboard.Router
 
     scope "/" do<%= if html do %>

--- a/installer/templates/phx_web/router.ex
+++ b/installer/templates/phx_web/router.ex
@@ -37,14 +37,12 @@ defmodule <%= web_namespace %>.Router do
   # If your application does not have an admins-only section yet,
   # you can use Plug.BasicAuth to set up some basic authentication
   # as long as you are also using SSL (which you should anyway).
-  if Mix.env() in [:dev, :test] do
-    import Phoenix.LiveDashboard.Router<%= unless html && live do %>
-
-    defdelegate fetch_live_flash(conn, opts), to: Phoenix.LiveView.Router<% end %>
+  if Mix.env() == :dev do
+    import Phoenix.LiveDashboard.Router
 
     scope "/" do<%= if html do %>
       pipe_through :browser<% else %>
-      pipe_through [:fetch_session, :fetch_live_flash, :protect_from_forgery]<% end %>
+      pipe_through [:fetch_session, :protect_from_forgery]<% end %>
       live_dashboard "/dashboard", metrics: <%= web_namespace %>.Telemetry
     end
   end<% end %>

--- a/installer/templates/phx_web/router.ex
+++ b/installer/templates/phx_web/router.ex
@@ -19,23 +19,7 @@ defmodule <%= web_namespace %>.Router do
     pipe_through :browser
 
     <%= if live do %>live "/", PageLive, :index<% else %>get "/", PageController, :index<% end %>
-  end<%= if dashboard do %>
-
-  # Enables LiveDashboard only for development
-  #
-  # If you want to use the LiveDashboard in production, you should put
-  # it behind authentication and allow only admins to access it.
-  # If your application does not have an admins-only section yet,
-  # you can use Plug.BasicAuth to set up some basic authentication
-  # as long as you are also using SSL (which you should anyway).
-  if Mix.env() == :dev do
-    import Phoenix.LiveDashboard.Router
-
-    scope "/" do
-      pipe_through :browser
-      live_dashboard "/dashboard", metrics: <%= web_namespace %>.Telemetry
-    end
-  end<% end %>
+  end
 
   # Other scopes may use custom stacks.
   # scope "/api", <%= web_namespace %> do
@@ -44,5 +28,24 @@ defmodule <%= web_namespace %>.Router do
 
   scope "/api", <%= web_namespace %> do
     pipe_through :api
+  end<% end %><%= if dashboard do %>
+
+  # Enables LiveDashboard only for development
+  #
+  # If you want to use the LiveDashboard in production, you should put
+  # it behind authentication and allow only admins to access it.
+  # If your application does not have an admins-only section yet,
+  # you can use Plug.BasicAuth to set up some basic authentication
+  # as long as you are also using SSL (which you should anyway).
+  if Mix.env() in [:dev, :test] do
+    import Phoenix.LiveDashboard.Router<%= unless html && live do %>
+
+    defdelegate fetch_live_flash(conn, opts), to: Phoenix.LiveView.Router<% end %>
+
+    scope "/" do<%= if html do %>
+      pipe_through :browser<% else %>
+      pipe_through [:fetch_session, :fetch_live_flash, :protect_from_forgery]<% end %>
+      live_dashboard "/dashboard", metrics: <%= web_namespace %>.Telemetry
+    end
   end<% end %>
 end

--- a/installer/templates/phx_web/templates/layout/app.html.eex
+++ b/installer/templates/phx_web/templates/layout/app.html.eex
@@ -14,8 +14,10 @@
       <section class="container">
         <nav role="navigation">
           <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if dashboard do %><%%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
-            <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li><%% end %><% end %>
+            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
+            <%= if dashboard do %><%%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
+              <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li>
+            <%% end %><% end %>
           </ul>
         </nav>
         <a href="https://phoenixframework.org/" class="phx-logo">

--- a/installer/templates/phx_web/templates/layout/app.html.eex
+++ b/installer/templates/phx_web/templates/layout/app.html.eex
@@ -14,7 +14,8 @@
       <section class="container">
         <nav role="navigation">
           <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
+            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if dashboard do %>
+            <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li><% end %>
           </ul>
         </nav>
         <a href="https://phoenixframework.org/" class="phx-logo">

--- a/installer/templates/phx_web/templates/layout/app.html.eex
+++ b/installer/templates/phx_web/templates/layout/app.html.eex
@@ -14,8 +14,8 @@
       <section class="container">
         <nav role="navigation">
           <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if dashboard do %>
-            <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li><% end %>
+            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li><%= if dashboard do %><%%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
+            <li><%%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li><%% end %><% end %>
           </ul>
         </nav>
         <a href="https://phoenixframework.org/" class="phx-logo">

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -305,6 +305,47 @@ defmodule Mix.Tasks.Phx.NewTest do
     end
   end
 
+  test "new with no_dashboard" do
+    in_tmp "new with no_dashboard", fn ->
+      Mix.Tasks.Phx.New.run([@app_name, "--no-dashboard"])
+
+      assert_file "phx_blog/mix.exs", &refute(&1 =~ ~r":phoenix_live_dashboard")
+
+      assert_file "phx_blog/lib/phx_blog_web/templates/layout/app.html.eex", fn file ->
+        refute file =~ ~s|<%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home)|
+      end
+
+      assert_file "phx_blog/lib/phx_blog_web/endpoint.ex", fn file ->
+        assert file =~ ~s|defmodule PhxBlogWeb.Endpoint|
+        refute file =~ ~s|socket "/live"|
+        refute file =~ ~s|plug Phoenix.LiveDashboard.RequestLogger|
+      end
+    end
+  end
+
+  test "new with no_html" do
+    in_tmp "new with no_html", fn ->
+      Mix.Tasks.Phx.New.run([@app_name, "--no-html"])
+
+      assert_file "phx_blog/mix.exs", fn file ->
+        refute file =~ ~s|:phoenix_live_view|
+        assert file =~ ~s|:phoenix_live_dashboard|
+      end
+
+      assert_file "phx_blog/lib/phx_blog_web/endpoint.ex", fn file ->
+        assert file =~ ~s|defmodule PhxBlogWeb.Endpoint|
+        assert file =~ ~s|socket "/live"|
+        assert file =~ ~s|plug Phoenix.LiveDashboard.RequestLogger|
+      end
+
+      assert_file "phx_blog/lib/phx_blog_web/router.ex", fn file ->
+        refute file =~ ~s|pipeline :browser|
+        assert file =~ ~s|defdelegate fetch_live_flash(conn, opts), to: Phoenix.LiveView.Router|
+        assert file =~ ~s|pipe_through [:fetch_session, :fetch_live_flash, :protect_from_forgery]|
+      end
+    end
+  end
+
   test "new with no_webpack" do
     in_tmp "new with no_webpack", fn ->
       Mix.Tasks.Phx.New.run([@app_name, "--no-webpack"])
@@ -382,15 +423,20 @@ defmodule Mix.Tasks.Phx.NewTest do
     end
   end
 
-  test "new with live without dashboard" do
-    in_tmp "new with live without dashboard", fn ->
+  test "new with live no_dashboard" do
+    in_tmp "new with live no_dashboard", fn ->
       Mix.Tasks.Phx.New.run([@app_name, "--live", "--no-dashboard"])
 
       assert_file "phx_blog/mix.exs", &refute(&1 =~ ~r":phoenix_live_dashboard")
 
-      # No Dashboard
       assert_file "phx_blog/lib/phx_blog_web/templates/layout/root.html.leex", fn file ->
         refute file =~ ~s|<%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home)|
+      end
+
+      assert_file "phx_blog/lib/phx_blog_web/endpoint.ex", fn file ->
+        assert file =~ ~s|defmodule PhxBlogWeb.Endpoint|
+        assert file =~ ~s|socket "/live"|
+        refute file =~ ~s|plug Phoenix.LiveDashboard.RequestLogger|
       end
     end
   end

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -340,8 +340,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/lib/phx_blog_web/router.ex", fn file ->
         refute file =~ ~s|pipeline :browser|
-        assert file =~ ~s|defdelegate fetch_live_flash(conn, opts), to: Phoenix.LiveView.Router|
-        assert file =~ ~s|pipe_through [:fetch_session, :fetch_live_flash, :protect_from_forgery]|
+        assert file =~ ~s|pipe_through [:fetch_session, :protect_from_forgery]|
       end
     end
   end


### PR DESCRIPTION
This corrects a number of issues introduced with the addition of :phoenix_live_dashboard.

- Adds `live_dashboard_path` to the `app.html.eex` dead view
- Conditions `live_dashboard` route on existence so the generated tests pass (#3740 // Thanks @aptinio! )
- Ensures the dashboard works even when `--no-html` is given (#3751 // Thanks @aaronrenner!)

When generated in a project without both html and live, we have to close the gap wrt the session. The router in such cases would look as follows:

```elixir
defmodule MyAppWeb.Router do
  use MyAppWeb, :router

  pipeline :api do
    plug :accepts, ["json"]
  end

  scope "/api", DevAppWeb do
    pipe_through :api
  end

  # Enables LiveDashboard only for development
  #
  # If you want to use the LiveDashboard in production, you should put
  # it behind authentication and allow only admins to access it.
  # If your application does not have an admins-only section yet,
  # you can use Plug.BasicAuth to set up some basic authentication
  # as long as you are also using SSL (which you should anyway).
  if Mix.env() in [:dev, :test] do
    import Phoenix.LiveDashboard.Router

    scope "/" do
      pipe_through [:fetch_session, :protect_from_forgery]
      live_dashboard "/dashboard", metrics: MyAppWeb.Telemetry
    end
  end
end
```