### PR TITLE
enabled source-maps

### DIFF
--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = (env, options) => {
       path: path.resolve(__dirname, '../priv/static/js'),
       publicPath: '/js/'
     },
-    devtool: devMode ? 'eval-cheap-module-source-map' : undefined,
+    devtool: devMode ? 'cheap-module-source-map' : undefined,
     module: {
       rules: [
         {


### PR DESCRIPTION
`eval-cheap-module-source-map` -> `cheap-module-source-map`
for some reason webpack won't create source maps with `eval-*-source-map`
No idea why, but this fixes it