### PR TITLE
Keep example and clarification consistent

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -125,7 +125,7 @@ def show(conn, %{"messenger" => messenger}) do
 end
 ```
 
-Hitting `/hello/Frank` now renders the HTML string we defined in the `show` action. Note that what we wrote in the action is not an `eex` template. It's a multi-line string, so we interpolate the `id` variable like this `#{id}`, instead of this `<%= id %>`.
+Hitting `/hello/Frank` now renders the HTML string we defined in the `show` action. Note that what we wrote in the action is not an `eex` template. It's a multi-line string, so we interpolate the `messenger` variable like this `#{messenger}`, instead of this `<%= messenger %>`.
 
 It is worth noting that the `text/2`, `json/2`, and `html/2` functions require neither a Phoenix view, nor a template to render.
 


### PR DESCRIPTION
The example code uses `#{messenger}` while the clarifying explanation uses `#{id}`.  Perhaps this was on purpose—and if so, please carry on—but it made me do a few double takes trying to figure out where `#{id}` was referenced in the example.