### PR TITLE
Fix helper paths for phx.gen.live with --web

### DIFF
--- a/priv/templates/phx.gen.live/index.html.leex
+++ b/priv/templates/phx.gen.live/index.html.leex
@@ -6,7 +6,7 @@
     title: @page_title,
     action: @live_action,
     <%= schema.singular %>: @<%= schema.singular %>,
-    return_to: Routes.<%= schema.singular %>_index_path(@socket, :index) %>
+    return_to: Routes.<%= schema.route_helper %>_index_path(@socket, :index) %>
 <%% end %>
 
 <table>
@@ -23,8 +23,8 @@
 <%= for {k, _} <- schema.attrs do %>        <td><%%= <%= schema.singular %>.<%= k %> %></td>
 <% end %>
         <td>
-          <span><%%= live_redirect "Show", to: Routes.<%= schema.singular %>_show_path(@socket, :show, <%= schema.singular %>) %></span>
-          <span><%%= live_patch "Edit", to: Routes.<%= schema.singular %>_index_path(@socket, :edit, <%= schema.singular %>) %></span>
+          <span><%%= live_redirect "Show", to: Routes.<%= schema.route_helper %>_show_path(@socket, :show, <%= schema.singular %>) %></span>
+          <span><%%= live_patch "Edit", to: Routes.<%= schema.route_helper %>_index_path(@socket, :edit, <%= schema.singular %>) %></span>
           <span><%%= link "Delete", to: "#", phx_click: "delete", phx_value_id: <%= schema.singular %>.id, data: [confirm: "Are you sure?"] %></span>
         </td>
       </tr>
@@ -32,4 +32,4 @@
   </tbody>
 </table>
 
-<span><%%= live_patch "New <%= schema.human_singular %>", to: Routes.<%= schema.singular %>_index_path(@socket, :new) %></span>
+<span><%%= live_patch "New <%= schema.human_singular %>", to: Routes.<%= schema.route_helper %>_index_path(@socket, :new) %></span>

--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -27,18 +27,19 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       connected_html = render(index_live)
 
       assert disconnected_html =~ "Listing <%= schema.human_plural %>"
-      assert connected_html =~ "Listing <%= schema.human_plural %>"
+      assert connected_html =~ "Listing <%= schema.human_plural %>"<%= if schema.string_attr do %>
 
-      <%= if schema.string_attr do %>assert disconnected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
-      <%= if schema.string_attr do %>assert connected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
+      assert disconnected_html =~ <%= schema.singular %>.<%= schema.string_attr %>
+      assert connected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
     end
 
     test "renders new <%= schema.singular %> form", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       {:ok, index_live, disconnected_html} = live(conn, Routes.<%= schema.route_helper %>_index_path(conn, :new))
-      connected_html = render(index_live)
+      connected_html = render(index_live)<%= if schema.string_attr do %>
 
-      <%= if schema.string_attr do %>assert disconnected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
-      <%= if schema.string_attr do %>assert connected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
+      assert disconnected_html =~ <%= schema.singular %>.<%= schema.string_attr %>
+      assert connected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
+
       assert disconnected_html =~ "New <%= schema.human_singular %>"
       assert connected_html =~ "New <%= schema.human_singular %>"
     end
@@ -48,7 +49,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     setup [:create_<%= schema.singular %>]
 
     test "shows <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, show_live, disconnected_html} = live(conn, Routes.<%= schema.route_helper %>_show_path(conn, :show, <%= schema.singular %>))
+      {:ok, show_live, disconnected_html} =
+        live(conn, Routes.<%= schema.route_helper %>_show_path(conn, :show, <%= schema.singular %>))
+
       connected_html = render(show_live)
 
       assert disconnected_html =~ "Show <%= schema.human_singular %>"
@@ -56,22 +59,26 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
 
     test "renders edit <%= schema.singular %> form", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, show_live, disconnected_html} = live(conn, Routes.<%= schema.route_helper %>_show_path(conn, :edit, <%= schema.singular %>))
+      {:ok, show_live, disconnected_html} =
+        live(conn, Routes.<%= schema.route_helper %>_show_path(conn, :edit, <%= schema.singular %>))
+
       assert disconnected_html =~ "Edit <%= schema.human_singular %>"
