### PR TITLE
fix generators for big argument list >50

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -351,4 +351,8 @@ defmodule Mix.Phoenix do
       Module.concat(["#{base}Web"])
     end
   end
+
+  def to_text(data) do
+    inspect data, limit: :infinity, printable_limit: :infinity
+  end
 end

--- a/priv/templates/phx.gen.context/test_cases.exs
+++ b/priv/templates/phx.gen.context/test_cases.exs
@@ -4,7 +4,7 @@
 
     import <%= inspect context.module %>Fixtures
 
-    @invalid_attrs <%= inspect for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
+    @invalid_attrs <%= inspect (for {key, _} <- schema.params.create, into: %{}, do: {key, nil}), limit: :infinity %>
 
     test "list_<%= schema.plural %>/0 returns all <%= schema.plural %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
@@ -17,7 +17,7 @@
     end
 
     test "create_<%= schema.singular %>/1 with valid data creates a <%= schema.singular %>" do
-      valid_attrs = <%= inspect schema.params.create %>
+      valid_attrs = <%= inspect schema.params.create, limit: :infinity %>
 
       assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(valid_attrs)<%= for {field, value} <- schema.params.create do %>
       assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>
@@ -29,7 +29,7 @@
 
     test "update_<%= schema.singular %>/2 with valid data updates the <%= schema.singular %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
-      update_attrs = <%= inspect schema.params.update %>
+      update_attrs = <%= inspect schema.params.update, limit: :infinity %>
 
       assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, update_attrs)<%= for {field, value} <- schema.params.update do %>
       assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>

--- a/priv/templates/phx.gen.context/test_cases.exs
+++ b/priv/templates/phx.gen.context/test_cases.exs
@@ -4,7 +4,7 @@
 
     import <%= inspect context.module %>Fixtures
 
-    @invalid_attrs <%= inspect (for {key, _} <- schema.params.create, into: %{}, do: {key, nil}), limit: :infinity %>
+    @invalid_attrs <%= Mix.Phoenix.to_text for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
 
     test "list_<%= schema.plural %>/0 returns all <%= schema.plural %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
@@ -17,7 +17,7 @@
     end
 
     test "create_<%= schema.singular %>/1 with valid data creates a <%= schema.singular %>" do
-      valid_attrs = <%= inspect schema.params.create, limit: :infinity %>
+      valid_attrs = <%= Mix.Phoenix.to_text schema.params.create %>
 
       assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(valid_attrs)<%= for {field, value} <- schema.params.create do %>
       assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>
@@ -29,7 +29,7 @@
 
     test "update_<%= schema.singular %>/2 with valid data updates the <%= schema.singular %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
-      update_attrs = <%= inspect schema.params.update, limit: :infinity %>
+      update_attrs = <%= Mix.Phoenix.to_text schema.params.update%>
 
       assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, update_attrs)<%= for {field, value} <- schema.params.update do %>
       assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>

--- a/priv/templates/phx.gen.html/controller_test.exs
+++ b/priv/templates/phx.gen.html/controller_test.exs
@@ -3,9 +3,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   import <%= inspect context.module %>Fixtures
 
-  @create_attrs <%= inspect schema.params.create %>
-  @update_attrs <%= inspect schema.params.update %>
-  @invalid_attrs <%= inspect for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
+  @create_attrs <%= inspect schema.params.create, limit: :infinity %>
+  @update_attrs <%= inspect schema.params.update, limit: :infinity %>
+  @invalid_attrs <%= inspect (for {key, _} <- schema.params.create, into: %{}, do: {key, nil}), limit: :infinity %>
 
   describe "index" do
     test "lists all <%= schema.plural %>", %{conn: conn} do

--- a/priv/templates/phx.gen.html/controller_test.exs
+++ b/priv/templates/phx.gen.html/controller_test.exs
@@ -3,9 +3,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   import <%= inspect context.module %>Fixtures
 
-  @create_attrs <%= inspect schema.params.create, limit: :infinity %>
-  @update_attrs <%= inspect schema.params.update, limit: :infinity %>
-  @invalid_attrs <%= inspect (for {key, _} <- schema.params.create, into: %{}, do: {key, nil}), limit: :infinity %>
+  @create_attrs <%= Mix.Phoenix.to_text schema.params.create %>
+  @update_attrs <%= Mix.Phoenix.to_text schema.params.update %>
+  @invalid_attrs <%= Mix.Phoenix.to_text (for {key, _} <- schema.params.create, into: %{}, do: {key, nil}) %>
 
   describe "index" do
     test "lists all <%= schema.plural %>", %{conn: conn} do

--- a/priv/templates/phx.gen.json/controller_test.exs
+++ b/priv/templates/phx.gen.json/controller_test.exs
@@ -11,7 +11,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   @update_attrs %{
 <%= schema.params.update |> Enum.map(fn {key, val} -> "    #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
   }
-  @invalid_attrs <%= inspect for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
+  @invalid_attrs <%= Mix.Phoenix.to_text for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}

