### PR TITLE
Private asset package by default

### DIFF
--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -1,6 +1,4 @@
 {
-  "repository": {},
-  "description": " ",
   "private": true,
   "scripts": {
     "deploy": "webpack --mode production",

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -1,7 +1,7 @@
 {
   "repository": {},
   "description": " ",
-  "license": "MIT",
+  "private": true,
   "scripts": {
     "deploy": "webpack --mode production",
     "watch": "webpack --mode development --watch"


### PR DESCRIPTION
I found `assets/package.json` from `phx.new` uses MIT license.

I believe it should be private and unlicensed by default, for following reasons:

- it is unlikely to publish the package to repository, since it's for final assets not for a library
- Elixir part of generated code does not have any license information

From [package.json](https://docs.npmjs.com/cli/v6/configuring-npm/package-json)

> Finally, if you do not wish to grant others the right to use a private or unpublished package under any terms:
>
> { "license": "UNLICENSED" }
>
> Consider also setting "private": true to prevent accidental publication.

---

Update: since `license` doesn't seem to be required, and npm does not emit error when `private` is true and `license` is omitted, updated this PR to omit license instead of using "UNLICENSED".
