### PR TITLE
Fixes gettext links in guide documentation

### DIFF
--- a/guides/directory_structure.md
+++ b/guides/directory_structure.md
@@ -107,4 +107,4 @@ By looking at `templates` and `views` directories, we can see Phoenix provides f
 
 Besides the directories mentioned, `lib/hello_web` has three files at its root. `lib/hello_web/endpoint.ex` is the entry-point for HTTP requests. Once the browser accesses `http://localhost:4000`, the endpoint starts processing the data, eventually leading to the router, which is defined in `lib/hello_web/router.ex`. The router defines the rules to dispatch requests to "controllers", which then uses "views" and "templates" to render HTML pages back to clients. We explore these layers in length in other guides, starting with the "Request life-cycle" guide coming next.
 
-Finally, there is a `lib/hello_web/gettext.ex` file which provides internationalization through [Gettext](https://hexdocs.com/gettext/). If you are not worried about internationalization, you can safely skip this file and its contents.
+Finally, there is a `lib/hello_web/gettext.ex` file which provides internationalization through [Gettext](https://hexdocs.pm/gettext/Gettext.html). If you are not worried about internationalization, you can safely skip this file and its contents.

--- a/guides/plug.md
+++ b/guides/plug.md
@@ -118,7 +118,7 @@ To see the assign in action, go to the layout in "lib/hello_web/templates/layout
   <p>Locale: <%= @locale %></p>
 ```
 
-Go to "http://localhost:4000/" and you should see the locale exhibited. Visit "http://localhost:4000/?locale=fr" and you should see the assign changed to "fr". Someone can use this information alongside [Gettext](https://hexdocs.com/gettext/) to provide a fully internationalized web application.
+Go to "http://localhost:4000/" and you should see the locale exhibited. Visit "http://localhost:4000/?locale=fr" and you should see the assign changed to "fr". Someone can use this information alongside [Gettext](https://hexdocs.pm/gettext/Gettext) to provide a fully internationalized web application.
 
 That's all there is to Plug. Phoenix embraces the plug design of composable transformations all the way up and down the stack. Let's see some examples!
 


### PR DESCRIPTION
In the current 1.5.0-rc.0 [Directory structure guide](https://hexdocs.pm/phoenix/1.5.0-rc.0/directory_structure.html#content) and [Plug guide](https://hexdocs.pm/phoenix/1.5.0-rc.0/plug.html#content) the links to `Gettext` currently take you to `https://hexdocs.com/gettext/` which redirects to `http://ww25.hexdocs.com/gettext` which then resolves to `http://ww25.hexdocs.com/?z`.

This PR corrects the link to point to `https://hexdocs.pm/gettext/Gettext.html`