### PR TITLE
Add support to `anchor` param on router helpers

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -6,10 +6,10 @@ defmodule Phoenix.Router.Helpers do
   alias Plug.Conn
 
   @anno (if :erlang.system_info(:otp_release) >= '19' do
-    [generated: true, unquote: false]
-  else
-    [line: -1, unquote: false]
-  end)
+           [generated: true, unquote: false]
+         else
+           [line: -1, unquote: false]
+         end)
 
   @doc """
   Callback invoked by the url generated in each helper module.
@@ -36,8 +36,10 @@ defmodule Phoenix.Router.Helpers do
 
   def url(router, other) do
     raise ArgumentError,
-      "expected a %Plug.Conn{}, a %Phoenix.Socket{}, a %URI{}, a struct with an :endpoint key, " <>
-      "or a Phoenix.Endpoint when building url for #{inspect(router)}, got: #{inspect(other)}"
+          "expected a %Plug.Conn{}, a %Phoenix.Socket{}, a %URI{}, a struct with an :endpoint key, " <>
+            "or a Phoenix.Endpoint when building url for #{inspect(router)}, got: #{
+              inspect(other)
+            }"
   end
 
   @doc """
@@ -64,8 +66,10 @@ defmodule Phoenix.Router.Helpers do
 
   def path(router, other, _path) do
     raise ArgumentError,
-      "expected a %Plug.Conn{}, a %Phoenix.Socket{}, a %URI{}, a struct with an :endpoint key, " <>
-      "or a Phoenix.Endpoint when building path for #{inspect(router)}, got: #{inspect(other)}"
+          "expected a %Plug.Conn{}, a %Phoenix.Socket{}, a %URI{}, a struct with an :endpoint key, " <>
+            "or a Phoenix.Endpoint when building path for #{inspect(router)}, got: #{
+              inspect(other)
+            }"
   end
 
   ## Helpers
@@ -74,7 +78,9 @@ defmodule Phoenix.Router.Helpers do
     case Map.fetch(conn.private, router) do
       {:ok, {local_script, _}} ->
         path_with_script(path, local_script)
-      :error -> nil
+
+      :error ->
+        nil
     end
   end
 
@@ -84,16 +90,22 @@ defmodule Phoenix.Router.Helpers do
         case Map.fetch(forwards, router) do
           {:ok, local_script} ->
             path_with_script(path, script_name ++ local_script)
-          :error -> nil
+
+          :error ->
+            nil
         end
-      :error -> nil
+
+      :error ->
+        nil
     end
   end
+
   defp build_conn_forward_path(_conn, _router, _path), do: nil
 
   defp path_with_script(path, []) do
     path
   end
+
   defp path_with_script(path, script) do
     "/" <> Enum.join(script, "/") <> path
   end
@@ -119,68 +131,123 @@ defmodule Phoenix.Router.Helpers do
 
     catch_all = Enum.map(groups, &defhelper_catch_all/1)
 
-    defhelper = quote @anno do
-      defhelper = fn helper, vars, opts, bins, segs, trailing_slash? ->
-        def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars)) do
-          unquote(:"#{helper}_path")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars), [])
-        end
+    defhelper =
+      quote @anno do
+        defhelper = fn helper, vars, opts, bins, segs, trailing_slash? ->
+          def unquote(:"#{helper}_path")(
+                conn_or_endpoint,
+                unquote(Macro.escape(opts)),
+                unquote_splicing(vars)
+              ) do
+            unquote(:"#{helper}_path")(
+              conn_or_endpoint,
+              unquote(Macro.escape(opts)),
+              unquote_splicing(vars),
+              []
+            )
+          end
 
-        def unquote(:"#{helper}_path")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars), params)
-            when is_list(params) or is_map(params) do
-          path(conn_or_endpoint, segments(unquote(segs), params, unquote(bins), unquote(trailing_slash?),
-                {unquote(helper), unquote(Macro.escape(opts)), unquote(Enum.map(vars, &Macro.to_string/1))}))
-        end
+          def unquote(:"#{helper}_path")(
+                conn_or_endpoint,
+                unquote(Macro.escape(opts)),
+                unquote_splicing(vars),
+                params
+              )
+              when is_list(params) or is_map(params) do
+            path(
+              conn_or_endpoint,
+              segments(
+                unquote(segs),
+                params,
+                unquote(bins),
+                unquote(trailing_slash?),
+                {unquote(helper), unquote(Macro.escape(opts)),
+                 unquote(Enum.map(vars, &Macro.to_string/1))}
+              )
+            )
+          end
 
-        def unquote(:"#{helper}_url")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars)) do
-          unquote(:"#{helper}_url")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars), [])
-        end
+          def unquote(:"#{helper}_url")(
+                conn_or_endpoint,
+                unquote(Macro.escape(opts)),
+                unquote_splicing(vars)
+              ) do
+            unquote(:"#{helper}_url")(
+              conn_or_endpoint,
+              unquote(Macro.escape(opts)),
+              unquote_splicing(vars),
+              []
+            )
+          end
 
