### PR TITLE
Ignore Elixir LS cached data

### DIFF
--- a/installer/templates/phx_single/gitignore
+++ b/installer/templates/phx_single/gitignore
@@ -32,3 +32,6 @@ npm-debug.log
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+
+# The Elixir Language Service caches data here if you're using it.
+/.elixir_ls/

--- a/installer/templates/phx_umbrella/apps/app_name/gitignore
+++ b/installer/templates/phx_umbrella/apps/app_name/gitignore
@@ -21,3 +21,6 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 <%= app_name %>-*.tar
+
+# The Elixir Language Service caches data here if you're using it.
+/.elixir_ls/

--- a/installer/templates/phx_umbrella/apps/app_name_web/gitignore
+++ b/installer/templates/phx_umbrella/apps/app_name_web/gitignore
@@ -32,3 +32,6 @@ npm-debug.log
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+
+# The Elixir Language Service caches data here if you're using it.
+/.elixir_ls/

--- a/installer/templates/phx_umbrella/gitignore
+++ b/installer/templates/phx_umbrella/gitignore
@@ -18,3 +18,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# The Elixir Language Service caches data here if you're using it.
+/.elixir_ls/


### PR DESCRIPTION
If you're using the Elixir language service then it caches files in a `.elixir_ls` directory alongside your other project files.  On the assumption that many other users are using Elixir LS, this pull request adds that directory to the template `.gitignore` file by default.