### PR TITLE
Update `@unsent` Plug.Conn states to include `:set_chunked` and `:set_file`

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -5,7 +5,7 @@ defmodule Phoenix.Controller do
   require Logger
   require Phoenix.Endpoint
 
-  @unsent [:unset, :set]
+  @unsent [:unset, :set, :set_chunked, :set_file]
 
   @moduledoc """
   Controllers are used to group common functionality in the same


### PR DESCRIPTION
We use `@unsent` to raise an `AlreadySentError` if trying to change the view or the layout after a response is sent. This updates the module variable to include the other unsent states from https://github.com/elixir-plug/plug/blob/40efbe4680f98eb063ea1e17f079c4243b6593cf/lib/plug/conn.ex#L258

It *might* be nicer to expose `unsent?`/`sent?` as functions on Plug.Conn itself. What do you think?