### PR TITLE
Run installer tests in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           apk add --no-progress --update git
           mix deps.get
       - run: mix test
+      - name: Run installer tests
+        run: mix test
+        working-directory: installer
       # - run: MIX_ENV=docs mix inch.report
 
   npm_test:


### PR DESCRIPTION
It appears that the installer tests accidentally were removed during the migration to GitHub Actions. This adds those tests back into CI.