### PR TITLE
Fix broken link to contexts guide

### DIFF
--- a/guides/testing/testing_contexts.md
+++ b/guides/testing/testing_contexts.md
@@ -4,7 +4,7 @@
 
 > **Requirement**: This guide expects that you have gone through [the Introduction to Testing guide](testing.html).
 
-> **Requirement**: This guide expects that you have gone through [the Context guide](context.html).
+> **Requirement**: This guide expects that you have gone through [the Contexts guide](contexts.html).
 
 At the end of the Introduction to Testing guide, we generated an HTML resource for posts using the following command:
 


### PR DESCRIPTION
The contexts guide link and name are pluralized, but this page was linking to a singular version that doesn't exist.

<img width="653" alt="Screenshot 2020-07-08 at 06 33 29" src="https://user-images.githubusercontent.com/191664/86880754-10caee80-c0e5-11ea-9ade-dd4654e29238.png">

<img width="950" alt="Screenshot 2020-07-08 at 12 13 45" src="https://user-images.githubusercontent.com/191664/86912214-813d3400-c114-11ea-8825-afef1a2565fd.png">


Not reading them in order means I am jumping around quite a bit :)