### PR TITLE
add example for channel.push

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -512,7 +512,7 @@ export class Channel {
    * channel.push("event")
    *   .receive("ok", payload => { console.log("phoenix replied:", payload) })
    *   .receive("error", err => { console.log("phoenix errored", err) })
-   *   .receive("timeout", () => { console.log("timed out pushing") })
+   *   .receive("timeout", () => console.log("timed out pushing"))
    * @param {string} event
    * @param {Object} payload
    * @param {number} [timeout]

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -503,6 +503,16 @@ export class Channel {
   canPush(){ return this.socket.isConnected() && this.isJoined() }
 
   /**
+   * Sends a message `event` to phoenix with the payload `payload`.
+   * Phoenix receives this in the `handle_in(event, payload, socket)`
+   * function. if phoenix replies or it times out (default 10000ms),
+   * then optionally the reply can be received.
+   *
+   * @example
+   * channel.push("event")
+   *   .receive("ok", payload => { console.log("phoenix replied:", payload) })
+   *   .receive("error", err => { console.log("phoenix errored", err) })
+   *   .receive("timeout", () => { console.log("timed out pushing") })
    * @param {string} event
    * @param {Object} payload
    * @param {number} [timeout]

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -511,7 +511,7 @@ export class Channel {
    * @example
    * channel.push("event")
    *   .receive("ok", payload => { console.log("phoenix replied:", payload) })
-   *   .receive("error", err => { console.log("phoenix errored", err) })
+   *   .receive("error", err => console.log("phoenix errored", err))
    *   .receive("timeout", () => console.log("timed out pushing"))
    * @param {string} event
    * @param {Object} payload

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -510,7 +510,7 @@ export class Channel {
    *
    * @example
    * channel.push("event")
-   *   .receive("ok", payload => { console.log("phoenix replied:", payload) })
+   *   .receive("ok", payload => console.log("phoenix replied:", payload))
    *   .receive("error", err => console.log("phoenix errored", err))
    *   .receive("timeout", () => console.log("timed out pushing"))
    * @param {string} event


### PR DESCRIPTION
it wasn't immediately obvious reading the documentation that I could receive replies from phoenix push events. I added an example

EDIT: wait, it's not working like that now for me.. I must have done something. I'll update when I figure out why.. :)