-      assert render(show_live) =~ "Edit <%= schema.human_singular %>"
-      <%= if schema.string_attr do %>assert disconnected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
-      <%= if schema.string_attr do %>assert render(show_live) =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
+      assert render(show_live) =~ "Edit <%= schema.human_singular %>"<%= if schema.string_attr do %>
+      assert disconnected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %><%= if schema.string_attr do %>
+      assert render(show_live) =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
 
       assert render_submit([show_live, "form"], "save", %{"<%= schema.singular %>" => @invalid_attrs}) =~
-               "Edit <%= schema.human_singular %>"
+               "Edit <%= schema.human_singular %>"<%= if schema.string_attr do %>
 
-      <%= if schema.string_attr do %>assert {:error, {:redirect, path}} =
-               render_submit([show_live, "form"], "save", %{"<%= schema.singular %>" => @update_attrs})
+      redirected_path = Routes.<%= schema.route_helper %>_show_path(conn, :show, <%= schema.singular %>)
+      render_submit([show_live, "form"], "save", %{"<%= schema.singular %>" => @update_attrs})
+      assert_redirect(show_live, redirected_path)
 
-      {:ok, _show_live, disconnected_html} = live(conn, path)
+      {:ok, _show_live, disconnected_html} = live(conn, redirected_path)
       assert disconnected_html =~ "some updated <%= schema.string_attr %>"<% else %>
-      assert {:error, {:redirect, _path}} =
-               render_submit([show_live, "form"], "save", %{"<%= schema.singular %>" => @update_attrs})<% end %>
+
+      render_submit([show_live, "form"], "save", %{"<%= schema.singular %>" => @update_attrs})
+      assert_redirect(show_live, Routes.<%= schema.route_helper %>_show_path(conn, :show, <%= schema.singular %>))<% end %>
     end
   end
 end

--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -71,7 +71,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       {:ok, _show_live, disconnected_html} = live(conn, path)
       assert disconnected_html =~ "some updated <%= schema.string_attr %>"<% else %>
       assert {:error, {:redirect, _path}} =
-               render_submit([show_live, "form-#{<%= schema.singular %>.id}"], "save", %{"<%= schema.singular %>" => @update_attrs})<%end %>
+               render_submit([show_live, "form"], "save", %{"<%= schema.singular %>" => @update_attrs})<% end %>
     end
   end
 end

--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -34,7 +34,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
 
     test "renders new <%= schema.singular %> form", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, index_live, disconnected_html} = live(conn, Routes.<%= schema.singular %>_index_path(conn, :new))
+      {:ok, index_live, disconnected_html} = live(conn, Routes.<%= schema.route_helper %>_index_path(conn, :new))
       connected_html = render(index_live)
 
       <%= if schema.string_attr do %>assert disconnected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
@@ -48,7 +48,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     setup [:create_<%= schema.singular %>]
 
     test "shows <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, show_live, disconnected_html} = live(conn, Routes.<%= schema.singular %>_show_path(conn, :show, <%= schema.singular %>))
+      {:ok, show_live, disconnected_html} = live(conn, Routes.<%= schema.route_helper %>_show_path(conn, :show, <%= schema.singular %>))
       connected_html = render(show_live)
 
       assert disconnected_html =~ "Show <%= schema.human_singular %>"
@@ -56,7 +56,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
 
     test "renders edit <%= schema.singular %> form", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, show_live, disconnected_html} = live(conn, Routes.<%= schema.singular %>_show_path(conn, :edit, <%= schema.singular %>))
+      {:ok, show_live, disconnected_html} = live(conn, Routes.<%= schema.route_helper %>_show_path(conn, :edit, <%= schema.singular %>))
       assert disconnected_html =~ "Edit <%= schema.human_singular %>"
       assert render(show_live) =~ "Edit <%= schema.human_singular %>"
       <%= if schema.string_attr do %>assert disconnected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>

--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -62,16 +62,16 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       <%= if schema.string_attr do %>assert disconnected_html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
       <%= if schema.string_attr do %>assert render(show_live) =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
 
-      assert render_submit([show_live, "#form-#{<%= schema.singular %>.id}"], "save", %{"<%= schema.singular %>" => @invalid_attrs}) =~
+      assert render_submit([show_live, "form"], "save", %{"<%= schema.singular %>" => @invalid_attrs}) =~
                "Edit <%= schema.human_singular %>"
 
       <%= if schema.string_attr do %>assert {:error, {:redirect, path}} =
