### PR TITLE
bump suggested node_version due to npm bug

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -119,7 +119,7 @@ The Phoenix Static buildpack uses a predefined Node version but to avoid surpris
 
 ```
 # Node version
-node_version=10.19.0
+node_version=10.20.1
 ```
 
 Please refer to the [configuration section](https://github.com/gjaldon/heroku-buildpack-phoenix-static#configuration) for full details. You can make your own custom build script, but for now we will use the [default one provided](https://github.com/gjaldon/heroku-buildpack-phoenix-static/blob/master/compile).


### PR DESCRIPTION
node 10.19.0 was bitten by this bug "invalid bin entry" - failing on npm install (sic!) https://github.com/npm/cli/issues/613

see also https://elixirforum.com/t/cant-deploy-phoenix-app-to-heroku/31023

💙

does this need to be "backported" to 1.5 branch to appear on site?