### PR TITLE
Speed up build times for webpack

### DIFF
--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -20,6 +20,7 @@
     "css-loader": "^3.4.2",
     "sass-loader": "^8.0.2",
     "node-sass": "^4.13.1",
+    "hard-source-webpack-plugin": "^0.13.1",
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "terser-webpack-plugin": "^2.3.2",

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const glob = require('glob');
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -23,7 +24,7 @@ module.exports = (env, options) => {
       path: path.resolve(__dirname, '../priv/static/js'),
       publicPath: '/js/'
     },
-    devtool: devMode ? 'source-map' : undefined,
+    devtool: devMode ? 'eval-cheap-module-source-map' : undefined,
     module: {
       rules: [
         {
@@ -47,5 +48,6 @@ module.exports = (env, options) => {
       new MiniCssExtractPlugin({ filename: '../css/[name].css' }),
       new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
     ]
+    .concat(devMode ? [new HardSourceWebpackPlugin()] : [])
   }
 };


### PR DESCRIPTION
On an unmodified default generated project (with --live) using the
Phoenix 1.5.3 installer, the build time is:

    $ webpack --mode development

    Version: webpack 4.41.5
    Time: 1681ms

Changing the source-map mode to `eval-cheap-module-source-map` changes
this time slightly:

    Time: 1397ms

The `hard-source-webpack-plugin` caches intermediate build steps, which
produces significantly faster rebuilds:

    Time: 474ms

Combining these two results in:

    Time: 193ms

This improvement seems to scale well too. On a project including
tailwind, the build time by default is close to 6 seconds, but with the
above config, 212ms.

`eval-cheap-module-source-map` preserves line numbers in the source
maps, but not column information. This seems like a resonable trade off
vs `eval-module-source-map` which is a bit slower.

    Time: 491ms