### PR TITLE
Add support for Mix Releases to phx.new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 /installer/tmp
 /installer/doc
 /installer/deps
+/installer/phx_new-*.ez
 
 erl_crash.dump

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -33,6 +33,10 @@ defmodule Mix.Tasks.Phx.New do
       Please check the driver docs for more information
       and requirements. Defaults to "postgres".
 
+    * `--mix-release` - leverage Mix Releases for the
+      generated project as opposed to the default `prod.secret.exs`
+      deployment strategy.
+
     * `--no-webpack` - do not generate webpack files
       for static asset building. When choosing this
       option, you will need to manually handle
@@ -104,11 +108,24 @@ defmodule Mix.Tasks.Phx.New do
   @version Mix.Project.config()[:version]
   @shortdoc "Creates a new Phoenix v#{@version} application"
 
-  @switches [dev: :boolean, webpack: :boolean, ecto: :boolean,
-             app: :string, module: :string, web_module: :string,
-             database: :string, binary_id: :boolean, html: :boolean,
-             gettext: :boolean, umbrella: :boolean, verbose: :boolean,
-             live: :boolean, dashboard: :boolean, install: :boolean]
+  @switches [
+    dev: :boolean,
+    webpack: :boolean,
+    ecto: :boolean,
+    app: :string,
+    module: :string,
+    web_module: :string,
+    database: :string,
+    binary_id: :boolean,
+    mix_release: :boolean,
+    html: :boolean,
+    gettext: :boolean,
+    umbrella: :boolean,
+    verbose: :boolean,
+    live: :boolean,
+    dashboard: :boolean,
+    install: :boolean
+  ]
 
   def run([version]) when version in ~w(-v --version) do
     Mix.shell().info("Phoenix v#{@version}")
@@ -209,6 +226,7 @@ defmodule Mix.Tasks.Phx.New do
         Mix.raise "Invalid option: " <> switch_to_string(switch)
     end
   end
+
   defp switch_to_string({name, nil}), do: name
   defp switch_to_string({name, val}), do: name <> "=" <> val
 

--- a/installer/lib/phx_new/project.ex
+++ b/installer/lib/phx_new/project.ex
@@ -23,12 +23,14 @@ defmodule Phx.New.Project do
     app = opts[:app] || Path.basename(project_path)
     app_mod = Module.concat([opts[:module] || Macro.camelize(app)])
 
-    %Project{base_path: project_path,
-             app: app,
-             app_mod: app_mod,
-             root_app: app,
-             root_mod: app_mod,
-             opts: opts}
+    %Project{
+      base_path: project_path,
+      app: app,
+      app_mod: app_mod,
+      root_app: app,
+      root_mod: app_mod,
+      opts: opts
+    }
   end
 
   def ecto?(%Project{binding: binding}) do
@@ -45,6 +47,10 @@ defmodule Phx.New.Project do
 
   def live?(%Project{binding: binding}) do
     Keyword.fetch!(binding, :live)
+  end
+
+  def mix_release?(%Project{binding: binding}) do
+    Keyword.fetch!(binding, :mix_release)
   end
 
   def dashboard?(%Project{binding: binding}) do
@@ -69,8 +75,12 @@ defmodule Phx.New.Project do
   end
 
   defp expand_path_with_bindings(path, %Project{} = project) do
