### PR TITLE
Configurable static compressors

### DIFF
--- a/lib/mix/tasks/phx.digest.ex
+++ b/lib/mix/tasks/phx.digest.ex
@@ -37,6 +37,7 @@ defmodule Mix.Tasks.Phx.Digest do
 
   @doc false
   def run(all_args) do
+    Mix.Task.run "compile", all_args
     {opts, args, _} = OptionParser.parse(all_args, switches: [output: :string], aliases: [o: :output])
     input_path = List.first(args) || @default_input_path
     output_path = opts[:output] || input_path

--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -119,7 +119,7 @@ defmodule Phoenix.Digester do
 
   defp compiled_file?(file_path) do
     compressors = Application.fetch_env!(:phoenix, :static_compressors)
-    compressed_extensions = Enum.map(compressors, &(&1.file_extension))
+    compressed_extensions = Enum.flat_map(compressors, &(&1.file_extensions))
 
     Regex.match?(@digested_file_regex, Path.basename(file_path)) ||
       Path.extname(file_path) in compressed_extensions ||
@@ -157,14 +157,15 @@ defmodule Phoenix.Digester do
       if compressor.compress_file?(file.absolute_path, file.content, file.digested_content) do
         compressed_digested = compressor.compress(file.digested_content)
         compressed = compressor.compress(file.content)
+        [file_extension | _] = compressor.file_extensions
 
         File.write!(
-          Path.join(path, file.digested_filename <> compressor.file_extension),
+          Path.join(path, file.digested_filename <> file_extension),
           compressed_digested
         )
 
         File.write!(
-          Path.join(path, file.filename <> compressor.file_extension),
+          Path.join(path, file.filename <> file_extension),
           compressed
         )
       end

