### PR TITLE
Clarify usage of enableLatencySim in app.js

### DIFF
--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -24,7 +24,7 @@ let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToke
 window.addEventListener("phx:page-loading-start", info => NProgress.start())
 window.addEventListener("phx:page-loading-stop", info => NProgress.done())
 
-// Connect if there are any LiveViews on the page
+// connect if there are any LiveViews on the page
 liveSocket.connect()
 
 // Expose liveSocket on window for web console debug logs and latency simulation:

--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -30,7 +30,6 @@ liveSocket.connect()
 // Expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()
 // >> liveSocket.enableLatencySim(1000)
-// The latency simulator is enabled for the duration of the browser session.
 // Call disableLatencySim() to disable:
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket

--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -24,11 +24,14 @@ let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToke
 window.addEventListener("phx:page-loading-start", info => NProgress.start())
 window.addEventListener("phx:page-loading-stop", info => NProgress.done())
 
-// connect if there are any LiveViews on the page
+// Connect if there are any LiveViews on the page
 liveSocket.connect()
 
-// expose liveSocket on window for web console debug logs and latency simulation:
+// Expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()
 // >> liveSocket.enableLatencySim(1000)
+// The latency simulator is enabled for the duration of the browser session.
+// Call disableLatencySim() to disable:
+// >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
 <% end %>

--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -27,7 +27,7 @@ window.addEventListener("phx:page-loading-stop", info => NProgress.done())
 // connect if there are any LiveViews on the page
 liveSocket.connect()
 
-// Expose liveSocket on window for web console debug logs and latency simulation:
+// expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()
 // >> liveSocket.enableLatencySim(1000)
 // Call disableLatencySim() to disable:

--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -31,6 +31,5 @@ liveSocket.connect()
 // >> liveSocket.enableDebug()
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim(1000)
-// >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
 <% end %>

--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -29,7 +29,8 @@ liveSocket.connect()
 
 // expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()
-// >> liveSocket.enableLatencySim(1000)
+// >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
+// >> liveSocket.disableLatencySim(1000)
 // Call disableLatencySim() to disable:
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket

--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -30,6 +30,6 @@ liveSocket.connect()
 // expose liveSocket on window for web console debug logs and latency simulation:
 // >> liveSocket.enableDebug()
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
-// >> liveSocket.disableLatencySim(1000)
+// >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
 <% end %>

--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -31,7 +31,6 @@ liveSocket.connect()
 // >> liveSocket.enableDebug()
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim(1000)
-// Call disableLatencySim() to disable:
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
 <% end %>


### PR DESCRIPTION
When I first used `liveSocket.enableLatencySim(1000)` it was hard to figure it out that it was still enabled as I did enable it on the app.js file directly. I did try to disable it with `liveSocket.enableLatencySim(0)`. 😄 

In my case I used the phoenix project generator `--live`. Perhaps, we could add the comment to the `app.js.
Related PR:
https://github.com/phoenixframework/phoenix_live_view/pull/933