### PR TITLE
Fix bug in mix phx.gen.json shell instructions

### DIFF
--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -141,7 +141,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
 
       Add the resource to your #{schema.web_namespace} :api scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
 
-          scope "/#{schema.web_path}", #{inspect Module.concat(context.web_module, schema.web_namespace)} do
+          scope "/#{schema.web_path}", #{inspect Module.concat(context.web_module, schema.web_namespace)}, as: :#{schema.web_path} do
             pipe_through :api
             ...
             resources "/#{schema.plural}", #{inspect schema.alias}Controller

--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -131,7 +131,7 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
 
       Add the resource to your Blog :api scope in lib/phoenix_web/router.ex:
 
-          scope "/blog", PhoenixWeb.Blog do
+          scope "/blog", PhoenixWeb.Blog, as: :blog do
             pipe_through :api
             ...
             resources "/posts", PostController


### PR DESCRIPTION
(Note: example given is from the phx.gen.json test)

After `mix phx.gen.json Blog Post posts title:string --web Blog` is run, the generated files rely on `Routes.blog_post_path`.

The outputted shell instructions should include the alias `as: :blog` in the routing scope so that `Routes.blog_post_path` works.
