### PR TITLE
replace remaining Mix.Config usage

### DIFF
--- a/installer/templates/phx_umbrella/config/dev.exs
+++ b/installer/templates/phx_umbrella/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"

--- a/installer/templates/phx_umbrella/config/prod.secret.exs
+++ b/installer/templates/phx_umbrella/config/prod.secret.exs
@@ -2,4 +2,4 @@
 # from environment variables. You can also hardcode secrets,
 # although such is generally not recommended and you have to
 # remember to add this file to your .gitignore.
-use Mix.Config
+import Config


### PR DESCRIPTION
As per https://github.com/phoenixframework/phoenix/commit/cbfc71c7fcd9c5b95ac5ed63719ac88a4927af85, `use Mix.Config` can be replaced with `import Config`.