--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -154,16 +154,16 @@ defmodule Phoenix.Digester do
     compressors = Application.fetch_env!(:phoenix, :static_compressors)
 
     Enum.each(compressors, fn(compressor) ->
-      if compressor.compress_file?(file.absolute_path, file.content, file.digested_content) do
-        compressed_digested = compressor.compress(file.digested_content)
-        compressed = compressor.compress(file.content)
-        [file_extension | _] = compressor.file_extensions
+      [file_extension | _] = compressor.file_extensions
 
+      with {:ok, compressed_digested} <- compressor.compress_file(file.digested_filename, file.digested_content) do
         File.write!(
           Path.join(path, file.digested_filename <> file_extension),
           compressed_digested
         )
+      end
 
+      with {:ok, compressed} <- compressor.compress_file(file.filename, file.content) do
         File.write!(
           Path.join(path, file.filename <> file_extension),
           compressed

--- a/lib/phoenix/digester/compressor.ex
+++ b/lib/phoenix/digester/compressor.ex
@@ -1,0 +1,5 @@
+defmodule Phoenix.Digester.Compressor do
+  @callback compress(binary()) :: binary()
+  @callback file_extension() :: String.t()
+  @callback compress_file?(Path.t(), binary(), binary()) :: bool()
+end

--- a/lib/phoenix/digester/compressor.ex
+++ b/lib/phoenix/digester/compressor.ex
@@ -1,5 +1,4 @@
 defmodule Phoenix.Digester.Compressor do
-  @callback compress(binary()) :: binary()
+  @callback compress_file(Path.t(), binary()) :: {:ok, binary()} | :error
   @callback file_extensions() :: nonempty_list(String.t())
-  @callback compress_file?(Path.t(), binary(), binary()) :: bool()
 end

--- a/lib/phoenix/digester/compressor.ex
+++ b/lib/phoenix/digester/compressor.ex
@@ -1,4 +1,44 @@
 defmodule Phoenix.Digester.Compressor do
+  @moduledoc ~S"""
+  Defines the `Phoenix.Digester.Compressor` behaviour for
+  implementing static file compressors.
+
+  A custom compressor expects 2 functions to be implemented.
+
+  By default, Phoenix uses only `Phoenix.Digester.Gzip` to compress
+  static files, but additional compressors can be defined and added
+  to the digest process.
+
+  ## Example
+
+  If you wanted to compress files using an external brotli compression
+  library, you could define a new module implementing the behaviour and add the
+  module to the list of configured Phoenix static compressors.
+
+      defmodule MyApp.BrotliCompressor do
+        @behaviour Phoenix.Digester.Compressor
+
+        def compress_file(file_path, content) do
+          valid_extension = Path.extname(file_path) in Application.fetch_env!(:phoenix, :gzippable_exts)
+          compressed_content = :brotli.encode(content)
+
+          if valid_extension && byte_size(compressed_content) < byte_size(content) do
+            {:ok, compressed_content}
+          else
+            :error
+          end
+        end
+
+        def file_extensions do
+          [".br"]
+        end
+      end
+
+      # config/config.exs
+      config :phoenix,
+        static_compressors: [Phoenix.Digester.Gzip, MyApp.BrotliCompressor],
+        # ...
+  """
   @callback compress_file(Path.t(), binary()) :: {:ok, binary()} | :error
   @callback file_extensions() :: nonempty_list(String.t())
 end

--- a/lib/phoenix/digester/compressor.ex
+++ b/lib/phoenix/digester/compressor.ex
@@ -1,5 +1,5 @@
 defmodule Phoenix.Digester.Compressor do
   @callback compress(binary()) :: binary()
-  @callback file_extension() :: String.t()
+  @callback file_extensions() :: nonempty_list(String.t())
   @callback compress_file?(Path.t(), binary(), binary()) :: bool()
 end

--- a/lib/phoenix/digester/gzip.ex
+++ b/lib/phoenix/digester/gzip.ex
@@ -1,5 +1,9 @@
 defmodule Phoenix.Digester.Gzip do
+  @moduledoc ~S"""
+  Gzip compressor for Phoenix.Digester
+  """
   @behaviour Phoenix.Digester.Compressor
+
   def compress_file(file_path, content) do
     if Path.extname(file_path) in Application.fetch_env!(:phoenix, :gzippable_exts) do
       {:ok, :zlib.gzip(content)}

--- a/lib/phoenix/digester/gzip.ex
+++ b/lib/phoenix/digester/gzip.ex
@@ -4,8 +4,8 @@ defmodule Phoenix.Digester.Gzip do
     :zlib.gzip(content)
   end
 
-  def file_extension do
-    ".gz"
+  def file_extensions do
+    [".gz"]
   end
 
   def compress_file?(file_path, _content, _digested_content) do

--- a/lib/phoenix/digester/gzip.ex
+++ b/lib/phoenix/digester/gzip.ex
@@ -1,0 +1,14 @@
+defmodule Phoenix.Digester.Gzip do
+  @behaviour Phoenix.Digester.Compressor
+  def compress(content) do
+    :zlib.gzip(content)
+  end
+
+  def file_extension do
+    ".gz"
+  end
+
+  def compress_file?(file_path, _content, _digested_content) do
+    Path.extname(file_path) in Application.fetch_env!(:phoenix, :gzippable_exts)
+  end
+end

--- a/lib/phoenix/digester/gzip.ex
+++ b/lib/phoenix/digester/gzip.ex
@@ -1,14 +1,14 @@
 defmodule Phoenix.Digester.Gzip do
   @behaviour Phoenix.Digester.Compressor
-  def compress(content) do
-    :zlib.gzip(content)
+  def compress_file(file_path, content) do
+    if Path.extname(file_path) in Application.fetch_env!(:phoenix, :gzippable_exts) do
+      {:ok, :zlib.gzip(content)}
+    else
+      :error
+    end
   end
 
   def file_extensions do
     [".gz"]
-  end
-
-  def compress_file?(file_path, _content, _digested_content) do
-    Path.extname(file_path) in Application.fetch_env!(:phoenix, :gzippable_exts)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -55,6 +55,7 @@ defmodule Phoenix.MixProject do
         filter_parameters: ["password"],
         serve_endpoints: false,
         gzippable_exts: ~w(.js .css .txt .text .html .json .svg .eot .ttf),
+        static_compressors: [Phoenix.Digester.Gzip],
         trim_on_html_eex_engine: true
       ]
     ]

--- a/test/phoenix/digester/gzip_test.exs
+++ b/test/phoenix/digester/gzip_test.exs
@@ -1,0 +1,13 @@
+defmodule Phoenix.Digester.GzipTest do
+  use ExUnit.Case, async: true
+  alias Phoenix.Digester.Gzip
+
+  test "compress_file/2 compresses file" do
+    file_path = "test/fixtures/digest/priv/static/css/app.css"
+    content = File.read!(file_path)
+
+    {:ok, compressed} = Gzip.compress_file(file_path, content)
+
+    assert is_binary(compressed)
+  end
+end

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -91,7 +91,6 @@ defmodule Phoenix.DigesterTest do
 
       json = Path.join(@output_path, "cache_manifest.json") |> json_read!()
       refute json["latest"]["precompressed.js.gz"]
-      refute json["latest"]["precompressed.js.br"]
 
       assert :ok = Phoenix.Digester.compile(@output_path, @output_path)
       assert output_files == assets_files(@output_path)


### PR DESCRIPTION
Following on the work in #3836 and #3840, I wanted to have a quick go at a more robust feature described in https://github.com/phoenixframework/phoenix/issues/3836#issuecomment-629623791

I added `compress_file?` to the behaviour to be able to not compress some assets with certain compressors if the content is too small (or similar).

I haven't written any docs/tests yet, and the naming/structure could use some updates, but figured I'd start the discussion with this 🙂