-        def unquote(:"#{helper}_url")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars), params)
-            when is_list(params) or is_map(params) do
-          url(conn_or_endpoint) <> unquote(:"#{helper}_path")(conn_or_endpoint, unquote(Macro.escape(opts)), unquote_splicing(vars), params)
+          def unquote(:"#{helper}_url")(
+                conn_or_endpoint,
+                unquote(Macro.escape(opts)),
+                unquote_splicing(vars),
+                params
+              )
+              when is_list(params) or is_map(params) do
+            url(conn_or_endpoint) <>
+              unquote(:"#{helper}_path")(
+                conn_or_endpoint,
+                unquote(Macro.escape(opts)),
+                unquote_splicing(vars),
+                params
+              )
+          end
         end
       end
-    end
 
-    defcatch_all = quote @anno do
-      defcatch_all = fn helper, lengths, routes ->
-	      for length <- lengths do
-	        binding = List.duplicate({:_, [], nil}, length)
-	        arity = length + 2
+    defcatch_all =
+      quote @anno do
+        defcatch_all = fn helper, lengths, routes ->
+          for length <- lengths do
+            binding = List.duplicate({:_, [], nil}, length)
+            arity = length + 2
 
-          def unquote(:"#{helper}_path")(conn_or_endpoint, action, unquote_splicing(binding)) do
-            path(conn_or_endpoint, "/")
-            raise_route_error(unquote(helper), :path, unquote(arity), action, [])
+            def unquote(:"#{helper}_path")(conn_or_endpoint, action, unquote_splicing(binding)) do
+              path(conn_or_endpoint, "/")
+              raise_route_error(unquote(helper), :path, unquote(arity), action, [])
+            end
+
+            def unquote(:"#{helper}_path")(
+                  conn_or_endpoint,
+                  action,
+                  unquote_splicing(binding),
+                  params
+                ) do
+              path(conn_or_endpoint, "/")
+              raise_route_error(unquote(helper), :path, unquote(arity + 1), action, params)
+            end
+
+            def unquote(:"#{helper}_url")(conn_or_endpoint, action, unquote_splicing(binding)) do
+              url(conn_or_endpoint)
+              raise_route_error(unquote(helper), :url, unquote(arity), action, [])
+            end
+
+            def unquote(:"#{helper}_url")(
+                  conn_or_endpoint,
+                  action,
+                  unquote_splicing(binding),
+                  params
+                ) do
+              url(conn_or_endpoint)
+              raise_route_error(unquote(helper), :url, unquote(arity + 1), action, params)
+            end
           end
 
-          def unquote(:"#{helper}_path")(conn_or_endpoint, action, unquote_splicing(binding), params) do
-            path(conn_or_endpoint, "/")
-            raise_route_error(unquote(helper), :path, unquote(arity + 1), action, params)
+          defp raise_route_error(unquote(helper), suffix, arity, action, params) do
+            Phoenix.Router.Helpers.raise_route_error(
+              __MODULE__,
+              "#{unquote(helper)}_#{suffix}",
+              arity,
+              action,
+              unquote(Macro.escape(routes)),
+              params
+            )
           end
-
-          def unquote(:"#{helper}_url")(conn_or_endpoint, action, unquote_splicing(binding)) do
-            url(conn_or_endpoint)
-            raise_route_error(unquote(helper), :url, unquote(arity), action, [])
-          end
-
-          def unquote(:"#{helper}_url")(conn_or_endpoint, action, unquote_splicing(binding), params) do
-            url(conn_or_endpoint)
-            raise_route_error(unquote(helper), :url, unquote(arity + 1), action, params)
-          end
-        end
-
-        defp raise_route_error(unquote(helper), suffix, arity, action, params) do
-          Phoenix.Router.Helpers.raise_route_error(
-            __MODULE__,
-            "#{unquote(helper)}_#{suffix}",
-            arity,
-            action,
-            unquote(Macro.escape(routes)),
-            params
-          )
         end
       end
-    end
 
     docs = Keyword.get(opts, :docs, true)
 
@@ -193,110 +260,123 @@ defmodule Phoenix.Router.Helpers do
     # * We inline most of the code for performance, so it is specific
     #   per helper module anyway.
     #
-    code = quote do
-      @moduledoc unquote(docs) && """
-      Module with named helpers generated from #{inspect unquote(env.module)}.
-      """
-      unquote(defhelper)
-      unquote(defcatch_all)
-      unquote_splicing(impls)
-      unquote_splicing(catch_all)
+    code =
+      quote do
+        @moduledoc unquote(docs) &&
+                     """
+                     Module with named helpers generated from #{inspect(unquote(env.module))}.
+                     """
+        unquote(defhelper)
+        unquote(defcatch_all)
+        unquote_splicing(impls)
+        unquote_splicing(catch_all)
 
-      @doc """
-      Generates the path information including any necessary prefix.
-      """
-      def path(data, path) do
-        Phoenix.Router.Helpers.path(unquote(env.module), data, path)
-      end
-
-      @doc """
-      Generates the connection/endpoint base URL without any path information.
-      """
-      def url(data) do
-        Phoenix.Router.Helpers.url(unquote(env.module), data)
-      end
-
-      @doc """
-      Generates path to a static asset given its file path.
-      """
-      def static_path(%Conn{private: private} = conn, path) do
-        private.phoenix_endpoint.static_path(path)
-      end
-
-      def static_path(%_{endpoint: endpoint} = conn, path) do
-        endpoint.static_path(path)
-      end
-
-      def static_path(endpoint, path) when is_atom(endpoint) do
-        endpoint.static_path(path)
-      end
-
-      @doc """
-      Generates url to a static asset given its file path.
-      """
-      def static_url(%Conn{private: private}, path) do
-        case private do
-          %{phoenix_static_url: %URI{} = uri} -> URI.to_string(uri) <> path
-          %{phoenix_static_url: url} when is_binary(url) -> url <> path
-          %{phoenix_endpoint: endpoint} -> static_url(endpoint, path)
+        @doc """
+        Generates the path information including any necessary prefix.
+        """
+        def path(data, path) do
+          Phoenix.Router.Helpers.path(unquote(env.module), data, path)
         end
