### PR TITLE
Demonstrate an issue with exception telemetry events

### DIFF
--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -147,7 +147,7 @@ defmodule Phoenix.Integration.EndpointTest do
       :plug_adapter_exception,
       [:plug_adapter, :call, :exception],
       fn event, measurements, metadata, :none ->
-        # IO.inspect {measurements, metadata}
+        IO.inspect {measurements, metadata}
         send(test, {:event, event, measurements, metadata})
       end,
       :none


### PR DESCRIPTION
I've come across a strange issue that happens inside a telemetry handler for the `[:plug_adapter, :call, :exception]` event.

Attempting to `inspect` a value inside the Telemetry handler causes a failure that I can't explain. I don't see the log entry that I would expect from the handler being detached...

I'm not totally sure this has something to do with Phoenix, but this particular event is executed inside of an existing `catch`:

https://github.com/phoenixframework/phoenix/blob/c85a23b2b72c0c29a44ed61e1137a5f79c428fee/lib/phoenix/endpoint/cowboy2_handler.ex#L76-L83

* First commit shows a handler functioning correctly
* Second commit shows an `IO.inspect` causing the rest of the handler fail to execute

@josevalim Any idea what could be happening here?