### PR TITLE
Add :conn to router_dispatch exception events

### DIFF
--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -30,7 +30,7 @@ defmodule Phoenix.Logger do
     * `[:phoenix, :router_dispatch, :exception]` - dispatched by `Phoenix.Router`
       after exceptions on dispatching a route
       * Measurement: `%{duration: native_time}`
-      * Metadata: `%{kind: :throw | :error | :exit, reason: term(), stacktrace: Exception.stacktrace()}`
+      * Metadata: `%{conn: Plug.Conn.t, kind: :throw | :error | :exit, reason: term(), stacktrace: Exception.stacktrace()}`
       * Disable logging: This event is not logged
 
     * `[:phoenix, :router_dispatch, :stop]` - dispatched by `Phoenix.Router`

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -359,13 +359,13 @@ defmodule Phoenix.Router do
         rescue
           e in Plug.Conn.WrapperError ->
             measurements = %{duration: System.monotonic_time() - start}
-            metadata = %{kind: :error, reason: e, stacktrace: __STACKTRACE__}
+            metadata = %{conn: conn, kind: :error, reason: e, stacktrace: __STACKTRACE__}
             :telemetry.execute([:phoenix, :router_dispatch, :exception], measurements, metadata)
             Plug.Conn.WrapperError.reraise(e)
         catch
           kind, reason ->
             measurements = %{duration: System.monotonic_time() - start}
-            metadata = %{kind: kind, reason: reason, stacktrace: __STACKTRACE__}
+            metadata = %{conn: conn, kind: kind, reason: reason, stacktrace: __STACKTRACE__}
             :telemetry.execute([:phoenix, :router_dispatch, :exception], measurements, metadata)
             Plug.Conn.WrapperError.reraise(piped_conn, kind, reason, __STACKTRACE__)
         end


### PR DESCRIPTION
Looking for feedback. This would allow introspection of the connection as it existed when the router_dispatch start event was executed, which will be helpful for debugging, especially in applications with more than one router.