### PR TITLE
Add description to Ecto telemetry metrics

### DIFF
--- a/installer/templates/phx_web/telemetry.ex
+++ b/installer/templates/phx_web/telemetry.ex
@@ -31,11 +31,11 @@ defmodule <%= web_namespace %>.Telemetry do
       ),<%= if ecto do %>
 
       # Database Metrics
-      summary("<%= app_name %>.repo.query.total_time", unit: {:native, :millisecond}),
-      summary("<%= app_name %>.repo.query.decode_time", unit: {:native, :millisecond}),
-      summary("<%= app_name %>.repo.query.query_time", unit: {:native, :millisecond}),
-      summary("<%= app_name %>.repo.query.queue_time", unit: {:native, :millisecond}),
-      summary("<%= app_name %>.repo.query.idle_time", unit: {:native, :millisecond}),<% end %>
+      summary("<%= app_name %>.repo.query.total_time", unit: {:native, :millisecond}, description: "The sum of the other measurements"),
+      summary("<%= app_name %>.repo.query.decode_time", unit: {:native, :millisecond}, description: "The time spent decoding the data received from the database"), 
+      summary("<%= app_name %>.repo.query.query_time", unit: {:native, :millisecond}, description: "The time spent executing the query"),
+      summary("<%= app_name %>.repo.query.queue_time", unit: {:native, :millisecond}, description: "The time spent waiting to check out a database connection"),
+      summary("<%= app_name %>.repo.query.idle_time", unit: {:native, :millisecond}, description: "The time the connection spent waiting before being checked out for the query"),<% end %>
 
       # VM Metrics
       summary("vm.memory.total", unit: {:byte, :kilobyte}),


### PR DESCRIPTION
Description text copied from https://hexdocs.pm/ecto/Ecto.Repo.html#content

As far as i can see 
* LiveDashboard does support this. 
* It's not immediately clear what metric means, especially something like `idle_time`