### PR TITLE
fix bufferedAmount check in js

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -955,7 +955,7 @@ export class Socket {
   }
 
   waitForBufferDone(callback, tries = 1) {
-    if (tries === 5 || !this.conn || (this.conn.bufferedAmount && this.conn.bufferedAmount === 0)) {
+    if (tries === 5 || !this.conn || !this.conn.bufferedAmount) {
       callback()
       return
     }


### PR DESCRIPTION
on `socket.disconnect()` `waitForBufferDone` always retries 5 times even with empty buffer because when `bufferedAmount === 0` then `if (this.conn.bufferedAmount)` evaluates to false

if I understood correctly, `!bufferedAmount` will be enough - for longpoll there is no buffering, so nothing to wait; for websocket - check for `0`