--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -4,9 +4,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   import Phoenix.LiveViewTest
   import <%= inspect context.module %>Fixtures
 
-  @create_attrs <%= inspect for {key, value} <- schema.params.create, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
-  @update_attrs <%= inspect for {key, value} <- schema.params.update, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
-  @invalid_attrs <%= inspect for {key, value} <- schema.params.create, into: %{}, do: {key, value |> Mix.Phoenix.Schema.live_form_value() |> Mix.Phoenix.Schema.invalid_form_value()} %>
+  @create_attrs <%= Mix.Phoenix.to_text for {key, value} <- schema.params.create, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
+  @update_attrs <%= Mix.Phoenix.to_text for {key, value} <- schema.params.update, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
+  @invalid_attrs <%= Mix.Phoenix.to_text for {key, value} <- schema.params.create, into: %{}, do: {key, value |> Mix.Phoenix.Schema.live_form_value() |> Mix.Phoenix.Schema.invalid_form_value()} %>
 
   defp create_<%= schema.singular %>(_) do
     <%= schema.singular %> = <%= schema.singular %>_fixture()

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -209,6 +209,18 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
     end
   end
 
+  test "when more than 50 attributes are given", config do
+    in_tmp_project config.test, fn ->
+      long_attribute_list = 0..55 |> Enum.map(&("attribute#{&1}:string")) |> Enum.join(" ")
+      Gen.Context.run(~w(Blog Post posts title #{long_attribute_list}))
+
+      assert_file "test/phoenix/blog_test.exs", fn file ->
+        refute file =~ "...}"
+      end
+    end
+  end
+
+
   test "generates context with no schema", config do
     in_tmp_project config.test, fn ->
       Gen.Context.run(~w(Blog Post posts title:string --no-schema))

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -308,6 +308,17 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
     end
   end
 
+  test "when more than 50 arguments are given", config do
+    in_tmp_project config.test, fn ->
+      long_attribute_list = 0..55 |> Enum.map(&("attribute#{&1}:string")) |> Enum.join(" ")
+      Gen.Html.run(~w(Blog Post posts #{long_attribute_list}))
+
+      assert_file "test/phoenix_web/controllers/post_controller_test.exs", fn file ->
+        refute file =~ "...}"
+      end
+    end
+  end
+
   describe "inside umbrella" do
     test "without context_app generators config uses web dir", config do
       in_tmp_umbrella_project config.test, fn ->

--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -117,6 +117,17 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
     end
   end
 
+  test "when more than 50 arguments are given", config do
+    in_tmp_project config.test, fn ->
+      long_attribute_list = 0..55 |> Enum.map(&("attribute#{&1}:string")) |> Enum.join(" ")
+      Gen.Json.run(~w(Blog Post posts #{long_attribute_list}))
+
+      assert_file "test/phoenix_web/controllers/post_controller_test.exs", fn file ->
+        refute file =~ "...}"
+      end
+    end
+  end
+
   test "with json --web namespace generates namedspaced web modules and directories", config do
     in_tmp_project config.test, fn ->
       Gen.Json.run(~w(Blog Post posts title:string --web Blog))

--- a/test/mix/tasks/phx.gen.live_test.exs
+++ b/test/mix/tasks/phx.gen.live_test.exs
@@ -331,6 +331,20 @@ defmodule Mix.Tasks.Phx.Gen.LiveTest do
     end
   end
 
+  test "when more than 50 attributes are given", config do
+    in_tmp_live_project config.test, fn ->
+      long_attribute_list = 0..55 |> Enum.map(&("attribute#{&1}:string")) |> Enum.join(" ")
+      Gen.Live.run(~w(Blog Post posts title #{long_attribute_list}))
+
+      assert_file "test/phoenix/blog_test.exs", fn file ->
+        refute file =~ "...}"
+      end
+      assert_file "test/phoenix_web/live/post_live_test.exs", fn file ->
+        refute file =~ "...}"
+      end
+    end
+  end
+
   describe "inside umbrella" do
     test "without context_app generators config uses web dir", config do
       in_tmp_live_umbrella_project config.test, fn ->


### PR DESCRIPTION
Hello, 
I've stumbled on an issue where generated test cases weren't valid because  `IO.inspect` and `Kernel.inspect` by default inspect only 50 elements in maps. Therefore
generating a schema for example :

`mix phx.gen.live NewPerformers Performer performers attr1 ... attr55`

will result in invalid maps in test cases where `@create_attrs` etc. will be truncated by `inspect`
with `...}` at the end
like this:

```%{attr1: "some value", ..., attr50: "some value, ...}```

It is my first look in the Phoenix code base so my fix is rather naive. I think that I might be fixed in a better way like maybe writing a helper or something. But for now, I have no better idea ;) 

Cheers
Piotr