### PR TITLE
Update example Dockerfile and add some notes

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -202,6 +202,11 @@ COPY assets/package.json assets/package-lock.json ./assets/
 RUN npm --prefix ./assets ci --progress=false --no-audit --loglevel=error
 
 COPY priv priv
+
+# Note: if your project uses a tool like https://purgecss.com/,
+# which customizes asset compilation based on what it finds in
+# your Elixir templates, you will need to move the asset compilation step
+# down so that `lib` is available.
 COPY assets assets
 # use webpack to compile npm dependencies - https://www.npmjs.com/package/webpack-deploy
 RUN npm run --prefix ./assets deploy

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -191,9 +191,11 @@ ENV MIX_ENV=prod
 COPY mix.exs mix.lock ./
 RUN mix deps.get --only $MIX_ENV
 RUN mkdir config
-# if our compile-time config changes, we may need to
-# recompile dependencies
-COPY config/config.exs config/prod.exs config/
+# Dependencies sometimes use compile-time configuration. Copying
+# these compile-time config files before we compile dependencies
+# ensures that any relevant config changes will trigger the dependencies
+# to be re-compiled.
+COPY config/config.exs config/$MIX_ENV.exs config/
 RUN mix deps.compile
 
 # build assets
@@ -244,5 +246,5 @@ At the end, you will have an application in `/app` ready to run as `bin/my_app s
 
 A few points about configuring a containerized application:
 
-- If you run your app in a container, the endpoint needs to listen on a "public" IP address like `0.0.0.0` so that the app can be reached from outside the container. Whether the host should publish the container's ports to its own public IP or to localhost depends on your needs.
-- The more configuration you can provide at runtime (using `config/runtime.exs`), the more reusable your images will be across environments. In particular, secrets like database credentials and your endpoint's `:secret_key_base` should not be compiled into the image, but rather should be provided when creating containers based on that image.
+- If you run your app in a container, the `Endpoint` needs to be configured to listen on a "public" `:ip` address (like `0.0.0.0.0.0.0.0`) so that the app can be reached from outside the container. Whether the host should publish the container's ports to its own public IP or to localhost depends on your needs.
+- The more configuration you can provide at runtime (using `config/runtime.exs`), the more reusable your images will be across environments. In particular, secrets like database credentials and API keys should not be compiled into the image, but rather should be provided when creating containers based on that image. This is why the `Endpoint`'s `:secret_key_base` is configured in `config/runtime.exs` by default.

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -194,7 +194,7 @@ RUN mkdir config
 # if our compile-time config changes, we may need to
 # recompile dependencies
 COPY config/config.exs config/prod.exs config/
-run mix deps.compile
+RUN mix deps.compile
 
 # build assets
 COPY assets/package.json assets/package-lock.json ./assets/


### PR DESCRIPTION
- Use an Elixir 1.11 image, built by the hexpm team
- Break apart build steps for better caching (eg, changing
  `config/prod.exs` does not require re-running `mix deps.get`)
- Add notes about configuring a containerized application