### PR TITLE
Cache compiled deps to improve integration tests speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-alpine-3.12.0
       env:
         ELIXIR_ASSERT_TIMEOUT: 2000
+    env:
+      CACHE_VERSION: 1
 
     strategy:
       fail-fast: false
@@ -55,11 +57,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
+        # Tar needs to be installed so actions/cache works properly
         run: |
           mix local.rebar --force
           mix local.hex --force
-          apk add --no-progress --update git
+          apk add --no-progress --update git tar
           mix deps.get
+      # This is used with the next step to ensure a cache is stored each time
+      - name: Get timestamp for cache key
+        id: timestamp-for-cache-key
+        run: |
+          echo "::set-output name=timestamp::$(/bin/date -u "+%s")"
+      - uses: actions/cache@v2
+        with:
+          path: tmp/integration_cache/build
+          key: ${{ env.CACHE_VERSION }}-integration_cache-${{ matrix.otp }}-${{ matrix.elixir }}-${{ steps.timestamp-for-cache-key.outputs.timestamp }}
+          restore-keys: |
+            ${{ env.CACHE_VERSION }}-integration_cache-${{ matrix.otp }}-${{ matrix.elixir }}-
       - name: Run integration tests
         run: mix test.integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       env:
         ELIXIR_ASSERT_TIMEOUT: 2000
     env:
-      CACHE_VERSION: 1
+      CACHE_VERSION: 2
 
     strategy:
       fail-fast: false

--- a/integration_test/code_generation/app_with_defaults_test.exs
+++ b/integration_test/code_generation/app_with_defaults_test.exs
@@ -1,5 +1,3 @@
-Code.require_file("../support/code_generator_case.exs", __DIR__)
-
 defmodule Phoenix.Integration.CodeGeneration.AppWithDefaultsTest do
   use Phoenix.Integration.CodeGeneratorCase, async: true
 

--- a/integration_test/code_generation/app_with_no_options_test.exs
+++ b/integration_test/code_generation/app_with_no_options_test.exs
@@ -1,5 +1,3 @@
-Code.require_file("../support/code_generator_case.exs", __DIR__)
-
 defmodule Phoenix.Integration.CodeGeneration.AppWithNoOptionsTest do
   use Phoenix.Integration.CodeGeneratorCase, async: true
 

--- a/integration_test/code_generation/umbrella_app_with_defaults_test.exs
+++ b/integration_test/code_generation/umbrella_app_with_defaults_test.exs
@@ -1,5 +1,3 @@
-Code.require_file("../support/code_generator_case.exs", __DIR__)
-
 defmodule Phoenix.Integration.CodeGeneration.UmbrellaAppWithDefaultsTest do
   use Phoenix.Integration.CodeGeneratorCase, async: true
 

--- a/integration_test/support/code_generator_case.ex
+++ b/integration_test/support/code_generator_case.ex
@@ -88,6 +88,6 @@ defmodule Phoenix.Integration.CodeGeneratorCase do
   end
 
   defp random_string(len) do
-    len |> :crypto.strong_rand_bytes() |> Base.encode64() |> binary_part(0, len)
+    len |> :crypto.strong_rand_bytes() |> Base.url_encode64() |> binary_part(0, len)
   end
 end

--- a/integration_test/support/code_generator_case.ex
+++ b/integration_test/support/code_generator_case.ex
@@ -1,6 +1,8 @@
 defmodule Phoenix.Integration.CodeGeneratorCase do
   use ExUnit.CaseTemplate
 
+  alias Phoenix.Integration.DepsCompiler
+
   using do
     quote do
       import unquote(__MODULE__)
@@ -16,6 +18,8 @@ defmodule Phoenix.Integration.CodeGeneratorCase do
     mix_run!(["phx.new", app_path, "--dev", "--no-install"] ++ opts, installer_root)
 
     mix_run!(~w(deps.get), app_root_path)
+
+    DepsCompiler.compile_deps(app_root_path)
 
     app_root_path
   end

--- a/integration_test/support/deps_compiler.ex
+++ b/integration_test/support/deps_compiler.ex
@@ -1,0 +1,60 @@
+defmodule Phoenix.Integration.DepsCompiler do
+  @moduledoc false
+
+  @instance __MODULE__
+  @registry_instance __MODULE__.Registry
+  @cache_supervisor_instance __MODULE__.CacheSupervisor
+
+  alias Phoenix.Integration.DepsCompiler.CacheServer
+
+  def start_link do
+    Supervisor.start_link(
+      [
+        {Registry, keys: :unique, name: @registry_instance},
+        {DynamicSupervisor, name: @cache_supervisor_instance, strategy: :one_for_one}
+      ],
+      strategy: :rest_for_one,
+      name: @instance
+    )
+  end
+
+  def compile_deps(app_root_path) do
+    app_root_path
+    |> Path.join("mix.lock")
+    |> calculate_file_hash()
+    |> get_cache_server()
+    |> CacheServer.compile_or_restore(app_root_path)
+
+    :ok
+  end
+
+  defp get_cache_server(mix_lock_hash) do
+    DynamicSupervisor.start_child(
+      @cache_supervisor_instance,
+      {CacheServer, [
+          hash: mix_lock_hash,
+          cache_root_path: cache_root_path(),
+          name: cache_server_instance_name(mix_lock_hash)
+        ]}
+    )
+    |> case do
+      {:ok, pid} -> pid
+      {:error, {:already_started, pid}} -> pid
+    end
+  end
+
+  defp cache_server_instance_name(mix_lock_hash) do
+    {:via, Registry, {@registry_instance, mix_lock_hash}}
+  end
+
+  defp cache_root_path do
+    Path.expand("../../tmp/integration_cache", __DIR__)
+  end
+
+  defp calculate_file_hash(path) do
+    file_contents = File.read!(path)
+
+    :crypto.hash(:sha256, file_contents)
+    |> Base.encode16(case: :lower)
+  end
+end

