### PR TITLE
Remove broken link on community page

### DIFF
--- a/guides/introduction/community.md
+++ b/guides/introduction/community.md
@@ -46,6 +46,4 @@ There are a number of places to connect with community members at all experience
 
   * [LearnPhoenix.tv: Learn how to Build Fast, Dependable Web Apps with Phoenix (Feb 2017)](https://www.learnphoenix.tv/)
 
-  * [Build Real-Time Web Apps with Phoenix (Oct 2016)](https://pragprog.com/screencast/v-bhphnx/build-real-time-web-apps-with-phoenix)
-
   * [LearnPhoenix.io: Build Scalable, Real-Time Apps with Phoenix, React, and React Native (Aug 2016)](https://www.learnphoenix.io/)


### PR DESCRIPTION
Hi all 👋  - My first PR on Phoenix 🎉 

I removed a broken link from the community page. 
Pragprog migrated its website in June and the screencast seems to be no longer available.
https://pragprog.com/support/index.html#new-site

I'll be glad to close/update the PR if anyone knows that it's a temporary issue 🙂 

Thanks for the great contributing doc 💜 