### PR TITLE
Add MIX_ENV when running digest

### DIFF
--- a/guides/deployment/deployment.md
+++ b/guides/deployment/deployment.md
@@ -48,7 +48,7 @@ Compilation of static assets happens in two steps:
 
 ```console
 $ npm run deploy --prefix ./assets
-$ mix phx.digest
+$ MIX_ENV=prod mix phx.digest
 Check your digested files at "priv/static".
 ```
 
@@ -103,7 +103,7 @@ $ MIX_ENV=prod mix compile
 
 # Compile assets
 $ npm run deploy --prefix ./assets
-$ mix phx.digest
+$ MIX_ENV=prod mix phx.digest
 
 # Custom tasks (like DB migrations)
 $ MIX_ENV=prod mix ecto.migrate

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -42,7 +42,7 @@ $ npm install --prefix ./assets
 
 # Compile assets
 $ npm run deploy --prefix ./assets
-$ mix phx.digest
+$ MIX_ENV=prod mix phx.digest
 ```
 
 *Note:* the `--prefix` flag on `npm` may not work on Windows. If so, replace the first command by `cd assets && npm run deploy && cd ..`.


### PR DESCRIPTION
This adds the `MIX_ENV=prod` to the docs when running `mix.digest`.
Omitting this will cause errors if there are dev only deps.