### PR TITLE
normalize directory tree markdown examples

### DIFF
--- a/guides/directory_structure.md
+++ b/guides/directory_structure.md
@@ -10,10 +10,10 @@ When we use `mix phx.new` to generate a new Phoenix application, it builds a top
 ├── config
 ├── deps
 ├── lib
-│   └── hello
-│   └── hello.ex
+│   ├── hello
+│   │   └── hello.ex
 │   └── hello_web
-│   └── hello_web.ex
+│       └── hello_web.ex
 ├── priv
 └── test
 ```

--- a/guides/mix_tasks.md
+++ b/guides/mix_tasks.md
@@ -355,7 +355,7 @@ First `priv/static` which should look similar to this:
 ```console
 ├── images
 │   └── phoenix.png
-├── robots.txt
+└── robots.txt
 ```
 
 And then `assets/` which should look similar to this:
@@ -365,8 +365,8 @@ And then `assets/` which should look similar to this:
 │   └── app.scss
 ├── js
 │   └── app.js
-├── vendor
-│   └── phoenix.js
+└── vendor
+    └── phoenix.js
 ```
 
 All of these files are our static assets. Now let's run the `mix phx.digest` task.


### PR DESCRIPTION
 - Directory structure:  Was not representing directories correctly
 - Mix Tasks: Wrong tree ending tokens