### PR TITLE
Update js dependencies, prepare for webpack 5

### DIFF
--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -54,7 +54,7 @@ Node.js is an optional dependency. Phoenix will use [webpack](https://webpack.js
 
 If we don't have any static assets, or we want to use another build tool, we can pass the `--no-webpack` flag when creating a new application and Node.js won't be required at all.
 
-We can get Node.js from the [download page](https://nodejs.org/en/download/). When selecting a package to download, it's important to note that Phoenix requires version 5.0.0 or greater.
+We can get Node.js from the [download page](https://nodejs.org/en/download/). When selecting a package to download, it's important to note that Phoenix requires version 10.13 or greater.
 
 Mac OS X users can also install Node.js via [homebrew](https://brew.sh/).
 

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -16,7 +16,7 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.0",
-    "copy-webpack-plugin": "^5.1.1",
+    "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^3.4.2",
     "sass-loader": "^8.0.2",
     "node-sass": "^4.13.1",

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -20,7 +20,7 @@
     "css-loader": "^5.0.1",
     "sass-loader": "^10.1.0",
     "sass": "^1.32.2",
-    "mini-css-extract-plugin": "^0.9.0",
+    "mini-css-extract-plugin": "^1.3.3",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "terser-webpack-plugin": "^2.3.2",
     "webpack": "^4.41.5",

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -18,7 +18,7 @@
     "babel-loader": "^8.0.0",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.0.1",
-    "sass-loader": "^8.0.2",
+    "sass-loader": "^10.1.0",
     "node-sass": "^4.13.1",
     "hard-source-webpack-plugin": "^0.13.1",
     "mini-css-extract-plugin": "^0.9.0",

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -13,9 +13,9 @@
     "topbar": "^0.1.4"<% end %>
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0",
-    "@babel/preset-env": "^7.0.0",
-    "babel-loader": "^8.0.0",
+    "@babel/core": "^7.12.10",
+    "@babel/preset-env": "^7.12.11",
+    "babel-loader": "^8.2.2",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.0.1",
     "sass-loader": "^10.1.0",

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -19,7 +19,7 @@
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.0.1",
     "sass-loader": "^10.1.0",
-    "node-sass": "^4.13.1",
+    "sass": "^1.32.2",
     "hard-source-webpack-plugin": "^0.13.1",
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -24,6 +24,6 @@
     "optimize-css-assets-webpack-plugin": "^5.0.4",
     "terser-webpack-plugin": "^4.2.3",
     "webpack": "^4.45.0",
-    "webpack-cli": "^3.3.2"
+    "webpack-cli": "^3.3.12"
   }
 }

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.0",
     "copy-webpack-plugin": "^6.4.1",
-    "css-loader": "^3.4.2",
+    "css-loader": "^5.0.1",
     "sass-loader": "^8.0.2",
     "node-sass": "^4.13.1",
     "hard-source-webpack-plugin": "^0.13.1",

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -13,17 +13,17 @@
     "topbar": "^0.1.4"<% end %>
   },
   "devDependencies": {
-    "@babel/core": "^7.12.10",
-    "@babel/preset-env": "^7.12.11",
+    "@babel/core": "^7.12.16",
+    "@babel/preset-env": "^7.12.16",
     "babel-loader": "^8.2.2",
     "copy-webpack-plugin": "^6.4.1",
-    "css-loader": "^5.0.1",
-    "sass-loader": "^10.1.0",
-    "sass": "^1.32.2",
-    "mini-css-extract-plugin": "^1.3.3",
+    "css-loader": "^5.0.2",
+    "sass-loader": "^10.1.1",
+    "sass": "^1.32.7",
+    "mini-css-extract-plugin": "^1.3.7",
     "optimize-css-assets-webpack-plugin": "^5.0.4",
     "terser-webpack-plugin": "^4.2.3",
-    "webpack": "^4.45.0",
+    "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   }
 }

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -23,7 +23,7 @@
     "mini-css-extract-plugin": "^1.3.3",
     "optimize-css-assets-webpack-plugin": "^5.0.4",
     "terser-webpack-plugin": "^4.2.3",
-    "webpack": "^4.41.5",
+    "webpack": "^4.45.0",
     "webpack-cli": "^3.3.2"
   }
 }

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -21,7 +21,7 @@
     "sass-loader": "^10.1.0",
     "sass": "^1.32.2",
     "mini-css-extract-plugin": "^1.3.3",
-    "optimize-css-assets-webpack-plugin": "^5.0.1",
+    "optimize-css-assets-webpack-plugin": "^5.0.4",
     "terser-webpack-plugin": "^2.3.2",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.2"

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -20,7 +20,6 @@
     "css-loader": "^5.0.1",
     "sass-loader": "^10.1.0",
     "sass": "^1.32.2",
