### PR TITLE
remove unused warning flash css class

### DIFF
--- a/installer/templates/phx_assets/app.scss
+++ b/installer/templates/phx_assets/app.scss
@@ -67,11 +67,6 @@
   background-color: #d9edf7;
   border-color: #bce8f1;
 }
-.alert-warning {
-  color: #8a6d3b;
-  background-color: #fcf8e3;
-  border-color: #faebcc;
-}
 .alert-danger {
   color: #a94442;
   background-color: #f2dede;


### PR DESCRIPTION
This is minor but I noticed that this seems to be an unused CSS class that was meant to be for a `:warning` flash message.

As far as I can tell flash messages only support `:info` and `:error` by default, and only those two are present in the `app.html.leex` templates.