### PR TITLE
Update package.json

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "./priv/static/phoenix.js",
   "module": "./assets/js/phoenix.js",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git://github.com/phoenixframework/phoenix.git"


### PR DESCRIPTION
### Change
Added "type": "module"

### Reason
Currently NodeJS will give the following error when trying to import phoenix.js:
`The requested module 'phoenix' is expected to be of type CommonJS, which does not support named exports. CommonJS modules can be imported by importing the default export.`
Indicating that the type of the package is a module will fix this.