### PR TITLE
Silence context generation warnings on `--no-context`

### DIFF
--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -254,6 +254,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     """
   end
 
+  def prompt_for_code_injection(%Context{generate?: false}), do: :ok
   def prompt_for_code_injection(%Context{} = context) do
     if Context.pre_existing?(context) do
       function_count = Context.function_count(context)

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -259,6 +259,31 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
     end
   end
 
+  test "with --no-context no warning is emitted when context exists", config do
+    in_tmp_project config.test, fn ->
+      Gen.Html.run(~w(Blog Post posts title:string))
+
+      assert_file "lib/phoenix/blog.ex"
+      assert_file "lib/phoenix/blog/post.ex"
+
+      Gen.Html.run(~w(Blog Comment comments title:string --no-context))
+      refute_received {:mix_shell, :info, ["You are generating into an existing context" <> _]}
+
+      assert_file "test/phoenix_web/controllers/comment_controller_test.exs", fn file ->
+        assert file =~ "defmodule PhoenixWeb.CommentControllerTest"
+      end
+
+      assert_file "lib/phoenix_web/controllers/comment_controller.ex", fn file ->
+        assert file =~ "defmodule PhoenixWeb.CommentController"
+        assert file =~ "use PhoenixWeb, :controller"
+      end
+
+      assert_file "lib/phoenix_web/views/comment_view.ex", fn file ->
+        assert file =~ "defmodule PhoenixWeb.CommentView"
+      end
+    end
+  end
+
   test "with --no-schema skips schema file generation", config do
     in_tmp_project config.test, fn ->
       Gen.Html.run(~w(Blog Comment comments title:string --no-schema))

--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -172,6 +172,31 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
     end
   end
 
+  test "with --no-context no warning is emitted when context exists", config do
+    in_tmp_project config.test, fn ->
+      Gen.Json.run(~w(Blog Post posts title:string))
+
+      assert_file "lib/phoenix/blog.ex"
+      assert_file "lib/phoenix/blog/post.ex"
+
+      Gen.Json.run(~w(Blog Comment comments title:string --no-context))
+      refute_received {:mix_shell, :info, ["You are generating into an existing context" <> _]}
+
+      assert_file "test/phoenix_web/controllers/comment_controller_test.exs", fn file ->
+        assert file =~ "defmodule PhoenixWeb.CommentControllerTest"
+      end
+
+      assert_file "lib/phoenix_web/controllers/comment_controller.ex", fn file ->
+        assert file =~ "defmodule PhoenixWeb.CommentController"
+        assert file =~ "use PhoenixWeb, :controller"
+      end
+
+      assert_file "lib/phoenix_web/views/comment_view.ex", fn file ->
+        assert file =~ "defmodule PhoenixWeb.CommentView"
+      end
+    end
+  end
+
   test "with --no-schema skips schema file generation", config do
     in_tmp_project config.test, fn ->
       Gen.Json.run(~w(Blog Comment comments title:string --no-schema))

--- a/test/mix/tasks/phx.gen.live_test.exs
+++ b/test/mix/tasks/phx.gen.live_test.exs
@@ -285,6 +285,26 @@ defmodule Mix.Tasks.Phx.Gen.LiveTest do
     end
   end
 
+  test "with --no-context does not emit warning when context exists", config do
+    in_tmp_live_project config.test, fn ->
+      Gen.Live.run(~w(Blog Post posts title:string))
+
+      assert_file "lib/phoenix/blog.ex"
+      assert_file "lib/phoenix/blog/post.ex"
+
+      Gen.Live.run(~w(Blog Comment comments title:string --no-context))
+      refute_received {:mix_shell, :info, ["You are generating into an existing context" <> _]}
+
+      assert_file "lib/phoenix_web/live/comment_live/index.ex"
+      assert_file "lib/phoenix_web/live/comment_live/show.ex"
+      assert_file "lib/phoenix_web/live/comment_live/form_component.ex"
+
+      assert_file "lib/phoenix_web/live/comment_live/index.html.leex"
+      assert_file "lib/phoenix_web/live/comment_live/show.html.leex"
+      assert_file "lib/phoenix_web/live/comment_live/form_component.html.leex"
+      assert_file "test/phoenix_web/live/comment_live_test.exs"
+    end
+  end
 
   test "with same singular and plural", config do
     in_tmp_live_project config.test, fn ->


### PR DESCRIPTION
When a context exists and a user issues `mix phx.gen.live --no-context`, there is a warning about generating into an existing context, even though the user is not using the context. This change prevents that warning from displaying in the shell.

**Note:** The files being output of the generators are not changing, only the warning/prompt.

The tests in this branch, without the corresponding production code applied, output the following:

```
 ** (RuntimeError) no shell process input given for yes?/1
 stacktrace:
   (mix 1.10.4) lib/mix/shell/process.ex:148: Mix.Shell.Process.yes?/1
   (phoenix 1.6.0-dev) lib/mix/tasks/phx.gen.context.ex:279: Mix.Tasks.Phx.Gen.Context.prompt_for_code_injection/1
   (phoenix 1.6.0-dev) lib/mix/tasks/phx.gen.live.ex:98: Mix.Tasks.Phx.Gen.Live.run/1
   test/mix/tasks/phx.gen.live_test.exs:288: anonymous fn/0 in Mix.Tasks.Phx.Gen.LiveTest."test with --no-context does not emit warning when context exists"/1
   (elixir 1.10.4) lib/file.ex:1544: File.cd!/2
   installer/test/mix_helper.exs:36: MixHelper.in_tmp_project/2
   test/mix/tasks/phx.gen.live_test.exs:282: (test)

```

While the reporting issue (#3994) was specifically targeting `mix phx.gen.live`, I found that the issue also applied to `mix phx.gen.json` and `mix.gen.html` as well.

Closes #3994 