### PR TITLE
Don't create compile-time dependencies for action_fallback

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -232,7 +232,7 @@ defmodule Phoenix.Controller do
       end
   """
   defmacro action_fallback(plug) do
-    Phoenix.Controller.Pipeline.__action_fallback__(plug)
+    Phoenix.Controller.Pipeline.__action_fallback__(plug, __CALLER__)
   end
 
   @doc """

--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -37,7 +37,8 @@ defmodule Phoenix.Controller.Pipeline do
   end
 
   @doc false
-  def __action_fallback__(plug) do
+  def __action_fallback__(plug, caller) do
+    plug = Macro.expand(plug, %{caller | function: {:init, 1}})
     quote bind_quoted: [plug: plug] do
       @phoenix_fallback Phoenix.Controller.Pipeline.validate_fallback(
                           plug,


### PR DESCRIPTION
The plug is not used at compile-time, it's safe not to create the compile-time dependency. This should break a lot of compile dependencies in phoenix applications using `action_fallback` - as a "central" component it tends to accumulate a lot of dependencies itself.