### PR TITLE
Fix typo

### DIFF
--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.Phx.Routes do
     Mix.Task.run("compile", args)
 
     {router_mod, opts} =
-      case OptionParser.parse(args, switches: [enpdoint: :string, router: :string]) do
+      case OptionParser.parse(args, switches: [endpoint: :string, router: :string]) do
         {opts, [passed_router], _} -> {router(passed_router, base), opts}
         {opts, [], _} -> {router(opts[:router], base), opts}
       end


### PR DESCRIPTION
The word in the `phx.routes` `mix` task appears to be misspelled. 

Disclaimer: I am learning phoenix/elixir and don't understand this code yet. This might not be the right fix so someone more knowledgeable should check.