### PR TITLE
Document self() is the channel server in join/3

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -167,11 +167,15 @@ defmodule Phoenix.Channel do
 
   `terminate/2`, however, won't be invoked in case of errors nor in
   case of exits. This is the same behaviour as you find in Elixir
-  abstractions like `GenServer` and others. Typically speaking, if you
-  want to clean something up, it is better to monitor your channel
-  process and do the clean up from another process.  Similar to GenServer,
+  abstractions like `GenServer` and others. Similar to `GenServer`,
   it would also be possible `:trap_exit` to guarantee that `terminate/2`
   is invoked. This practice is not encouraged though.
+
+  Typically speaking, if you want to clean something up, it is better to
+  monitor your channel process and do the clean up from another process.
+  All channel callbacks including `join/3` are called from within the
+  channel process. Therefore, `self()` in any of them returns the PID to
+  be monitored.
 
   ## Exit reasons when stopping a channel
 


### PR DESCRIPTION
## This patch

The documentation of channels does not reveal the underlying implementation (which is good).

Therefore, if you want to monitor the channel, as recommended in the docs of `terminate/2`, the user needs to be explicitly told which PID to monitor, and when it is a good idea to spawn it.

To realize this is not obvious without being documented, compare with the situation in the socket `connect/3` callback. Similar entry point from a user's perspective, but `self()` there is not the one to monitor if you want to keep track of the socket itself.

## Feedback

Since we are here, let me also comment that as a user the perils of `terminate/2` + trapping exits are not clear from the docs. You wonder. "Why is it discouraged? If you cannot trust `terminate/2`, why does the callback exist in the first place?"

From the point of view of the user, a channel is not an arbitrary/generic GenServer, from the point of view of the user, a channel is a process of some sort managed by Phoenix. Why documenting `terminate/2` to say that you cannot rely on it? If the solution is a monitor, why doesn't Phoenix implement a monitor for me and provide a robust callback?

Furthermore, I have stopped channels in several ways, taking things down, sending `kill` signals, killing sockets, ..., I have not been able to terminate a channel without the callback being called.

Of course, the docs are correct. My point is that since a channel is managed by the framework, as a user I'd appreciate something less vague like "even if you trap exists, if this concrete thing happens, the callback won't be invoked". That way, you can evaluate the risk. Also, some legit use cases for the callback would answer the question "why is it in the behaviour if you cannot trust it?"

Unfortunately, I do not know enough to volunteer a patch, so leaving only a comment.
