### PR TITLE
Add a link to telemetry events in the guide

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -147,6 +147,10 @@ took to get the response:
 :telemetry.execute([:phoenix, :endpoint, :stop], %{duration: duration}, %{conn: conn})
 ```
 
+### Phoenix Telemetry Events
+
+A full list of all Phoenix telemetry events can be found in `Phoenix.Logger`
+
 ## Metrics
 
 > Metrics are aggregations of Telemetry events with a


### PR DESCRIPTION
It's currently very difficult to discover the documentation with the full list of Phoenix telemetry events. Searching `telemetry` in the docs surfaces the guide to the top and `Phoenix.Logger` (where they're defined) as the last search result. Adding a callout and link to the full list in the guide should improve discoverability.