### PR TITLE
Log the transport URL, not the endpoint URL

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -1024,7 +1024,7 @@ export class Socket {
    * @private
    */
   onConnOpen(){
-    if(this.hasLogger()) this.log("transport", `connected to ${this.endPointURL()}`)
+    if(this.hasLogger()) this.log("transport", `connected to ${this.conn.url || this.endPointURL()}`)
     this.unloaded = false
     this.closeWasClean = false
     this.flushSendBuffer()
@@ -1276,6 +1276,10 @@ export class LongPoll {
 
   endpointURL(){
     return Ajax.appendParams(this.pollEndpoint, {token: this.token})
+  }
+
+  get url() {
+    return this.endpointURL();
   }
 
   closeAndRetry(){


### PR DESCRIPTION
We were confused by the following logger output after setting our `transport` to `LongPoll`:

```plain
socket: transport: connected to wss://example.com/live/websocket`
```

This PR adds a WebSocket-API-compatible [url] property to `LongPoll`, after which `Socket.onConnOpen` can report `this.conn.url` reflecting the URL over which the connection was made. In case of a custom transport without such a property, it falls back to `Socket.endpointURL`.

[url]: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/url
