### PR TITLE
Fix formatting with phx.gen.json generated code

### DIFF
--- a/priv/templates/phx.gen.json/view.ex
+++ b/priv/templates/phx.gen.json/view.ex
@@ -11,7 +11,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def render("<%= schema.singular %>.json", %{<%= schema.singular %>: <%= schema.singular %>}) do
-    %{id: <%= schema.singular %>.id<%= for {k, _} <- schema.attrs do %>,
-      <%= k %>: <%= schema.singular %>.<%= k %><% end %>}
+    %{
+<%= [{:id, :id} | schema.attrs] |> Enum.map(fn {k, _} -> "      #{k}: #{schema.singular}.#{k}" end) |> Enum.join(",\n")  %>
+    }
   end
 end


### PR DESCRIPTION
When running `mix phx.gen.json`, the following formatting error is returned
```shell-session
$ mix format --check-formatted
** (Mix) mix format failed due to --check-formatted.
The following files were not formatted:

  * lib/phx_blog_web/views/post_view.ex
```

Below is the diff the formatter generates
```diff
diff --git a/lib/phx_blog_web/views/post_view.ex b/lib/phx_blog_web/views/post_view.ex
index 8462ba6..c009fd3 100644
--- a/lib/phx_blog_web/views/post_view.ex
+++ b/lib/phx_blog_web/views/post_view.ex
@@ -11,8 +11,6 @@ defmodule PhxBlogWeb.PostView do
   end
 
   def render("post.json", %{post: post}) do
-    %{id: post.id,
-      title: post.title,
-      body: post.body}
+    %{id: post.id, title: post.title, body: post.body}
   end
 end
```
This PR copies the same attribute map generator logic in the fixtures file template and generates this function as follows:

```elixir
  def render("post.json", %{post: post}) do
    %{
      id: post.id,
      title: post.title,
      body: post.body
    }
  end
```
