### PR TITLE
Add Elixir 1.11 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Can't run integration tests before OTP 20.2 due to incompatiblity with cowlib.
+          # Can't run integration tests before OTP 21 due to incompatiblity with cowlib.
           #
           # See https://github.com/phoenixframework/phoenix/issues/3903
           - elixir: 1.9.4
-            otp: 20.3.8.26
+            otp: 21.3.8.17
           - elixir: 1.10.4
             otp: 21.3.8.17
           - elixir: 1.11.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,7 @@ jobs:
           - elixir: 1.9.4
             otp: 20.3.8.26
           - elixir: 1.10.4
-            otp: 21.3.8.17
-          - elixir: 1.10.4
-            otp: 23.0.3
+            otp: 23.1.1
           - elixir: 1.11.0
             otp: 21.3.8.18
           - elixir: 1.11.0
@@ -54,8 +52,6 @@ jobs:
             otp: 21.2.7
           - elixir: 1.10.4
             otp: 21.3.8.17
-          - elixir: 1.10.4
-            otp: 23.0.3
           - elixir: 1.11.0
             otp: 21.3.8.18
           - elixir: 1.11.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
             otp: 21.3.8.17
           - elixir: 1.10.4
             otp: 23.0.3
+          - elixir: 1.11.0
+            otp: 21.3.8.18
+          - elixir: 1.11.0
+            otp: 23.1.1
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies
@@ -52,6 +56,10 @@ jobs:
             otp: 21.3.8.17
           - elixir: 1.10.4
             otp: 23.0.3
+          - elixir: 1.11.0
+            otp: 21.3.8.18
+          - elixir: 1.11.0
+            otp: 23.1.1
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           #
           # See https://github.com/phoenixframework/phoenix/issues/3903
           - elixir: 1.9.4
-            otp: 21.2.7
+            otp: 20.3.8.26
           - elixir: 1.10.4
             otp: 21.3.8.17
           - elixir: 1.11.0


### PR DESCRIPTION
This pull request adds Elixir 1.11 to CI and updates Erlang/OTP minor and/or patch versions to their latest.

Its main distinction from https://github.com/phoenixframework/phoenix/pull/4015 is that it mantains conformity to [José Valim advice](https://github.com/dashbitco/broadway/pull/188#issuecomment-649314540):
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported [major] Erlang/OTP
> * For the last Elixir version, also test the latest supported [major] Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.
