### PR TITLE
Move ‘invalid-feedback’ style selector block to non-LV section

### DIFF
--- a/installer/templates/phx_assets/app.scss
+++ b/installer/templates/phx_assets/app.scss
@@ -3,13 +3,8 @@
 @import "../node_modules/nprogress/nprogress.css";
 
 /* LiveView specific classes for your customizations */
-.invalid-feedback {
-  color: #a94442;
-  display: block;
-  margin: -1rem 0 2rem;
-}
-
-.phx-no-feedback.invalid-feedback, .phx-no-feedback .invalid-feedback {
+.phx-no-feedback.invalid-feedback,
+.phx-no-feedback .invalid-feedback {
   display: none;
 }
 
@@ -88,4 +83,9 @@
 }
 .alert:empty {
   display: none;
+}
+.invalid-feedback {
+  color: #a94442;
+  display: block;
+  margin: -1rem 0 2rem;
 }


### PR DESCRIPTION
The 'invalid-feedback' class is used in standard generated forms.