### PR TITLE
Add fixtures module to generators

### DIFF
--- a/lib/mix/phoenix/context.ex
+++ b/lib/mix/phoenix/context.ex
@@ -12,6 +12,7 @@ defmodule Mix.Phoenix.Context do
             basename: nil,
             file: nil,
             test_file: nil,
+            test_fixtures_file: nil,
             dir: nil,
             generate?: true,
             context_app: nil,
@@ -32,6 +33,8 @@ defmodule Mix.Phoenix.Context do
     file      = dir <> ".ex"
     test_dir  = Mix.Phoenix.context_test_path(ctx_app, basedir)
     test_file = test_dir <> "_test.exs"
+    test_fixtures_dir = Mix.Phoenix.context_app_path(ctx_app, "test/support/fixtures")
+    test_fixtures_file = Path.join([test_fixtures_dir, basedir <> "_fixtures.ex"])
     generate? = Keyword.get(opts, :context, true)
 
     %Context{
@@ -44,6 +47,7 @@ defmodule Mix.Phoenix.Context do
       basename: basename,
       file: file,
       test_file: test_file,
+      test_fixtures_file: test_fixtures_file,
       dir: dir,
       generate?: generate?,
       context_app: ctx_app,
@@ -53,6 +57,8 @@ defmodule Mix.Phoenix.Context do
   def pre_existing?(%Context{file: file}), do: File.exists?(file)
 
   def pre_existing_tests?(%Context{test_file: file}), do: File.exists?(file)
+
+  def pre_existing_test_fixtures?(%Context{test_fixtures_file: file}), do: File.exists?(file)
 
   def function_count(%Context{file: file}) do
     {_ast, count} =

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -137,6 +137,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     if schema.generate?, do: Gen.Schema.copy_new_files(schema, paths, binding)
     inject_schema_access(context, paths, binding)
     inject_tests(context, paths, binding)
+    inject_test_fixture(context, paths, binding)
 
     context
   end
@@ -163,6 +164,16 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     paths
     |> Mix.Phoenix.eval_from("priv/templates/phx.gen.context/test_cases.exs", binding)
     |> inject_eex_before_final_end(test_file, binding)
+  end
+
+  defp inject_test_fixture(%Context{test_fixtures_file: test_fixtures_file} = context, paths, binding) do
+    unless Context.pre_existing_test_fixtures?(context) do
+      Mix.Generator.create_file(test_fixtures_file, Mix.Phoenix.eval_from(paths, "priv/templates/phx.gen.context/fixtures_module.ex", binding))
+    end
+
+    paths
+    |> Mix.Phoenix.eval_from("priv/templates/phx.gen.context/fixtures.ex", binding)
+    |> inject_eex_before_final_end(test_fixtures_file, binding)
   end
 
   defp inject_eex_before_final_end(content_to_inject, file_path, binding) do

--- a/priv/templates/phx.gen.context/fixtures.ex
+++ b/priv/templates/phx.gen.context/fixtures.ex
@@ -1,0 +1,11 @@
+
+  def <%= schema.singular %>_fixture(attrs \\ %{}) do
+    {:ok, <%= schema.singular %>} =
+      attrs
+      |> Enum.into(%{
+<%= schema.params.create |> Enum.map(fn {key, val} -> "        #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
+      })
+      |> <%= inspect context.module %>.create_<%= schema.singular %>()
+
+    <%= schema.singular %>
+  end

--- a/priv/templates/phx.gen.context/fixtures_module.ex
+++ b/priv/templates/phx.gen.context/fixtures_module.ex
@@ -1,0 +1,6 @@
+defmodule <%= inspect context.module %>Fixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `<%= inspect context.module %>` context.
+  """
+end

--- a/priv/templates/phx.gen.context/test_cases.exs
+++ b/priv/templates/phx.gen.context/test_cases.exs
@@ -2,18 +2,9 @@
   describe "<%= schema.plural %>" do
     alias <%= inspect schema.module %>
 
-    @valid_attrs <%= inspect schema.params.create %>
-    @update_attrs <%= inspect schema.params.update %>
+    import <%= inspect context.module %>Fixtures
+
     @invalid_attrs <%= inspect for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
-
-    def <%= schema.singular %>_fixture(attrs \\ %{}) do
-      {:ok, <%= schema.singular %>} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> <%= inspect context.alias %>.create_<%= schema.singular %>()
-
-      <%= schema.singular %>
-    end
 
     test "list_<%= schema.plural %>/0 returns all <%= schema.plural %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
@@ -26,7 +17,9 @@
     end
 
     test "create_<%= schema.singular %>/1 with valid data creates a <%= schema.singular %>" do
-      assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(@valid_attrs)<%= for {field, value} <- schema.params.create do %>
+      valid_attrs = <%= inspect schema.params.create %>
+
+      assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(valid_attrs)<%= for {field, value} <- schema.params.create do %>
       assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>
     end
 
@@ -36,7 +29,9 @@
 
     test "update_<%= schema.singular %>/2 with valid data updates the <%= schema.singular %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, @update_attrs)<%= for {field, value} <- schema.params.update do %>
+      update_attrs = <%= inspect schema.params.update %>
+
+      assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, update_attrs)<%= for {field, value} <- schema.params.update do %>
       assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>
     end
 

--- a/priv/templates/phx.gen.html/controller_test.exs
+++ b/priv/templates/phx.gen.html/controller_test.exs
@@ -1,16 +1,11 @@
 defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ControllerTest do
   use <%= inspect context.web_module %>.ConnCase
 
-  alias <%= inspect context.module %>
+  import <%= inspect context.module %>Fixtures
 
   @create_attrs <%= inspect schema.params.create %>
   @update_attrs <%= inspect schema.params.update %>
   @invalid_attrs <%= inspect for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
-
-  def fixture(:<%= schema.singular %>) do
-    {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(@create_attrs)
-    <%= schema.singular %>
-  end
 
   describe "index" do
     test "lists all <%= schema.plural %>", %{conn: conn} do
@@ -83,7 +78,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   defp create_<%= schema.singular %>(_) do
-    <%= schema.singular %> = fixture(:<%= schema.singular %>)
+    <%= schema.singular %> = <%= schema.singular %>_fixture()
     %{<%= schema.singular %>: <%= schema.singular %>}
   end
 end

--- a/priv/templates/phx.gen.json/controller_test.exs
+++ b/priv/templates/phx.gen.json/controller_test.exs
@@ -1,7 +1,8 @@
 defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ControllerTest do
   use <%= inspect context.web_module %>.ConnCase
 
-  alias <%= inspect context.module %>
+  import <%= inspect context.module %>Fixtures
+
   alias <%= inspect schema.module %>
 
   @create_attrs %{
@@ -11,11 +12,6 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 <%= schema.params.update |> Enum.map(fn {key, val} -> "    #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
   }
   @invalid_attrs <%= inspect for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
-
-  def fixture(:<%= schema.singular %>) do
-    {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(@create_attrs)
-    <%= schema.singular %>
-  end
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
@@ -82,7 +78,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   defp create_<%= schema.singular %>(_) do
-    <%= schema.singular %> = fixture(:<%= schema.singular %>)
+    <%= schema.singular %> = <%= schema.singular %>_fixture()
     %{<%= schema.singular %>: <%= schema.singular %>}
   end
 end

--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -2,20 +2,14 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   use <%= inspect context.web_module %>.ConnCase
 
   import Phoenix.LiveViewTest
-
-  alias <%= inspect context.module %>
+  import <%= inspect context.module %>Fixtures
 
   @create_attrs <%= inspect schema.params.create %>
   @update_attrs <%= inspect schema.params.update %>
   @invalid_attrs <%= inspect for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
 
-  defp fixture(:<%= schema.singular %>) do
-    {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(@create_attrs)
-    <%= schema.singular %>
-  end
-
   defp create_<%= schema.singular %>(_) do
-    <%= schema.singular %> = fixture(:<%= schema.singular %>)
+    <%= schema.singular %> = <%= schema.singular %>_fixture()
     %{<%= schema.singular %>: <%= schema.singular %>}
   end
 

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -37,6 +37,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       assert String.ends_with?(context.dir, "lib/phoenix/blog")
       assert String.ends_with?(context.file, "lib/phoenix/blog.ex")
       assert String.ends_with?(context.test_file, "test/phoenix/blog_test.exs")
+      assert String.ends_with?(context.test_fixtures_file, "test/support/fixtures/blog_fixtures.ex")
       assert String.ends_with?(context.schema.file, "lib/phoenix/blog/post.ex")
     end
   end
@@ -64,6 +65,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       assert String.ends_with?(context.dir, "lib/phoenix/site/blog")
       assert String.ends_with?(context.file, "lib/phoenix/site/blog.ex")
       assert String.ends_with?(context.test_file, "test/phoenix/site/blog_test.exs")
+      assert String.ends_with?(context.test_fixtures_file, "test/support/fixtures/site/blog_fixtures.ex")
       assert String.ends_with?(context.schema.file, "lib/phoenix/site/blog/post.ex")
     end
   end
@@ -80,6 +82,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       context = Context.new("Blog", schema, [])
       assert Context.pre_existing?(context)
       refute Context.pre_existing_tests?(context)
+      refute Context.pre_existing_test_fixtures?(context)
 
       File.mkdir_p!("test/phoenix/blog")
       File.write!(context.test_file, """
@@ -87,6 +90,13 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       end
       """)
       assert Context.pre_existing_tests?(context)
+
+      File.mkdir_p!("test/support/fixtures")
+      File.write!(context.test_fixtures_file, """
+      defmodule Phoenix.BlogFixtures do
+      end
+      """)
+      assert Context.pre_existing_test_fixtures?(context)
     end
   end
 
@@ -142,7 +152,13 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       assert_file "test/phoenix/blog_test.exs", fn file ->
         assert file =~ "use Phoenix.DataCase"
         assert file =~ "describe \"posts\" do"
+        assert file =~ "import Phoenix.BlogFixtures"
+      end
+
+      assert_file "test/support/fixtures/blog_fixtures.ex", fn file ->
+        assert file =~ "defmodule Phoenix.BlogFixtures do"
         assert file =~ "def post_fixture(attrs \\\\ %{})"
+        assert file =~ "title: \"some title\""
       end
 
       assert [path] = Path.wildcard("priv/repo/migrations/*_create_posts.exs")
@@ -167,7 +183,13 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       assert_file "test/phoenix/blog_test.exs", fn file ->
         assert file =~ "use Phoenix.DataCase"
         assert file =~ "describe \"comments\" do"
+        assert file =~ "import Phoenix.BlogFixtures"
+      end
+
+      assert_file "test/support/fixtures/blog_fixtures.ex", fn file ->
+        assert file =~ "defmodule Phoenix.BlogFixtures do"
         assert file =~ "def comment_fixture(attrs \\\\ %{})"
+        assert file =~ "title: \"some title\""
       end
 
       assert [path] = Path.wildcard("priv/repo/migrations/*_create_comments.exs")
@@ -206,7 +228,13 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       assert_file "test/phoenix/blog_test.exs", fn file ->
         assert file =~ "use Phoenix.DataCase"
         assert file =~ "describe \"posts\" do"
+        assert file =~ "import Phoenix.BlogFixtures"
+      end
+
+      assert_file "test/support/fixtures/blog_fixtures.ex", fn file ->
+        assert file =~ "defmodule Phoenix.BlogFixtures do"
         assert file =~ "def post_fixture(attrs \\\\ %{})"
+        assert file =~ "title: \"some title\""
       end
 
       assert Path.wildcard("priv/repo/migrations/*_create_posts.exs") == []


### PR DESCRIPTION
This adds a fixtures module to the output of `phx.gen.context` and uses the module throughout `phx.gen.live`, `phx.gen.html` and phx.gen.json`. The module looks like this:

```elixir
defmodule DemoLiveApp.BlogFixtures do
  @moduledoc """
  This module defines test helpers for creating
  entities via the `DemoLiveApp.Blog` context.
  """

  def post_fixture(attrs \\ %{}) do
    {:ok, post} =
      attrs
      |> Enum.into(%{
        content: "some content",
        rating: 42,
        title: "some title"
      })
      |> DemoLiveApp.Blog.create_post()

    post
  end
end
```

This change originally came about from #3797 and has been discussed further here: https://github.com/aaronrenner/phoenix_generator_proposals_live/pull/1.

Any feedback or suggestions would be appreciated!

Fixes #3797 