### PR TITLE
include Elixir Discord as part of "community"

### DIFF
--- a/guides/introduction/community.md
+++ b/guides/introduction/community.md
@@ -7,6 +7,8 @@ There are a number of places to connect with community members at all experience
   * We're on Freenode IRC in the [\#elixir-lang](http://webchat.freenode.net/?channels=elixir-lang) channel.
 
   * [Request an invitation](https://elixir-slackin.herokuapp.com/) and join the #phoenix channel on [Slack](https://elixir-lang.slack.com).
+  
+  * Feel free to join and checkout the #phoenix channel on [Discord](https://discord.gg/elixir).
 
   * Read about [bug reports](https://github.com/phoenixframework/phoenix/blob/master/CONTRIBUTING.md#bug-reports) or open an issue in the Phoenix [issue tracker](https://github.com/phoenixframework/phoenix/issues).
 

--- a/guides/introduction/community.md
+++ b/guides/introduction/community.md
@@ -8,7 +8,7 @@ There are a number of places to connect with community members at all experience
 
   * [Request an invitation](https://elixir-slackin.herokuapp.com/) and join the #phoenix channel on [Slack](https://elixir-lang.slack.com).
   
-  * Feel free to join and checkout the #phoenix channel on [Discord](https://discord.gg/elixir).
+  * Feel free to join and check out the #phoenix channel on [Discord](https://discord.gg/elixir).
 
   * Read about [bug reports](https://github.com/phoenixframework/phoenix/blob/master/CONTRIBUTING.md#bug-reports) or open an issue in the Phoenix [issue tracker](https://github.com/phoenixframework/phoenix/issues).
 

--- a/installer/templates/phx_web/templates/page/index.html.eex
+++ b/installer/templates/phx_web/templates/page/index.html.eex
@@ -44,6 +44,9 @@
       <li>
         <a href="https://elixir-slackin.herokuapp.com/">Elixir on Slack</a>
       </li>
+      <li>
+        <a href="https://discord.gg/elixir">Elixir on Discord</a>
+      </li>
     </ul>
   </article>
 </section>


### PR DESCRIPTION
The Elixir Discord has grown to a considerable size (and Discord uses Elixir *wink wink*),
so I (think) it's due time to include it as a part of "the community"