### PR TITLE
only do code reloading when env is dev

### DIFF
--- a/lib/mix/tasks/compile.phoenix.ex
+++ b/lib/mix/tasks/compile.phoenix.ex
@@ -10,9 +10,11 @@ defmodule Mix.Tasks.Compile.Phoenix do
   def run(_args) do
     {:ok, _} = Application.ensure_all_started(:phoenix)
 
-    case touch() do
-      [] -> {:noop, []}
-      _  -> {:ok, []}
+    if Mix.env() == :dev do
+      case touch() do
+        [] -> {:noop, []}
+        _  -> {:ok, []}
+      end
     end
   end
 


### PR DESCRIPTION
when using CodeReloader with vscode, the elixir_ls would continue to recompile the files I have `__phoenix_recompile__?` over and over. see https://github.com/elixir-lsp/elixir-ls/issues/239

I figure others who may be using vscode are likely to be experiencing the same problem. since the language server compiles the code with env test, this change will prevent the infinite loop as shown in the above bug report by restricting code reloading only to be in the dev environment.

question: would it be preferable instead if this were configurable or if it were to say, `Mix.env() != :test`?