### PR TITLE
Fix broken link in Deploying with Heroku guide.

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -352,7 +352,7 @@ build:
 
 ### Setup releases and Dockerfile
 
-Now we need to define a `Dockerfile` at the root folder of your project that contains your application. We recommend to use releases when doing so, as the release will allow us to build a container with only the parts of Erlang and Elixir we actually use. Follow [the releases docs](/releases.html). At the end of the guide, there is a sample Dockerfile file you can use.
+Now we need to define a `Dockerfile` at the root folder of your project that contains your application. We recommend to use releases when doing so, as the release will allow us to build a container with only the parts of Erlang and Elixir we actually use. Follow [the releases docs](releases.html). At the end of the guide, there is a sample Dockerfile file you can use.
 
 Once you have the image definition setup, you can push your app to heroku and you can see it starts building the image and deploy it.
 


### PR DESCRIPTION
I noticed the link out to the releases documentation was broken on the Deploying with Heroku guide. I'm presuming it was meant to link to the Phoenix releases docs, which just means changing from an absolute to a relative link.

Hopefully this is ok to merge. If so, do you know how I would go about fixing this guide for old versions of the documentation? I'm presuming they run from a tag, but I obviously can't update the release tag. This link seems to have been introduced in v1.4.12 of the docs, so the following would need updating:

- v1.4.12
- v1.4.13
- v1.4.14
- v1.4.15
- v1.4.16
- v1.5.0-rc.0

I'm happy to do this, I'm just not sure about the process given they are for released versions and the docs live with the code.

Thanks!