### PR TITLE
Fix Cowboy.Drainer link

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -202,7 +202,7 @@ defmodule Phoenix.Endpoint do
 
     * `:drainer` - a drainer process that triggers when your application is
       shutting to wait for any on-going request to finish. It accepts all
-      options as defined by [`Plug.Cowboy`](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.Drainer.httml).
+      options as defined by [`Plug.Cowboy`](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.Drainer.html).
       Defaults to `[]` and can be disabled by setting it to false.
 
   ## Endpoint API


### PR DESCRIPTION
This is such a great addition to Phoenix defaults!

One side question: Is there a best practice on draining keep-alive connections now? I have done some hacky things in the past like set an app config and then check it in the controller, but I'm wondering if there's a better solution.