### PR TITLE
include `module` field in package.json

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -4,6 +4,7 @@
   "description": "The official JavaScript client for the Phoenix web framework.",
   "license": "MIT",
   "main": "./priv/static/phoenix.js",
+  "module": "./assets/js/phoenix.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/phoenixframework/phoenix.git"


### PR DESCRIPTION
makes it easy to just `import { Socket } from 'phoenix'` when using rollup.