### PR TITLE
Default pushed payload to an empty object if not provided

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -525,7 +525,7 @@ export class Channel {
    * @param {number} [timeout]
    * @returns {Push}
    */
-  push(event, payload, timeout = this.timeout){
+  push(event, payload = {}, timeout = this.timeout){
     if(!this.joinedOnce){
       throw new Error(`tried to push '${event}' to '${this.topic}' before joining. Use channel.join() before pushing events`)
     }


### PR DESCRIPTION
The documentation provides an example like `channel.push("event")`, but that no longer works with an undefined payload object. An empty object should be the equivalent functionality as the previous undefined case.

#4079 

-----

A second option is to update this code: 

```
  encode(msg, callback){
    if(msg.payload.constructor === ArrayBuffer){
```

to 

```
  encode(msg, callback){
    if(msg.payload && msg.payload.constructor === ArrayBuffer){
```

However, I like the idea of not worrying about an undefined msg.payload in the code. But this approach should be completely side effect free, since it would be equivalent to the code that used to work.