### PR TITLE
Explicitly mention `mix phx.new` in Installation guide

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -46,7 +46,7 @@ Once we have Elixir and Erlang, we are ready to install the Phoenix application 
 $ mix archive.install hex phx_new 1.5.0
 ```
 
-We will use this generator to generate new applications in the next guide, called [Up and Running](up_and_running.html).
+The `phx.new` generator is now available to generate new applications in the next guide, called [Up and Running](up_and_running.html). The flags mentioned below are command line options to the generator; see all available options by calling `mix help phx.new`.
 
 ## node.js
 


### PR DESCRIPTION
It is indeed mentioned in _Up and Running_, but this is the page I re-read first every time I return to Phoenix after several months with other langs, and always have to click around because I forgot what the exact command is (plus it also changed from `mix phoenix.new` at one point). It might also be prudent to give proper context to newcomers as well.

Thanks for considering!