### PR TITLE
Webpack > Use --watch instead of --watch-stdin

### DIFF
--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -16,7 +16,7 @@ config :<%= app_name %>, <%= endpoint_module %>,
       "node_modules/webpack/bin/webpack.js",
       "--mode",
       "development",
-      "--watch-stdin",
+      "--watch",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]<% else %>[]<% end %>


### PR DESCRIPTION
This allows Webpack 5. 

Fixes https://github.com/phoenixframework/phoenix/issues/4020