-    Regex.replace(Regex.recompile!(~r/:[a-zA-Z0-9_]+/), path, fn ":" <> key, _ ->
-        project |> Map.fetch!(:"#{key}") |> to_string()
+    ~r/:[a-zA-Z0-9_]+/
+    |> Regex.recompile!()
+    |> Regex.replace(path, fn ":" <> key, _ ->
+      project
+      |> Map.fetch!(:"#{key}")
+      |> to_string()
     end)
   end
 end

--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -7,7 +7,6 @@ defmodule Phx.New.Single do
     {:eex,  "phx_single/config/config.exs",             :project, "config/config.exs"},
     {:eex,  "phx_single/config/dev.exs",                :project, "config/dev.exs"},
     {:eex,  "phx_single/config/prod.exs",               :project, "config/prod.exs"},
-    {:eex,  "phx_single/config/prod.secret.exs",        :project, "config/prod.secret.exs"},
     {:eex,  "phx_single/config/test.exs",               :project, "config/test.exs"},
     {:eex,  "phx_single/lib/app_name/application.ex",   :project, "lib/:app/application.ex"},
     {:eex,  "phx_single/lib/app_name.ex",               :project, "lib/:app.ex"},
@@ -29,6 +28,17 @@ defmodule Phx.New.Single do
     {:keep, "phx_test/channels",                        :project, "test/:lib_web_name/channels"},
     {:keep, "phx_test/controllers",                     :project, "test/:lib_web_name/controllers"},
     {:eex,  "phx_test/views/error_view_test.exs",       :project, "test/:lib_web_name/views/error_view_test.exs"},
+  ]
+
+  template :default_release, [
+    {:eex, "phx_single/config/prod.secret.exs", :project, "config/prod.secret.exs"}
+  ]
+
+  template :mix_release, [
+    {:eex, "phx_mix_release/config/releases.exs", :project, "config/releases.exs"},
+    {:eex, "phx_mix_release/rel/env.bat.eex",     :project, "rel/env.bat.eex"},
+    {:eex, "phx_mix_release/rel/env.sh.eex",      :project, "rel/env.sh.eex"},
+    {:eex, "phx_mix_release/rel/vm.args.eex",     :project, "rel/vm.args.eex"}
   ]
 
   template :gettext, [
@@ -140,6 +150,12 @@ defmodule Phx.New.Single do
 
     if Project.gettext?(project), do: gen_gettext(project)
 
+    if Project.mix_release?(project) do
+      gen_mix_release(project)
+    else
+      gen_default_release(project)
+    end
+
     case {Project.webpack?(project), Project.html?(project)} do
       {true, _}      -> gen_webpack(project)
       {false, true}  -> gen_static(project)
@@ -151,6 +167,14 @@ defmodule Phx.New.Single do
 
   def gen_html(project) do
     copy_from project, __MODULE__, :html
+  end
+
+  def gen_mix_release(project) do
+    copy_from(project, __MODULE__, :mix_release)
+  end
+
+  def gen_default_release(project) do
+    copy_from(project, __MODULE__, :default_release)
   end
 
   def gen_gettext(project) do

--- a/installer/templates/phx_mix_release/config/releases.exs
+++ b/installer/templates/phx_mix_release/config/releases.exs
@@ -1,0 +1,58 @@
+# In this file, we load run-time configuration and secrets
+# from environment variables via Mix Releases. If you have
+# any use case specific configuration that needs to be dealt
+# with be sure to checkout the `Config.Provider` documentation.
+
+import Config
+import System, only: [fetch_env!: 1]
+
+# Fetch Phoenix related configurations
+phoenix_secret_key_base = fetch_env!("APP_SECRET_KEY_BASE")
+phoenix_host = fetch_env!("APP_HOST")
+phoenix_origin = fetch_env!("APP_ORIGIN")
+phoenix_port = "APP_PORT" |> fetch_env!() |> String.to_integer()
+<%= if ecto do %>
+# Fetch Ecto related configurations
+database_name = fetch_env!("DATABASE_NAME")
+database_user = fetch_env!("DATABASE_USER")
+database_password = fetch_env!("DATABASE_PASSWORD")
+database_host = fetch_env!("DATABASE_HOST")
+database_port = fetch_env!("DATABASE_PORT")
+database_pool_size = "DATABASE_POOL_SIZE" |> fetch_env!() |> String.to_integer()
+<% end %>
+# Set run-time Phoenix configuration options
+config :<%= app_name %>, <%= endpoint_module %>,
+  url: [host: phoenix_host, port: phoenix_port],
+  check_origin: phoenix_origin,
+  http: [:inet6, port: phoenix_port],
+  secret_key_base: phoenix_secret_key_base
+<%= if ecto do %>
+# Set run-time Ecto configuration options
+config :<%= app_name %>, <%= app_module %>.Repo,
+  database: database_name,
+  username: database_user,
+  password: database_password,
+  hostname: database_host,
+  port: database_port,
+  pool_size: database_pool_size
+<% else %>
+# Set run-time Repo configuration options
+#
+# If your application also depends on a database, be sure to add
+# those run-time configurations here as well. Something like:
+#
+#     database_name = fetch_env!("DATABASE_NAME")
+#     database_user = fetch_env!("DATABASE_USER")
+#     database_password = fetch_env!("DATABASE_PASSWORD")
+#     database_host = fetch_env!("DATABASE_HOST")
+#     database_port = fetch_env!("DATABASE_PORT")
+#     database_pool_size = fetch_env!("DATABASE_POOL_SIZE")
+#
+#     config :<%= app_name %>, <%= app_module %>.Repo,
+#       database: database_name,
+#       username: database_user,
+#       password: database_password,
+#       hostname: database_host,
+#       port: database_port,
+#       pool_size: database_pool_size
+<% end %>

--- a/installer/templates/phx_mix_release/rel/env.bat.eex
+++ b/installer/templates/phx_mix_release/rel/env.bat.eex
@@ -1,0 +1,6 @@
+@echo off
+rem Set the release to work across nodes. If using the long name format like
+rem the one below (my_app@127.0.0.1), you need to also uncomment the
+rem RELEASE_DISTRIBUTION variable below. Must be "sname", "name" or "none".
+rem set RELEASE_DISTRIBUTION=name
+rem set RELEASE_NODE=<%%= @release.name %>@127.0.0.1

--- a/installer/templates/phx_mix_release/rel/env.sh.eex
+++ b/installer/templates/phx_mix_release/rel/env.sh.eex
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Sets and enables heart (recommended only in daemon mode)
+# case $RELEASE_COMMAND in
+#   daemon*)
+#     HEART_COMMAND="$RELEASE_ROOT/bin/$RELEASE_NAME $RELEASE_COMMAND"
+#     export HEART_COMMAND
+#     export ELIXIR_ERL_OPTIONS="-heart"
+#     ;;
+#   *)
+#     ;;
+# esac
+
+# Set the release to work across nodes. If using the long name format like
+# the one below (my_app@127.0.0.1), you need to also uncomment the
+# RELEASE_DISTRIBUTION variable below. Must be "sname", "name" or "none".
+# export RELEASE_DISTRIBUTION=name
+# export RELEASE_NODE=<%%= @release.name %>@127.0.0.1

--- a/installer/templates/phx_mix_release/rel/vm.args.eex
+++ b/installer/templates/phx_mix_release/rel/vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, and others)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10

