### PR TITLE
Updated Dockerfile in releases.md

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -190,7 +190,7 @@ ENV MIX_ENV=prod
 # install mix dependencies
 COPY mix.exs mix.lock ./
 COPY config config
-RUN mix do deps.get, deps.compile
+RUN mix do deps.get --only $MIX_ENV, deps.compile
 
 # build assets
 COPY assets/package.json assets/package-lock.json ./assets/


### PR DESCRIPTION
Added `deps.get --only $MIX_ENV` to use the environment variable. This ensures mix only pulls the dependencies necessary for the type of mix environment set within the dockerfile.