### PR TITLE
Use 127.0.0.1 in dev and test

### DIFF
--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -7,7 +7,9 @@ import Config
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :<%= app_name %>, <%= endpoint_module %>,
-  http: [port: 4000],
+  # Binding to loopback ipv4 address prevents access from other machines.
+  # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
+  http: [ip: {127, 0, 0, 1}, port: 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/installer/templates/phx_single/config/test.exs
+++ b/installer/templates/phx_single/config/test.exs
@@ -3,7 +3,7 @@ import Config
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :<%= app_name %>, <%= endpoint_module %>,
-  http: [port: 4002],
+  http: [ip: {127, 0, 0, 1}, port: 4002],
   server: false
 
 # Print only warnings and errors during test

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -5,7 +5,9 @@
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :<%= web_app_name %>, <%= endpoint_module %>,
-  http: [port: 4000],
+  # Binding to loopback ipv4 address prevents access from other machines.
+  # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
+  http: [ip: {127, 0, 0, 1}, port: 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/test.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/test.exs
@@ -1,5 +1,5 @@
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :<%= web_app_name %>, <%= endpoint_module %>,
-  http: [port: 4002],
+  http: [ip: {127, 0, 0, 1}, port: 4002],
   server: false


### PR DESCRIPTION
When `:ip` is not given, phoenix is listening on all interfaces. This is not desired for dev/test mode, where it's unlikely to expose servers to public interfaces.

Add `:ip` option with ipv4 loopback (`127.0.0.1`) to all generated dev/test configuration.

(kind of related: #3400)