### PR TITLE
Use `input_name` in generated LiveView error helpers instead of `input_id`

### DIFF
--- a/installer/templates/phx_web/views/error_helpers.ex
+++ b/installer/templates/phx_web/views/error_helpers.ex
@@ -12,7 +12,7 @@ defmodule <%= @web_namespace %>.ErrorHelpers do
     Enum.map(Keyword.get_values(form.errors, field), fn error ->
       content_tag(:span, translate_error(error),
         class: "invalid-feedback",
-        phx_feedback_for: input_id(form, field)
+        phx_feedback_for: input_name(form, field)
       )
     end)
   end<% end %><%= if @gettext do %>


### PR DESCRIPTION
This updates the generators in line with https://github.com/phoenixframework/phoenix_live_view/pull/1278