### PR TITLE
Fix link formatting issue caused by ex_doc autolinking.

### DIFF
--- a/guides/deployment/deployment.md
+++ b/guides/deployment/deployment.md
@@ -10,7 +10,7 @@ When preparing an application for deployment, there are three main steps:
 
 In this guide, we will learn how to get the production environment running locally. You can use the same techniques in this guide to run your application in production, but depending on your deployment infrastructure, extra steps will be necessary.
 
-As an example of deploying to other infrastructures, we also discuss two different approaches in our guides: using [Elixir's releases with `mix release`](releases.html) and [by using Heroku](heroku.html). The release guide also has a sample Docker file you can use if you prefer to deploy with container technologies.
+As an example of deploying to other infrastructures, we also discuss two different approaches in our guides: using [Elixir's releases](releases.html) with `mix release` and [by using Heroku](heroku.html). The release guide also has a sample Docker file you can use if you prefer to deploy with container technologies.
 
 Let's explore those steps above one by one.
 


### PR DESCRIPTION
ex_doc autolinks `mix release`. See https://hexdocs.pm/ex_doc/readme.html#auto-linking
This causes a formatting issue when we are already inside a link. 
This pulls the autolinked `mix release` outside of the link to releases.html.

You can see the formatting issue here:
https://hexdocs.pm/phoenix/deployment.html#content