### PR TITLE
Add --colors option in watchers for colorized Webpack output

### DIFF
--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -17,6 +17,7 @@ config :<%= app_name %>, <%= endpoint_module %>,
       "--mode",
       "development",
       "--watch-stdin",
+      "--colors",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]<% else %>[]<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -15,6 +15,7 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
       "--mode",
       "development",
       "--watch-stdin",
+      "--colors",
       cd: Path.expand("../apps/<%= web_app_name %>/assets", __DIR__)
     ]
   ]<% else %>[]<% end %>


### PR DESCRIPTION
Added the --colors option for the Endpoint config in dev.exs
Having a colorized output is a little prettier.
Changes added for both regular and umbrella app generation.