### PR TITLE
Fix type in Views guide page

### DIFF
--- a/guides/views.md
+++ b/guides/views.md
@@ -180,7 +180,7 @@ The view's job is not only to render HTML templates. Views are about data presen
 
 Phoenix uses [Jason](https://github.com/michalmuskala/jason) to encode JSON, so all we need to do in our views is format the data we'd like to respond with as a list or a map, and Phoenix will do the rest.
 
-While it is possible to respond with JSON back directly from the controller and skip the view, Phoenix Views provide a much more strucgtured approach for doing  so. Let's take our `PageController`, and see what it might look like when we respond with some static page maps as JSON, instead of HTML.
+While it is possible to respond with JSON back directly from the controller and skip the view, Phoenix Views provide a much more structured approach for doing  so. Let's take our `PageController`, and see what it might look like when we respond with some static page maps as JSON, instead of HTML.
 
 ```elixir
 defmodule HelloWeb.PageController do


### PR DESCRIPTION
A really simple PR fixing a typo in "structure" word in Views guide page.