### PR TITLE
Fix version number before link to v1.5 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@
 
 ## v1.5
 
-The CHANGELOG for v1.4 releases can be found [in the v1.5 branch](https://github.com/phoenixframework/phoenix/blob/v1.5/CHANGELOG.md).
+The CHANGELOG for v1.5 releases can be found [in the v1.5 branch](https://github.com/phoenixframework/phoenix/blob/v1.5/CHANGELOG.md).


### PR DESCRIPTION
The text pointing to v1.5 release changelog references v1.4