### PR TITLE
restore Endpoint subscribe/2 and unsubscribe/1 callbacks

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -308,6 +308,18 @@ defmodule Phoenix.Endpoint do
   # Channels
 
   @doc """
+  Subscribes the caller to the given topic.
+
+  See `Phoenix.PubSub.subscribe/3` for options.
+  """
+  @callback subscribe(topic, opts :: Keyword.t) :: :ok | {:error, term}
+
+  @doc """
+  Unsubscribes the caller from the given topic.
+  """
+  @callback unsubscribe(topic) :: :ok | {:error, term}
+
+  @doc """
   Broadcasts a `msg` as `event` in the given `topic` to all nodes.
   """
   @callback broadcast(topic, event, msg) :: :ok | {:error, term}


### PR DESCRIPTION
:wave: hi hi

I see that in the change from 1.4 to 1.5 the `c:Phoenix.Endpoint.subscribe/2` and `c:Phoenix.Endpoint.unsubscribe/1` callbacks and implementations were removed (specifically by [this commit](https://github.com/phoenixframework/phoenix/commit/b7d7751d4fdae3e5e3b26605652e57d73ca4bd32)). It looks like later the callback implementations were undeprecated by [this commit](https://github.com/phoenixframework/phoenix/commit/3d9a6fc73f6cec4e1b0ca3e94fbe1b98a797fe8f) but the callbacks themselves weren't restored.

I understand that these callbacks probably aren't very desirable if y'all intend to deprecate & remove them in the future, but for the time being having them really helps when writing tooling on top of Phoenix that leverages (un)subscribing directly from the Endpoint (and also Mox-ing).