### PR TITLE
Test with elixir 1.11.0 and OTP 23.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
         include:
           - elixir: 1.9.4
             otp: 20.3.8.26
-          - elixir: 1.10.4
+          - elixir: 1.11.0
             otp: 21.3.8.17
-          - elixir: 1.10.4
-            otp: 23.0.3
+          - elixir: 1.11.0
+            otp: 23.1.1
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
@@ -48,10 +48,10 @@ jobs:
           # See https://github.com/phoenixframework/phoenix/issues/3903
           - elixir: 1.9.4
             otp: 21.2.7
-          - elixir: 1.10.4
+          - elixir: 1.11.0
             otp: 21.3.8.17
-          - elixir: 1.10.4
-            otp: 23.0.3
+          - elixir: 1.11.0
+            otp: 23.1.1
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
@@ -69,8 +69,8 @@ jobs:
       - uses: actions/checkout@v2.3.1
       - uses: actions/setup-elixir@v1.3.0
         with:
-          otp-version: 23.0.3
-          elixir-version: 1.10.4
+          otp-version: 23.1.1
+          elixir-version: 1.11.0
       - name: Install Dependencies
         run: |
           mix local.rebar --force


### PR DESCRIPTION
This upgrades ci to test on Elixir 1.11.0 and OTP 23.1.1.