### PR TITLE
allow custom error response from socket handler

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -820,14 +820,15 @@ defmodule Phoenix.Endpoint do
 
           subprotocols: ["sip", "mqtt"]
 
-    * `:error_handler` - custom error handler for connection errors,
-      MFA tuple called with a Plug.Conn and an error reason, returning a Plug.Conn
-
-      For example:
+    * `:error_handler` - custom error handler for connection errors.
+      If `c:Phoenix.Socket.connect/3` returns an `{:error, reason}` tuple,
+      the error handler will be called with the error reason. For WebSockets,
+      the error handler must be a MFA tuple that receives a `Plug.Conn`, the
+      error reason, and returns a `Plug.Conn` with a response. For example:
 
           error_handler: {MySocket, :handle_error, []}
 
-      And then in `MySocket`:
+      and a `{:error, :rate_limit}` return may be handled on `MySocket` as:
 
           def handle_error(conn, :rate_limit), do: Plug.Conn.send_resp(conn, 429, "Too many requests")
 

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -820,6 +820,9 @@ defmodule Phoenix.Endpoint do
 
           subprotocols: ["sip", "mqtt"]
 
+    * `:error_handler` - custom error handler for connection errors,
+      MFA tuple called with a Plug.Conn and an error reason, returning a Plug.Conn
+
   ## Longpoll configuration
 
   The following configuration applies only to `:longpoll`:

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -823,6 +823,14 @@ defmodule Phoenix.Endpoint do
     * `:error_handler` - custom error handler for connection errors,
       MFA tuple called with a Plug.Conn and an error reason, returning a Plug.Conn
 
+      For example:
+
+          error_handler: {MySocket, :handle_error, []}
+
+      And then in `MySocket`:
+
+          def handle_error(conn, :rate_limit), do: Plug.Conn.send_resp(conn, 429, "Too many requests")
+
   ## Longpoll configuration
 
   The following configuration applies only to `:longpoll`:

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -203,8 +203,8 @@ defmodule Phoenix.Socket do
   See `Phoenix.Token` documentation for examples in
   performing token verification on connect.
   """
-  @callback connect(params :: map, Socket.t) :: {:ok, Socket.t} | {:error, integer, [{binary, binary}], String.t} | :error
-  @callback connect(params :: map, Socket.t, connect_info :: map) :: {:ok, Socket.t} | {:error, integer, [{binary, binary}], String.t} | :error
+  @callback connect(params :: map, Socket.t) :: {:ok, Socket.t} | {:error, term}
+  @callback connect(params :: map, Socket.t, connect_info :: map) :: {:ok, Socket.t} | {:error, term}
 
   @doc ~S"""
   Identifies the socket connection.
@@ -450,12 +450,11 @@ defmodule Phoenix.Socket do
         result
 
       :error ->
-        :error
+        {:error, :undefined}
     end
   end
 
   defp result({:ok, _}), do: :ok
-  defp result(:error), do: :error
   defp result({:error, _}), do: :error
 
   def __init__({state, %{id: id, endpoint: endpoint} = socket}) do
@@ -587,20 +586,20 @@ defmodule Phoenix.Socket do
           invalid ->
             Logger.error "#{inspect handler}.id/1 returned invalid identifier " <>
                            "#{inspect invalid}. Expected nil or a string."
-            :error
+            {:error, :undefined}
         end
 
       {:error, _reason} = err ->
         err
 
       :error ->
-        :error
+        {:error, :undefined}
 
       invalid ->
         connect_arity = if function_exported?(handler, :connect, 3), do: "connect/3", else: "connect/2"
         Logger.error "#{inspect handler}. #{connect_arity} returned invalid value #{inspect invalid}. " <>
                      "Expected {:ok, socket} or :error"
-        :error
+        {:error, :undefined}
     end
   end
 

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -198,7 +198,10 @@ defmodule Phoenix.Socket do
 
       {:ok, assign(socket, :user_id, verified_user_id)}
 
-  To deny connection, return `:error`.
+  To deny connection, return `:error`. An empty 403 response will be
+  returned since browsers do not allow accessing the server response
+  due to security reasons. However, if you want to send a custom error response
+  to non-browser clients, return a {:error, status_code, headers, body} tuple.
 
   See `Phoenix.Token` documentation for examples in
   performing token verification on connect.

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -457,7 +457,7 @@ defmodule Phoenix.Socket do
 
   defp result({:ok, _}), do: :ok
   defp result(:error), do: :error
