### PR TITLE
user_socket.ex docs: Grammar

### DIFF
--- a/installer/templates/phx_web/channels/user_socket.ex
+++ b/installer/templates/phx_web/channels/user_socket.ex
@@ -20,7 +20,7 @@ defmodule <%= web_namespace %>.UserSocket do
     {:ok, socket}
   end
 
-  # Socket id's are topics that allow you to identify all sockets for a given user:
+  # Socket `id`s are topics that allow you to identify all sockets for a given user:
   #
   #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
   #


### PR DESCRIPTION
The id (when not lowercased because it's code) is that Freudian thing, and "id's" would be the possessive rather than the plural :)