### PR TITLE
Expose trace context headers in websockets and long polling

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -768,7 +768,11 @@ defmodule Phoenix.Endpoint do
 
         * `:peer_data` - the result of `Plug.Conn.get_peer_data/1`
 
-        * `:trace_context_headers` - a list of all trace context headers
+        * `:trace_context_headers` - a list of all trace context headers. Supported
+          headers are defined by the [W3C Trace Context Specification](https://www.w3.org/TR/trace-context-1/).
+          These headers are necessary for libraries such as [OpenTelemetry](https://opentelemetry.io/) to extract
+          trace propagation information to know this request is part of a larger trace
+          in progress.
 
         * `:x_headers` - all request headers that have an "x-" prefix
 
@@ -791,7 +795,7 @@ defmodule Phoenix.Endpoint do
 
           socket "/socket", AppWeb.UserSocket,
             websocket: [
-              connect_info: [:peer_data, :x_headers, :uri, session: [store: :cookie]]
+              connect_info: [:peer_data, :trace_context_headers, :x_headers, :uri, session: [store: :cookie]]
             ]
 
       With arbitrary keywords:

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -768,6 +768,8 @@ defmodule Phoenix.Endpoint do
 
         * `:peer_data` - the result of `Plug.Conn.get_peer_data/1`
 
+        * `:trace_context_headers` - a list of all trace context headers
+
         * `:x_headers` - all request headers that have an "x-" prefix
 
         * `:uri` - a `%URI{}` with information from the conn

--- a/test/phoenix/integration/long_poll_channels_test.exs
+++ b/test/phoenix/integration/long_poll_channels_test.exs
@@ -60,12 +60,14 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
     def connect(params, socket, connect_info) do
       unless params["logging"] == "enabled", do: Logger.disable(self())
       address = Tuple.to_list(connect_info.peer_data.address) |> Enum.join(".")
+      trace_context_headers = Enum.into(connect_info.trace_context_headers, %{})
       uri = Map.from_struct(connect_info.uri)
       x_headers = Enum.into(connect_info.x_headers, %{})
 
       connect_info =
         connect_info
         |> update_in([:peer_data], &Map.put(&1, :address, address))
+        |> Map.put(:trace_context_headers, trace_context_headers)
         |> Map.put(:uri, uri)
         |> Map.put(:x_headers, x_headers)
 
@@ -127,7 +129,7 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
         window_ms: 200,
         pubsub_timeout_ms: 200,
         check_origin: ["//example.com"],
-        connect_info: [:x_headers, :peer_data, :uri]
+        connect_info: [:trace_context_headers, :x_headers, :peer_data, :uri]
       ]
   end
 
@@ -281,6 +283,23 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
       assert %{"connect_info" =>
                %{"x_headers" =>
                  %{"x-application" => "Phoenix"}}} = status_msg.payload
+    end
+
+    test "#{@mode}: transport trace_context_headers are extracted to the socket connect_info" do
+      ctx_headers =
+        %{"traceparent" => "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        "tracestate" => "congo=t61rcWkgMz"}
+      session = join("/ws/connect_info", "room:lobby", @vsn, @mode, %{}, %{}, ctx_headers)
+
+      # pull messages
+      resp = poll(:get, "/ws/connect_info", @vsn, session)
+      assert resp.body["status"] == 200
+
+      [_phx_reply, _user_entered, status_msg] = resp.body["messages"]
+
+      assert %{"connect_info" =>
+        %{"trace_context_headers" =>
+           ctx_headers}} = status_msg.payload
     end
 
     test "#{@mode}: transport peer_data is extracted to the socket connect_info" do


### PR DESCRIPTION
In order to correlate distributed traces to actions within websockets we need to have access to trace context headers in order to extract the context without complicated workarounds. 

The [W3C Trace Context Headers](https://www.w3.org/TR/trace-context-1/) are in a firm place naming-wise to add support in Phoenix for usage by projects such as OpenTelemetry. This PR exposes the two official context headers to the `connect_info` map. This is necessary to provide seamless tracing of websockets for users in the `opentelemetry_phoenix` project.

/cc @josevalim @tsloughter @hauleth 