### PR TITLE
Silence an "Already up" message during mix test

### DIFF
--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -65,7 +65,7 @@ defmodule <%= app_module %>.MixProject do
       setup: ["deps.get"<%= if ecto do %>, "ecto.setup"<% end %><%= if webpack do %>, "cmd npm install --prefix assets"<% end %>]<%= if ecto do %>,
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test"]<% end %>
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %>
     ]
   end
 end

--- a/installer/templates/phx_umbrella/apps/app_name/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/mix.exs
@@ -51,7 +51,7 @@ defmodule <%= app_module %>.MixProject do
       setup: ["deps.get"<%= if ecto do %>, "ecto.setup"<% end %>]<%= if ecto do %>,
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate", "test"]<% end %>
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %>
     ]
   end
 end

--- a/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
@@ -59,7 +59,7 @@ defmodule <%= web_namespace %>.MixProject do
   defp aliases do
     [
       setup: ["deps.get"<%= if webpack do %>, "cmd npm install --prefix assets"<% end %>]<%= if ecto do %>,
-      test: ["ecto.create --quiet", "ecto.migrate", "test"]<% end %>
+      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %>
     ]
   end
 end


### PR DESCRIPTION
...for new generated projects.

Example output before:

```sh
$ mix test
Compiling 21 files (.ex)
Generated example app

08:08:00.701 [info]  Already up
.......

Finished in 0.07 seconds
7 tests, 0 failures

Randomized with seed 806821
```

Output after:

```sh
$ mix test
Compiling 21 files (.ex)
Generated example app
.......

Finished in 0.07 seconds
7 tests, 0 failures

Randomized with seed 662040
```