-      end
 
-      def static_url(%_{endpoint: endpoint} = conn, path) do
-        static_url(endpoint, path)
-      end
-
-      def static_url(endpoint, path) when is_atom(endpoint) do
-        endpoint.static_url <> endpoint.static_path(path)
-      end
-
-      @doc """
-      Generates an integrity hash to a static asset given its file path.
-      """
-      def static_integrity(%Conn{private: %{phoenix_endpoint: endpoint}}, path) do
-        static_integrity(endpoint, path)
-      end
-
-      def static_integrity(%_{endpoint: endpoint}, path) do
-        static_integrity(endpoint, path)
-      end
-
-      def static_integrity(endpoint, path) when is_atom(endpoint) do
-        endpoint.static_integrity(path)
-      end
-
-      # Functions used by generated helpers
-      # Those are inlined here for performance
-
-      defp to_param(int) when is_integer(int), do: Integer.to_string(int)
-      defp to_param(bin) when is_binary(bin), do: bin
-      defp to_param(false), do: "false"
-      defp to_param(true), do: "true"
-      defp to_param(data), do: Phoenix.Param.to_param(data)
-
-      defp segments(segments, [], _reserved, trailing_slash?, _opts) do
-        maybe_append_slash(segments, trailing_slash?)
-      end
-
-      defp segments(segments, query, reserved, trailing_slash?, _opts) when is_list(query) or is_map(query) do
-        dict = for {k, v} <- query,
-               not ((k = to_string(k)) in reserved),
-               do: {k, v}
-
-
-        case Conn.Query.encode dict, &to_param/1 do
-          "" -> maybe_append_slash(segments, trailing_slash?)
-          o  -> maybe_append_slash(segments, trailing_slash?) <> "?" <> o
+        @doc """
+        Generates the connection/endpoint base URL without any path information.
+        """
+        def url(data) do
+          Phoenix.Router.Helpers.url(unquote(env.module), data)
         end
-      end
 
-      if unquote(trailing_slash?) do
-        defp maybe_append_slash("/", _), do: "/"
-        defp maybe_append_slash(path, true), do: path <> "/"
-      end
+        @doc """
+        Generates path to a static asset given its file path.
+        """
+        def static_path(%Conn{private: private} = conn, path) do
+          private.phoenix_endpoint.static_path(path)
+        end
 
-      defp maybe_append_slash(path, _), do: path
-    end
+        def static_path(%_{endpoint: endpoint} = conn, path) do
+          endpoint.static_path(path)
+        end
+
+        def static_path(endpoint, path) when is_atom(endpoint) do
+          endpoint.static_path(path)
+        end
+
+        @doc """
+        Generates url to a static asset given its file path.
+        """
+        def static_url(%Conn{private: private}, path) do
+          case private do
+            %{phoenix_static_url: %URI{} = uri} -> URI.to_string(uri) <> path
+            %{phoenix_static_url: url} when is_binary(url) -> url <> path
+            %{phoenix_endpoint: endpoint} -> static_url(endpoint, path)
+          end
+        end
+
+        def static_url(%_{endpoint: endpoint} = conn, path) do
+          static_url(endpoint, path)
+        end
+
+        def static_url(endpoint, path) when is_atom(endpoint) do
+          endpoint.static_url <> endpoint.static_path(path)
+        end
+
+        @doc """
+        Generates an integrity hash to a static asset given its file path.
+        """
+        def static_integrity(%Conn{private: %{phoenix_endpoint: endpoint}}, path) do
+          static_integrity(endpoint, path)
+        end
+
+        def static_integrity(%_{endpoint: endpoint}, path) do
+          static_integrity(endpoint, path)
+        end
+
+        def static_integrity(endpoint, path) when is_atom(endpoint) do
+          endpoint.static_integrity(path)
+        end
+
+        # Functions used by generated helpers
+        # Those are inlined here for performance
+
+        defp to_param(int) when is_integer(int), do: Integer.to_string(int)
+        defp to_param(bin) when is_binary(bin), do: bin
+        defp to_param(false), do: "false"
+        defp to_param(true), do: "true"
+        defp to_param(data), do: Phoenix.Param.to_param(data)
+
+        defp segments(segments, [], _reserved, trailing_slash?, _opts) do
+          maybe_append_slash(segments, trailing_slash?)
+        end
+
+        defp segments(segments, query, reserved, trailing_slash?, _opts)
+             when is_list(query) or is_map(query) do
+          dict =
+            for {k, v} <- query,
+                not ((k = to_string(k)) in ["anchor" | reserved]),
+                do: {k, v}
+
+          encoded_path =
+            case Conn.Query.encode(dict, &to_param/1) do
+              "" -> maybe_append_slash(segments, trailing_slash?)
+              o -> maybe_append_slash(segments, trailing_slash?) <> "?" <> o
+            end
+
+          maybe_append_anchor(encoded_path, maybe_anchor(query))
+        end
+
+        defp maybe_anchor(query) when is_list(query), do: Keyword.get(query, :anchor, nil)
+        defp maybe_anchor(query) when is_map(query), do: Map.get(query, :anchor, nil)
+
+        defp maybe_append_anchor(path, ""), do: path
+        defp maybe_append_anchor(path, nil), do: path
+        defp maybe_append_anchor(path, anchor), do: path <> "##{anchor}"
+
+        if unquote(trailing_slash?) do
+          defp maybe_append_slash("/", _), do: "/"
+          defp maybe_append_slash(path, true), do: path <> "/"
+        end
+
+        defp maybe_append_slash(path, _), do: path
+      end
 
     Module.create(Module.concat(env.module, Helpers), code, line: env.line, file: env.file)
   end
