### PR TITLE
Update conn in Cowboy2 Handler

### DIFF
--- a/lib/phoenix/endpoint/cowboy2_handler.ex
+++ b/lib/phoenix/endpoint/cowboy2_handler.ex
@@ -60,6 +60,7 @@ defmodule Phoenix.Endpoint.Cowboy2Handler do
 
         {:plug, conn, handler, opts} ->
           %{adapter: {@connection, req}} =
+            conn =
             conn
             |> handler.call(opts)
             |> maybe_send(handler)

--- a/lib/phoenix/endpoint/cowboy2_handler.ex
+++ b/lib/phoenix/endpoint/cowboy2_handler.ex
@@ -61,9 +61,9 @@ defmodule Phoenix.Endpoint.Cowboy2Handler do
         {:plug, conn, handler, opts} ->
           %{adapter: {@connection, req}} =
             conn =
-            conn
-            |> handler.call(opts)
-            |> maybe_send(handler)
+              conn
+              |> handler.call(opts)
+              |> maybe_send(handler)
 
           :telemetry.execute(
             [:plug_adapter, :call, :stop],

--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -161,7 +161,7 @@ defmodule Phoenix.Integration.EndpointTest do
       assert_receive {:event, [:plug_adapter, :call, :stop], %{duration: _},
                       %{
                         adapter: :phoenix_cowboy,
-                        conn: %{request_path: "/"},
+                        conn: %{request_path: "/", status: 200},
                         plug: ProdEndpoint
                       }}
 


### PR DESCRIPTION
This PR updates the Cowboy2 Handler so that it updates the conn after `call` - this is done so the telemetry event will get the updated values, for example the response `status`.

This mirrors the existing behavior of `plug_adapter` telemetry events in `plug_cowboy`...

https://github.com/elixir-plug/plug_cowboy/blob/master/lib/plug/cowboy/handler.ex#L40-L45