### PR TITLE
CI: include `mix compile` in `test-setup`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -9,6 +9,7 @@ all-test:
 
 test:
     FROM +test-setup
+    RUN MIX_ENV=test mix deps.compile
     COPY --dir assets config installer lib integration_test priv test ./
     RUN mix test
 
@@ -102,4 +103,3 @@ test-setup:
    RUN mix local.rebar --force
    RUN mix local.hex --force
    RUN mix deps.get
-   RUN MIX_ENV=test mix compile

--- a/Earthfile
+++ b/Earthfile
@@ -104,3 +104,4 @@ test-setup:
    RUN mix local.rebar --force
    RUN mix local.hex --force
    RUN mix deps.get
+   RUN MIX_ENV=test mix compile

--- a/Earthfile
+++ b/Earthfile
@@ -75,10 +75,10 @@ integration-test:
 
 npm:
     FROM +test-setup
-    # use node 12 + npm
+    # Use Node 12 + matching NPM
     RUN apk add "nodejs>12.0" && apk add "npm>12.0"
     RUN mkdir assets
-    # copy package.json + lockfile separatelly to improve caching (js changes dont require `npm install` anymore)
+    # Copy package.json + lockfile separatelly to improve caching (JS changes don't trigger `npm install` anymore)
     COPY assets/package* assets
     WORKDIR assets
     RUN npm install

--- a/Earthfile
+++ b/Earthfile
@@ -78,7 +78,7 @@ npm:
     # use node 12 + npm
     RUN apk add "nodejs>12.0" && apk add "npm>12.0"
     RUN mkdir assets
-    # copy package.json + lockfile separatelly improve caching (js changes dont require `npm install` anymore)
+    # copy package.json + lockfile separatelly to improve caching (js changes dont require `npm install` anymore)
     COPY assets/package* assets
     WORKDIR assets
     RUN npm install

--- a/Earthfile
+++ b/Earthfile
@@ -74,18 +74,16 @@ integration-test:
     END
 
 npm:
-    ARG ELIXIR=1.10.4
-    ARG OTP=23.0.3
-    FROM node:12
-    COPY +npm-setup/assets /assets
-    WORKDIR assets
-    RUN npm install && npm test
-
-npm-setup:
     FROM +test-setup
-    COPY assets assets
-    RUN mix deps.get
-    SAVE ARTIFACT assets
+    # use node 12 + npm
+    RUN apk add "nodejs>12.0" && apk add "npm>12.0"
+    RUN mkdir assets
+    # copy package.json + lockfile separatelly improve caching (js changes dont require `npm install` anymore)
+    COPY assets/package* assets
+    WORKDIR assets
+    RUN npm install
+    COPY assets/ .
+    RUN npm test
 
 setup-base:
    ARG ELIXIR=1.11.2


### PR DESCRIPTION
Problem: 
- when re-running `earthly` locally after changing a test Elixir file, we see a full recompilation of all the dependencies. 

Solution: 
- in the test-setup preparation step we can also compile all the packages with `MIX_ENV=test`. That way they get reused for all the dependent steps. 