### PR TITLE
Add default to first param of generated Schema.changeset function

### DIFF
--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -43,8 +43,8 @@
 
   """
   def create_<%= schema.singular %>(attrs \\ %{}) do
-    %<%= inspect schema.alias %>{}
-    |> <%= inspect schema.alias %>.changeset(attrs)
+    attrs
+    |> <%= inspect schema.alias %>.changeset()
     |> Repo.insert()
   end
 

--- a/priv/templates/phx.gen.schema/schema.ex
+++ b/priv/templates/phx.gen.schema/schema.ex
@@ -1,6 +1,8 @@
 defmodule <%= inspect schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
+
+  alias <%= inspect schema.module %>
 <%= if schema.binary_id do %>
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id<% end %>
@@ -12,7 +14,7 @@ defmodule <%= inspect schema.module %> do
   end
 
   @doc false
-  def changeset(<%= schema.singular %>, attrs) do
+  def changeset(<%= schema.singular %> \\ %<%= inspect schema.alias %>{}, attrs) do
     <%= schema.singular %>
     |> cast(attrs, [<%= Enum.map_join(schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
     |> validate_required([<%= Enum.map_join(schema.attrs, ", ", &inspect(elem(&1, 0))) %>])

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -310,7 +310,7 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
       Gen.Schema.run(~w(Blog.Post posts title))
 
       assert_file "lib/phoenix/blog/post.ex", fn file ->
-        assert file =~ "import Ecto.Changeset\n\n  schema"
+        assert file =~ "import Ecto.Changeset\n\n  alias Phoenix.Blog.Post\n\n  schema"
       end
     end
   end


### PR DESCRIPTION
This is a very minor tweak that I have made to every schema I have ever generated with mix `mix phx.gen`.
```elixir
  def changeset(user, attrs) do
    user
    |> cast(attrs, [:name])
    |> validate_required([:name])
  end
```
becomes:
```elixir
  def changeset(user \\ %User{}, attrs) do
    user
    |> cast(attrs, [:name])
    |> validate_required([:name])
  end
```
and
```elixir
  def create_user(attrs \\ %{}) do
    %User{}
    |> User.changeset(attrs)
    |> Repo.insert()
  end
```
becomes
```elixir
  def create_user(attrs \\ %{}) do
    attrs
    |> User.changeset()
    |> Repo.insert()
  end
```