### PR TITLE
Typos and clarification in ":pubsub_server not configured" error

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -403,13 +403,15 @@ defmodule Phoenix.Channel.Server do
     unless pubsub_server do
       raise """
       The :pubsub_server was not configured for endpoint #{inspect(socket.endpoint)}.
-      Make sure to start a PubSub proccess in your application supervision tree:
+      Make sure to start a PubSub process in your application supervision tree:
 
           {Phoenix.PubSub, [name: YOURAPP.PubSub, adapter: Phoenix.PubSub.PG2]}
 
-      And then list it your endpoint config:
+      And then add it to your endpoint config:
 
-          pubsub_server: YOURAPP.PubSub
+          config :YOURAPP, YOURAPPWeb.Endpoint,
+            # ...
+            pubsub_server: YOURAPP.PubSub
       """
     end
 


### PR DESCRIPTION
Someone [was unsure](https://elixir-lang.slack.com/archives/C03EPRA3B/p1590040764311100) about where to add the config, and I agree it's not as clear as it could be.

We could even mention config/config.exs by name, but we don't mention filenames for the supervision tree, so maybe this strikes the right balance.

Also fixed "proccess" and "list it your" typos.