### PR TITLE
Remove live view signing salt in non-liveview project

### DIFF
--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -17,8 +17,8 @@ config :<%= app_name %>, <%= endpoint_module %>,
   url: [host: "localhost"],
   secret_key_base: "<%= secret_key_base %>",
   render_errors: [view: <%= web_namespace %>.ErrorView, accepts: ~w(<%= if html do %>html <% end %>json), layout: false],
-  pubsub_server: <%= app_module %>.PubSub,
-  live_view: [signing_salt: "<%= lv_signing_salt %>"]
+  pubsub_server: <%= app_module %>.PubSub<%= if live do %>,
+  live_view: [signing_salt: "<%= lv_signing_salt %>"] <% end %>
 
 # Configures Elixir's Logger
 config :logger, :console,


### PR DESCRIPTION
When running `mix phx.new project_name`, I get a  live_view signing salt config in `config.exs`, although it's not a live_view project. This PR conditionally adds this config only for live_view projects. 