### PR TITLE
Update default socket serializer to use V2

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -424,7 +424,7 @@ defmodule Phoenix.Socket do
       connect_info: connect_info
     } = map
 
-    vsn = params["vsn"] || "1.0.0"
+    vsn = params["vsn"] || "2.0.0"
 
     options = Keyword.merge(socket_options, options)
     start = System.monotonic_time()

--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -281,7 +281,7 @@ defmodule Phoenix.ChannelTest do
     map = %{
       endpoint: endpoint,
       transport: :channel_test,
-      options: [serializer: [{NoopSerializer, "~> 1.0.0"}]],
+      options: [serializer: [{NoopSerializer, ">= 1.0.0"}]],
       params: __stringify__(params),
       connect_info: connect_info
     }


### PR DESCRIPTION
Since v1.4, the [socket documentation states that `Phoenix.Socket.V2.JSONSerializer` is used by default](https://github.com/phoenixframework/phoenix/blob/v1.4/lib/phoenix/socket.ex#L89-L92).

However, that is not the case because when the `vsn` parameter is excluded, it gets set to `"1.0.0"` making the default `V1.JSONSerializer`.

This changes that to be `"2.0.0"` when `vsn` is not explicitly provided in the connect params in order to match documentation and use `V2.JSONSerializer` by default.