### PR TITLE
Remove `master` now that github defaults to `main`

### DIFF
--- a/guides/deployment/gigalixir.md
+++ b/guides/deployment/gigalixir.md
@@ -128,7 +128,7 @@ $ gigalixir config
 Our project is now ready to be deployed on Gigalixir.
 
 ```console
-$ git push gigalixir master
+$ git push gigalixir
 ```
 
 Check the status of your deploy and wait until the app is `Healthy`


### PR DESCRIPTION
We added support to push to gigalixir via the master branch or the main branch. This means `git push gigalixir` should work in the majority of cases.