### PR TITLE
Use consistent naming of Node.js in docs

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 * Elixir version (elixir -v):
 * Phoenix version (mix deps):
-* NodeJS version (node -v):
+* Node.js version (node -v):
 * NPM version (npm -v):
 * Operating system:
 

--- a/guides/deployment/gigalixir.md
+++ b/guides/deployment/gigalixir.md
@@ -83,7 +83,7 @@ $ git remote -v
 
 ### Specifying versions
 
-The buildpacks we use default to Elixir, Erlang, and Nodejs versions that are quite old and it's generally a good idea to run the same version in production as you do in development, so let's do that.
+The buildpacks we use default to Elixir, Erlang, and Node.js versions that are quite old and it's generally a good idea to run the same version in production as you do in development, so let's do that.
 
 ```console
 $ echo "elixir_version=1.10.3" > elixir_buildpack.config

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -115,10 +115,10 @@ Buildpack added. Next release on mysterious-meadow-6277 will use:
   2. https://github.com/gjaldon/heroku-buildpack-phoenix-static.git
 ```
 
-The Phoenix Static buildpack uses a predefined Node version but to avoid surprises when deploying, it is best to explicitly list the Node version we want in production to be the same we are using during development or in your continuous integration servers. This is done by creating a config file named `phoenix_static_buildpack.config` in the root directory of your project with your target version of Node:
+The Phoenix Static buildpack uses a predefined Node.js version but to avoid surprises when deploying, it is best to explicitly list the Node.js version we want in production to be the same we are using during development or in your continuous integration servers. This is done by creating a config file named `phoenix_static_buildpack.config` in the root directory of your project with your target version of Node.js:
 
 ```
-# Node version
+# Node.js version
 node_version=10.20.1
 ```
 

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -4,7 +4,7 @@ In order to build a Phoenix application, we will need a few dependencies install
 
   * the Erlang VM and the Elixir programming language
   * a database - Phoenix recommends PostgreSQL but you can pick others or not use a database at all
-  * Node.JS for assets - which can be opt-out, especially if you are building APIs
+  * Node.js for assets - which can be opt-out, especially if you are building APIs
   * and other optional packages.
 
 Please take a look at this list and make sure to install anything necessary for your system. Having dependencies installed in advance can prevent frustrating problems later on.
@@ -48,15 +48,15 @@ $ mix archive.install hex phx_new 1.5.7
 
 We will use this generator to generate new applications in the next guide, called [Up and Running](up_and_running.html).
 
-## node.js
+## Node.js
 
-Node is an optional dependency. Phoenix will use [webpack](https://webpack.js.org/) to compile static assets (JavaScript, CSS, etc), by default. Webpack uses the node package manager (npm) to install its dependencies, and npm requires node.js.
+Node.js is an optional dependency. Phoenix will use [webpack](https://webpack.js.org/) to compile static assets (JavaScript, CSS, etc), by default. Webpack uses the node package manager (npm) to install its dependencies, and npm requires Node.js.
 
-If we don't have any static assets, or we want to use another build tool, we can pass the `--no-webpack` flag when creating a new application and node won't be required at all.
+If we don't have any static assets, or we want to use another build tool, we can pass the `--no-webpack` flag when creating a new application and Node.js won't be required at all.
 
-We can get node.js from the [download page](https://nodejs.org/en/download/). When selecting a package to download, it's important to note that Phoenix requires version 5.0.0 or greater.
+We can get Node.js from the [download page](https://nodejs.org/en/download/). When selecting a package to download, it's important to note that Phoenix requires version 5.0.0 or greater.
 
-Mac OS X users can also install node.js via [homebrew](https://brew.sh/).
+Mac OS X users can also install Node.js via [homebrew](https://brew.sh/).
 
 ## PostgreSQL
 
@@ -74,4 +74,4 @@ Mac OS X and Windows users already have a filesystem watcher but Linux users mus
 
 ## Summary
 
-At the end of this section, you must have installed Elixir, Hex, Phoenix, PostgreSQL and node.js. Now that we have everything installed, let's create our first Phoenix application and get [up and running](up_and_running.html).
+At the end of this section, you must have installed Elixir, Hex, Phoenix, PostgreSQL and Node.js. Now that we have everything installed, let's create our first Phoenix application and get [up and running](up_and_running.html).

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -235,8 +235,8 @@ defmodule Mix.Tasks.Phx.New do
   defp print_webpack_info(_project, _gen) do
     Mix.shell().info """
     Phoenix uses an optional assets build tool called webpack
-    that requires node.js and npm. Installation instructions for
-    node.js, which includes npm, can be found at http://nodejs.org.
+    that requires Node.js and npm. Installation instructions for
+    Node.js, which includes npm, can be found at http://nodejs.org.
 
     The command listed next expect that you have npm available.
     If you don't want webpack, you can re-run this generator

--- a/lib/phoenix/endpoint/watcher.ex
+++ b/lib/phoenix/endpoint/watcher.ex
@@ -38,7 +38,7 @@ defmodule Phoenix.Endpoint.Watcher do
     end
   end
 
-  # We specially handle node to make sure we
+  # We specially handle Node.js to make sure we
   # provide a good getting started experience.
   defp validate("node", [script|_], merged_opts) do
     script_path = Path.expand(script, cd(merged_opts))
@@ -51,7 +51,7 @@ defmodule Phoenix.Endpoint.Watcher do
         exit(:shutdown)
 
       not File.exists?(script_path) ->
-        Logger.error "Could not start node watcher because script #{inspect script_path} does not " <>
+        Logger.error "Could not start Node.js watcher because script #{inspect script_path} does not " <>
                      "exist. Your Phoenix application is still running, however assets " <>
                      "won't be compiled. You may fix this by running \"npm install\" inside the \"assets\" directory."
         exit(:shutdown)


### PR DESCRIPTION
Across the Phoenix docs, Node.js is spelled differently as e.g. "node", "NodeJS", "Node.JS", etc, but the correct spelling is Node.js. This is corrected across the project in this PR.

The term "node" is also easy to confuse with erlang nodes, so it improves the clarity to use Node.js.

References for Node.js being the correct spelling:
- https://nodejs.org/en/
- https://github.com/nodejs/node/pull/33088