-    "hard-source-webpack-plugin": "^0.13.1",
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "terser-webpack-plugin": "^2.3.2",

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -10,7 +10,7 @@
     "phoenix": "file:<%= phoenix_webpack_path %>"<%= if html do %>,
     "phoenix_html": "file:<%= phoenix_html_webpack_path %>"<% end %><%= if live do %>,
     "phoenix_live_view": "file:<%= phoenix_live_view_webpack_path %>",
-    "topbar": "^0.1.4"<% end %>
+    "topbar": "^1.0.1"<% end %>
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -22,7 +22,7 @@
     "sass": "^1.32.2",
     "mini-css-extract-plugin": "^1.3.3",
     "optimize-css-assets-webpack-plugin": "^5.0.4",
-    "terser-webpack-plugin": "^2.3.2",
+    "terser-webpack-plugin": "^4.2.3",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.2"
   }

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -45,7 +45,7 @@ module.exports = (env, options) => {
     },
     plugins: [
       new MiniCssExtractPlugin({ filename: '../css/app.css' }),
-      new CopyWebpackPlugin({ patterns: [{ from: "static/", to: "../" }] }),
+      new CopyWebpackPlugin({ patterns: [{ from: 'static/', to: '../' }] }),
     ]
   }
 };

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -46,7 +46,7 @@ module.exports = (env, options) => {
     },
     plugins: [
       new MiniCssExtractPlugin({ filename: '../css/app.css' }),
-      new CopyWebpackPlugin([{ from: 'static/', to: '../' }])
+      new CopyWebpackPlugin({ patterns: [{ from: "static/", to: "../" }] }),
     ]
     .concat(devMode ? [new HardSourceWebpackPlugin()] : [])
   }

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const glob = require('glob');
-const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
@@ -48,6 +47,5 @@ module.exports = (env, options) => {
       new MiniCssExtractPlugin({ filename: '../css/app.css' }),
       new CopyWebpackPlugin({ patterns: [{ from: "static/", to: "../" }] }),
     ]
-    .concat(devMode ? [new HardSourceWebpackPlugin()] : [])
   }
 };


### PR DESCRIPTION
This PR updates all javascript dependencies to their newest versions, but also removes and changes some of them to prepare for upgrading to webpack 5.

### Dependency changes:
- All js dependencies are updated to latest version that still support webpack 4
- Version numbers in `package.json` are updated to reflect the latest current version, with `^` for minor version upgrades
- ~The `webpack` version is now also prefixed with `^` for minor version updates. It was locked to a single version before~ (update: this was done in https://github.com/phoenixframework/phoenix/pull/4198 in the meantime)
- HardSourceWebpackPlugin was not compatible with the latest `mini-css-extract-plugin`. Also [it should not be necessary in webpack 5](https://github.com/mzgoddard/hard-source-webpack-plugin/issues/514#issuecomment-687621600), so it is removed in https://github.com/phoenixframework/phoenix/pull/4146/commits/2ada2fe4324e27018b91dddd6add6905cf33ace6
- The `node-sass` plugin [has been deprecated](https://github.com/sass/node-sass/blob/master/README.md) and the `sass-loader` [recommends using `dart-sass` instead](https://github.com/webpack-contrib/sass-loader). I have replaced `node-sass` with `sass` in https://github.com/phoenixframework/phoenix/pull/4146/commits/bc4310236db27a23e2b354a8a478a60492618c3b

### Other changes:
- Several webpack plugins now require Node.js 10.13. I have updated the minimum Node.js version in `installation.md`
- ~Node.js is spelled differently across Phoenix as e.g. "node", "NodeJS", "Node.JS", etc, but the correct spelling is Node.js. This is corrected across the project~ (Update: This has been done in https://github.com/phoenixframework/phoenix/pull/4150)

I have created a new `phx_new` package locally and verified that I can install a new phoenix project with these updated packages, and that the `iex -S mix phx.server` runs. 

I haven't verified that it works with releases yet.

### Notes on warnings:
Currently we get a lot of warnings during `npm install`:

```
npm WARN deprecated chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
```

As I understand it, these errors will be fixed in webpack 5, and we can't do anything about them before upgrading to webpack 5. `chokidar@2.1.8`, `resolve-url@0.2.1`, `urix@0.1.0`, `fsevents@1.2.13` are all dependencies of `webpack@4.45.0`.

### The path ahead

This PR paves the way for upgrading to webpack 5, by removing some plugins and updating others to versions compatible with webpack 5. Also, updating to webpack 5 should fix the above deprecations.

Should we wait until Phoenix 1.6 with an upgrade to webpack 5, or would it be ok to include it in Phoenix 1.5?