### PR TITLE
Bind to localhost by default in dev

### DIFF
--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -7,7 +7,13 @@ import Config
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :<%= app_name %>, <%= endpoint_module %>,
-  http: [port: 4000],
+  http: [
+    # Binding to localhost prevents access from other machines.
+    # If you run Phoenix in a container or virtual machine, change
+    # to `ip: {0, 0, 0, 0}` to allow access from the host machine.
+    ip: {127, 0, 0, 1},
+    port: 4000
+  ],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -25,12 +25,16 @@ config :logger, level: :info
 #       ...
 #       url: [host: "example.com", port: 443],
 #       https: [
+#         ip: {0, 0, 0, 0},
 #         port: 443,
 #         cipher_suite: :strong,
 #         keyfile: System.get_env("SOME_APP_SSL_KEY_PATH"),
 #         certfile: System.get_env("SOME_APP_SSL_CERT_PATH"),
 #         transport_options: [socket_opts: [:inet6]]
 #       ]
+#
+# If you intend to run Phoenix behind a reverse proxy, consider
+# changing `ip` to `{127, 0, 0, 1}` to prevent direct access.
 #
 # The `cipher_suite` is set to `:strong` to support only the
 # latest and more secure SSL ciphers. This means old browsers


### PR DESCRIPTION
For comparison, binding to localhost by default in development has been Rails' behavior since 2013 - https://guides.rubyonrails.org/4_2_release_notes.html#default-host-for-rails-server