-               render_submit([show_live, "#form-#{<%= schema.singular %>.id}"], "save", %{"<%= schema.singular %>" => @update_attrs})
+               render_submit([show_live, "form"], "save", %{"<%= schema.singular %>" => @update_attrs})
 
       {:ok, _show_live, disconnected_html} = live(conn, path)
       assert disconnected_html =~ "some updated <%= schema.string_attr %>"<% else %>
       assert {:error, {:redirect, _path}} =
-               render_submit([show_live, "#form-#{<%= schema.singular %>.id}"], "save", %{"<%= schema.singular %>" => @update_attrs})<%end %>
+               render_submit([show_live, "form-#{<%= schema.singular %>.id}"], "save", %{"<%= schema.singular %>" => @update_attrs})<%end %>
     end
   end
 end

--- a/priv/templates/phx.gen.live/show.html.leex
+++ b/priv/templates/phx.gen.live/show.html.leex
@@ -6,7 +6,7 @@
     title: @page_title,
     action: @live_action,
     <%= schema.singular %>: @<%= schema.singular %>,
-    return_to: Routes.<%= schema.singular %>_show_path(@socket, :show, @<%= schema.singular %>) %>
+    return_to: Routes.<%= schema.route_helper %>_show_path(@socket, :show, @<%= schema.singular %>) %>
 <%% end %>
 
 <ul>
@@ -18,5 +18,5 @@
 <% end %>
 </ul>
 
-<span><%%= live_patch "Edit", to: Routes.<%= schema.singular %>_show_path(@socket, :edit, @<%= schema.singular %>), class: "button" %></span>
-<span><%%= live_redirect "Back", to: Routes.<%= schema.singular %>_index_path(@socket, :index) %></span>
+<span><%%= live_patch "Edit", to: Routes.<%= schema.route_helper %>_show_path(@socket, :edit, @<%= schema.singular %>), class: "button" %></span>
+<span><%%= live_redirect "Back", to: Routes.<%= schema.route_helper %>_index_path(@socket, :index) %></span>

--- a/test/mix/tasks/phx.gen.live_test.exs
+++ b/test/mix/tasks/phx.gen.live_test.exs
@@ -202,14 +202,26 @@ defmodule Mix.Tasks.Phx.Gen.LiveTest do
       end
 
       assert_file "lib/phoenix_web/live/blog/post_live/index.html.leex", fn file ->
-        assert file =~ " Routes.post_index_path(@socket, :index)"
+        assert file =~ " Routes.blog_post_index_path(@socket, :index)"
+        assert file =~ " Routes.blog_post_index_path(@socket, :edit, post)"
+        assert file =~ " Routes.blog_post_index_path(@socket, :new)"
+        assert file =~ " Routes.blog_post_show_path(@socket, :show, post)"
       end
 
       assert_file "lib/phoenix_web/live/blog/post_live/show.html.leex", fn file ->
-        assert file =~ " Routes.post_index_path(@socket, :index)"
+        assert file =~ " Routes.blog_post_index_path(@socket, :index)"
+        assert file =~ " Routes.blog_post_show_path(@socket, :show, @post)"
+        assert file =~ " Routes.blog_post_show_path(@socket, :edit, @post)"
       end
 
       assert_file "lib/phoenix_web/live/blog/post_live/form_component.html.leex"
+
+      assert_file "test/phoenix_web/live/blog/post_live_test.exs", fn file ->
+        assert file =~ " Routes.blog_post_index_path(conn, :index)"
+        assert file =~ " Routes.blog_post_index_path(conn, :new)"
+        assert file =~ " Routes.blog_post_show_path(conn, :show, post)"
+        assert file =~ " Routes.blog_post_show_path(conn, :edit, post)"
+      end
 
       assert_receive {:mix_shell, :info, ["""
 


### PR DESCRIPTION
- Ensure scoped routes via `--web` are generated properly.  (e.g. `user_path ==> admin_user_path`)
- Select the form component via the `"form"` tag (so it works with at-myself)
- Fix formatting (albeit there may still be some formatting to fix in the generated app, depending on the length of the path helper)

// @aaronrenner 