### PR TITLE
Docs: Fix Presence docs code typo

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -37,7 +37,7 @@ defmodule Phoenix.Presence do
 
       children = [
         ...
-        MyAppWeb.PubSub,
+        {Phoenix.PubSub, name: MyApp.PubSub},
         MyAppWeb.Presence,
         MyAppWeb.Endpoint
       ]

--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -21,7 +21,7 @@ defmodule Phoenix.Presence do
   which uses `Phoenix.Presence` and provide the `:otp_app` which
   holds your configuration, as well as the `:pubsub_server`.
 
-      defmodule MyApp.Presence do
+      defmodule MyAppWeb.Presence do
         use Phoenix.Presence,
           otp_app: :my_app,
           pubsub_server: MyApp.PubSub


### PR DESCRIPTION
Fixes #3941

This pull request fixes the Presence module name In the first code snippet of `lib/phoenix/presence.ex` to include `Web`, for consistency with the `MyAppWeb.Presence` module name used throughout the rest of the docs:

```elixir
      defmodule MyAppWeb.Presence do
        use Phoenix.Presence,
          otp_app: :my_app,
          pubsub_server: MyApp.PubSub
      end
```

This pull request also updates the `lib/my_app/application.ex` > `children = [`snippet to remove `Web` from `MyApp.PubSub`, as PubSub by default is not generated under `MyAppWeb`:

```elixir
  Next, add the new supervisor to your supervision tree in
  `lib/my_app/application.ex`. It must be after the PubSub child
  and before the endpoint:

      children = [
        ...
        {Phoenix.PubSub, name: MyApp.PubSub},
        MyAppWeb.Presence,
        MyAppWeb.Endpoint
      ]
```
