### PR TITLE
Fix a few minor typos in guides

### DIFF
--- a/guides/deployment/deployment.md
+++ b/guides/deployment/deployment.md
@@ -52,7 +52,7 @@ $ mix phx.digest
 Check your digested files at "priv/static".
 ```
 
-*Note:* the `--prefix` flag on `npm` may not work on Windows. If so, replace the first command by `cd assets && npm run deply && cd ..`.
+*Note:* the `--prefix` flag on `npm` may not work on Windows. If so, replace the first command by `cd assets && npm run deploy && cd ..`.
 
 And that is it! The first command builds the assets and the second generates digests as well as a cache manifest file so Phoenix can quickly serve assets in production.
 

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -45,7 +45,7 @@ $ npm run deploy --prefix ./assets
 $ mix phx.digest
 ```
 
-*Note:* the `--prefix` flag on `npm` may not work on Windows. If so, replace the first command by `cd assets && npm run deply && cd ..`.
+*Note:* the `--prefix` flag on `npm` may not work on Windows. If so, replace the first command by `cd assets && npm run deploy && cd ..`.
 
 And now run `mix release`:
 


### PR DESCRIPTION
A few minor typos were introduced in a recent commit that I happen to stumble upon.