### PR TITLE
Warn if the host provided for the Endpoint is invalid

### DIFF
--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -303,6 +303,10 @@ defmodule Phoenix.Endpoint.Supervisor do
     host   = host_to_binary(url[:host] || "localhost")
     port   = port_to_integer(url[:port] || port)
 
+    if host =~ ~r/\:/ do
+      Logger.warn("host #{inspect(host)} is invalid")
+    end
+
     %URI{scheme: scheme, port: port, host: host}
   end
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -302,8 +302,8 @@ defmodule Phoenix.Endpoint.Supervisor do
     host   = host_to_binary(url[:host] || "localhost")
     port   = port_to_integer(url[:port] || port)
 
-    if host =~ ~r/\:/ do
-      Logger.warn(":host configuration value #{inspect(host)} for #{inspect(endpoint)} is invalid")
+    if host =~ ":" do
+      Logger.warn("url: [host: ...] configuration value #{inspect(host)} for #{inspect(endpoint)} is invalid")
     end
 
     %URI{scheme: scheme, port: port, host: host}

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -285,10 +285,9 @@ defmodule Phoenix.Endpoint.Supervisor do
   end
 
   defp build_url(endpoint, url) do
-    build_url(endpoint.config(:https), endpoint.config(:http), url)
-  end
+    https = endpoint.config(:https)
+    http  = endpoint.config(:http)
 
-  defp build_url(https, http, url) do
     {scheme, port} =
       cond do
         https ->
@@ -304,7 +303,7 @@ defmodule Phoenix.Endpoint.Supervisor do
     port   = port_to_integer(url[:port] || port)
 
     if host =~ ~r/\:/ do
-      Logger.warn("host #{inspect(host)} is invalid")
+      Logger.warn(":host configuration value #{inspect(host)} for #{inspect(endpoint)} is invalid")
     end
 
     %URI{scheme: scheme, port: port, host: host}

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -10,7 +10,9 @@ defmodule Phoenix.Endpoint.EndpointTest do
            force_ssl: [subdomains: true],
            cache_static_manifest: "../../../../test/fixtures/digest/compile/cache_manifest.json",
            pubsub_server: :endpoint_pub]
+
   Application.put_env(:phoenix, __MODULE__.Endpoint, @config)
+  Application.put_env(:phoenix, __MODULE__.InvalidEndpoint, put_in(@config[:url][:host], "http://example.com"))
 
   defmodule Endpoint do
     use Phoenix.Endpoint, otp_app: :phoenix
@@ -23,6 +25,10 @@ defmodule Phoenix.Endpoint.EndpointTest do
   end
 
   defmodule NoConfigEndpoint do
+    use Phoenix.Endpoint, otp_app: :phoenix
+  end
+
+  defmodule InvalidEndpoint do
     use Phoenix.Endpoint, otp_app: :phoenix
   end
 
@@ -45,6 +51,12 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert ExUnit.CaptureLog.capture_log(fn ->
       NoConfigEndpoint.start_link()
     end) =~ "no configuration"
+  end
+
+  test "warns if host is invalid" do
+    assert ExUnit.CaptureLog.capture_log(fn ->
+      InvalidEndpoint.start_link()
+    end) =~ "host \"http://example.com\" is invalid"
   end
 
   test "has reloadable configuration" do

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -56,7 +56,7 @@ defmodule Phoenix.Endpoint.EndpointTest do
   test "warns if host is invalid" do
     assert ExUnit.CaptureLog.capture_log(fn ->
       InvalidEndpoint.start_link()
-    end) =~ "host \"http://example.com\" is invalid"
+    end) =~ ":host configuration value \"http://example.com\" for Phoenix.Endpoint.EndpointTest.InvalidEndpoint is invalid"
   end
 
   test "has reloadable configuration" do

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -12,7 +12,6 @@ defmodule Phoenix.Endpoint.EndpointTest do
            pubsub_server: :endpoint_pub]
 
   Application.put_env(:phoenix, __MODULE__.Endpoint, @config)
-  Application.put_env(:phoenix, __MODULE__.InvalidEndpoint, put_in(@config[:url][:host], "http://example.com"))
 
   defmodule Endpoint do
     use Phoenix.Endpoint, otp_app: :phoenix
@@ -25,10 +24,6 @@ defmodule Phoenix.Endpoint.EndpointTest do
   end
 
   defmodule NoConfigEndpoint do
-    use Phoenix.Endpoint, otp_app: :phoenix
-  end
-
-  defmodule InvalidEndpoint do
     use Phoenix.Endpoint, otp_app: :phoenix
   end
 
@@ -51,12 +46,6 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert ExUnit.CaptureLog.capture_log(fn ->
       NoConfigEndpoint.start_link()
     end) =~ "no configuration"
-  end
-
-  test "warns if host is invalid" do
-    assert ExUnit.CaptureLog.capture_log(fn ->
-      InvalidEndpoint.start_link()
-    end) =~ ":host configuration value \"http://example.com\" for Phoenix.Endpoint.EndpointTest.InvalidEndpoint is invalid"
   end
 
   test "has reloadable configuration" do


### PR DESCRIPTION
I'm pretty sure the validation may be improved, but this PR is to gather feedback related to https://github.com/phoenixframework/phoenix_live_view/issues/911#issuecomment-632905958

Decided to warn instead of raise to follow the same pattern already in use for validating Endpoint config, but I can change to raise if it's better.