### PR TITLE
Fix code style

### DIFF
--- a/guides/testing/testing_contexts.md
+++ b/guides/testing/testing_contexts.md
@@ -96,12 +96,12 @@ defmodule Hello.DataCase do
 
   using do
     quote do
-      alias Hello.Repo
-
       import Ecto
       import Ecto.Changeset
       import Ecto.Query
       import Hello.DataCase
+      
+      alias Hello.Repo
     end
   end
 

--- a/installer/templates/phx_ecto/data_case.ex
+++ b/installer/templates/phx_ecto/data_case.ex
@@ -18,12 +18,12 @@ defmodule <%= @app_module %>.DataCase do
 
   using do
     quote do
-      alias <%= @app_module %>.Repo
-
       import Ecto
       import Ecto.Changeset
       import Ecto.Query
       import <%= @app_module %>.DataCase
+
+      alias <%= @app_module %>.Repo
     end
   end
 


### PR DESCRIPTION
According to https://github.com/lexmag/elixir-style-guide#modules, the
order should be use/import/alias/require. So, I adjust this piece of
code to follow the rule.
