### PR TITLE
Docs: MyApp.Endpoint -> MyAppWeb.Endpoint 

### DIFF
--- a/guides/deployment/deployment.md
+++ b/guides/deployment/deployment.md
@@ -60,7 +60,7 @@ Keep in mind that, if you by any chance forget to run the steps above, Phoenix w
 
 ```console
 $ PORT=4001 MIX_ENV=prod mix phx.server
-10:50:18.732 [info] Running MyApp.Endpoint with Cowboy on http://example.com
+10:50:18.732 [info] Running MyAppWeb.Endpoint with Cowboy on http://example.com
 10:50:18.735 [error] Could not find static manifest at "my_app/_build/prod/lib/foo/priv/static/cache_manifest.json". Run "mix phx.digest" after building your static files or remove the configuration from "config/prod.exs".
 ```
 
@@ -72,7 +72,7 @@ To run Phoenix in production, we need to set the `PORT` and `MIX_ENV` environmen
 
 ```console
 $ PORT=4001 MIX_ENV=prod mix phx.server
-10:59:19.136 [info] Running MyApp.Endpoint with Cowboy on http://example.com
+10:59:19.136 [info] Running MyAppWeb.Endpoint with Cowboy on http://example.com
 ```
 
 To run in detached mode so that the Phoenix server does not stop and continues to run even if you close the terminal:
@@ -87,7 +87,7 @@ You can also run your application inside an interactive shell:
 
 ```console
 $ PORT=4001 MIX_ENV=prod iex -S mix phx.server
-10:59:19.136 [info] Running MyApp.Endpoint with Cowboy on http://example.com
+10:59:19.136 [info] Running MyAppWeb.Endpoint with Cowboy on http://example.com
 ```
 
 ## Putting it all together

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -68,7 +68,7 @@ You can start the release by calling `_build/prod/rel/my_app/bin/my_app start`, 
 Open up `config/runtime.exs` (formerly `config/prod.secret.exs`) and you should find a section about "Using releases" with a configuration to set. Go ahead and uncomment that line or manually add the line below, adapted to your application names:
 
 ```elixir
-config :my_app, MyApp.Endpoint, server: true
+config :my_app, MyAppWeb.Endpoint, server: true
 ```
 
 Now assemble the release once again:

--- a/guides/howto/using_ssl.md
+++ b/guides/howto/using_ssl.md
@@ -40,7 +40,7 @@ If you would like to use HTTPS in development, a self-signed certificate can be 
 With your self-signed certificate, your development configuration in `config/dev.exs` can be updated to run an HTTPS endpoint:
 
 ```elixir
-config :my_app, MyApp.Endpoint,
+config :my_app, MyAppWeb.Endpoint,
   ...
   https: [
     port: 4001,
@@ -57,14 +57,14 @@ This can replace your `http` configuration, or you can run HTTP and HTTPS server
 In many cases, you'll want to force all incoming requests to use SSL by redirecting HTTP to HTTPS. This can be accomplished by setting the `:force_ssl` option in your endpoint configuration. It expects a list of options which are forwarded to `Plug.SSL`. By default it sets the "strict-transport-security" header in HTTPS requests, forcing browsers to always use HTTPS. If an unsafe (HTTP) request is sent, it redirects to the HTTPS version using the `:host` specified in the `:url` configuration. For example:
 
 ```elixir
-config :my_app, MyApp.Endpoint,
+config :my_app, MyAppWeb.Endpoint,
   force_ssl: [rewrite_on: [:x_forwarded_proto]]
 ```
 
 To dynamically redirect to the `host` of the current request, set `:host` in the `:force_ssl` configuration to `nil`.
 
 ```elixir
