### PR TITLE
Add link to Phoenix LiveDashboard in Logger's docs

### DIFF
--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -62,7 +62,6 @@ defmodule Phoenix.Logger do
   To see an example of how Phoenix LiveDashboard uses these events to create
   metrics, visit <https://hexdocs.pm/phoenix_live_dashboard/metrics.html>.
 
-
   ## Parameter filtering
 
   When logging parameters, Phoenix can filter out sensitive parameters

--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -59,6 +59,9 @@ defmodule Phoenix.Logger do
       * Metadata: `%{event: binary, params: term, socket: Phoenix.Socket.t}`
       * Disable logging: This event cannot be disabled
 
+  To see an example of how Phoenix LiveDashboard uses these events to create
+  metrics, visit <https://hexdocs.pm/phoenix_live_dashboard/metrics.html>.
+
 
   ## Parameter filtering
 


### PR DESCRIPTION
Without a deep understanding of how Telemetry events work, it wasn't straight forward on how to use these events to capture specific metrics about a request.

The Phoenix LiveDashboard metrics documentation pulls together everything into a complete example so it seemed like a natural source to cross link.