### PR TITLE
Fix guides: plug code typo

### DIFF
--- a/guides/plug.md
+++ b/guides/plug.md
@@ -214,7 +214,7 @@ In particular, controller plugs provide a feature that allows us to execute plug
 defmodule HelloWeb.HelloController do
   use HelloWeb, :controller
 
-  plug HelloWeb.Plugs.Locale, "en" when action_name in [:index]
+  plug HelloWeb.Plugs.Locale, "en" when action in [:index]
 ```
 
 And the plug will only be executed for the `index` action.


### PR DESCRIPTION
`action_name` typo will result in:

```
CompileError
lib/hello_web/controllers/hello_controller.ex:4: cannot find or invoke local action_name/0 inside guard. Only macros can be invoked in a guard and they must be defined before their invocation. Called as: action_name()
```

Should be `action` as defined in https://hexdocs.pm/phoenix/Phoenix.Controller.html#module-guards