--- a/integration_test/support/deps_compiler/cache_server.ex
+++ b/integration_test/support/deps_compiler/cache_server.ex
@@ -1,0 +1,66 @@
+defmodule Phoenix.Integration.DepsCompiler.CacheServer do
+  @moduledoc false
+
+  alias Phoenix.Integration.CodeGeneratorCase
+
+  use GenServer
+
+  def start_link(opts) when is_list(opts) do
+    {start_opts, server_opts} = Keyword.split(opts, [:name])
+
+    hash = Keyword.fetch!(server_opts, :hash)
+    cache_root_path = Keyword.fetch!(server_opts, :cache_root_path)
+
+    GenServer.start_link(__MODULE__, %{hash: hash, cache_root_path: cache_root_path}, start_opts)
+  end
+
+  def compile_or_restore(server, app_root_path, timeout \\ 90_000) do
+    case GenServer.call(server, {:maybe_compile, app_root_path}, timeout) do
+      :compiled ->
+        :ok
+
+      {:cache_hit, cache_path} ->
+        File.cp_r!(
+          cache_path,
+          app_root_path
+        )
+
+        File.cp_r!(
+          Path.join([app_root_path, "_build", "dev"]),
+          Path.join([app_root_path, "_build", "test"])
+        )
+
+        :ok
+    end
+  end
+
+  @impl true
+  def init(state), do: {:ok, state}
+
+  @impl true
+  def handle_call({:maybe_compile, app_root_path}, _from, state) do
+    build_cache_with_hash_path = Path.join([state.cache_root_path, "build", state.hash])
+
+    if File.dir?(build_cache_with_hash_path) do
+      {:reply, {:cache_hit, build_cache_with_hash_path}, state}
+    else
+      CodeGeneratorCase.mix_run!(["deps.compile"], app_root_path)
+
+      File.mkdir_p!(build_cache_with_hash_path)
+
+      # Using the system's copy command with -rL to expand the symbolic links in the
+      # rebar compiled dependencies. Rebar compiles its dependencies in deps/ and
+      # symlinks them into _build/. This means if we restored the cache to a new project
+      # and left the symlinks to deps in tact, the rebar-based dependencies would have to be
+      # recompiled because their compiled code would be missing.
+      {_output, 0} =
+        System.cmd("cp", [
+          "-rL",
+          Path.join(app_root_path, "_build"),
+          build_cache_with_hash_path
+        ])
+
+      {:reply, :compiled, state}
+    end
+  end
+end

--- a/integration_test/test_helper.exs
+++ b/integration_test/test_helper.exs
@@ -1,8 +1,8 @@
-Code.require_file("./support/code_generator_case.exs", __DIR__)
-
 # Compile installer app up front so multiple test cases
 # don't try to compile it at the same time.
 Phoenix.Integration.CodeGeneratorCase.mix_run!(["do", "deps.get,", "compile"], "./installer")
+
+{:ok, _} = Phoenix.Integration.DepsCompiler.start_link()
 
 ExUnit.configure(max_cases: 2, timeout: 180_000)
 ExUnit.start()

--- a/mix.exs
+++ b/mix.exs
@@ -42,6 +42,13 @@ defmodule Phoenix.MixProject do
   end
 
   defp elixirc_paths(:docs), do: ["lib", "installer/lib"]
+  defp elixirc_paths(:test) do
+    if System.get_env("TEST_SUITE") == "integration" do
+      ["lib", "integration_test/support"]
+    else
+      ["lib"]
+    end
+  end
   defp elixirc_paths(_), do: ["lib"]
 
   def application do


### PR DESCRIPTION
This adds caching to the integration test suite to improve the test suite speed from ~80 seconds to ~15 seconds when fully cached. Here is the approach this takes:

1. Dependencies are downloaded each time using `mix deps.get`. This generates the project's `mix.lock` file and ensures we get the newest versions of the dependencies each test run.
2. A hash is generated from the `mix.lock` file and used as the cache key when compiling or restoring dependencies. Projects with the same `mix.lock` file will use the same precompiled dependencies. There was an issue where projects with the same `mix.lock` hash would both receive a cache miss and start compiling the same dependencies in parallel. To fix this issue, this PR uses a GenServer per cache key to ensure multiple projects won't compile the same dependencies at the same time.

 ## Other notes

1. Since the build times when everything is cached are significantly better, this also adds caching to the Github build. I added a step to generate a new timestamp to be used in the cache key, which when combined with the `restore-keys` option makes it so each test run has the cache from the previous test run.
2. I added `integration_test/support` to the build path when running with `TEST_SUITE=integration`. I chose this route because it removed a bunch of `Code.require_file/2` calls I'd have to write.

I'd definitely appreciate any feedback on how things can be improved here. I'm thinking once we have decent caching with the integration tests, we can migrate tests out of `phx_new_test.exs` into here and start adding more integration coverage.

/cc @josevalim 