-config :my_app, MyApp.Endpoint,
+config :my_app, MyAppWeb.Endpoint,
   force_ssl: [rewrite_on: [:x_forwarded_proto], host: nil]
 ```
 

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -154,7 +154,7 @@ defmodule Phoenix.Channel do
       def handle_in("new_msg", %{"uid" => uid, "body" => body}, socket) do
         ...
         broadcast_from!(socket, "new_msg", %{uid: uid, body: body})
-        MyApp.Endpoint.broadcast_from!(self(), "room:superadmin",
+        MyAppWeb.Endpoint.broadcast_from!(self(), "room:superadmin",
           "new_msg", %{uid: uid, body: body})
         {:noreply, socket}
       end
@@ -162,8 +162,8 @@ defmodule Phoenix.Channel do
       # within controller
       def create(conn, params) do
         ...
-        MyApp.Endpoint.broadcast!("room:" <> rid, "new_msg", %{uid: uid, body: body})
-        MyApp.Endpoint.broadcast!("room:superadmin", "new_msg", %{uid: uid, body: body})
+        MyAppWeb.Endpoint.broadcast!("room:" <> rid, "new_msg", %{uid: uid, body: body})
+        MyAppWeb.Endpoint.broadcast!("room:superadmin", "new_msg", %{uid: uid, body: body})
         redirect(conn, to: "/")
       end
 
@@ -223,7 +223,7 @@ defmodule Phoenix.Channel do
   preference, a more efficient and simple approach would be to subscribe a
   single channel to relevant notifications via your endpoint. For example:
 
-      defmodule MyApp.Endpoint.NotificationChannel do
+      defmodule MyAppWeb.Endpoint.NotificationChannel do
         use Phoenix.Channel
 
         def join("notification:" <> user_id, %{"ids" => ids}, socket) do
@@ -239,7 +239,7 @@ defmodule Phoenix.Channel do
         end
 
         def handle_in("unwatch", %{"product_id" => id}, socket) do
-          {:reply, :ok, MyApp.Endpoint.unsubscribe("product:#{id}")}
+          {:reply, :ok, MyAppWeb.Endpoint.unsubscribe("product:#{id}")}
         end
 
         defp put_new_topics(socket, topics) do
@@ -248,7 +248,7 @@ defmodule Phoenix.Channel do
             if topic in topics do
               acc
             else
-              :ok = MyApp.Endpoint.subscribe(topic)
+              :ok = MyAppWeb.Endpoint.subscribe(topic)
               assign(acc, :topics, [topic | topics])
             end
           end)

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -14,10 +14,10 @@ defmodule Phoenix.Channel do
   match on all topics starting with a given prefix by using a splat (the `*`
   character) as the last character in the topic pattern:
 
-      channel "room:*", MyApp.RoomChannel
+      channel "room:*", MyAppWeb.RoomChannel
 
   Any topic coming into the router with the `"room:"` prefix would dispatch
-  to `MyApp.RoomChannel` in the above example. Topics can also be pattern
+  to `MyAppWeb.RoomChannel` in the above example. Topics can also be pattern
   matched in your channels' `join/3` callback to pluck out the scoped pattern:
 
       # handles the special `"lobby"` subtopic
@@ -89,10 +89,10 @@ defmodule Phoenix.Channel do
 
         if changeset.valid? do
           post = Repo.insert!(changeset)
-          response = MyApp.PostView.render("show.json", %{post: post})
+          response = MyAppWeb.PostView.render("show.json", %{post: post})
           {:reply, {:ok, response}, socket}
         else
-          response = MyApp.ChangesetView.render("errors.json", %{changeset: changeset})
+          response = MyAppWeb.ChangesetView.render("errors.json", %{changeset: changeset})
           {:reply, {:error, response}, socket}
         end
       end

--- a/lib/phoenix/code_reloader.ex
+++ b/lib/phoenix/code_reloader.ex
@@ -26,7 +26,7 @@ defmodule Phoenix.CodeReloader do
 
   This is configured in your application environment like:
 
-      config :your_app, YourApp.Endpoint,
+      config :your_app, YourAppWeb.Endpoint,
         reloadable_compilers: [:gettext, :phoenix, :elixir],
         reloadable_apps: [:ui, :backend]
 

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -886,11 +886,11 @@ defmodule Phoenix.Endpoint do
   Checks if Endpoint's web server has been configured to start.
 
     * `otp_app` - The OTP app running the endpoint, for example `:my_app`
-    * `endpoint` - The endpoint module, for example `MyApp.Endpoint`
+    * `endpoint` - The endpoint module, for example `MyAppWeb.Endpoint`
 
   ## Examples
 
-      iex> Phoenix.Endpoint.server?(:my_app, MyApp.Endpoint)
+      iex> Phoenix.Endpoint.server?(:my_app, MyAppWeb.Endpoint)
       true
 
   """

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -24,7 +24,7 @@ defmodule Phoenix.Endpoint do
   generator, an endpoint was automatically generated as
   part of your application:
 
-      defmodule YourApp.Endpoint do
+      defmodule YourAppWeb.Endpoint do
         use Phoenix.Endpoint, otp_app: :your_app
 
         # plug ...
@@ -39,7 +39,7 @@ defmodule Phoenix.Endpoint do
   added to the supervision tree as follows:
 
       children = [
-        YourApp.Endpoint
+        YourAppWeb.Endpoint
       ]
 
   ## Endpoint configuration
@@ -47,7 +47,7 @@ defmodule Phoenix.Endpoint do
   All endpoints are configured in your application environment.
   For example:
 
-      config :your_app, YourApp.Endpoint,
+      config :your_app, YourAppWeb.Endpoint,
         secret_key_base: "kjoy3o1zeidquwy1398juxzldjlksahdk3"
 
   Endpoint configuration is split into two categories. Compile-time
@@ -59,8 +59,8 @@ defmodule Phoenix.Endpoint do
   after your application is started and can be read through the
   `c:config/2` function:
 
-      YourApp.Endpoint.config(:port)
-      YourApp.Endpoint.config(:some_config, :default_value)
+      YourAppWeb.Endpoint.config(:port)
+      YourAppWeb.Endpoint.config(:some_config, :default_value)
 
   ### Dynamic configuration
 
@@ -748,7 +748,7 @@ defmodule Phoenix.Endpoint do
       are allowed, or a function provided as MFA tuple. Defaults to `:check_origin`
       setting at endpoint configuration.
 
-      If `true`, the header is checked against `:host` in `YourApp.Endpoint.config(:url)[:host]`.
+      If `true`, the header is checked against `:host` in `YourAppWeb.Endpoint.config(:url)[:host]`.
 
       If `false`, your app is vulnerable to Cross-Site WebSocket Hijacking (CSWSH)
       attacks. Only use in development, when the host is truly unknown or when

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -15,8 +15,8 @@ defmodule Phoenix.Token do
   the id from a database. For example:
 
       iex> user_id = 1
-      iex> token = Phoenix.Token.sign(MyApp.Endpoint, "user auth", user_id)
-      iex> Phoenix.Token.verify(MyApp.Endpoint, "user auth", token, max_age: 86400)
+      iex> token = Phoenix.Token.sign(MyAppWeb.Endpoint, "user auth", user_id)
+      iex> Phoenix.Token.verify(MyAppWeb.Endpoint, "user auth", token, max_age: 86400)
       {:ok, 1}
 
   In that example we have a user's id, we generate a token and
@@ -233,7 +233,7 @@ defmodule Phoenix.Token do
       no :secret_key_base configuration found in #{inspect(endpoint)}.
       Ensure your environment has the necessary mix configuration. For example:
 
-          config :my_app, MyApp.Endpoint,
+          config :my_app, MyAppWeb.Endpoint,
               secret_key_base: ...
 
       """


### PR DESCRIPTION
This fixes #4094 

Ran a find-and-replace for `MyApp.Endpoint` -> `MyAppWeb.Endpoint` and `YourApp.Endpoint` -> `YourAppWeb.Endpoint` in the docs

Phoenix generates the endpoint under AppWeb, not under App; I think the docs should reflect this, as I discovered this issue when attempting to use `broadcast!` functions taken from the docs