### PR TITLE
Upgrade copy-webpack-plugin to version 6.0.3

### DIFF
--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -16,7 +16,7 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.0",
-    "copy-webpack-plugin": "^5.1.1",
+    "copy-webpack-plugin": "^6.0.3",
     "css-loader": "^3.4.2",
     "sass-loader": "^8.0.2",
     "node-sass": "^4.13.1",

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = (env, options) => {
     },
     plugins: [
       new MiniCssExtractPlugin({ filename: '../css/[name].css' }),
-      new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
+      new CopyWebpackPlugin({ patterns: [{ from: 'static/', to: '../' }] })
     ]
     .concat(devMode ? [new HardSourceWebpackPlugin()] : [])
   }


### PR DESCRIPTION
`copy-webpack-plugin` version 5.1.1 is stucked with a vulnerable dependency: `serialize-javascript@2.1.2`. [A major version upgrade is required](https://github.com/webpack-contrib/copy-webpack-plugin/issues/509).

This new version introduces [several breaking changes](https://github.com/webpack-contrib/copy-webpack-plugin/releases/tag/v6.0.0):

> the plugin now accepts an object, you should change `new CopyPlugin(patterns, options)` to `new CopyPlugin({ patterns, options })`