-  defp result({:error, _, _, _}), do: :error
+  defp result({:error, _}), do: :error
 
   def __init__({state, %{id: id, endpoint: endpoint} = socket}) do
     _ = id && endpoint.subscribe(id, link: true)
@@ -590,6 +590,9 @@ defmodule Phoenix.Socket do
                            "#{inspect invalid}. Expected nil or a string."
             :error
         end
+
+      {:error, _reason} = err ->
+        err
 
       :error ->
         :error

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -198,10 +198,8 @@ defmodule Phoenix.Socket do
 
       {:ok, assign(socket, :user_id, verified_user_id)}
 
-  To deny connection, return `:error`. An empty 403 response will be
-  returned since browsers do not allow accessing the server response
-  due to security reasons. However, if you want to send a custom error response
-  to non-browser clients, return a {:error, status_code, headers, body} tuple.
+  To deny connection, return `:error` or `{:error, reason}`.
+  TBD
 
   See `Phoenix.Token` documentation for examples in
   performing token verification on connect.
@@ -593,16 +591,13 @@ defmodule Phoenix.Socket do
             :error
         end
 
-      {:error, status_code, headers, body} = err when is_number(status_code) and is_list(headers) and is_binary(body) ->
-        err
-
       :error ->
         :error
 
       invalid ->
         connect_arity = if function_exported?(handler, :connect, 3), do: "connect/3", else: "connect/2"
         Logger.error "#{inspect handler}. #{connect_arity} returned invalid value #{inspect invalid}. " <>
-                     "Expected {:ok, socket}, {:error, status_code, headers, body} or :error"
+                     "Expected {:ok, socket} or :error"
         :error
     end
   end

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -203,8 +203,8 @@ defmodule Phoenix.Socket do
   See `Phoenix.Token` documentation for examples in
   performing token verification on connect.
   """
-  @callback connect(params :: map, Socket.t) :: {:ok, Socket.t} | {:error, term}
-  @callback connect(params :: map, Socket.t, connect_info :: map) :: {:ok, Socket.t} | {:error, term}
+  @callback connect(params :: map, Socket.t) :: {:ok, Socket.t} | {:error, term} | :error
+  @callback connect(params :: map, Socket.t, connect_info :: map) :: {:ok, Socket.t} | {:error, term} | :error
 
   @doc ~S"""
   Identifies the socket connection.

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -198,8 +198,7 @@ defmodule Phoenix.Socket do
 
       {:ok, assign(socket, :user_id, verified_user_id)}
 
-  To deny connection, return `:error` or `{:error, reason}`.
-  TBD
+  To deny connection, return `:error`.
 
   See `Phoenix.Token` documentation for examples in
   performing token verification on connect.

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -450,11 +450,12 @@ defmodule Phoenix.Socket do
         result
 
       :error ->
-        {:error, :undefined}
+        :error
     end
   end
 
   defp result({:ok, _}), do: :ok
+  defp result(:error), do: :error
   defp result({:error, _}), do: :error
 
   def __init__({state, %{id: id, endpoint: endpoint} = socket}) do
@@ -586,20 +587,20 @@ defmodule Phoenix.Socket do
           invalid ->
             Logger.error "#{inspect handler}.id/1 returned invalid identifier " <>
                            "#{inspect invalid}. Expected nil or a string."
-            {:error, :undefined}
+            :error
         end
+
+      :error ->
+        :error
 
       {:error, _reason} = err ->
         err
-
-      :error ->
-        {:error, :undefined}
 
       invalid ->
         connect_arity = if function_exported?(handler, :connect, 3), do: "connect/3", else: "connect/2"
         Logger.error "#{inspect handler}. #{connect_arity} returned invalid value #{inspect invalid}. " <>
                      "Expected {:ok, socket} or :error"
-        {:error, :undefined}
+        :error
     end
   end
 

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -599,7 +599,7 @@ defmodule Phoenix.Socket do
       invalid ->
         connect_arity = if function_exported?(handler, :connect, 3), do: "connect/3", else: "connect/2"
         Logger.error "#{inspect handler}. #{connect_arity} returned invalid value #{inspect invalid}. " <>
