### PR TITLE
Checks origins host names case insensitive

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -614,9 +614,9 @@ defmodule Phoenix.Socket.Transport do
   defp compare_host?(_request_host, nil),
     do: true
   defp compare_host?(request_host, "*." <> allowed_host),
-    do: String.ends_with?(request_host, allowed_host)
+    do: String.ends_with?(String.downcase(request_host), String.downcase(allowed_host))
   defp compare_host?(request_host, allowed_host),
-    do: request_host == allowed_host
+    do: String.downcase(request_host) == String.downcase(allowed_host)
 
   # TODO: Deprecate {:system, env_var} once we require Elixir v1.9+
   defp host_to_binary({:system, env_var}), do: host_to_binary(System.get_env(env_var))

--- a/test/phoenix/socket/transport_test.exs
+++ b/test/phoenix/socket/transport_test.exs
@@ -81,10 +81,10 @@ defmodule Phoenix.Socket.TransportTest do
     test "wildcard subdomains" do
       origins = ["https://*.ex.com", "http://*.ex.com"]
 
-      conn = check_origin("http://org1.ex.com", check_origin: origins)
-      refute conn.halted
-      conn = check_origin("https://org1.ex.com", check_origin: origins)
-      refute conn.halted
+      refute check_origin("http://org1.ex.com", check_origin: origins).halted
+      refute check_origin("HTTP://ORG1.EX.COM", check_origin: origins).halted
+      refute check_origin("https://org1.ex.com", check_origin: origins).halted
+      refute check_origin("HTTPS://ORG1.EX.COM", check_origin: origins).halted
     end
 
     test "nested wildcard subdomains" do
@@ -148,9 +148,12 @@ defmodule Phoenix.Socket.TransportTest do
       # Only host match
       refute check_origin("http://example.com/", check_origin: origins).halted
       refute check_origin("https://example.com/", check_origin: origins).halted
+      refute check_origin("HTTP://EXAMpLE.com/", check_origin: origins).halted
+      refute check_origin("HTTPs://EXAMpLE.com/", check_origin: origins).halted
 
       # Scheme + host match (checks port due to scheme)
       refute check_origin("http://scheme.com/", check_origin: origins).halted
+      refute check_origin("HTTP://SCHEME.Com/", check_origin: origins).halted
 
       conn = check_origin("https://scheme.com/", check_origin: origins)
       assert conn.halted
@@ -162,6 +165,7 @@ defmodule Phoenix.Socket.TransportTest do
 
       # Scheme + host + port match
       refute check_origin("http://port.com:81/", check_origin: origins).halted
+      refute check_origin("HTTP://PORT.Com:81/", check_origin: origins).halted
 
       conn = check_origin("http://port.com:82/", check_origin: origins)
       assert conn.halted


### PR DESCRIPTION
URLs schemes and hosts are case insensitive and should checked that way.