### PR TITLE
Add notes on cowboy 2.8.0 and Erlang 22

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -27,6 +27,8 @@ Elixir code compiles to Erlang byte code to run on the Erlang virtual machine. W
 
 When we install Elixir using instructions from the Elixir [Installation Page](https://elixir-lang.org/install.html),  we will usually get Erlang too. If Erlang was not installed along with Elixir, please see the [Erlang Instructions](https://elixir-lang.org/install.html#installing-erlang) section of the Elixir Installation Page for instructions.
 
+> A note about Erlang and Phoenix: while Phoenix itself only requires Erlang 20 or later, one of Phoenix's dependencies, [cowboy](https://github.com/ninenines/cowboy), depends on Erlang 22 or later since cowboy 2.8.0. It is recommended to either install Erlang 22 or add `{:cowboy, "~> 2.7.0"}` to your mix.exs once your app has been created.
+
 ## Phoenix
 
 To check that we are on Elixir 1.6 and Erlang 20 or later, run:

--- a/guides/introduction/up_and_running.md
+++ b/guides/introduction/up_and_running.md
@@ -67,6 +67,8 @@ Ok, let's give it a try. First, we'll `cd` into the `hello/` directory we've jus
 $ cd hello
 ```
 
+> If you followed the [Installation Guide](installation.html) and opted to add `{:cowboy, "~> 2.7.0"}` to your mix.exs, go ahead and do that now and run `mix deps.get`.
+
 Now we'll create our database:
 
 ```console


### PR DESCRIPTION
Added some notes about cowboy 2.8.0 requiring Erlang 22 in the installation and up and running guides. 

Trying to run `mix ecto.create` while running Erlang 21.0.9 gave me the error `Could not compile dependency :cowboy`, even though the installation guide says "Erlang 20 or later". I added some notes based on @josevalim's suggestions in #3903 to let new Phoenix developers know about the issue and how to resolve it. I didn't want to update the installation guide to say "Erlang 22 or later" since it's just a cowboy dependency and not a Phoenix one.