-                     "Expected {:ok, socket} or :error"
+                     "Expected {:ok, socket}, {:error, reason} or :error"
         :error
     end
   end

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -100,7 +100,7 @@ defmodule Phoenix.Transports.LongPoll do
       "phx:lp:"
       <> Base.encode64(:crypto.strong_rand_bytes(16))
       <> (System.system_time(:millisecond) |> Integer.to_string)
-      
+
     keys = Keyword.get(opts, :connect_info, [])
     connect_info = Transport.connect_info(conn, endpoint, keys)
     arg = {endpoint, handler, opts, conn.params, priv_topic, connect_info}

--- a/lib/phoenix/transports/long_poll_server.ex
+++ b/lib/phoenix/transports/long_poll_server.ex
@@ -38,6 +38,9 @@ defmodule Phoenix.Transports.LongPoll.Server do
 
       :error ->
         :ignore
+
+      {:error, _reason} ->
+        :ignore
     end
   end
 

--- a/lib/phoenix/transports/long_poll_server.ex
+++ b/lib/phoenix/transports/long_poll_server.ex
@@ -36,7 +36,7 @@ defmodule Phoenix.Transports.LongPoll.Server do
         schedule_inactive_shutdown(state.window_ms)
         {:ok, state}
 
-      {:error, :undefined} ->
+      :error ->
         :ignore
     end
   end

--- a/lib/phoenix/transports/long_poll_server.ex
+++ b/lib/phoenix/transports/long_poll_server.ex
@@ -36,8 +36,8 @@ defmodule Phoenix.Transports.LongPoll.Server do
         schedule_inactive_shutdown(state.window_ms)
         {:ok, state}
 
-    :error ->
-      :ignore
+      {:error, :undefined} ->
+        :ignore
     end
   end
 

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -2,16 +2,11 @@ defmodule Phoenix.Transports.WebSocket do
   @moduledoc false
   alias Phoenix.Socket.{V1, V2, Transport}
 
