### PR TITLE
Replace deprecated node-sass with sass

### DIFF
--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -19,7 +19,7 @@
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.4.2",
     "sass-loader": "^8.0.2",
-    "node-sass": "^4.13.1",
+    "sass": "^1.27.0",
     "hard-source-webpack-plugin": "^0.13.1",
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",


### PR DESCRIPTION
This should work fine since `sass-loader` [supports both libraries](https://github.com/webpack-contrib/sass-loader#implementation) by default:

> By default the loader resolve the implementation based on your dependencies. Just add required implementation to package.json (sass or node-sass package) and install dependencies.

I'm not entirely sure wether the `.sass-cache` in `.gitignore` is still needed though.

Closes #4042.