### PR TITLE
Make code snippet match text; uses render_to_string not render_to_iodata

### DIFF
--- a/guides/views.md
+++ b/guides/views.md
@@ -131,7 +131,7 @@ iex(2)> Phoenix.View.render(HelloWeb.PageView, "test.html", message: "<script>ba
 {:safe, ["This is the message: ", "&lt;script&gt;badThings();&lt;/script&gt;"]}
 ```
 
-If we need only the rendered string, without the whole tuple, we can use the `render_to_iodata/3`.
+If we need only the rendered string, without the whole tuple, we can use `render_to_string/3`.
 
 ```elixir
 iex(5)> Phoenix.View.render_to_string(HelloWeb.PageView, "test.html", message: "Hello from IEx!")


### PR DESCRIPTION
The code snipper makes use of `render_to_string/3` but the preceeding text instead references `render_to_iodata/3`.

This mismatch is confusing.