### PR TITLE
Fix broken link to Gettext in docs

### DIFF
--- a/guides/plug.md
+++ b/guides/plug.md
@@ -118,7 +118,7 @@ To see the assign in action, go to the layout in "lib/hello_web/templates/layout
   <p>Locale: <%= @locale %></p>
 ```
 
-Go to "http://localhost:4000/" and you should see the locale exhibited. Visit "http://localhost:4000/?locale=fr" and you should see the assign changed to "fr". Someone can use this information alongside [Gettext](https://hexdocs.pm/gettext/Gettext) to provide a fully internationalized web application.
+Go to "http://localhost:4000/" and you should see the locale exhibited. Visit "http://localhost:4000/?locale=fr" and you should see the assign changed to "fr". Someone can use this information alongside [Gettext](https://hexdocs.pm/gettext/Gettext.html) to provide a fully internationalized web application.
 
 That's all there is to Plug. Phoenix embraces the plug design of composable transformations all the way up and down the stack. Let's see some examples!
 


### PR DESCRIPTION
Use the correct link to Gettext under the Plug section in the guides.