@@ -329,13 +409,15 @@ defmodule Phoenix.Router.Helpers do
   def defhelper_catch_all({helper, routes_and_exprs}) do
     routes =
       routes_and_exprs
-      |> Enum.map(fn {routes, exprs} -> {routes.plug_opts, Enum.map(exprs.binding, &elem(&1, 0))} end)
+      |> Enum.map(fn {routes, exprs} ->
+        {routes.plug_opts, Enum.map(exprs.binding, &elem(&1, 0))}
+      end)
       |> Enum.sort()
 
     lengths =
-	    routes
-	    |> Enum.map(fn {_, bindings} -> length(bindings) end)
-	    |> Enum.uniq()
+      routes
+      |> Enum.map(fn {_, bindings} -> length(bindings) end)
+      |> Enum.uniq()
 
     quote do
       defcatch_all.(
@@ -352,11 +434,11 @@ defmodule Phoenix.Router.Helpers do
   def raise_route_error(mod, fun, arity, action, routes, params) do
     cond do
       not Keyword.has_key?(routes, action) ->
-        "no action #{inspect action} for #{inspect mod}.#{fun}/#{arity}"
+        "no action #{inspect(action)} for #{inspect(mod)}.#{fun}/#{arity}"
         |> invalid_route_error(fun, routes)
 
       is_list(params) or is_map(params) ->
-        "no function clause for #{inspect mod}.#{fun}/#{arity} and action #{inspect action}"
+        "no function clause for #{inspect(mod)}.#{fun}/#{arity} and action #{inspect(action)}"
         |> invalid_route_error(fun, routes)
 
       true ->
@@ -371,7 +453,8 @@ defmodule Phoenix.Router.Helpers do
         "\n    #{fun}(conn_or_endpoint, #{bindings}, params \\\\ [])"
       end
 
-    raise ArgumentError, "#{prelude}. The following actions/clauses are supported:\n#{suggestions}"
+    raise ArgumentError,
+          "#{prelude}. The following actions/clauses are supported:\n#{suggestions}"
   end
 
   defp invalid_param_error(mod, fun, arity, action, routes) do
@@ -405,13 +488,25 @@ defmodule Phoenix.Router.Helpers do
   end
 
   defp expand_segments([{:|, _, [h, t]}], acc),
-    do: quote(do: unquote(expand_segments([h], acc)) <> "/" <> Enum.map_join(unquote(t), "/", fn(s) -> URI.encode(s, &URI.char_unreserved?/1) end))
+    do:
+      quote(
+        do:
+          unquote(expand_segments([h], acc)) <>
+            "/" <>
+            Enum.map_join(unquote(t), "/", fn s -> URI.encode(s, &URI.char_unreserved?/1) end)
+      )
 
-  defp expand_segments([h|t], acc) when is_binary(h),
+  defp expand_segments([h | t], acc) when is_binary(h),
     do: expand_segments(t, quote(do: unquote(acc) <> unquote("/" <> h)))
 
-  defp expand_segments([h|t], acc),
-    do: expand_segments(t, quote(do: unquote(acc) <> "/" <> URI.encode(to_param(unquote(h)), &URI.char_unreserved?/1)))
+  defp expand_segments([h | t], acc),
+    do:
+      expand_segments(
+        t,
+        quote(
+          do: unquote(acc) <> "/" <> URI.encode(to_param(unquote(h)), &URI.char_unreserved?/1)
+        )
+      )
 
   defp expand_segments([], acc),
     do: acc

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -114,17 +114,31 @@ defmodule Phoenix.Router.HelpersTest do
   test "url helper with query strings" do
     assert Helpers.post_path(__MODULE__, :show, 5, id: 3) == "/posts/5"
     assert Helpers.post_path(__MODULE__, :show, 5, foo: "bar") == "/posts/5?foo=bar"
+
+    assert Helpers.post_path(__MODULE__, :show, 5, foo: "bar", anchor: "foo-bar") ==
+             "/posts/5?foo=bar#foo-bar"
+
+    assert Helpers.post_url(__MODULE__, :show, 5, foo: "bar", anchor: "foo-bar") ==
+             "https://example.com/posts/5?foo=bar#foo-bar"
+
+    assert Helpers.post_path(__MODULE__, :show, 5, foo: "bar", anchor: "") == "/posts/5?foo=bar"
+
+    assert Helpers.post_url(__MODULE__, :show, 5, foo: "bar", anchor: "") ==
+             "https://example.com/posts/5?foo=bar"
+
     assert Helpers.post_path(__MODULE__, :show, 5, foo: :bar) == "/posts/5?foo=bar"
     assert Helpers.post_path(__MODULE__, :show, 5, foo: true) == "/posts/5?foo=true"
     assert Helpers.post_path(__MODULE__, :show, 5, foo: false) == "/posts/5?foo=false"
     assert Helpers.post_path(__MODULE__, :show, 5, foo: nil) == "/posts/5?foo="
 
     assert Helpers.post_path(__MODULE__, :show, 5, foo: ~w(bar baz)) ==
-           "/posts/5?foo[]=bar&foo[]=baz"
+             "/posts/5?foo[]=bar&foo[]=baz"
+
     assert Helpers.post_path(__MODULE__, :show, 5, foo: %{id: 5}) ==
-           "/posts/5?foo[id]=5"
+             "/posts/5?foo[id]=5"
+
     assert Helpers.post_path(__MODULE__, :show, 5, foo: %{__struct__: Foo, id: 5}) ==
-           "/posts/5?foo=5"
+             "/posts/5?foo=5"
   end
 
   test "url helper with param protocol" do
@@ -159,12 +173,16 @@ defmodule Phoenix.Router.HelpersTest do
 
     assert Helpers.post_path(__MODULE__, :file, ["foo", "bar/baz"]) == "/posts/file/foo/bar%2Fbaz"
     assert Helpers.post_path(__MODULE__, :file, ["foo", "bar"], []) == "/posts/file/foo/bar"
-    assert Helpers.post_path(__MODULE__, :file, ["foo", "bar baz"], []) == "/posts/file/foo/bar%20baz"
+
+    assert Helpers.post_path(__MODULE__, :file, ["foo", "bar baz"], []) ==
+             "/posts/file/foo/bar%20baz"
 
     assert Helpers.chat_path(__MODULE__, :show, ["chat"]) == "/chat"
     assert Helpers.chat_path(__MODULE__, :show, ["chat", "foo"]) == "/chat/foo"
     assert Helpers.chat_path(__MODULE__, :show, ["chat/foo"]) == "/chat%2Ffoo"
-    assert Helpers.chat_path(__MODULE__, :show, ["chat/foo", "bar/baz"]) == "/chat%2Ffoo/bar%2Fbaz"
+
+    assert Helpers.chat_path(__MODULE__, :show, ["chat/foo", "bar/baz"]) ==
+             "/chat%2Ffoo/bar%2Fbaz"
 
     assert Helpers.top_path(__MODULE__, :top) == "/posts/top"
     assert Helpers.top_path(__MODULE__, :top, id: 5) == "/posts/top?id=5"
@@ -174,12 +192,13 @@ defmodule Phoenix.Router.HelpersTest do
 
     error_message = fn helper, arity ->
       """
-      no action :skip for #{inspect Helpers}.#{helper}/#{arity}. The following actions/clauses are supported:
+      no action :skip for #{inspect(Helpers)}.#{helper}/#{arity}. The following actions/clauses are supported:
 
           #{helper}(conn_or_endpoint, :file, file, params \\\\ [])
           #{helper}(conn_or_endpoint, :show, id, params \\\\ [])
 
-      """ |> String.trim
+      """
+      |> String.trim()
     end
 
     assert_raise ArgumentError, error_message.("post_path", 3), fn ->
@@ -202,25 +221,31 @@ defmodule Phoenix.Router.HelpersTest do
       Helpers.post_url("oops", :skip, 5, foo: "bar", other: "param")
     end
 
-    assert_raise ArgumentError, ~r/when building path for Phoenix.Router.HelpersTest.Router/, fn ->
-      Helpers.post_path("oops", :skip, 5, foo: "bar", other: "param")
-    end
+    assert_raise ArgumentError,
+                 ~r/when building path for Phoenix.Router.HelpersTest.Router/,
+                 fn ->
+                   Helpers.post_path("oops", :skip, 5, foo: "bar", other: "param")
+                 end
   end
 
   test "top-level named routes with complex ids" do
     assert Helpers.post_path(__MODULE__, :show, "==d--+") ==
-      "/posts/%3D%3Dd--%2B"
+             "/posts/%3D%3Dd--%2B"
+
     assert Helpers.post_path(__MODULE__, :show, "==d--+", []) ==
-      "/posts/%3D%3Dd--%2B"
+             "/posts/%3D%3Dd--%2B"
+
     assert Helpers.top_path(__MODULE__, :top, id: "==d--+") ==
-      "/posts/top?id=%3D%3Dd--%2B"
+             "/posts/top?id=%3D%3Dd--%2B"
 
     assert Helpers.post_path(__MODULE__, :file, ["==d--+", ":O.jpg"]) ==
-      "/posts/file/%3D%3Dd--%2B/%3AO.jpg"
+             "/posts/file/%3D%3Dd--%2B/%3AO.jpg"
+
     assert Helpers.post_path(__MODULE__, :file, ["==d--+", ":O.jpg"], []) ==
-      "/posts/file/%3D%3Dd--%2B/%3AO.jpg"
+             "/posts/file/%3D%3Dd--%2B/%3AO.jpg"
+
     assert Helpers.post_path(__MODULE__, :file, ["==d--+", ":O.jpg"], xx: "/=+/") ==
-      "/posts/file/%3D%3Dd--%2B/%3AO.jpg?xx=%2F%3D%2B%2F"
+             "/posts/file/%3D%3Dd--%2B/%3AO.jpg?xx=%2F%3D%2B%2F"
   end
 
   test "top-level named routes with trailing slashes" do
@@ -252,8 +277,10 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.message_path(__MODULE__, :delete, "8=/=d", []) == "/admin/messages/8%3D%2F%3Dd"
     assert Helpers.message_path(__MODULE__, :delete, "8=/=d") == "/admin/messages/8%3D%2F%3Dd"
 
-    assert Helpers.user_path(__MODULE__, :show, "1a+/31d", [dog: "8d="]) == "/users/1a%2B%2F31d?dog=8d%3D"
-    assert Helpers.user_path(__MODULE__, :index, [cat: "=8+/&"]) == "/users?cat=%3D8%2B%2F%26"
+    assert Helpers.user_path(__MODULE__, :show, "1a+/31d", dog: "8d=") ==
+             "/users/1a%2B%2F31d?dog=8d%3D"
+
+    assert Helpers.user_path(__MODULE__, :index, cat: "=8+/&") == "/users?cat=%3D8%2B%2F%26"
   end
 
   test "resources generates named routes for :create, :update, :delete" do
@@ -285,55 +312,69 @@ defmodule Phoenix.Router.HelpersTest do
       Helpers.user_comment_file_path(__MODULE__, :skip, 123, 456, foo: "bar")
     end
 
-    assert_raise ArgumentError, ~r/no function clause for Phoenix.Router.HelpersTest.Router.Helpers.user_comment_path\/3 and action :show/, fn ->
-      Helpers.user_comment_path(__MODULE__, :show, 123)
-    end
+    assert_raise ArgumentError,
+                 ~r/no function clause for Phoenix.Router.HelpersTest.Router.Helpers.user_comment_path\/3 and action :show/,
+                 fn ->
+                   Helpers.user_comment_path(__MODULE__, :show, 123)
+                 end
   end
 
   test "multi-level nested resources generated named routes with complex ids" do
     assert Helpers.user_comment_path(__MODULE__, :index, "f4/d+~=", []) ==
-      "/users/f4%2Fd%2B~%3D/comments"
+             "/users/f4%2Fd%2B~%3D/comments"
+
     assert Helpers.user_comment_path(__MODULE__, :index, "f4/d+~=") ==
-      "/users/f4%2Fd%2B~%3D/comments"
+             "/users/f4%2Fd%2B~%3D/comments"
+
     assert Helpers.user_comment_path(__MODULE__, :edit, "f4/d+~=", "x-+=/", []) ==
-      "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F/edit"
+             "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F/edit"
+
     assert Helpers.user_comment_path(__MODULE__, :edit, "f4/d+~=", "x-+=/") ==
-      "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F/edit"
+             "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F/edit"
+
     assert Helpers.user_comment_path(__MODULE__, :show, "f4/d+~=", "x-+=/", []) ==
-      "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F"
+             "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F"
+
     assert Helpers.user_comment_path(__MODULE__, :show, "f4/d+~=", "x-+=/") ==
-      "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F"
+             "/users/f4%2Fd%2B~%3D/comments/x-%2B%3D%2F"
+
     assert Helpers.user_comment_path(__MODULE__, :new, "/==/", []) ==
-      "/users/%2F%3D%3D%2F/comments/new"
+             "/users/%2F%3D%3D%2F/comments/new"
+
     assert Helpers.user_comment_path(__MODULE__, :new, "/==/") ==
-      "/users/%2F%3D%3D%2F/comments/new"
+             "/users/%2F%3D%3D%2F/comments/new"
 
     assert Helpers.user_comment_file_path(__MODULE__, :show, "f4/d+~=", "/==/", "x-+=/", []) ==
-      "/users/f4%2Fd%2B~%3D/comments/%2F%3D%3D%2F/files/x-%2B%3D%2F"
+             "/users/f4%2Fd%2B~%3D/comments/%2F%3D%3D%2F/files/x-%2B%3D%2F"
+
     assert Helpers.user_comment_file_path(__MODULE__, :show, "f4/d+~=", "/==/", "x-+=/") ==
-      "/users/f4%2Fd%2B~%3D/comments/%2F%3D%3D%2F/files/x-%2B%3D%2F"
+             "/users/f4%2Fd%2B~%3D/comments/%2F%3D%3D%2F/files/x-%2B%3D%2F"
   end
 
   test "2-Level nested resources generates nested named routes for :index, :edit, :show, :new" do
     assert Helpers.user_comment_file_path(__MODULE__, :index, 99, 1, []) ==
-      "/users/99/comments/1/files"
+             "/users/99/comments/1/files"
+
     assert Helpers.user_comment_file_path(__MODULE__, :index, 99, 1) ==
-      "/users/99/comments/1/files"
+             "/users/99/comments/1/files"
 
     assert Helpers.user_comment_file_path(__MODULE__, :edit, 88, 1, 2, []) ==
-      "/users/88/comments/1/files/2/edit"
+             "/users/88/comments/1/files/2/edit"
+
     assert Helpers.user_comment_file_path(__MODULE__, :edit, 88, 1, 2) ==
-      "/users/88/comments/1/files/2/edit"
+             "/users/88/comments/1/files/2/edit"
 
     assert Helpers.user_comment_file_path(__MODULE__, :show, 123, 1, 2, []) ==
-      "/users/123/comments/1/files/2"
+             "/users/123/comments/1/files/2"
+
     assert Helpers.user_comment_file_path(__MODULE__, :show, 123, 1, 2) ==
-      "/users/123/comments/1/files/2"
+             "/users/123/comments/1/files/2"
 
     assert Helpers.user_comment_file_path(__MODULE__, :new, 88, 1, []) ==
-      "/users/88/comments/1/files/new"
+             "/users/88/comments/1/files/new"
+
     assert Helpers.user_comment_file_path(__MODULE__, :new, 88, 1) ==
-      "/users/88/comments/1/files/new"
+             "/users/88/comments/1/files/new"
   end
 
   test "resources without block generates named routes for :index, :edit, :show, :new" do
@@ -382,7 +423,10 @@ defmodule Phoenix.Router.HelpersTest do
   test "scoped route helpers generated unscoped :as options" do
     assert Helpers.my_admin_message_path(__MODULE__, :index, []) == "/admin/new/unscoped/messages"
     assert Helpers.my_admin_message_path(__MODULE__, :index) == "/admin/new/unscoped/messages"
-    assert Helpers.my_admin_message_path(__MODULE__, :show, 1, []) == "/admin/new/unscoped/messages/1"
+
+    assert Helpers.my_admin_message_path(__MODULE__, :show, 1, []) ==
+             "/admin/new/unscoped/messages/1"
+
     assert Helpers.my_admin_message_path(__MODULE__, :show, 1) == "/admin/new/unscoped/messages/1"
   end
 
@@ -397,7 +441,9 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.trail_path(__MODULE__, :open) == "/trails/open"
     assert Helpers.trail_path(__MODULE__, :open, id: 5) == "/trails/open?id=5"
     assert Helpers.trail_path(__MODULE__, :open, %{"id" => "foo"}) == "/trails/open?id=foo"
-    assert Helpers.trail_path(__MODULE__, :open, %{"id" => "foo bar"}) == "/trails/open?id=foo+bar"
+
+    assert Helpers.trail_path(__MODULE__, :open, %{"id" => "foo bar"}) ==
+             "/trails/open?id=foo+bar"
   end
 
   test "scoped route helpers generated with trailing slashes for resource" do
@@ -423,9 +469,13 @@ defmodule Phoenix.Router.HelpersTest do
   test "scoped route helpers generated within scoped routes with trailing slashes" do
     assert Helpers.trail_path(__MODULE__, :nested_path) == "/trails/nested/path/"
     assert Helpers.trail_path(__MODULE__, :nested_path, []) == "/trails/nested/path/"
-    assert Helpers.trail_path(__MODULE__, :nested_path, [id: 5]) == "/trails/nested/path/?id=5"
-    assert Helpers.trail_path(__MODULE__, :nested_path, %{"id" => "foo"}) == "/trails/nested/path/?id=foo"
-    assert Helpers.trail_path(__MODULE__, :nested_path, %{"id" => "foo bar"}) == "/trails/nested/path/?id=foo+bar"
+    assert Helpers.trail_path(__MODULE__, :nested_path, id: 5) == "/trails/nested/path/?id=5"
+
+    assert Helpers.trail_path(__MODULE__, :nested_path, %{"id" => "foo"}) ==
+             "/trails/nested/path/?id=foo"
+
+    assert Helpers.trail_path(__MODULE__, :nested_path, %{"id" => "foo bar"}) ==
+             "/trails/nested/path/?id=foo+bar"
   end
 
   test "can pass an {m, f, a} tuple as a plug argument" do
@@ -493,7 +543,7 @@ defmodule Phoenix.Router.HelpersTest do
 
   test "helpers properly encode named and query string params" do
     assert Router.Helpers.post_path(__MODULE__, :show, "my path", foo: "my param") ==
-      "/posts/my%20path?foo=my+param"
+             "/posts/my%20path?foo=my+param"
   end
 
   test "duplicate helpers with unique arities" do
@@ -502,9 +552,14 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.product_path(__MODULE__, :show, 123) == "/products/123"
     assert Helpers.product_path(__MODULE__, :show, 123, foo: "bar") == "/products/123?foo=bar"
     assert Helpers.product_path(__MODULE__, :show, 123, "asc") == "/products/123/asc"
-    assert Helpers.product_path(__MODULE__, :show, 123, "asc", foo: "bar") == "/products/123/asc?foo=bar"
+
+    assert Helpers.product_path(__MODULE__, :show, 123, "asc", foo: "bar") ==
+             "/products/123/asc?foo=bar"
+
     assert Helpers.product_path(__MODULE__, :show, 123, "asc", 1) == "/products/123/asc/1"
-    assert Helpers.product_path(__MODULE__, :show, 123, "asc", 1, foo: "bar") == "/products/123/asc/1?foo=bar"
+
+    assert Helpers.product_path(__MODULE__, :show, 123, "asc", 1, foo: "bar") ==
+             "/products/123/asc/1?foo=bar"
   end
 
   ## Script name
@@ -528,9 +583,11 @@ defmodule Phoenix.Router.HelpersTest do
   end
 
   def conn_with_script_name(script_name \\ ~w(api)) do
-    conn = conn(:get, "/")
-           |> put_private(:phoenix_endpoint, ScriptName)
-    put_in conn.script_name, script_name
+    conn =
+      conn(:get, "/")
+      |> put_private(:phoenix_endpoint, ScriptName)
+
+    put_in(conn.script_name, script_name)
   end
 
   defp uri_with_script_name do
@@ -548,28 +605,33 @@ defmodule Phoenix.Router.HelpersTest do
 
   test "urls use script name" do
     assert Helpers.page_url(ScriptName, :root) ==
-           "https://example.com/api/"
+             "https://example.com/api/"
+
     assert Helpers.page_url(conn_with_script_name(~w(foo)), :root) ==
-           "https://example.com/foo/"
+             "https://example.com/foo/"
+
     assert Helpers.page_url(uri_with_script_name(), :root) ==
-           "https://example.com:123/api/"
+             "https://example.com:123/api/"
 
     assert Helpers.post_url(ScriptName, :show, 5) ==
-           "https://example.com/api/posts/5"
+             "https://example.com/api/posts/5"
+
     assert Helpers.post_url(conn_with_script_name(), :show, 5) ==
-           "https://example.com/api/posts/5"
+             "https://example.com/api/posts/5"
+
     assert Helpers.post_url(conn_with_script_name(~w(foo)), :show, 5) ==
-           "https://example.com/foo/posts/5"
+             "https://example.com/foo/posts/5"
+
     assert Helpers.post_url(uri_with_script_name(), :show, 5) ==
-           "https://example.com:123/api/posts/5"
+             "https://example.com:123/api/posts/5"
   end
 
   test "static use endpoint script name only" do
     assert Helpers.static_path(conn_with_script_name(~w(foo)), "/images/foo.png") ==
-           "/api/images/foo.png"
+             "/api/images/foo.png"
 
     assert Helpers.static_url(conn_with_script_name(~w(foo)), "/images/foo.png") ==
-           "https://static.example.com/api/images/foo.png"
+             "https://static.example.com/api/images/foo.png"
   end
 
   ## Dynamics
@@ -579,8 +641,9 @@ defmodule Phoenix.Router.HelpersTest do
     conn = Phoenix.Controller.put_router_url(conn_with_endpoint(), url)
 
     assert Helpers.url(conn) == url
+
     assert Helpers.admin_message_url(conn, :show, 1) ==
-      url <> "/admin/new/messages/1"
+             url <> "/admin/new/messages/1"
   end
 
   test "phoenix_router_url with URI takes precedence over endpoint" do
@@ -588,8 +651,9 @@ defmodule Phoenix.Router.HelpersTest do
     conn = Phoenix.Controller.put_router_url(conn_with_endpoint(), uri)
 
     assert Helpers.url(conn) == "https://phoenixframework.org:123/path"
+
     assert Helpers.admin_message_url(conn, :show, 1) ==
-      "https://phoenixframework.org:123/path/admin/new/messages/1"
+             "https://phoenixframework.org:123/path/admin/new/messages/1"
   end
 
   test "phoenix_static_url with string takes precedence over endpoint" do
@@ -614,19 +678,27 @@ defmodule Phoenix.Router.HelpersTest do
     uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123}
 
     conn = Phoenix.Controller.put_static_url(conn_with_endpoint(), uri)
-    assert Helpers.static_url(conn, "/images/foo.png") == "https://phoenixframework.org:123/images/foo.png"
+
+    assert Helpers.static_url(conn, "/images/foo.png") ==
+             "https://phoenixframework.org:123/images/foo.png"
 
     conn = Phoenix.Controller.put_static_url(conn_with_script_name(), uri)
-    assert Helpers.static_url(conn, "/images/foo.png") == "https://phoenixframework.org:123/images/foo.png"
+
+    assert Helpers.static_url(conn, "/images/foo.png") ==
+             "https://phoenixframework.org:123/images/foo.png"
   end
 
   test "phoenix_static_url set to URI with path results in static url with that path" do
     uri = %URI{scheme: "https", host: "phoenixframework.org", port: 123, path: "/path"}
 
     conn = Phoenix.Controller.put_static_url(conn_with_endpoint(), uri)
-    assert Helpers.static_url(conn, "/images/foo.png") == "https://phoenixframework.org:123/path/images/foo.png"
+
+    assert Helpers.static_url(conn, "/images/foo.png") ==
+             "https://phoenixframework.org:123/path/images/foo.png"
 
     conn = Phoenix.Controller.put_static_url(conn_with_script_name(), uri)
-    assert Helpers.static_url(conn, "/images/foo.png") == "https://phoenixframework.org:123/path/images/foo.png"
+
+    assert Helpers.static_url(conn, "/images/foo.png") ==
+             "https://phoenixframework.org:123/path/images/foo.png"
   end
 end


### PR DESCRIPTION
## Objective
Add support to `anchor` param on router helpers.

### Details
Recently I had a specific use case for navigation based on hash anchor coming from the URL, I was trying to understand how could I do it by the current support from the URL helpers and I thought that could be useful add this support by default.

I have applied the format tool on those files and I am not sure if it would be appreciated, let me know if I should revert it. Due to it, the review might be a little hard, the proposal changes start on 
`segments` function at `lib/phoenix/router/helpers.ex:350` and are being tested on `url helper with query strings` spec beginning at `test/phoenix/router/helpers_test.exs:114`.