### PR TITLE
Update template app.scss for modal

### DIFF
--- a/installer/templates/phx_assets/app.scss
+++ b/installer/templates/phx_assets/app.scss
@@ -34,7 +34,7 @@
 
 .phx-modal-content {
   background-color: #fefefe;
-  margin: 15% auto;
+  margin: 15vh auto;
   padding: 20px;
   border: 1px solid #888;
   width: 80%;


### PR DESCRIPTION
Vertical % for padding and margins is a percent of the width. When maximizing the browser to full screen especially with a large form, this causes modal to be pushed down the page.

"vh" units seems to be simplest fix here, as the modal is used full screen. If you wanted to generalize it to work within any container, you could do absolute and top/bottom percent (as that refers to the height).

https://css-tricks.com/oh-hey-padding-percentage-is-based-on-the-parent-elements-width/