### PR TITLE
heroku.md: Remove unnecessary "longpoll: false"

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -168,8 +168,7 @@ defmodule HelloWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :hello
 
   socket "/socket", HelloWeb.UserSocket,
-    websocket: [timeout: 45_000],
-    longpoll: false
+    websocket: [timeout: 45_000]
 
   ...
 end


### PR DESCRIPTION
Per https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3, this is already the default, so perhaps not worth mentioning.

Unless I'm missing something and this setting is extra important in the context of Heroku – if so, perhaps the docs could say a bit more about that.