### PR TITLE
use "/" to detect invalid hosts instead of ":"

### DIFF
--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -302,7 +302,7 @@ defmodule Phoenix.Endpoint.Supervisor do
     host   = host_to_binary(url[:host] || "localhost")
     port   = port_to_integer(url[:port] || port)
 
-    if host =~ "/" do
+    if host =~ ~r"[^:]:\d" do
       Logger.warn("url: [host: ...] configuration value #{inspect(host)} for #{inspect(endpoint)} is invalid")
     end
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -302,7 +302,7 @@ defmodule Phoenix.Endpoint.Supervisor do
     host   = host_to_binary(url[:host] || "localhost")
     port   = port_to_integer(url[:port] || port)
 
-    if host =~ ":" do
+    if host =~ "/" do
       Logger.warn("url: [host: ...] configuration value #{inspect(host)} for #{inspect(endpoint)} is invalid")
     end
 
@@ -410,7 +410,7 @@ defmodule Phoenix.Endpoint.Supervisor do
 
   defp cache_static_manifest(endpoint) do
     if inner = endpoint.config(:cache_static_manifest) do
-      {app, inner} = 
+      {app, inner} =
         case inner do
           {_, _} = inner -> inner
           inner when is_binary(inner) -> {endpoint.config(:otp_app), inner}
@@ -439,7 +439,7 @@ defmodule Phoenix.Endpoint.Supervisor do
 
   @doc """
   List of keys which we ensure are unchanged from compile time to runtime. For
-  example, the :force_ssl option must be available at compile time in order to 
+  example, the :force_ssl option must be available at compile time in order to
   work properly. We check these keys so we can warn the user that changing the
   option at runtime may lead to undesirable behavior.
   """


### PR DESCRIPTION
`":"` is a valid character if the host is an IPv6 address.

edit: this assumes the http protocol, we don't need to handle `file://`, do we?

Fixes #3975