### PR TITLE
Remove extraneous line break in Community docs

### DIFF
--- a/guides/introduction/community.md
+++ b/guides/introduction/community.md
@@ -38,8 +38,7 @@ There are a number of places to connect with community members at all experience
 
   * [The Complete Elixir and Phoenix Bootcamp Master Functional Programming Techniques with Elixir and Phoenix while Learning to Build Compelling Web Applications (by Stephen Grider - 2017)](https://www.udemy.com/the-complete-elixir-and-phoenix-bootcamp-and-tutorial/)
 
-  * [Discover Elixir & Phoenix (by Tristan Edwards
- - 2017)](https://www.ludu.co/course/discover-elixir-phoenix)
+  * [Discover Elixir & Phoenix (by Tristan Edwards - 2017)](https://www.ludu.co/course/discover-elixir-phoenix)
 
   * [Phoenix Framework Tutorial (by Tensor Programming - 2017)](https://www.youtube.com/watch?v=irDC1nWKhZ8&index=6&list=PLJbE2Yu2zumAgKjSPyFtvYjP5LqgzafQq)
 


### PR DESCRIPTION
The line break made the second line in the paragraph be interpreted as a separate bulleted list item rather than a continuation of the link on the first line.

The live page: https://hexdocs.pm/phoenix/community.html