### PR TITLE
Fix Phoenix.Router.Route.build/13 spec

### DIFF
--- a/lib/phoenix/router/route.ex
+++ b/lib/phoenix/router/route.ex
@@ -46,7 +46,7 @@ defmodule Phoenix.Router.Route do
   Receives the verb, path, plug, options and helper
   and returns a `Phoenix.Router.Route` struct.
   """
-  @spec build(non_neg_integer, :match | :forward, atom, String.t, String.t | nil, atom, atom, atom | nil, atom, map, map, map, boolean) :: t
+  @spec build(non_neg_integer, :match | :forward, atom, String.t, String.t | nil, atom, atom, atom | nil, list(atom), map, map, map, boolean) :: t
   def build(line, kind, verb, path, host, plug, plug_opts, helper, pipe_through, private, assigns, metadata, trailing_slash?)
       when is_atom(verb) and (is_binary(host) or is_nil(host)) and
            is_atom(plug) and (is_binary(helper) or is_nil(helper)) and


### PR DESCRIPTION
`pipe_through` is a list of atoms, as noted in the [module docs](https://github.com/phoenixframework/phoenix/blob/60b87846f3dde0800f93c7db375c356d6dbdc6b9/lib/phoenix/router/route.ex#L22)