### PR TITLE
Update to webpack v5

### DIFF
--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -8,21 +8,19 @@
     "phoenix": "file:<%= @phoenix_webpack_path %>"<%= if @html do %>,
     "phoenix_html": "file:<%= @phoenix_html_webpack_path %>"<% end %><%= if @live do %>,
     "phoenix_live_view": "file:<%= @phoenix_live_view_webpack_path %>",
-    "topbar": "^0.1.4"<% end %>
+    "topbar": "^1.x"<% end %>
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
-    "babel-loader": "^8.0.0",
-    "copy-webpack-plugin": "^5.1.1",
-    "css-loader": "^3.4.2",
-    "sass-loader": "^8.0.2",
-    "sass": "^1.27.0",
-    "hard-source-webpack-plugin": "^0.13.1",
-    "mini-css-extract-plugin": "^0.9.0",
-    "optimize-css-assets-webpack-plugin": "^5.0.1",
-    "terser-webpack-plugin": "^2.3.2",
-    "webpack": "4.41.5",
-    "webpack-cli": "^3.3.2"
+    "@babel/core": "^7.x",
+    "@babel/preset-env": "^7.x",
+    "babel-loader": "^8.x",
+    "copy-webpack-plugin": "^7.x",
+    "css-loader": "^5.x",
+    "css-minimizer-webpack-plugin": "^1.x",
+    "mini-css-extract-plugin": "^1.x",
+    "sass": "^1.x",
+    "sass-loader": "^10.x",
+    "webpack": "^5.x",
+    "webpack-cli": "^4.x"
   }
 }

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -1,30 +1,21 @@
 const path = require('path');
 const glob = require('glob');
-const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const TerserPlugin = require('terser-webpack-plugin');
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = (env, options) => {
   const devMode = options.mode !== 'production';
 
   return {
-    optimization: {
-      minimizer: [
-        new TerserPlugin({ cache: true, parallel: true, sourceMap: devMode }),
-        new OptimizeCSSAssetsPlugin({})
-      ]
-    },
     entry: {
       'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
     },
     output: {
-      filename: '[name].js',
       path: path.resolve(__dirname, '../priv/static/js'),
+      filename: '[name].js',
       publicPath: '/js/'
     },
-    devtool: devMode ? 'eval-cheap-module-source-map' : undefined,
     module: {
       rules: [
         {
@@ -45,9 +36,19 @@ module.exports = (env, options) => {
       ]
     },
     plugins: [
-      new MiniCssExtractPlugin({ filename: '../css/[name].css' }),
-      new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
-    ]
-    .concat(devMode ? [new HardSourceWebpackPlugin()] : [])
+      new MiniCssExtractPlugin({ filename: '../css/app.css' }),
+      new CopyWebpackPlugin({
+        patterns: [
+          { from: 'static/', to: '../' }
+        ]
+      })
+    ],
+    optimization: {
+      minimizer: [
+        '...',
+        new CssMinimizerPlugin()
+      ]
+    },
+    devtool: devMode ? 'source-map' : undefined
   }
 };

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -18,7 +18,8 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
       "node_modules/webpack/bin/webpack.js",
       "--mode",
       "development",
-      "--watch-stdin",
+      "--watch",
+      "--watch-options-stdin",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]<% else %>[]<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -16,7 +16,8 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
       "node_modules/webpack/bin/webpack.js",
       "--mode",
       "development",
-      "--watch-stdin",
+      "--watch",
+      "--watch-options-stdin",
       cd: Path.expand("../apps/<%= @web_app_name %>/assets", __DIR__)
     ]
   ]<% else %>[]<% end %>

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -149,14 +149,14 @@ defmodule Phoenix.Endpoint do
       You can configure it to whatever build tool or command you want:
 
           [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development",
-              "--watch-stdin"]]
+              "--watch", "--watch-options-stdin"]]
 
       The `:cd` option can be used on a watcher to override the folder from
       which the watcher will run. By default this will be the project's root:
       `File.cwd!()`
 
           [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development",
-              "--watch-stdin", cd: "my_frontend"]]
+              "--watch", "--watch-options-stdin", cd: "my_frontend"]]
 
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of


### PR DESCRIPTION
**Revision**

- Including v1.x version annotation within package.json
- Again "source-map" instead of "eval-cheap-source-map" for now

Background "source-map":
Terser plugin doesn't work with "eval-cheap-module-source-map".

Suggestion for additional PR (if it will improve build time):
```
const webpack = require('webpack');
...
plugins: [
  new webpack.EvalSourceMapDevToolPlugin({
     exclude: ['./vendor/**/*.js']
   })
]
devtool: false
```

---

**Initial** 

Including update to webpack 5.
Some things are probably opinionated.
- Obvious "fixed" versions within package.json (real version is anyway in package-lock.json)
- No license field in package.json as not defined it must be MIT ...

Edit:
- Replaced `optimize-css-assets-webpack-plugin` with `css-minimizer-webpack-plugin` (Thx @optikfluffel)
- `source-map` instead of  `eval-cheap-source-map`

~Has open Issue (warning in CLI, but seem to work anyway): https://github.com/webpack/webpack-cli/issues/1918~
Concerns discussion: https://elixirforum.com/t/upgrade-to-webpack-5/35010

Resolve #4020 