### PR TITLE
Correct typespecs for delegated ConnTest.get_flash/{1,2}

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -273,13 +273,13 @@ defmodule Phoenix.ConnTest do
   @doc """
   Gets the whole flash storage.
   """
-  @spec get_flash(Conn.t) :: Conn.t
+  @spec get_flash(Conn.t) :: map
   defdelegate get_flash(conn), to: Phoenix.Controller
 
   @doc """
   Gets the given key from the flash storage.
   """
-  @spec get_flash(Conn.t, term) :: Conn.t
+  @spec get_flash(Conn.t, term) :: term
   defdelegate get_flash(conn, key), to: Phoenix.Controller
 
   @doc """


### PR DESCRIPTION
While reading through the documentation for `Phoenix.ConnTest`, I came across some type specifications that appear to be incorrect. This is a quick change to resolve the issue. 🙂 