### PR TITLE
Fix :eaddrinuse errors when running in CI

### DIFF
--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -1,21 +1,32 @@
 Code.require_file "../../support/http_client.exs", __DIR__
+Code.require_file "../../support/endpoint_helper.exs", __DIR__
 
 defmodule Phoenix.Integration.EndpointTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
 
+  import Phoenix.Integration.EndpointHelper
+
   alias Phoenix.Integration.AdapterTest.ProdEndpoint
   alias Phoenix.Integration.AdapterTest.DevEndpoint
   alias Phoenix.Integration.AdapterTest.ProdInet6Endpoint
 
+  # Set up the following module variables containing
+  # port numbers for use in the rest of the module.
+  @port_names [:dev, :prod, :prod_inet6]
+
+  for {port_name, port_number} <- Enum.zip(@port_names, get_unused_port_numbers(length(@port_names))) do
+    Module.put_attribute(__MODULE__, port_name, port_number)
+  end
+
   Application.put_env(:endpoint_int, ProdEndpoint,
-    http: [port: "4807"], url: [host: "example.com"], server: true, drainer: false,
+    http: [port: @prod], url: [host: "example.com"], server: true, drainer: false,
     render_errors: [accepts: ~w(html json)])
   Application.put_env(:endpoint_int, DevEndpoint,
-    http: [port: "4808"], debug_errors: true, drainer: false)
+    http: [port: @dev], debug_errors: true, drainer: false)
 
   Application.put_env(:endpoint_int, ProdInet6Endpoint,
-    http: [port: "4806", transport_options: [socket_opts: [:inet6]]],
+    http: [port: @prod_inet6, transport_options: [socket_opts: [:inet6]]],
     url: [host: "example.com"],
     server: true)
 
@@ -99,9 +110,6 @@ defmodule Phoenix.Integration.EndpointTest do
       end
     end
   end
-
-  @prod 4807
-  @dev  4808
 
   alias Phoenix.Integration.HTTPClient
 

--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -11,13 +11,11 @@ defmodule Phoenix.Integration.EndpointTest do
   alias Phoenix.Integration.AdapterTest.DevEndpoint
   alias Phoenix.Integration.AdapterTest.ProdInet6Endpoint
 
-  # Set up the following module variables containing
-  # port numbers for use in the rest of the module.
-  @port_names [:dev, :prod, :prod_inet6]
-
-  for {port_name, port_number} <- Enum.zip(@port_names, get_unused_port_numbers(length(@port_names))) do
-    Module.put_attribute(__MODULE__, port_name, port_number)
-  end
+  # Find available ports to use for this test
+  [dev, prod, prod_inet6] = get_unused_port_numbers(3)
+  @dev dev
+  @prod prod
+  @prod_inet6 prod_inet6
 
   Application.put_env(:endpoint_int, ProdEndpoint,
     http: [port: @prod], url: [host: "example.com"], server: true, drainer: false,

--- a/test/support/endpoint_helper.exs
+++ b/test/support/endpoint_helper.exs
@@ -1,0 +1,27 @@
+defmodule Phoenix.Integration.EndpointHelper do
+  @moduledoc """
+  Utility functions for integration testing endpoints.
+  """
+
+  @doc """
+  Finds `n` unused network port numbers.
+  """
+  def get_unused_port_numbers(n) when is_integer(n) and n > 1 do
+    (1..n)
+    # Open up `n` sockets at the same time, so we don't get
+    # duplicate port numbers
+    |> Enum.map(&listen_on_os_assigned_port/1)
+    |> Enum.map(&get_port_number_and_close/1)
+  end
+
+  defp listen_on_os_assigned_port(_) do
+    {:ok, socket} = :gen_tcp.listen(0, [])
+    socket
+  end
+
+  defp get_port_number_and_close(socket) do
+    {:ok, port_number} = :inet.port(socket)
+    :gen_tcp.close(socket)
+    port_number
+  end
+end


### PR DESCRIPTION
It appears there have been several failures in CI recently due to `:eaddrinuse` errors on the `test/phoenix/integration/endpoint_test.exs`

* https://github.com/phoenixframework/phoenix/runs/1142688759
* https://github.com/phoenixframework/phoenix/runs/1124717272

This attempts to fix the issue by leveraging `:gen_tcp.listen(0,[])` to have the OS provide several unused ports.

/cc @josevalim 