-  defmodule ErrorHandler do
-    def handle(conn, :wrong_method), do: Plug.Conn.send_resp(conn, 400, "")
-    def handle(conn, _reason), do: Plug.Conn.send_resp(conn, 403, "")
-  end
-
   def default_config() do
     [
       path: "/websocket",
       serializer: [{V1.JSONSerializer, "~> 1.0.0"}, {V2.JSONSerializer, "~> 2.0.0"}],
-      error_handler: {ErrorHandler, :handle, []},
+      error_handler: {__MODULE__, :handle_error, []},
       timeout: 60_000,
       transport_log: false,
       compress: false
@@ -48,4 +43,7 @@ defmodule Phoenix.Transports.WebSocket do
     {m, f, args} = opts[:error_handler]
     {:error, apply(m, f, [conn, :wrong_method | args])}
   end
+
+  def handle_error(conn, :wrong_method), do: Plug.Conn.send_resp(conn, 400, "")
+  def handle_error(conn, _reason), do: Plug.Conn.send_resp(conn, 403, "")
 end

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -32,6 +32,7 @@ defmodule Phoenix.Transports.WebSocket do
 
         case handler.connect(config) do
           {:ok, state} -> {:ok, conn, state}
+          :error -> {:error, Plug.Conn.send_resp(conn, 403, "")}
           {:error, reason} ->
             {m, f, args} = opts[:error_handler]
             {:error, apply(m, f, [conn, reason | args])}
@@ -39,11 +40,9 @@ defmodule Phoenix.Transports.WebSocket do
     end
   end
 
-  def connect(conn, _, _, opts) do
-    {m, f, args} = opts[:error_handler]
-    {:error, apply(m, f, [conn, :wrong_method | args])}
+  def connect(conn, _, _, _) do
+    {:error, Plug.Conn.send_resp(conn, 400, "")}
   end
 
-  def handle_error(conn, :wrong_method), do: Plug.Conn.send_resp(conn, 400, "")
   def handle_error(conn, _reason), do: Plug.Conn.send_resp(conn, 403, "")
 end

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -32,6 +32,7 @@ defmodule Phoenix.Transports.WebSocket do
         case handler.connect(config) do
           {:ok, state} -> {:ok, conn, state}
           :error -> {:error, Plug.Conn.send_resp(conn, 403, "")}
+          {:error, status, body} -> {:error, Plug.Conn.send_resp(conn, status, body)}
         end
     end
   end

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -31,13 +31,19 @@ defmodule Phoenix.Transports.WebSocket do
 
         case handler.connect(config) do
           {:ok, state} -> {:ok, conn, state}
-          :error -> {:error, Plug.Conn.send_resp(conn, 403, "")}
-          {:error, status, body} -> {:error, Plug.Conn.send_resp(conn, status, body)}
+          :error -> {:error, resp(conn, 403, [], "")}
+          {:error, status, headers, body} -> {:error, resp(conn, status, headers, body)}
         end
     end
   end
 
   def connect(conn, _, _, _) do
-    {:error, Plug.Conn.send_resp(conn, 400, "")}
+    {:error, resp(conn, 400, [], "")}
+  end
+
+  defp resp(conn, status, headers, body) do
+    headers
+    |> Enum.reduce(conn, fn ({k, v}, conn) -> Plug.Conn.put_req_header(conn, k, v) end)
+    |> Plug.Conn.send_resp(status, body)
   end
 end

--- a/test/phoenix/integration/long_poll_channels_test.exs
+++ b/test/phoenix/integration/long_poll_channels_test.exs
@@ -91,10 +91,6 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
       :error
     end
 
-    def connect(%{"ratelimit" => "true"}, _socket) do
-      {:error, 429, [{"x-ratelimit-limit", "10"}], %{"error" => "Too many requests"}}
-    end
-
     def connect(params, socket) do
       unless params["logging"] == "enabled", do: Logger.disable(self())
       {:ok, assign(socket, :user_id, params["user_id"])}
@@ -384,11 +380,6 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
     describe "with #{vsn} serializer #{inspect serializer}" do
       test "refuses connects that error with 403 response" do
         resp = poll :get, "/ws", @vsn, %{"reject" => "true"}, %{}
-        assert resp.body["status"] == 403
-      end
-
-      test "refuses connects that error with custom error response" do
-        resp = poll :get, "/ws", @vsn, %{"ratelimit" => "true"}, %{}
         assert resp.body["status"] == 403
       end
 

--- a/test/phoenix/integration/long_poll_channels_test.exs
+++ b/test/phoenix/integration/long_poll_channels_test.exs
@@ -88,7 +88,11 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
     channel "room:*", RoomChannel
 
     def connect(%{"reject" => "true"}, _socket) do
-      :error
+      :error_logger_tty_h
+    end
+
+    def connect(%{"custom_error" => "true"}, _socket) do
+      {:error, :custom}
     end
 
     def connect(params, socket) do
@@ -380,6 +384,9 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
     describe "with #{vsn} serializer #{inspect serializer}" do
       test "refuses connects that error with 403 response" do
         resp = poll :get, "/ws", @vsn, %{"reject" => "true"}, %{}
+        assert resp.body["status"] == 403
+
+        resp = poll :get, "/ws", @vsn, %{"custom_error" => "true"}, %{}
         assert resp.body["status"] == 403
       end
 

--- a/test/phoenix/integration/long_poll_channels_test.exs
+++ b/test/phoenix/integration/long_poll_channels_test.exs
@@ -88,7 +88,7 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
     channel "room:*", RoomChannel
 
     def connect(%{"reject" => "true"}, _socket) do
-      :error_logger_tty_h
+      :error
     end
 
     def connect(%{"custom_error" => "true"}, _socket) do

--- a/test/phoenix/integration/websocket_channels_test.exs
+++ b/test/phoenix/integration/websocket_channels_test.exs
@@ -146,9 +146,9 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
     end
   end
 
-  defmodule CustomConnectionErrorHandler do
-    def handle(conn, {:error, :rate_limit}), do: {:error, Plug.Conn.send_resp(conn, 429, "Too many requests")}
-    defdelegate handle(conn, error), to: Phoenix.Transports.WebSocket.ConnectionErrorHandler
+  defmodule CustomErrorHandler do
+    def handle(conn, :rate_limit), do: {:error, Plug.Conn.send_resp(conn, 429, "Too many requests")}
+    defdelegate handle(conn, error), to: Phoenix.Transports.WebSocket.ErrorHandler
   end
 
   defmodule Endpoint do
@@ -162,7 +162,7 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
       websocket: [
         check_origin: ["//example.com"],
         timeout: 200,
-        connection_error_handler: &CustomConnectionErrorHandler.handle/2
+        error_handler: {CustomErrorHandler, :handle, []}
       ]
 
     socket "/ws/admin", UserSocket,

--- a/test/phoenix/integration/websocket_channels_test.exs
+++ b/test/phoenix/integration/websocket_channels_test.exs
@@ -147,7 +147,7 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
   end
 
   defmodule CustomErrorHandler do
-    def handle(conn, :rate_limit), do: {:error, Plug.Conn.send_resp(conn, 429, "Too many requests")}
+    def handle(conn, :rate_limit), do: Plug.Conn.send_resp(conn, 429, "Too many requests")
     defdelegate handle(conn, error), to: Phoenix.Transports.WebSocket.ErrorHandler
   end
 

--- a/test/phoenix/integration/websocket_channels_test.exs
+++ b/test/phoenix/integration/websocket_channels_test.exs
@@ -144,11 +144,9 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
     def id(socket) do
       if id = socket.assigns.user_id, do: "user_sockets:#{id}"
     end
-  end
 
-  defmodule CustomErrorHandler do
-    def handle(conn, :rate_limit), do: Plug.Conn.send_resp(conn, 429, "Too many requests")
-    defdelegate handle(conn, error), to: Phoenix.Transports.WebSocket.ErrorHandler
+    def handle_error(conn, :rate_limit), do: Plug.Conn.send_resp(conn, 429, "Too many requests")
+    defdelegate handle_error(conn, error), to: Phoenix.Transports.WebSocket
   end
 
   defmodule Endpoint do
@@ -162,7 +160,7 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
       websocket: [
         check_origin: ["//example.com"],
         timeout: 200,
-        error_handler: {CustomErrorHandler, :handle, []}
+        error_handler: {UserSocket, :handle_error, []}
       ]
 
     socket "/ws/admin", UserSocket,

--- a/test/phoenix/integration/websocket_channels_test.exs
+++ b/test/phoenix/integration/websocket_channels_test.exs
@@ -146,7 +146,6 @@ defmodule Phoenix.Integration.WebSocketChannelsTest do
     end
 
     def handle_error(conn, :rate_limit), do: Plug.Conn.send_resp(conn, 429, "Too many requests")
-    defdelegate handle_error(conn, error), to: Phoenix.Transports.WebSocket
   end
 
   defmodule Endpoint do

--- a/test/phoenix/test/channel_test.exs
+++ b/test/phoenix/test/channel_test.exs
@@ -320,7 +320,7 @@ defmodule Phoenix.Test.ChannelTest do
   end
 
   test "connects and joins topics directly" do
-    {:error, :undefined} = connect(UserSocket, %{"reject" => true})
+    :error = connect(UserSocket, %{"reject" => true})
     {:ok, socket} = connect(UserSocket, %{})
     socket = subscribe_and_join!(socket, "foo:ok")
     push(socket, "broadcast", %{"foo" => "bar"})
@@ -349,7 +349,7 @@ defmodule Phoenix.Test.ChannelTest do
   end
 
   test "connects with atom parameter keys as strings" do
-    {:error, :undefined} = connect(UserSocket, %{reject: true})
+    :error = connect(UserSocket, %{reject: true})
   end
 
   ## handle_out

--- a/test/phoenix/test/channel_test.exs
+++ b/test/phoenix/test/channel_test.exs
@@ -320,7 +320,7 @@ defmodule Phoenix.Test.ChannelTest do
   end
 
   test "connects and joins topics directly" do
-    :error = connect(UserSocket, %{"reject" => true})
+    {:error, :undefined} = connect(UserSocket, %{"reject" => true})
     {:ok, socket} = connect(UserSocket, %{})
     socket = subscribe_and_join!(socket, "foo:ok")
     push(socket, "broadcast", %{"foo" => "bar"})
@@ -349,7 +349,7 @@ defmodule Phoenix.Test.ChannelTest do
   end
 
   test "connects with atom parameter keys as strings" do
-    :error = connect(UserSocket, %{reject: true})
+    {:error, :undefined} = connect(UserSocket, %{reject: true})
   end
 
   ## handle_out


### PR DESCRIPTION
This is a half-done PR to illustrate my point: It'd be great if you could return a custom error from the `connect` function of the WebSocket handler.

Right now when you return `:error` from it, it always returns a 403 status code. I'm not sure why, because it could be possible that you want to return a 400 or 429, for example, in certain situations. And adding a body to explain the error is missing, too, in my opinion.

For example, I want to return a 400 with a detailed error message since my endpoint requires a specific header to be set.

If you're okay with this in general, I can add a proper test and change the docs, too.