### PR TITLE
Use ip option instead of transport socket_opts

### DIFF
--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -25,11 +25,11 @@ config :logger, level: :info
 #       ...
 #       url: [host: "example.com", port: 443],
 #       https: [
+#         ip: {0, 0, 0, 0, 0, 0, 0, 0},
 #         port: 443,
 #         cipher_suite: :strong,
 #         keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
-#         certfile: System.get_env("SOME_APP_SSL_CERT_PATH"),
-#         transport_options: [socket_opts: [:inet6]]
+#         certfile: System.get_env("SOME_APP_SSL_CERT_PATH")
 #       ]
 #
 # The `cipher_suite` is set to `:strong` to support only the

--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -22,10 +22,10 @@ config :logger, level: :info
 # to the previous section and set your `:url` port to 443:
 #
 #     config :<%= web_app_name %>, <%= endpoint_module %>,
-#       ...
+#       ...,
 #       url: [host: "example.com", port: 443],
 #       https: [
-#         ip: {0, 0, 0, 0, 0, 0, 0, 0},
+#         ...,
 #         port: 443,
 #         cipher_suite: :strong,
 #         keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),

--- a/installer/templates/phx_single/config/prod.secret.exs
+++ b/installer/templates/phx_single/config/prod.secret.exs
@@ -13,8 +13,8 @@ secret_key_base =
 
 config :<%= app_name %>, <%= endpoint_module %>,
   http: [
-    port: String.to_integer(System.get_env("PORT") || "4000"),
-    transport_options: [socket_opts: [:inet6]]
+    ip: {0, 0, 0, 0, 0, 0, 0, 0},
+    port: String.to_integer(System.get_env("PORT") || "4000")
   ],
   secret_key_base: secret_key_base
 

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
@@ -20,11 +20,11 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
 #       ...
 #       url: [host: "example.com", port: 443],
 #       https: [
+#         ip: {0, 0, 0, 0, 0, 0, 0, 0},
 #         port: 443,
 #         cipher_suite: :strong,
 #         keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
-#         certfile: System.get_env("SOME_APP_SSL_CERT_PATH"),
-#         transport_options: [socket_opts: [:inet6]]
+#         certfile: System.get_env("SOME_APP_SSL_CERT_PATH")
 #       ]
 #
 # The `cipher_suite` is set to `:strong` to support only the

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
@@ -17,10 +17,10 @@ config :<%= web_app_name %>, <%= endpoint_module %>,
 # to the previous section and set your `:url` port to 443:
 #
 #     config :<%= web_app_name %>, <%= endpoint_module %>,
-#       ...
+#       ...,
 #       url: [host: "example.com", port: 443],
 #       https: [
-#         ip: {0, 0, 0, 0, 0, 0, 0, 0},
+#         ...,
 #         port: 443,
 #         cipher_suite: :strong,
 #         keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/prod.secret.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/prod.secret.exs
@@ -7,8 +7,8 @@ secret_key_base =
 
 config :<%= web_app_name %>, <%= endpoint_module %>,
   http: [
-    port: String.to_integer(System.get_env("PORT") || "4000"),
-    transport_options: [socket_opts: [:inet6]]
+    ip: {0, 0, 0, 0, 0, 0, 0, 0},
+    port: String.to_integer(System.get_env("PORT") || "4000")
   ],
   secret_key_base: secret_key_base
 

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -46,8 +46,10 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/config/prod.exs", fn file ->
         assert file =~ "port: 80"
-        assert file =~ ":inet6"
+        assert file =~ "import_config \"prod.secret.exs\""
       end
+
+      assert_file "phx_blog/config/prod.secret.exs", ~r/ip: {0, 0, 0, 0, 0, 0, 0, 0}/
 
       assert_file "phx_blog/lib/phx_blog/application.ex", ~r/defmodule PhxBlog.Application do/
       assert_file "phx_blog/lib/phx_blog.ex", ~r/defmodule PhxBlog do/

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -71,8 +71,10 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file root_path(@app, "config/prod.exs"), fn file ->
         assert file =~ "port: 80"
-        assert file =~ ":inet6"
+        assert file =~ "import_config \"prod.secret.exs\""
       end
+
+      assert_file root_path(@app, "config/prod.secret.exs"), ~r/ip: {0, 0, 0, 0, 0, 0, 0, 0}/
 
       assert_file app_path(@app, ".formatter.exs"), fn file ->
         assert file =~ "import_deps: [:ecto]"
@@ -638,9 +640,10 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
         assert_file "../config/prod.exs", fn file ->
           assert file =~ "port: 80"
-          assert file =~ ":inet6"
           assert file =~ "import_config \"prod.secret.exs\""
         end
+
+        assert_file "../config/prod.secret.exs", ~r/ip: {0, 0, 0, 0, 0, 0, 0, 0}/
 
         assert_file "another/lib/another/application.ex", ~r/defmodule Another.Application do/
         assert_file "another/mix.exs", ~r/mod: {Another.Application, \[\]}/


### PR DESCRIPTION
#3551 converted the config from list to keyword by moving the first `inet` / `inet6` option under `transport_options[:socket_opts]`.

All options is down to [ranch_top](https://ninenines.eu/docs/en/ranch/1.7/manual/ranch_tcp/)

This can be simplified by using `:ip` option  actually, since ranch seems to pick up right socket based on the `:ip` option.

Also it could be simpler to use, since if a user want to bind to specific ip address by changing only `:ip` option, not two places to make sure use right `socket opts`.

## Docs

[ranch_tcp (1.7)](https://ninenines.eu/docs/en/ranch/1.7/manual/ranch_tcp/)

> inet
>     Set up the socket for IPv4.
> inet6
>     Set up the socket for IPv6.
> ip
>     Interface to listen on. Listen on all interfaces by default.

See also [ranch (1.7)](https://ninenines.eu/docs/en/ranch/1.7/manual/ranch/)

> Transport options.
>
> socket_opts
>     Socket options given to Transport:listen/1. Please refer to the documentation of the transport module you are using for more details.

## Example

```elixir
[http: [port: 4000]]
[http: [:inet, port: 4000]]
[http: [port: 4000, ip: {0, 0, 0, 0}]]
[http: [port: 4000, transport_options: [socket_opts: [:inet]]]]
# => 0.0.0.0:4000

[http: [ip: {127, 0, 0, 1}, port: 4000]]
# => 127.0.0.1:4000

[http: [:inet6, port: 4000]]
[http: [port: 4000, ip: {0, 0, 0, 0, 0, 0, 0, 0}]]
[http: [port: 4000, transport_options: [socket_opts: [:inet6]]]]
# => :::4000

http: [ip: {0, 0, 0, 0, 0, 0, 0, 1}, port: 4000],
# => ::1:4000
```