### PR TITLE
Use entrypoint name for extracted CSS

### DIFF
--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -44,7 +44,7 @@ module.exports = (env, options) => {
       ]
     },
     plugins: [
-      new MiniCssExtractPlugin({ filename: '../css/app.css' }),
+      new MiniCssExtractPlugin({ filename: '../css/[name].css' }),
       new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
     ]
   }


### PR DESCRIPTION
Instead of hard-coding `app`, we should use the entrypoint name, which
allows multiple CSS entrypoints to be generated automatically. This is
especially useful when you want to segregate your frontends, such as
both "public" and "admin" sections which need entirely independent CSS
assets.