--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -11,7 +11,12 @@ import Config
 # before starting your production server.
 config :<%= web_app_name %>, <%= endpoint_module %>,
   url: [host: "example.com", port: 80],
+  <%= if mix_release do %>
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  server: true
+  <% else %>
   cache_static_manifest: "priv/static/cache_manifest.json"
+  <% end %>
 
 # Do not print debug messages in production
 config :logger, level: :info
@@ -49,7 +54,9 @@ config :logger, level: :info
 #       force_ssl: [hsts: true]
 #
 # Check `Plug.SSL` for all available options in `force_ssl`.
+<%= unless mix_release do %>
 
 # Finally import the config/prod.secret.exs which loads secrets
 # and configuration from environment variables.
 import_config "prod.secret.exs"
+<% end %>


### PR DESCRIPTION
While this PR is not 100% ready (tests need to be added/updated, template white spacing needs to be cleaned up, and docs need to be updated), I wanted to gauge interest in adding a new CLI flag to `mix phx.new`. This new CLI flag would give the user the option to generate a new Phoenix project that leverages Mix Releases as opposed to the default `prod.secret.exs` strategy.

Sample usage would be something like:
```
$ mix phx.new my_app --mix-release --live --binary-id
```

I find that with most of the Phoenix projects that I personally start, setting up Mix Releases is usually one of the first things I do. I also find this to be the case in a professional work settings as well regardless of deployment target (Docker/VM).

Curious how other people feel about this proposal as well. If the Phoenix team is `:ok` with adding this new flag to the installer, then I'll go ahead and add the aforementioned missing bits.

Thanks!