### PR TITLE
Fix bug in presence documentation example

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -100,7 +100,7 @@ defmodule Phoenix.Presence do
         users = presences |> Map.keys() |> Accounts.get_users_map()
 
         for {key, %{metas: metas}} <- presences, into: %{} do
-          {key, %{metas: metas, user: users[key]}}
+          {key, %{metas: metas, user: users[String.to_integer(key)]}}
         end
       end
 


### PR DESCRIPTION
The example presence code has a bug where it's building a map of users keyed by id, but then using a key that it gets from the presences map to index into it. The users table is going to have integer primary keys, but presences keys are cast to a string (see https://hexdocs.pm/phoenix/Phoenix.Presence.html#c:track/3) 

This means that the code as written will always return `nil` for the user.

I'm not sure if adding `String.to_integer` here is the cleanest approach, please let me know if there's a better a way to do this!