### PR TITLE
Fix formatting with phx.gen.html generated code

### DIFF
--- a/priv/templates/phx.gen.html/controller_test.exs
+++ b/priv/templates/phx.gen.html/controller_test.exs
@@ -71,6 +71,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     test "deletes chosen <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       conn = delete(conn, Routes.<%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>))
       assert redirected_to(conn) == Routes.<%= schema.route_helper %>_path(conn, :index)
+
       assert_error_sent 404, fn ->
         get(conn, Routes.<%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>))
       end

--- a/priv/templates/phx.gen.schema/migration.exs
+++ b/priv/templates/phx.gen.schema/migration.exs
@@ -9,7 +9,7 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.
 <% end %>
       timestamps()
     end
-<%= for index <- schema.indexes do %>
+<%= if Enum.any?(schema.indexes) do %><%= for index <- schema.indexes do %>
     <%= index %><% end %>
-  end
+<% end %>  end
 end


### PR DESCRIPTION
When generating code with `phx.gen.html`, the following files have formatting errors
```shell-session
$ mix format --check-formatted
     
 ** (Mix) mix format failed due to --check-formatted.
 The following files were not formatted:
     
  * test/phx_blog_web/controllers/post_controller_test.exs
  * priv/repo/migrations/20201020032211_create_posts.exs
```
Below is the diff the formatter generates
```diff
diff --git a/priv/repo/migrations/20201020032428_create_posts.exs b/priv/repo/migrations/20201020032428_create_posts.exs
index 4270def..18029ab 100644
--- a/priv/repo/migrations/20201020032428_create_posts.exs
+++ b/priv/repo/migrations/20201020032428_create_posts.exs
@@ -8,6 +8,5 @@ defmodule PhxBlog.Repo.Migrations.CreatePosts do
 
       timestamps()
     end
-
   end
 end
diff --git a/test/phx_blog_web/controllers/post_controller_test.exs b/test/phx_blog_web/controllers/post_controller_test.exs
index e7c103c..11a2a8a 100644
--- a/test/phx_blog_web/controllers/post_controller_test.exs
+++ b/test/phx_blog_web/controllers/post_controller_test.exs
@@ -70,6 +70,7 @@ defmodule PhxBlogWeb.PostControllerTest do
     test "deletes chosen post", %{conn: conn, post: post} do
       conn = delete(conn, Routes.post_path(conn, :delete, post))
       assert redirected_to(conn) == Routes.post_path(conn, :index)
+
       assert_error_sent 404, fn ->
         get(conn, Routes.post_path(conn, :show, post))
       end

```

This change fixes these formatter errors in the generators. I've tested this locally with the following commands:

* `mix phx.gen.html Blog Post posts title body:string`
* `mix phx.gen.html Blog Post posts title:unique body:string`
