### PR TITLE
Add flag to skip prompt when generator find an existing context

### DIFF
--- a/integration_test/test/code_generation/app_with_mssql_adapter_test.exs
+++ b/integration_test/test/code_generation/app_with_mssql_adapter_test.exs
@@ -84,12 +84,25 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMSSQLAdapterTest do
     end
   end
 
-  describe "phx.gen.auth + pbkdf2" do
+  describe "phx.gen.auth + pbkdf2 + existing context" do
     test "has no compilation or formatter warnings" do
       with_installer_tmp("new with defaults", fn tmp_dir ->
         {app_root_path, _} = generate_phoenix_app(tmp_dir, "phx_blog", ["--database", "mssql", "--live"])
 
-        mix_run!(~w(phx.gen.auth Accounts User users --hashing-lib pbkdf2), app_root_path)
+        mix_run!(~w(phx.gen.html Accounts Group groups name), app_root_path)
+
+        modify_file(Path.join(app_root_path, "lib/phx_blog_web/router.ex"), fn file ->
+          inject_before_final_end(file, """
+
+            scope "/", PhxBlogWeb do
+              pipe_through [:browser]
+
+              resources "/groups", GroupController
+            end
+          """)
+        end)
+
+        mix_run!(~w(phx.gen.auth Accounts User users --hashing-lib pbkdf2 --merge-with-existing-context), app_root_path)
 
         assert_no_compilation_warnings(app_root_path)
         assert_passes_formatter_check(app_root_path)
@@ -99,9 +112,22 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMSSQLAdapterTest do
     @tag database: :mssql
     test "has a passing test suite" do
       with_installer_tmp("app_with_defaults", fn tmp_dir ->
-        {app_root_path, _} = generate_phoenix_app(tmp_dir, "default_app", ["--database", "mssql", "--live"])
+        {app_root_path, _} = generate_phoenix_app(tmp_dir, "phx_blog", ["--database", "mssql", "--live"])
 
-        mix_run!(~w(phx.gen.auth Accounts User users --hashing-lib pbkdf2), app_root_path)
+        mix_run!(~w(phx.gen.html Accounts Group groups name), app_root_path)
+
+        modify_file(Path.join(app_root_path, "lib/phx_blog_web/router.ex"), fn file ->
+          inject_before_final_end(file, """
+
+            scope "/", PhxBlogWeb do
+              pipe_through [:browser]
+
+              resources "/groups", GroupController
+            end
+          """)
+        end)
+
+        mix_run!(~w(phx.gen.auth Accounts User users --hashing-lib pbkdf2 --merge-with-existing-context), app_root_path)
 
         drop_test_database(app_root_path)
         assert_tests_pass(app_root_path)

--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -81,7 +81,8 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
   alias Mix.Tasks.Phx.Gen
   alias Mix.Tasks.Phx.Gen.Auth.{HashingLibrary, Injector, Migration}
 
-  @switches [web: :string, binary_id: :boolean, hashing_lib: :string, table: :string]
+  @switches [web: :string, binary_id: :boolean, hashing_lib: :string,
+             table: :string, merge_with_existing_context: :boolean]
 
   @doc false
   def run(args) do
@@ -254,6 +255,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
     paths
     |> Mix.Phoenix.eval_from("priv/templates/phx.gen.auth/context_functions.ex", binding)
+    |> prepend_newline()
     |> inject_before_final_end(file)
   end
 
@@ -264,6 +266,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
     paths
     |> Mix.Phoenix.eval_from("priv/templates/phx.gen.auth/test_cases.exs", binding)
+    |> prepend_newline()
     |> inject_before_final_end(test_file)
   end
 
@@ -599,6 +602,8 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
   defp pad(i) when i < 10, do: <<?0, ?0 + i>>
   defp pad(i), do: to_string(i)
+
+  defp prepend_newline(string) when is_binary(string), do: "\n" <> string
 
   defp get_ecto_adapter!(%Schema{repo: repo}) do
     if Code.ensure_loaded?(repo) do

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -211,6 +211,34 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
     end
   end
 
+  test "generates into existing context without prompt with --merge-with-existing-context", config do
+    in_tmp_project config.test, fn ->
+      Gen.Context.run(~w(Blog Post posts title))
+
+      assert_file "lib/phoenix/blog.ex", fn file ->
+        assert file =~ "def get_post!"
+        assert file =~ "def list_posts"
+        assert file =~ "def create_post"
+        assert file =~ "def update_post"
+        assert file =~ "def delete_post"
+        assert file =~ "def change_post"
+      end
+
+      Gen.Context.run(~w(Blog Comment comments message:string --merge-with-existing-context))
+
+      refute_received {:mix_shell, :info, ["You are generating into an existing context" <> _notice]}
+
+      assert_file "lib/phoenix/blog.ex", fn file ->
+        assert file =~ "def get_comment!"
+        assert file =~ "def list_comments"
+        assert file =~ "def create_comment"
+        assert file =~ "def update_comment"
+        assert file =~ "def delete_comment"
+        assert file =~ "def change_comment"
+      end
+    end
+  end
+
   test "when more than 50 attributes are given", config do
     in_tmp_project config.test, fn ->
       long_attribute_list = 0..55 |> Enum.map(&("attribute#{&1}:string")) |> Enum.join(" ")

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -199,6 +199,34 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
     end
   end
 
+  test "generates into existing context without prompt with --merge-with-existing-context", config do
+    in_tmp_project config.test, fn ->
+      Gen.Html.run(~w(Blog Post posts title))
+
+      assert_file "lib/phoenix/blog.ex", fn file ->
+        assert file =~ "def get_post!"
+        assert file =~ "def list_posts"
+        assert file =~ "def create_post"
+        assert file =~ "def update_post"
+        assert file =~ "def delete_post"
+        assert file =~ "def change_post"
+      end
+
+      Gen.Html.run(~w(Blog Comment comments message:string --merge-with-existing-context))
+
+      refute_received {:mix_shell, :info, ["You are generating into an existing context" <> _notice]}
+
+      assert_file "lib/phoenix/blog.ex", fn file ->
+        assert file =~ "def get_comment!"
+        assert file =~ "def list_comments"
+        assert file =~ "def create_comment"
+        assert file =~ "def update_comment"
+        assert file =~ "def delete_comment"
+        assert file =~ "def change_comment"
+      end
+    end
+  end
+
   test "with --web namespace generates namedspaced web modules and directories", config do
     in_tmp_project config.test, fn ->
       Gen.Html.run(~w(Blog Post posts title:string --web Blog))

--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -117,6 +117,34 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
     end
   end
 
+  test "generates into existing context without prompt with --merge-with-existing-context", config do
+    in_tmp_project config.test, fn ->
+      Gen.Json.run(~w(Blog Post posts title))
+
+      assert_file "lib/phoenix/blog.ex", fn file ->
+        assert file =~ "def get_post!"
+        assert file =~ "def list_posts"
+        assert file =~ "def create_post"
+        assert file =~ "def update_post"
+        assert file =~ "def delete_post"
+        assert file =~ "def change_post"
+      end
+
+      Gen.Json.run(~w(Blog Comment comments message:string --merge-with-existing-context))
+
+      refute_received {:mix_shell, :info, ["You are generating into an existing context" <> _notice]}
+
+      assert_file "lib/phoenix/blog.ex", fn file ->
+        assert file =~ "def get_comment!"
+        assert file =~ "def list_comments"
+        assert file =~ "def create_comment"
+        assert file =~ "def update_comment"
+        assert file =~ "def delete_comment"
+        assert file =~ "def change_comment"
+      end
+    end
+  end
+
   test "when more than 50 arguments are given", config do
     in_tmp_project config.test, fn ->
       long_attribute_list = 0..55 |> Enum.map(&("attribute#{&1}:string")) |> Enum.join(" ")

--- a/test/mix/tasks/phx.gen.live_test.exs
+++ b/test/mix/tasks/phx.gen.live_test.exs
@@ -181,6 +181,34 @@ defmodule Mix.Tasks.Phx.Gen.LiveTest do
     end
   end
 
+  test "generates into existing context without prompt with --merge-with-existing-context", config do
+    in_tmp_live_project config.test, fn ->
+      Gen.Live.run(~w(Blog Post posts title))
+
+      assert_file "lib/phoenix/blog.ex", fn file ->
+        assert file =~ "def get_post!"
+        assert file =~ "def list_posts"
+        assert file =~ "def create_post"
+        assert file =~ "def update_post"
+        assert file =~ "def delete_post"
+        assert file =~ "def change_post"
+      end
+
+      Gen.Live.run(~w(Blog Comment comments message:string --merge-with-existing-context))
+
+      refute_received {:mix_shell, :info, ["You are generating into an existing context" <> _notice]}
+
+      assert_file "lib/phoenix/blog.ex", fn file ->
+        assert file =~ "def get_comment!"
+        assert file =~ "def list_comments"
+        assert file =~ "def create_comment"
+        assert file =~ "def update_comment"
+        assert file =~ "def delete_comment"
+        assert file =~ "def change_comment"
+      end
+    end
+  end
+
   test "with --web namespace generates namespaced web modules and directories", config do
     in_tmp_live_project config.test, fn ->
       Gen.Live.run(~w(Blog Post posts title:string --web Blog))


### PR DESCRIPTION
This adds new `--merge-with-existing-context` and `--no-merge-with-existing-context` options to the `phx.gen.context` family of generators. This allows us to have an integration test that merges`phx.gen.auth` generated code with an existing context (a prerequisite for me to clean up some duplicate fixture generation code). This test also found a formatting error where we were missing a blank newline between the existing context's functions/tests and `phx.gen.auth`'s functions/tests. I've also added unit tests and documentation for these new options. 

I was unable to add unit tests for `--no-merge-with-existing-context` because `System.halt/0` is called in the generator and kills the tests.