### PR TITLE
Implement put_new_flash/3

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1391,6 +1391,22 @@ defmodule Phoenix.Controller do
   end
 
   @doc """
+  Persists a value in flash but only if the key does not exist yet.
+
+  Returns the updated connection.
+
+  ## Examples
+
+      iex> conn = put_new_flash(conn, :info, "Welcome Back!")
+      iex> get_flash(conn, :info)
+      "Welcome Back!"
+
+  """
+  def put_new_flash(conn, key, message) do
+    persist_flash(conn, Map.put_new(get_flash(conn), flash_key(key), message))
+  end
+
+  @doc """
   Returns a map of previously set flash messages or an empty map.
 
   ## Examples

--- a/test/phoenix/controller/flash_test.exs
+++ b/test/phoenix/controller/flash_test.exs
@@ -128,6 +128,18 @@ defmodule Phoenix.Controller.FlashTest do
     assert get_flash(conn, "notice") == "false alarm!"
   end
 
+  test "put_new_flash/3 only adds key/message if the key does not exist yet" do
+    conn =
+      conn(:get, "/")
+      |> with_session
+      |> fetch_flash([])
+      |> put_new_flash(:error, "oh noes!")
+      |> put_new_flash(:error, "boom!")
+
+    assert get_flash(conn, :error) == "oh noes!"
+    assert get_flash(conn, "error") == "oh noes!"
+  end
+
   test "clear_flash/1 clears the flash messages" do
     conn =
       conn(:get, "/")


### PR DESCRIPTION
When messing around with phx_gen_auth I needed to put a key/message into the flash but only if the key didn't not exist prior. What do you think of this change?