### PR TITLE
Add Telemetry link to Absinthe

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -520,7 +520,7 @@ libraries currently emitting `:telemetry` events.
 Library authors are actively encouraged to send a PR adding
 their own (in alphabetical order, please):
 
-* [Absinthe](https://hexdocs.pm/absinthe) - Coming Soon!
+* [Absinthe](https://hexdocs.pm/absinthe) - [Events](https://hexdocs.pm/absinthe/telemetry.html)
 * [Broadway](https://hexdocs.pm/broadway) - [Events](https://hexdocs.pm/broadway/Broadway.html#module-telemetry)
 * [Ecto](https://hexdocs.pm/ecto) - [Events](https://hexdocs.pm/ecto/Ecto.Repo.html#module-telemetry-events)
 * [Oban](https://hexdocs.pm/oban) - [Events](https://hexdocs.pm/oban/Oban.Telemetry.html)


### PR DESCRIPTION
Absinthe library added Telemetry events in [version 1.5](https://github.com/absinthe-graphql/absinthe/blob/master/CHANGELOG.md#v150-alpha).