### PR TITLE
Precompile generator templates

### DIFF
--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -11,12 +11,12 @@ defmodule Mix.Phoenix do
   def eval_from(apps, source_file_path, binding) do
     sources = Enum.map(apps, &to_app_source(&1, source_file_path))
 
-    content =
+    source =
       Enum.find_value(sources, fn source ->
-        File.exists?(source) && File.read!(source)
+        if File.exists?(source), do: source
       end) || raise "could not find #{source_file_path} in any of the sources"
 
-    EEx.eval_string(content, binding)
+    EEx.eval_file(source, assigns: binding)
   end
 
   @doc """
@@ -38,12 +38,12 @@ defmodule Mix.Phoenix do
 
       case format do
         :text -> Mix.Generator.create_file(target, File.read!(source))
-        :eex  -> Mix.Generator.create_file(target, EEx.eval_file(source, binding))
+        :eex  -> Mix.Generator.create_file(target, EEx.eval_file(source, assigns: binding))
         :new_eex ->
           if File.exists?(target) do
             :ok
           else
-            Mix.Generator.create_file(target, EEx.eval_file(source, binding))
+            Mix.Generator.create_file(target, EEx.eval_file(source, assigns: binding))
           end
       end
     end

--- a/lib/mix/phoenix/aggregate_template_source.ex
+++ b/lib/mix/phoenix/aggregate_template_source.ex
@@ -1,0 +1,22 @@
+defmodule Mix.Phoenix.AggregateTemplateSource do
+  @moduledoc false
+
+  @callback template_sources() :: [module]
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Mix.Phoenix.TemplateSource
+      @behaviour unquote(__MODULE__)
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __before_compile__(_env) do
+    quote do
+      @impl true
+      def render_template(template_path, assigns) do
+        Mix.Phoenix.render_template(template_sources(), template_path, assigns)
+      end
+    end
+  end
+end

--- a/lib/mix/phoenix/template_source.ex
+++ b/lib/mix/phoenix/template_source.ex
@@ -1,0 +1,84 @@
+defmodule Mix.Phoenix.TemplateSource do
+  @moduledoc false
+
+  @type template_path :: String.t()
+  @type binding :: keyword
+
+  @callback render_template(template_path, binding) :: {:ok, String.t()} | {:error, :not_found}
+
+  defmacro __using__(options) do
+    template_patterns = Keyword.fetch!(options, :template_patterns) |> List.wrap()
+    exclude_patterns = Keyword.get(options, :exclude_patterns, []) |> List.wrap()
+
+    quote do
+      @phoenix_template_source_template_patterns unquote(template_patterns)
+      @phoenix_template_source_exclude_patterns unquote(exclude_patterns)
+      @behaviour unquote(__MODULE__)
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    template_patterns =
+      Module.get_attribute(env.module, :phoenix_template_source_template_patterns)
+
+    exclude_patterns = Module.get_attribute(env.module, :phoenix_template_source_exclude_patterns)
+
+    generated_function_heads =
+      for path <- template_paths(template_patterns, exclude_patterns) do
+        compiled = EEx.compile_file(path)
+        private_function_name = String.to_atom(path)
+
+        quote do
+          @external_resource unquote(path)
+          @file unquote(path)
+          defp unquote(private_function_name)(var!(assigns)) do
+            _ = var!(assigns)
+            unquote(compiled)
+          end
+
+          def render_template(unquote(path), assigns) do
+            {:ok, unquote(private_function_name)(assigns)}
+          end
+        end
+      end
+
+    quote do
+      unquote(generated_function_heads)
+      def render_template(_template, assigns), do: {:error, :not_found}
+
+      @doc false
+      def __mix_recompile__? do
+        unquote(hash(template_patterns, exclude_patterns)) !=
+          unquote(__MODULE__).hash(
+            @phoenix_template_source_template_patterns,
+            @phoenix_template_source_exclude_patterns
+          )
+      end
+    end
+  end
+
+  @doc false
+  def hash(template_patterns, exclude_patterns) do
+    template_paths(template_patterns, exclude_patterns)
+    |> Enum.sort()
+    |> :erlang.md5()
+  end
+
+  @doc false
+  def template_paths(template_patterns, exclude_patterns) do
+    MapSet.difference(
+      MapSet.new(files_from_patterns(template_patterns)),
+      MapSet.new(files_from_patterns(exclude_patterns))
+    )
+    |> MapSet.to_list()
+  end
+
+  defp files_from_patterns(patterns) do
+    patterns
+    |> Stream.flat_map(&Path.wildcard/1)
+    |> Stream.uniq()
+    |> Stream.filter(&File.regular?/1)
+    |> Enum.to_list()
+  end
+end

--- a/lib/mix/phoenix/template_sources/local_app.ex
+++ b/lib/mix/phoenix/template_sources/local_app.ex
@@ -1,0 +1,14 @@
+defmodule Mix.Phoenix.TemplateSources.LocalApp do
+  @moduledoc false
+
+  @behaviour Mix.Phoenix.TemplateSource
+
+  @impl true
+  def render_template(template_path, binding) when is_list(binding) do
+    if File.exists?(template_path) do
+      {:ok, EEx.eval_file(template_path, [assigns: binding])}
+    else
+      {:error, :not_found}
+    end
+  end
+end

--- a/lib/mix/phoenix/template_sources/phoenix.ex
+++ b/lib/mix/phoenix/template_sources/phoenix.ex
@@ -1,0 +1,19 @@
+defmodule Mix.Phoenix.TemplateSources.Phoenix do
+  @moduledoc false
+
+  @behaviour Mix.Phoenix.TemplateSource
+
+  @impl true
+  def render_template(template_path, binding) when is_list(binding) do
+    path = phoenix_template_path(template_path)
+    if File.exists?(path) do
+      {:ok, EEx.eval_file(path, [assigns: binding])}
+    else
+      {:error, :not_found}
+    end
+  end
+
+  defp phoenix_template_path(template_path) do
+    Application.app_dir(:phoenix, template_path)
+  end
+end

--- a/lib/mix/phoenix/template_sources/phoenix_compiled.ex
+++ b/lib/mix/phoenix/template_sources/phoenix_compiled.ex
@@ -1,0 +1,20 @@
+defmodule Mix.Phoenix.TemplateSources.PhoenixCompiled do
+  @moduledoc false
+
+  use Mix.Phoenix.AggregateTemplateSource
+
+  @impl true
+  def template_sources do
+    [
+      Mix.Tasks.Phx.Gen.Auth,
+      Mix.Tasks.Phx.Gen.Channel,
+      Mix.Tasks.Phx.Gen.Context,
+      Mix.Tasks.Phx.Gen.Embedded,
+      Mix.Tasks.Phx.Gen.Json,
+      Mix.Tasks.Phx.Gen.Html,
+      Mix.Tasks.Phx.Gen.Live,
+      Mix.Tasks.Phx.Gen.Presence,
+      Mix.Tasks.Phx.Gen.Schema
+    ]
+  end
+end

--- a/lib/mix/tasks/phx.gen.auth/template_sources/context_functions.ex
+++ b/lib/mix/tasks/phx.gen.auth/template_sources/context_functions.ex
@@ -1,0 +1,7 @@
+defmodule Mix.Tasks.Phx.Gen.Auth.TemplateSources.ContextFunctions do
+  @moduledoc false
+
+  use Mix.Phoenix.TemplateSource, template_patterns: [
+    "priv/templates/phx.gen.auth/context_functions.ex"
+  ]
+end

--- a/lib/mix/tasks/phx.gen.auth/template_sources/primary.ex
+++ b/lib/mix/tasks/phx.gen.auth/template_sources/primary.ex
@@ -1,0 +1,10 @@
+defmodule Mix.Tasks.Phx.Gen.Auth.TemplateSources.Primary do
+  @moduledoc false
+
+  use Mix.Phoenix.TemplateSource,
+    template_patterns: [ "priv/templates/phx.gen.auth/*.*" ],
+    exclude_patterns: [
+      "priv/templates/phx.gen.auth/context_functions.ex",
+      "priv/templates/phx.gen.auth/test_cases.exs"
+    ]
+end

--- a/lib/mix/tasks/phx.gen.auth/template_sources/test_cases.ex
+++ b/lib/mix/tasks/phx.gen.auth/template_sources/test_cases.ex
@@ -1,0 +1,7 @@
+defmodule Mix.Tasks.Phx.Gen.Auth.TemplateSources.TestCases do
+  @moduledoc false
+
+  use Mix.Phoenix.TemplateSource, template_patterns: [
+    "priv/templates/phx.gen.auth/test_cases.exs"
+  ]
+end

--- a/lib/mix/tasks/phx.gen.channel.ex
+++ b/lib/mix/tasks/phx.gen.channel.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
 
   """
   use Mix.Task
+  use Mix.Phoenix.TemplateSource, template_patterns: ["priv/templates/phx.gen.channel/*.*"]
 
   @doc false
   def run(args) do
@@ -37,7 +38,7 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Channel")
 
-    Mix.Phoenix.copy_from paths(), "priv/templates/phx.gen.channel", binding, [
+    Mix.Phoenix.copy_from Mix.Phoenix.template_sources(), "priv/templates/phx.gen.channel", binding, [
       {:eex, "channel.ex",       Path.join(web_prefix, "channels/#{binding[:path]}_channel.ex")},
       {:eex, "channel_test.exs", Path.join(test_prefix, "channels/#{binding[:path]}_channel_test.exs")},
     ]
@@ -65,9 +66,5 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
       raise_with_help()
     end
     args
-  end
-
-  defp paths do
-    [".", :phoenix]
   end
 end

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -74,6 +74,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
   """
 
   use Mix.Task
+  use Mix.Phoenix.TemplateSource, template_patterns: ["priv/templates/phx.gen.context/*.*"]
 
   alias Mix.Phoenix.{Context, Schema}
   alias Mix.Tasks.Phx.Gen
@@ -92,7 +93,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
 
     {context, schema} = build(args)
     binding = [context: context, schema: schema]
-    paths = Mix.Phoenix.generator_paths()
+    paths = Mix.Phoenix.template_sources()
 
     prompt_for_conflicts(context)
     prompt_for_code_injection(context)

--- a/lib/mix/tasks/phx.gen.embedded.ex
+++ b/lib/mix/tasks/phx.gen.embedded.ex
@@ -26,6 +26,7 @@ defmodule Mix.Tasks.Phx.Gen.Embedded do
     * `:datetime` - An alias for `:naive_datetime`
   """
   use Mix.Task
+  use Mix.Phoenix.TemplateSource, template_patterns: ["priv/templates/phx.gen.embedded/*.*"]
 
   alias Mix.Phoenix.Schema
 
@@ -39,7 +40,7 @@ defmodule Mix.Tasks.Phx.Gen.Embedded do
 
     schema = build(args)
 
-    paths = Mix.Phoenix.generator_paths()
+    paths = Mix.Phoenix.template_sources()
 
     prompt_for_conflicts(schema)
 

--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -74,6 +74,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   information.
   """
   use Mix.Task
+  use Mix.Phoenix.TemplateSource, template_patterns: ["priv/templates/phx.gen.html/*.*"]
 
   alias Mix.Phoenix.{Context, Schema}
   alias Mix.Tasks.Phx.Gen
@@ -88,7 +89,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
     Gen.Context.prompt_for_code_injection(context)
 
     binding = [context: context, schema: schema, inputs: inputs(schema)]
-    paths = Mix.Phoenix.generator_paths()
+    paths = Mix.Phoenix.template_sources()
 
     prompt_for_conflicts(context)
 

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -74,6 +74,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
   """
 
   use Mix.Task
+  use Mix.Phoenix.TemplateSource, template_patterns: ["priv/templates/phx.gen.json/*.*"]
 
   alias Mix.Phoenix.Context
   alias Mix.Tasks.Phx.Gen
@@ -88,7 +89,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
     Gen.Context.prompt_for_code_injection(context)
 
     binding = [context: context, schema: schema]
-    paths = Mix.Phoenix.generator_paths()
+    paths = Mix.Phoenix.template_sources()
 
     prompt_for_conflicts(context)
 

--- a/lib/mix/tasks/phx.gen.live.ex
+++ b/lib/mix/tasks/phx.gen.live.ex
@@ -82,6 +82,7 @@ defmodule Mix.Tasks.Phx.Gen.Live do
   information.
   """
   use Mix.Task
+  use Mix.Phoenix.TemplateSource, template_patterns: ["priv/templates/phx.gen.live/*.*"]
 
   alias Mix.Phoenix.{Context}
   alias Mix.Tasks.Phx.Gen
@@ -96,7 +97,7 @@ defmodule Mix.Tasks.Phx.Gen.Live do
     Gen.Context.prompt_for_code_injection(context)
 
     binding = [context: context, schema: schema, inputs: Gen.Html.inputs(schema)]
-    paths = Mix.Phoenix.generator_paths()
+    paths = Mix.Phoenix.template_sources()
 
     prompt_for_conflicts(context)
 

--- a/lib/mix/tasks/phx.gen.presence.ex
+++ b/lib/mix/tasks/phx.gen.presence.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Phx.Gen.Presence do
   `my_presence` is the snake-cased version of the provided module name.
   """
   use Mix.Task
+  use Mix.Phoenix.TemplateSource, template_patterns: ["priv/templates/phx.gen.presence/*.*"]
 
   @doc false
   def run([]) do
@@ -38,7 +39,7 @@ defmodule Mix.Tasks.Phx.Gen.Presence do
       {:eex, "presence.ex", Path.join(web_prefix, "channels/#{binding[:path]}.ex")},
     ]
 
-    Mix.Phoenix.copy_from paths(), "priv/templates/phx.gen.presence", binding, files
+    Mix.Phoenix.copy_from Mix.Phoenix.template_sources(), "priv/templates/phx.gen.presence", binding, files
 
     Mix.shell().info """
 
@@ -53,9 +54,5 @@ defmodule Mix.Tasks.Phx.Gen.Presence do
     You're all set! See the Phoenix.Presence docs for more details:
     http://hexdocs.pm/phoenix/Phoenix.Presence.html
     """
-  end
-
-  defp paths do
-    [".", :phoenix]
   end
 end

--- a/lib/mix/tasks/phx.gen.schema.ex
+++ b/lib/mix/tasks/phx.gen.schema.ex
@@ -99,6 +99,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   configuration or `--migration` to force generation of the migration.
   """
   use Mix.Task
+  use Mix.Phoenix.TemplateSource, template_patterns: ["priv/templates/phx.gen.schema/*.*"]
 
   alias Mix.Phoenix.Schema
 
@@ -112,7 +113,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
     end
 
     schema = build(args, [])
-    paths = Mix.Phoenix.generator_paths()
+    paths = Mix.Phoenix.template_sources()
 
     prompt_for_conflicts(schema)
 

--- a/priv/templates/phx.gen.auth/_menu.html.eex
+++ b/priv/templates/phx.gen.auth/_menu.html.eex
@@ -1,10 +1,10 @@
 <ul>
-<%%= if @current_<%= schema.singular %> do %>
-  <li><%%= @current_<%= schema.singular %>.email %></li>
-  <li><%%= link "Settings", to: Routes.<%= schema.route_helper %>_settings_path(@conn, :edit) %></li>
-  <li><%%= link "Log out", to: Routes.<%= schema.route_helper %>_session_path(@conn, :delete), method: :delete %></li>
+<%%= if @current_<%= @schema.singular %> do %>
+  <li><%%= @current_<%= @schema.singular %>.email %></li>
+  <li><%%= link "Settings", to: Routes.<%= @schema.route_helper %>_settings_path(@conn, :edit) %></li>
+  <li><%%= link "Log out", to: Routes.<%= @schema.route_helper %>_session_path(@conn, :delete), method: :delete %></li>
 <%% else %>
-  <li><%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %></li>
-  <li><%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %></li>
+  <li><%%= link "Register", to: Routes.<%= @schema.route_helper %>_registration_path(@conn, :new) %></li>
+  <li><%%= link "Log in", to: Routes.<%= @schema.route_helper %>_session_path(@conn, :new) %></li>
 <%% end %>
 </ul>

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -1,19 +1,19 @@
-defmodule <%= inspect auth_module %> do
+defmodule <%= inspect @auth_module %> do
   import Plug.Conn
   import Phoenix.Controller
 
-  alias <%= inspect context.module %>
-  alias <%= inspect context.web_module %>.Router.Helpers, as: Routes
+  alias <%= inspect @context.module %>
+  alias <%= inspect @context.web_module %>.Router.Helpers, as: Routes
 
   # Make the remember me cookie valid for 60 days.
   # If you want bump or reduce this value, also change
-  # the token expiry itself in <%= inspect schema.alias %>Token.
+  # the token expiry itself in <%= inspect @schema.alias %>Token.
   @max_age 60 * 60 * 24 * 60
-  @remember_me_cookie "_<%= web_app_name %>_<%= schema.singular %>_remember_me"
+  @remember_me_cookie "_<%= @web_app_name %>_<%= @schema.singular %>_remember_me"
   @remember_me_options [sign: true, max_age: @max_age, same_site: "Lax"]
 
   @doc """
-  Logs the <%= schema.singular %> in.
+  Logs the <%= @schema.singular %> in.
 
   It renews the session ID and clears the whole session
   to avoid fixation attacks. See the renew_session
@@ -24,16 +24,16 @@ defmodule <%= inspect auth_module %> do
   disconnected on log out. The line can be safely removed
   if you are not using LiveView.
   """
-  def log_in_<%= schema.singular %>(conn, <%= schema.singular %>, params \\ %{}) do
-    token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
-    <%= schema.singular %>_return_to = get_session(conn, :<%= schema.singular %>_return_to)
+  def log_in_<%= @schema.singular %>(conn, <%= @schema.singular %>, params \\ %{}) do
+    token = <%= inspect @context.alias %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
+    <%= @schema.singular %>_return_to = get_session(conn, :<%= @schema.singular %>_return_to)
 
     conn
     |> renew_session()
-    |> put_session(:<%= schema.singular %>_token, token)
-    |> put_session(:live_socket_id, "<%= schema.plural %>_sessions:#{Base.url_encode64(token)}")
+    |> put_session(:<%= @schema.singular %>_token, token)
+    |> put_session(:live_socket_id, "<%= @schema.plural %>_sessions:#{Base.url_encode64(token)}")
     |> maybe_write_remember_me_cookie(token, params)
-    |> redirect(to: <%= schema.singular %>_return_to || signed_in_path(conn))
+    |> redirect(to: <%= @schema.singular %>_return_to || signed_in_path(conn))
   end
 
   defp maybe_write_remember_me_cookie(conn, token, %{"remember_me" => "true"}) do
@@ -66,16 +66,16 @@ defmodule <%= inspect auth_module %> do
   end
 
   @doc """
-  Logs the <%= schema.singular %> out.
+  Logs the <%= @schema.singular %> out.
 
   It clears all session data for safety. See renew_session.
   """
-  def log_out_<%= schema.singular %>(conn) do
-    <%= schema.singular %>_token = get_session(conn, :<%= schema.singular %>_token)
-    <%= schema.singular %>_token && <%= inspect context.alias %>.delete_session_token(<%= schema.singular %>_token)
+  def log_out_<%= @schema.singular %>(conn) do
+    <%= @schema.singular %>_token = get_session(conn, :<%= @schema.singular %>_token)
+    <%= @schema.singular %>_token && <%= inspect @context.alias %>.delete_session_token(<%= @schema.singular %>_token)
 
     if live_socket_id = get_session(conn, :live_socket_id) do
-      <%= inspect(endpoint_module) %>.broadcast(live_socket_id, "disconnect", %{})
+      <%= inspect(@endpoint_module) %>.broadcast(live_socket_id, "disconnect", %{})
     end
 
     conn
@@ -85,23 +85,23 @@ defmodule <%= inspect auth_module %> do
   end
 
   @doc """
-  Authenticates the <%= schema.singular %> by looking into the session
+  Authenticates the <%= @schema.singular %> by looking into the session
   and remember me token.
   """
-  def fetch_current_<%= schema.singular %>(conn, _opts) do
-    {<%= schema.singular %>_token, conn} = ensure_<%= schema.singular %>_token(conn)
-    <%= schema.singular %> = <%= schema.singular %>_token && <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(<%= schema.singular %>_token)
-    assign(conn, :current_<%= schema.singular %>, <%= schema.singular %>)
+  def fetch_current_<%= @schema.singular %>(conn, _opts) do
+    {<%= @schema.singular %>_token, conn} = ensure_<%= @schema.singular %>_token(conn)
+    <%= @schema.singular %> = <%= @schema.singular %>_token && <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_session_token(<%= @schema.singular %>_token)
+    assign(conn, :current_<%= @schema.singular %>, <%= @schema.singular %>)
   end
 
-  defp ensure_<%= schema.singular %>_token(conn) do
-    if <%= schema.singular %>_token = get_session(conn, :<%= schema.singular %>_token) do
-      {<%= schema.singular %>_token, conn}
+  defp ensure_<%= @schema.singular %>_token(conn) do
+    if <%= @schema.singular %>_token = get_session(conn, :<%= @schema.singular %>_token) do
+      {<%= @schema.singular %>_token, conn}
     else
       conn = fetch_cookies(conn, signed: [@remember_me_cookie])
 
-      if <%= schema.singular %>_token = conn.cookies[@remember_me_cookie] do
-        {<%= schema.singular %>_token, put_session(conn, :<%= schema.singular %>_token, <%= schema.singular %>_token)}
+      if <%= @schema.singular %>_token = conn.cookies[@remember_me_cookie] do
+        {<%= @schema.singular %>_token, put_session(conn, :<%= @schema.singular %>_token, <%= @schema.singular %>_token)}
       else
         {nil, conn}
       end
@@ -109,10 +109,10 @@ defmodule <%= inspect auth_module %> do
   end
 
   @doc """
-  Used for routes that require the <%= schema.singular %> to not be authenticated.
+  Used for routes that require the <%= @schema.singular %> to not be authenticated.
   """
-  def redirect_if_<%= schema.singular %>_is_authenticated(conn, _opts) do
-    if conn.assigns[:current_<%= schema.singular %>] do
+  def redirect_if_<%= @schema.singular %>_is_authenticated(conn, _opts) do
+    if conn.assigns[:current_<%= @schema.singular %>] do
       conn
       |> redirect(to: signed_in_path(conn))
       |> halt()
@@ -122,25 +122,25 @@ defmodule <%= inspect auth_module %> do
   end
 
   @doc """
-  Used for routes that require the <%= schema.singular %> to be authenticated.
+  Used for routes that require the <%= @schema.singular %> to be authenticated.
 
-  If you want to enforce the <%= schema.singular %> email is confirmed before
+  If you want to enforce the <%= @schema.singular %> email is confirmed before
   they use the application at all, here would be a good place.
   """
-  def require_authenticated_<%= schema.singular %>(conn, _opts) do
-    if conn.assigns[:current_<%= schema.singular %>] do
+  def require_authenticated_<%= @schema.singular %>(conn, _opts) do
+    if conn.assigns[:current_<%= @schema.singular %>] do
       conn
     else
       conn
       |> put_flash(:error, "You must log in to access this page.")
       |> maybe_store_return_to()
-      |> redirect(to: Routes.<%= schema.route_helper %>_session_path(conn, :new))
+      |> redirect(to: Routes.<%= @schema.route_helper %>_session_path(conn, :new))
       |> halt()
     end
   end
 
   defp maybe_store_return_to(%{method: "GET"} = conn) do
-    put_session(conn, :<%= schema.singular %>_return_to, current_path(conn))
+    put_session(conn, :<%= @schema.singular %>_return_to, current_path(conn))
   end
 
   defp maybe_store_return_to(conn), do: conn

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -1,140 +1,140 @@
-defmodule <%= inspect auth_module %>Test do
-  use <%= inspect context.web_module %>.ConnCase<%= test_case_options %>
+defmodule <%= inspect @auth_module %>Test do
+  use <%= inspect @context.web_module %>.ConnCase<%= @test_case_options %>
 
-  alias <%= inspect context.module %>
-  alias <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Auth
-  import <%= inspect context.module %>Fixtures
+  alias <%= inspect @context.module %>
+  alias <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>Auth
+  import <%= inspect @context.module %>Fixtures
 
-  @remember_me_cookie "_<%= web_app_name %>_<%= schema.singular %>_remember_me"
+  @remember_me_cookie "_<%= @web_app_name %>_<%= @schema.singular %>_remember_me"
 
   setup %{conn: conn} do
     conn =
       conn
-      |> Map.replace!(:secret_key_base, <%= inspect endpoint_module %>.config(:secret_key_base))
+      |> Map.replace!(:secret_key_base, <%= inspect @endpoint_module %>.config(:secret_key_base))
       |> init_test_session(%{})
 
-    %{<%= schema.singular %>: <%= schema.singular %>_fixture(), conn: conn}
+    %{<%= @schema.singular %>: <%= @schema.singular %>_fixture(), conn: conn}
   end
 
-  describe "log_in_<%= schema.singular %>/3" do
-    test "stores the <%= schema.singular %> token in the session", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(conn, <%= schema.singular %>)
-      assert token = get_session(conn, :<%= schema.singular %>_token)
-      assert get_session(conn, :live_socket_id) == "<%= schema.plural %>_sessions:#{Base.url_encode64(token)}"
+  describe "log_in_<%= @schema.singular %>/3" do
+    test "stores the <%= @schema.singular %> token in the session", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = <%= inspect @schema.alias %>Auth.log_in_<%= @schema.singular %>(conn, <%= @schema.singular %>)
+      assert token = get_session(conn, :<%= @schema.singular %>_token)
+      assert get_session(conn, :live_socket_id) == "<%= @schema.plural %>_sessions:#{Base.url_encode64(token)}"
       assert redirected_to(conn) == "/"
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token)
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_session_token(token)
     end
 
-    test "clears everything previously stored in the session", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> put_session(:to_be_removed, "value") |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
+    test "clears everything previously stored in the session", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = conn |> put_session(:to_be_removed, "value") |> <%= inspect @schema.alias %>Auth.log_in_<%= @schema.singular %>(<%= @schema.singular %>)
       refute get_session(conn, :to_be_removed)
     end
 
-    test "redirects to the configured path", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> put_session(:<%= schema.singular %>_return_to, "/hello") |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
+    test "redirects to the configured path", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = conn |> put_session(:<%= @schema.singular %>_return_to, "/hello") |> <%= inspect @schema.alias %>Auth.log_in_<%= @schema.singular %>(<%= @schema.singular %>)
       assert redirected_to(conn) == "/hello"
     end
 
-    test "writes a cookie if remember_me is configured", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> fetch_cookies() |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>, %{"remember_me" => "true"})
-      assert get_session(conn, :<%= schema.singular %>_token) == conn.cookies[@remember_me_cookie]
+    test "writes a cookie if remember_me is configured", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = conn |> fetch_cookies() |> <%= inspect @schema.alias %>Auth.log_in_<%= @schema.singular %>(<%= @schema.singular %>, %{"remember_me" => "true"})
+      assert get_session(conn, :<%= @schema.singular %>_token) == conn.cookies[@remember_me_cookie]
 
       assert %{value: signed_token, max_age: max_age} = conn.resp_cookies[@remember_me_cookie]
-      assert signed_token != get_session(conn, :<%= schema.singular %>_token)
+      assert signed_token != get_session(conn, :<%= @schema.singular %>_token)
       assert max_age == 5_184_000
     end
   end
 
-  describe "logout_<%= schema.singular %>/1" do
-    test "erases session and cookies", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+  describe "logout_<%= @schema.singular %>/1" do
+    test "erases session and cookies", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      <%= @schema.singular %>_token = <%= inspect @context.alias %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
 
       conn =
         conn
-        |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token)
-        |> put_req_cookie(@remember_me_cookie, <%= schema.singular %>_token)
+        |> put_session(:<%= @schema.singular %>_token, <%= @schema.singular %>_token)
+        |> put_req_cookie(@remember_me_cookie, <%= @schema.singular %>_token)
         |> fetch_cookies()
-        |> <%= inspect schema.alias %>Auth.log_out_<%= schema.singular %>()
+        |> <%= inspect @schema.alias %>Auth.log_out_<%= @schema.singular %>()
 
-      refute get_session(conn, :<%= schema.singular %>_token)
+      refute get_session(conn, :<%= @schema.singular %>_token)
       refute conn.cookies[@remember_me_cookie]
       assert %{max_age: 0} = conn.resp_cookies[@remember_me_cookie]
       assert redirected_to(conn) == "/"
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(<%= schema.singular %>_token)
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_session_token(<%= @schema.singular %>_token)
     end
 
     test "broadcasts to the given live_socket_id", %{conn: conn} do
-      live_socket_id = "<%= schema.plural %>_sessions:abcdef-token"
-      <%= inspect(endpoint_module) %>.subscribe(live_socket_id)
+      live_socket_id = "<%= @schema.plural %>_sessions:abcdef-token"
+      <%= inspect(@endpoint_module) %>.subscribe(live_socket_id)
 
       conn
       |> put_session(:live_socket_id, live_socket_id)
-      |> <%= inspect(schema.alias) %>Auth.log_out_<%= schema.singular %>()
+      |> <%= inspect(@schema.alias) %>Auth.log_out_<%= @schema.singular %>()
 
       assert_receive %Phoenix.Socket.Broadcast{
         event: "disconnect",
-        topic: "<%= schema.plural %>_sessions:abcdef-token"
+        topic: "<%= @schema.plural %>_sessions:abcdef-token"
       }
     end
 
-    test "works even if <%= schema.singular %> is already logged out", %{conn: conn} do
-      conn = conn |> fetch_cookies() |> <%= inspect schema.alias %>Auth.log_out_<%= schema.singular %>()
-      refute get_session(conn, :<%= schema.singular %>_token)
+    test "works even if <%= @schema.singular %> is already logged out", %{conn: conn} do
+      conn = conn |> fetch_cookies() |> <%= inspect @schema.alias %>Auth.log_out_<%= @schema.singular %>()
+      refute get_session(conn, :<%= @schema.singular %>_token)
       assert %{max_age: 0} = conn.resp_cookies[@remember_me_cookie]
       assert redirected_to(conn) == "/"
     end
   end
 
-  describe "fetch_current_<%= schema.singular %>/2" do
-    test "authenticates <%= schema.singular %> from session", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
-      conn = conn |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token) |> <%= inspect schema.alias %>Auth.fetch_current_<%= schema.singular %>([])
-      assert conn.assigns.current_<%= schema.singular %>.id == <%= schema.singular %>.id
+  describe "fetch_current_<%= @schema.singular %>/2" do
+    test "authenticates <%= @schema.singular %> from session", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      <%= @schema.singular %>_token = <%= inspect @context.alias %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
+      conn = conn |> put_session(:<%= @schema.singular %>_token, <%= @schema.singular %>_token) |> <%= inspect @schema.alias %>Auth.fetch_current_<%= @schema.singular %>([])
+      assert conn.assigns.current_<%= @schema.singular %>.id == <%= @schema.singular %>.id
     end
 
-    test "authenticates <%= schema.singular %> from cookies", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+    test "authenticates <%= @schema.singular %> from cookies", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       logged_in_conn =
-        conn |> fetch_cookies() |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>, %{"remember_me" => "true"})
+        conn |> fetch_cookies() |> <%= inspect @schema.alias %>Auth.log_in_<%= @schema.singular %>(<%= @schema.singular %>, %{"remember_me" => "true"})
 
-      <%= schema.singular %>_token = logged_in_conn.cookies[@remember_me_cookie]
+      <%= @schema.singular %>_token = logged_in_conn.cookies[@remember_me_cookie]
       %{value: signed_token} = logged_in_conn.resp_cookies[@remember_me_cookie]
 
       conn =
         conn
         |> put_req_cookie(@remember_me_cookie, signed_token)
-        |> <%= inspect schema.alias %>Auth.fetch_current_<%= schema.singular %>([])
+        |> <%= inspect @schema.alias %>Auth.fetch_current_<%= @schema.singular %>([])
 
-      assert get_session(conn, :<%= schema.singular %>_token) == <%= schema.singular %>_token
-      assert conn.assigns.current_<%= schema.singular %>.id == <%= schema.singular %>.id
+      assert get_session(conn, :<%= @schema.singular %>_token) == <%= @schema.singular %>_token
+      assert conn.assigns.current_<%= @schema.singular %>.id == <%= @schema.singular %>.id
     end
 
-    test "does not authenticate if data is missing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      _ = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
-      conn = <%= inspect schema.alias %>Auth.fetch_current_<%= schema.singular %>(conn, [])
-      refute get_session(conn, :<%= schema.singular %>_token)
-      refute conn.assigns.current_<%= schema.singular %>
+    test "does not authenticate if data is missing", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      _ = <%= inspect @context.alias %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
+      conn = <%= inspect @schema.alias %>Auth.fetch_current_<%= @schema.singular %>(conn, [])
+      refute get_session(conn, :<%= @schema.singular %>_token)
+      refute conn.assigns.current_<%= @schema.singular %>
     end
   end
 
-  describe "redirect_if_<%= schema.singular %>_is_authenticated/2" do
-    test "redirects if <%= schema.singular %> is authenticated", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> assign(:current_<%= schema.singular %>, <%= schema.singular %>) |> <%= inspect schema.alias %>Auth.redirect_if_<%= schema.singular %>_is_authenticated([])
+  describe "redirect_if_<%= @schema.singular %>_is_authenticated/2" do
+    test "redirects if <%= @schema.singular %> is authenticated", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = conn |> assign(:current_<%= @schema.singular %>, <%= @schema.singular %>) |> <%= inspect @schema.alias %>Auth.redirect_if_<%= @schema.singular %>_is_authenticated([])
       assert conn.halted
       assert redirected_to(conn) == "/"
     end
 
-    test "does not redirect if <%= schema.singular %> is not authenticated", %{conn: conn} do
-      conn = <%= inspect schema.alias %>Auth.redirect_if_<%= schema.singular %>_is_authenticated(conn, [])
+    test "does not redirect if <%= @schema.singular %> is not authenticated", %{conn: conn} do
+      conn = <%= inspect @schema.alias %>Auth.redirect_if_<%= @schema.singular %>_is_authenticated(conn, [])
       refute conn.halted
       refute conn.status
     end
   end
 
-  describe "require_authenticated_<%= schema.singular %>/2" do
-    test "redirects if <%= schema.singular %> is not authenticated", %{conn: conn} do
-      conn = conn |> fetch_flash() |> <%= inspect schema.alias %>Auth.require_authenticated_<%= schema.singular %>([])
+  describe "require_authenticated_<%= @schema.singular %>/2" do
+    test "redirects if <%= @schema.singular %> is not authenticated", %{conn: conn} do
+      conn = conn |> fetch_flash() |> <%= inspect @schema.alias %>Auth.require_authenticated_<%= @schema.singular %>([])
       assert conn.halted
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_session_path(conn, :new)
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_session_path(conn, :new)
       assert get_flash(conn, :error) == "You must log in to access this page."
     end
 
@@ -142,30 +142,30 @@ defmodule <%= inspect auth_module %>Test do
       halted_conn =
         %{conn | path_info: ["foo"], query_string: ""}
         |> fetch_flash()
-        |> <%= inspect schema.alias %>Auth.require_authenticated_<%= schema.singular %>([])
+        |> <%= inspect @schema.alias %>Auth.require_authenticated_<%= @schema.singular %>([])
 
       assert halted_conn.halted
-      assert get_session(halted_conn, :<%= schema.singular %>_return_to) == "/foo"
+      assert get_session(halted_conn, :<%= @schema.singular %>_return_to) == "/foo"
 
       halted_conn =
         %{conn | path_info: ["foo"], query_string: "bar=baz"}
         |> fetch_flash()
-        |> <%= inspect schema.alias %>Auth.require_authenticated_<%= schema.singular %>([])
+        |> <%= inspect @schema.alias %>Auth.require_authenticated_<%= @schema.singular %>([])
 
       assert halted_conn.halted
-      assert get_session(halted_conn, :<%= schema.singular %>_return_to) == "/foo?bar=baz"
+      assert get_session(halted_conn, :<%= @schema.singular %>_return_to) == "/foo?bar=baz"
 
       halted_conn =
         %{conn | path_info: ["foo"], query_string: "bar", method: "POST"}
         |> fetch_flash()
-        |> <%= inspect schema.alias %>Auth.require_authenticated_<%= schema.singular %>([])
+        |> <%= inspect @schema.alias %>Auth.require_authenticated_<%= @schema.singular %>([])
 
       assert halted_conn.halted
-      refute get_session(halted_conn, :<%= schema.singular %>_return_to)
+      refute get_session(halted_conn, :<%= @schema.singular %>_return_to)
     end
 
-    test "does not redirect if <%= schema.singular %> is authenticated", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> assign(:current_<%= schema.singular %>, <%= schema.singular %>) |> <%= inspect schema.alias %>Auth.require_authenticated_<%= schema.singular %>([])
+    test "does not redirect if <%= @schema.singular %> is authenticated", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = conn |> assign(:current_<%= @schema.singular %>, <%= @schema.singular %>) |> <%= inspect @schema.alias %>Auth.require_authenticated_<%= @schema.singular %>([])
       refute conn.halted
       refute conn.status
     end

--- a/priv/templates/phx.gen.auth/confirmation_controller.ex
+++ b/priv/templates/phx.gen.auth/confirmation_controller.ex
@@ -1,17 +1,17 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ConfirmationController do
-  use <%= inspect context.web_module %>, :controller
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>ConfirmationController do
+  use <%= inspect @context.web_module %>, :controller
 
-  alias <%= inspect context.module %>
+  alias <%= inspect @context.module %>
 
   def new(conn, _params) do
     render(conn, "new.html")
   end
 
-  def create(conn, %{"<%= schema.singular %>" => %{"email" => email}}) do
-    if <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(email) do
-      <%= inspect context.alias %>.deliver_<%= schema.singular %>_confirmation_instructions(
-        <%= schema.singular %>,
-        &Routes.<%= schema.route_helper %>_confirmation_url(conn, :confirm, &1)
+  def create(conn, %{"<%= @schema.singular %>" => %{"email" => email}}) do
+    if <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email(email) do
+      <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_confirmation_instructions(
+        <%= @schema.singular %>,
+        &Routes.<%= @schema.route_helper %>_confirmation_url(conn, :confirm, &1)
       )
     end
 
@@ -25,27 +25,27 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     |> redirect(to: "/")
   end
 
-  # Do not log in the <%= schema.singular %> after confirmation to avoid a
-  # leaked token giving the <%= schema.singular %> access to the account.
+  # Do not log in the <%= @schema.singular %> after confirmation to avoid a
+  # leaked token giving the <%= @schema.singular %> access to the account.
   def confirm(conn, %{"token" => token}) do
-    case <%= inspect context.alias %>.confirm_<%= schema.singular %>(token) do
+    case <%= inspect @context.alias %>.confirm_<%= @schema.singular %>(token) do
       {:ok, _} ->
         conn
-        |> put_flash(:info, "<%= schema.human_singular %> confirmed successfully.")
+        |> put_flash(:info, "<%= @schema.human_singular %> confirmed successfully.")
         |> redirect(to: "/")
 
       :error ->
-        # If there is a current <%= schema.singular %> and the account was already confirmed,
+        # If there is a current <%= @schema.singular %> and the account was already confirmed,
         # then odds are that the confirmation link was already visited, either
-        # by some automation or by the <%= schema.singular %> themselves, so we redirect without
+        # by some automation or by the <%= @schema.singular %> themselves, so we redirect without
         # a warning message.
         case conn.assigns do
-          %{current_<%= schema.singular %>: %{confirmed_at: confirmed_at}} when not is_nil(confirmed_at) ->
+          %{current_<%= @schema.singular %>: %{confirmed_at: confirmed_at}} when not is_nil(confirmed_at) ->
             redirect(conn, to: "/")
 
           %{} ->
             conn
-            |> put_flash(:error, "<%= schema.human_singular %> confirmation link is invalid or it has expired.")
+            |> put_flash(:error, "<%= @schema.human_singular %> confirmation link is invalid or it has expired.")
             |> redirect(to: "/")
         end
     end

--- a/priv/templates/phx.gen.auth/confirmation_controller_test.exs
+++ b/priv/templates/phx.gen.auth/confirmation_controller_test.exs
@@ -1,94 +1,94 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ConfirmationControllerTest do
-  use <%= inspect context.web_module %>.ConnCase<%= test_case_options %>
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>ConfirmationControllerTest do
+  use <%= inspect @context.web_module %>.ConnCase<%= @test_case_options %>
 
-  alias <%= inspect context.module %>
-  alias <%= inspect schema.repo %>
-  import <%= inspect context.module %>Fixtures
+  alias <%= inspect @context.module %>
+  alias <%= inspect @schema.repo %>
+  import <%= inspect @context.module %>Fixtures
 
   setup do
-    %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+    %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
   end
 
-  describe "GET /<%= schema.singular %>s/confirm" do
+  describe "GET /<%= @schema.singular %>s/confirm" do
     test "renders the confirmation page", %{conn: conn} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_confirmation_path(conn, :new))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_confirmation_path(conn, :new))
       response = html_response(conn, 200)
       assert response =~ "<h1>Resend confirmation instructions</h1>"
     end
   end
 
-  describe "POST /<%= schema.singular %>s/confirm" do
+  describe "POST /<%= @schema.singular %>s/confirm" do
     @tag :capture_log
-    test "sends a new confirmation token", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+    test "sends a new confirmation token", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_confirmation_path(conn, :create), %{
-          "<%= schema.singular %>" => %{"email" => <%= schema.singular %>.email}
+        post(conn, Routes.<%= @schema.route_helper %>_confirmation_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{"email" => <%= @schema.singular %>.email}
         })
 
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :info) =~ "If your email is in our system"
-      assert Repo.get_by!(<%= inspect context.alias %>.<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id).context == "confirm"
+      assert Repo.get_by!(<%= inspect @context.alias %>.<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id).context == "confirm"
     end
 
-    test "does not send confirmation token if <%= schema.human_singular %> is confirmed", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      Repo.update!(<%= inspect context.alias %>.<%= inspect schema.alias %>.confirm_changeset(<%= schema.singular %>))
+    test "does not send confirmation token if <%= @schema.human_singular %> is confirmed", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      Repo.update!(<%= inspect @context.alias %>.<%= inspect @schema.alias %>.confirm_changeset(<%= @schema.singular %>))
 
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_confirmation_path(conn, :create), %{
-          "<%= schema.singular %>" => %{"email" => <%= schema.singular %>.email}
+        post(conn, Routes.<%= @schema.route_helper %>_confirmation_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{"email" => <%= @schema.singular %>.email}
         })
 
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :info) =~ "If your email is in our system"
-      refute Repo.get_by(<%= inspect context.alias %>.<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+      refute Repo.get_by(<%= inspect @context.alias %>.<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
 
     test "does not send confirmation token if email is invalid", %{conn: conn} do
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_confirmation_path(conn, :create), %{
-          "<%= schema.singular %>" => %{"email" => "unknown@example.com"}
+        post(conn, Routes.<%= @schema.route_helper %>_confirmation_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{"email" => "unknown@example.com"}
         })
 
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :info) =~ "If your email is in our system"
-      assert Repo.all(<%= inspect context.alias %>.<%= inspect schema.alias %>Token) == []
+      assert Repo.all(<%= inspect @context.alias %>.<%= inspect @schema.alias %>Token) == []
     end
   end
 
-  describe "GET /<%= schema.singular %>s/confirm/:token" do
-    test "confirms the given token once", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+  describe "GET /<%= @schema.singular %>s/confirm/:token" do
+    test "confirms the given token once", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_<%= schema.singular %>_confirmation_instructions(<%= schema.singular %>, url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_confirmation_instructions(<%= @schema.singular %>, url)
         end)
 
-      conn = get(conn, Routes.<%= schema.route_helper %>_confirmation_path(conn, :confirm, token))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_confirmation_path(conn, :confirm, token))
       assert redirected_to(conn) == "/"
-      assert get_flash(conn, :info) =~ "<%= schema.human_singular %> confirmed successfully"
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id).confirmed_at
-      refute get_session(conn, :<%= schema.singular %>_token)
-      assert Repo.all(<%= inspect context.alias %>.<%= inspect schema.alias %>Token) == []
+      assert get_flash(conn, :info) =~ "<%= @schema.human_singular %> confirmed successfully"
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>!(<%= @schema.singular %>.id).confirmed_at
+      refute get_session(conn, :<%= @schema.singular %>_token)
+      assert Repo.all(<%= inspect @context.alias %>.<%= inspect @schema.alias %>Token) == []
 
       # When not logged in
-      conn = get(conn, Routes.<%= schema.route_helper %>_confirmation_path(conn, :confirm, token))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_confirmation_path(conn, :confirm, token))
       assert redirected_to(conn) == "/"
-      assert get_flash(conn, :error) =~ "<%= schema.human_singular %> confirmation link is invalid or it has expired"
+      assert get_flash(conn, :error) =~ "<%= @schema.human_singular %> confirmation link is invalid or it has expired"
 
       # When logged in
       conn =
         build_conn()
-        |> log_in_<%= schema.singular %>(<%= schema.singular %>)
-        |> get(Routes.<%= schema.route_helper %>_confirmation_path(conn, :confirm, token))
+        |> log_in_<%= @schema.singular %>(<%= @schema.singular %>)
+        |> get(Routes.<%= @schema.route_helper %>_confirmation_path(conn, :confirm, token))
 
       assert redirected_to(conn) == "/"
       refute get_flash(conn, :error)
     end
 
-    test "does not confirm email with invalid token", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_confirmation_path(conn, :confirm, "oops"))
+    test "does not confirm email with invalid token", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = get(conn, Routes.<%= @schema.route_helper %>_confirmation_path(conn, :confirm, "oops"))
       assert redirected_to(conn) == "/"
-      assert get_flash(conn, :error) =~ "<%= schema.human_singular %> confirmation link is invalid or it has expired"
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id).confirmed_at
+      assert get_flash(conn, :error) =~ "<%= @schema.human_singular %> confirmation link is invalid or it has expired"
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>!(<%= @schema.singular %>.id).confirmed_at
     end
   end
 end

--- a/priv/templates/phx.gen.auth/confirmation_new.html.eex
+++ b/priv/templates/phx.gen.auth/confirmation_new.html.eex
@@ -1,6 +1,6 @@
 <h1>Resend confirmation instructions</h1>
 
-<%%= form_for :<%= schema.singular %>, Routes.<%= schema.route_helper %>_confirmation_path(@conn, :create), fn f -> %>
+<%%= form_for :<%= @schema.singular %>, Routes.<%= @schema.route_helper %>_confirmation_path(@conn, :create), fn f -> %>
   <%%= label f, :email %>
   <%%= email_input f, :email, required: true %>
 
@@ -10,6 +10,6 @@
 <%% end %>
 
 <p>
-  <%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %> |
-  <%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %>
+  <%%= link "Register", to: Routes.<%= @schema.route_helper %>_registration_path(@conn, :new) %> |
+  <%%= link "Log in", to: Routes.<%= @schema.route_helper %>_session_path(@conn, :new) %>
 </p>

--- a/priv/templates/phx.gen.auth/confirmation_view.ex
+++ b/priv/templates/phx.gen.auth/confirmation_view.ex
@@ -1,3 +1,3 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ConfirmationView do
-  use <%= inspect context.web_module %>, :view
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>ConfirmationView do
+  use <%= inspect @context.web_module %>, :view
 end

--- a/priv/templates/phx.gen.auth/conn_case.exs
+++ b/priv/templates/phx.gen.auth/conn_case.exs
@@ -1,26 +1,26 @@
 
   @doc """
-  Setup helper that registers and logs in <%= schema.plural %>.
+  Setup helper that registers and logs in <%= @schema.plural %>.
 
-      setup :register_and_log_in_<%= schema.singular %>
+      setup :register_and_log_in_<%= @schema.singular %>
 
-  It stores an updated connection and a registered <%= schema.singular %> in the
-  test context.
+  It stores an updated connection and a registered <%= @schema.singular %> in the
+  test @context.
   """
-  def register_and_log_in_<%= schema.singular %>(%{conn: conn}) do
-    <%= schema.singular %> = <%= inspect context.module %>Fixtures.<%= schema.singular %>_fixture()
-    %{conn: log_in_<%= schema.singular %>(conn, <%= schema.singular %>), <%= schema.singular %>: <%= schema.singular %>}
+  def register_and_log_in_<%= @schema.singular %>(%{conn: conn}) do
+    <%= @schema.singular %> = <%= inspect @context.module %>Fixtures.<%= @schema.singular %>_fixture()
+    %{conn: log_in_<%= @schema.singular %>(conn, <%= @schema.singular %>), <%= @schema.singular %>: <%= @schema.singular %>}
   end
 
   @doc """
-  Logs the given `<%= schema.singular %>` into the `conn`.
+  Logs the given `<%= @schema.singular %>` into the `conn`.
 
   It returns an updated `conn`.
   """
-  def log_in_<%= schema.singular %>(conn, <%= schema.singular %>) do
-    token = <%= inspect context.module %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+  def log_in_<%= @schema.singular %>(conn, <%= @schema.singular %>) do
+    token = <%= inspect @context.module %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
 
     conn
     |> Phoenix.ConnTest.init_test_session(%{})
-    |> Plug.Conn.put_session(:<%= schema.singular %>_token, token)
+    |> Plug.Conn.put_session(:<%= @schema.singular %>_token, token)
   end

--- a/priv/templates/phx.gen.auth/context_fixtures_functions.ex
+++ b/priv/templates/phx.gen.auth/context_fixtures_functions.ex
@@ -1,20 +1,20 @@
 
-  def unique_<%= schema.singular %>_email, do: "<%= schema.singular %>#{System.unique_integer()}@example.com"
-  def valid_<%= schema.singular %>_password, do: "hello world!"
+  def unique_<%= @schema.singular %>_email, do: "<%= @schema.singular %>#{System.unique_integer()}@example.com"
+  def valid_<%= @schema.singular %>_password, do: "hello world!"
 
-  def <%= schema.singular %>_fixture(attrs \\ %{}) do
-    {:ok, <%= schema.singular %>} =
+  def <%= @schema.singular %>_fixture(attrs \\ %{}) do
+    {:ok, <%= @schema.singular %>} =
       attrs
       |> Enum.into(%{
-        email: unique_<%= schema.singular %>_email(),
-        password: valid_<%= schema.singular %>_password()
+        email: unique_<%= @schema.singular %>_email(),
+        password: valid_<%= @schema.singular %>_password()
       })
-      |> <%= inspect context.module %>.register_<%= schema.singular %>()
+      |> <%= inspect @context.module %>.register_<%= @schema.singular %>()
 
-    <%= schema.singular %>
+    <%= @schema.singular %>
   end
 
-  def extract_<%= schema.singular %>_token(fun) do
+  def extract_<%= @schema.singular %>_token(fun) do
     {:ok, captured} = fun.(&"[TOKEN]#{&1}[TOKEN]")
     [_, token, _] = String.split(captured.body, "[TOKEN]")
     token

--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -1,103 +1,103 @@
-  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Token, <%= inspect schema.alias %>Notifier}
+  alias <%= inspect @context.module %>.{<%= inspect @schema.alias %>, <%= inspect @schema.alias %>Token, <%= inspect @schema.alias %>Notifier}
 
   ## Database getters
 
   @doc """
-  Gets a <%= schema.singular %> by email.
+  Gets a <%= @schema.singular %> by email.
 
   ## Examples
 
-      iex> get_<%= schema.singular %>_by_email("foo@example.com")
-      %<%= inspect schema.alias %>{}
+      iex> get_<%= @schema.singular %>_by_email("foo@example.com")
+      %<%= inspect @schema.alias %>{}
 
-      iex> get_<%= schema.singular %>_by_email("unknown@example.com")
+      iex> get_<%= @schema.singular %>_by_email("unknown@example.com")
       nil
 
   """
-  def get_<%= schema.singular %>_by_email(email) when is_binary(email) do
-    Repo.get_by(<%= inspect schema.alias %>, email: email)
+  def get_<%= @schema.singular %>_by_email(email) when is_binary(email) do
+    Repo.get_by(<%= inspect @schema.alias %>, email: email)
   end
 
   @doc """
-  Gets a <%= schema.singular %> by email and password.
+  Gets a <%= @schema.singular %> by email and password.
 
   ## Examples
 
-      iex> get_<%= schema.singular %>_by_email_and_password("foo@example.com", "correct_password")
-      %<%= inspect schema.alias %>{}
+      iex> get_<%= @schema.singular %>_by_email_and_password("foo@example.com", "correct_password")
+      %<%= inspect @schema.alias %>{}
 
-      iex> get_<%= schema.singular %>_by_email_and_password("foo@example.com", "invalid_password")
+      iex> get_<%= @schema.singular %>_by_email_and_password("foo@example.com", "invalid_password")
       nil
 
   """
-  def get_<%= schema.singular %>_by_email_and_password(email, password)
+  def get_<%= @schema.singular %>_by_email_and_password(email, password)
       when is_binary(email) and is_binary(password) do
-    <%= schema.singular %> = Repo.get_by(<%= inspect schema.alias %>, email: email)
-    if <%= inspect schema.alias %>.valid_password?(<%= schema.singular %>, password), do: <%= schema.singular %>
+    <%= @schema.singular %> = Repo.get_by(<%= inspect @schema.alias %>, email: email)
+    if <%= inspect @schema.alias %>.valid_password?(<%= @schema.singular %>, password), do: <%= @schema.singular %>
   end
 
   @doc """
-  Gets a single <%= schema.singular %>.
+  Gets a single <%= @schema.singular %>.
 
-  Raises `Ecto.NoResultsError` if the <%= inspect schema.alias %> does not exist.
+  Raises `Ecto.NoResultsError` if the <%= inspect @schema.alias %> does not exist.
 
   ## Examples
 
-      iex> get_<%= schema.singular %>!(123)
-      %<%= inspect schema.alias %>{}
+      iex> get_<%= @schema.singular %>!(123)
+      %<%= inspect @schema.alias %>{}
 
-      iex> get_<%= schema.singular %>!(456)
+      iex> get_<%= @schema.singular %>!(456)
       ** (Ecto.NoResultsError)
 
   """
-  def get_<%= schema.singular %>!(id), do: Repo.get!(<%= inspect schema.alias %>, id)
+  def get_<%= @schema.singular %>!(id), do: Repo.get!(<%= inspect @schema.alias %>, id)
 
-  ## <%= schema.human_singular %> registration
+  ## <%= @schema.human_singular %> registration
 
   @doc """
-  Registers a <%= schema.singular %>.
+  Registers a <%= @schema.singular %>.
 
   ## Examples
 
-      iex> register_<%= schema.singular %>(%{field: value})
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> register_<%= @schema.singular %>(%{field: value})
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> register_<%= schema.singular %>(%{field: bad_value})
+      iex> register_<%= @schema.singular %>(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
-  def register_<%= schema.singular %>(attrs) do
-    %<%= inspect schema.alias %>{}
-    |> <%= inspect schema.alias %>.registration_changeset(attrs)
+  def register_<%= @schema.singular %>(attrs) do
+    %<%= inspect @schema.alias %>{}
+    |> <%= inspect @schema.alias %>.registration_changeset(attrs)
     |> Repo.insert()
   end
 
   @doc """
-  Returns an `%Ecto.Changeset{}` for tracking <%= schema.singular %> changes.
+  Returns an `%Ecto.Changeset{}` for tracking <%= @schema.singular %> changes.
 
   ## Examples
 
-      iex> change_<%= schema.singular %>_registration(<%= schema.singular %>)
-      %Ecto.Changeset{data: %<%= inspect schema.alias %>{}}
+      iex> change_<%= @schema.singular %>_registration(<%= @schema.singular %>)
+      %Ecto.Changeset{data: %<%= inspect @schema.alias %>{}}
 
   """
-  def change_<%= schema.singular %>_registration(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs \\ %{}) do
-    <%= inspect schema.alias %>.registration_changeset(<%= schema.singular %>, attrs, hash_password: false)
+  def change_<%= @schema.singular %>_registration(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>, attrs \\ %{}) do
+    <%= inspect @schema.alias %>.registration_changeset(<%= @schema.singular %>, attrs, hash_password: false)
   end
 
   ## Settings
 
   @doc """
-  Returns an `%Ecto.Changeset{}` for changing the <%= schema.singular %> email.
+  Returns an `%Ecto.Changeset{}` for changing the <%= @schema.singular %> email.
 
   ## Examples
 
-      iex> change_<%= schema.singular %>_email(<%= schema.singular %>)
-      %Ecto.Changeset{data: %<%= inspect schema.alias %>{}}
+      iex> change_<%= @schema.singular %>_email(<%= @schema.singular %>)
+      %Ecto.Changeset{data: %<%= inspect @schema.alias %>{}}
 
   """
-  def change_<%= schema.singular %>_email(<%= schema.singular %>, attrs \\ %{}) do
-    <%= inspect schema.alias %>.email_changeset(<%= schema.singular %>, attrs)
+  def change_<%= @schema.singular %>_email(<%= @schema.singular %>, attrs \\ %{}) do
+    <%= inspect @schema.alias %>.email_changeset(<%= @schema.singular %>, attrs)
   end
 
   @doc """
@@ -106,101 +106,101 @@
 
   ## Examples
 
-      iex> apply_<%= schema.singular %>_email(<%= schema.singular %>, "valid password", %{email: ...})
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> apply_<%= @schema.singular %>_email(<%= @schema.singular %>, "valid password", %{email: ...})
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> apply_<%= schema.singular %>_email(<%= schema.singular %>, "invalid password", %{email: ...})
+      iex> apply_<%= @schema.singular %>_email(<%= @schema.singular %>, "invalid password", %{email: ...})
       {:error, %Ecto.Changeset{}}
 
   """
-  def apply_<%= schema.singular %>_email(<%= schema.singular %>, password, attrs) do
-    <%= schema.singular %>
-    |> <%= inspect schema.alias %>.email_changeset(attrs)
-    |> <%= inspect schema.alias %>.validate_current_password(password)
+  def apply_<%= @schema.singular %>_email(<%= @schema.singular %>, password, attrs) do
+    <%= @schema.singular %>
+    |> <%= inspect @schema.alias %>.email_changeset(attrs)
+    |> <%= inspect @schema.alias %>.validate_current_password(password)
     |> Ecto.Changeset.apply_action(:update)
   end
 
   @doc """
-  Updates the <%= schema.singular %> email using the given token.
+  Updates the <%= @schema.singular %> email using the given token.
 
-  If the token matches, the <%= schema.singular %> email is updated and the token is deleted.
+  If the token matches, the <%= @schema.singular %> email is updated and the token is deleted.
   The confirmed_at date is also updated to the current time.
   """
-  def update_<%= schema.singular %>_email(<%= schema.singular %>, token) do
-    context = "change:#{<%= schema.singular %>.email}"
+  def update_<%= @schema.singular %>_email(<%= @schema.singular %>, token) do
+    context = "change:#{<%= @schema.singular %>.email}"
 
-    with {:ok, query} <- <%= inspect schema.alias %>Token.verify_change_email_token_query(token, context),
-         %<%= inspect schema.alias %>Token{sent_to: email} <- Repo.one(query),
-         {:ok, _} <- Repo.transaction(<%= schema.singular %>_email_multi(<%= schema.singular %>, email, context)) do
+    with {:ok, query} <- <%= inspect @schema.alias %>Token.verify_change_email_token_query(token, context),
+         %<%= inspect @schema.alias %>Token{sent_to: email} <- Repo.one(query),
+         {:ok, _} <- Repo.transaction(<%= @schema.singular %>_email_multi(<%= @schema.singular %>, email, context)) do
       :ok
     else
       _ -> :error
     end
   end
 
-  defp <%= schema.singular %>_email_multi(<%= schema.singular %>, email, context) do
-    changeset = <%= schema.singular %> |> <%= inspect schema.alias %>.email_changeset(%{email: email}) |> <%= inspect schema.alias %>.confirm_changeset()
+  defp <%= @schema.singular %>_email_multi(<%= @schema.singular %>, email, context) do
+    changeset = <%= @schema.singular %> |> <%= inspect @schema.alias %>.email_changeset(%{email: email}) |> <%= inspect @schema.alias %>.confirm_changeset()
 
     Ecto.Multi.new()
-    |> Ecto.Multi.update(:<%= schema.singular %>, changeset)
-    |> Ecto.Multi.delete_all(:tokens, <%= inspect schema.alias %>Token.<%= schema.singular %>_and_contexts_query(<%= schema.singular %>, [context]))
+    |> Ecto.Multi.update(:<%= @schema.singular %>, changeset)
+    |> Ecto.Multi.delete_all(:tokens, <%= inspect @schema.alias %>Token.<%= @schema.singular %>_and_contexts_query(<%= @schema.singular %>, [context]))
   end
 
   @doc """
-  Delivers the update email instructions to the given <%= schema.singular %>.
+  Delivers the update email instructions to the given <%= @schema.singular %>.
 
   ## Examples
 
-      iex> deliver_update_email_instructions(<%= schema.singular %>, current_email, &Routes.<%= schema.singular %>_update_email_url(conn, :edit, &1))
+      iex> deliver_update_email_instructions(<%= @schema.singular %>, current_email, &Routes.<%= @schema.singular %>_update_email_url(conn, :edit, &1))
       {:ok, %{to: ..., body: ...}}
 
   """
-  def deliver_update_email_instructions(%<%= inspect schema.alias %>{} = <%= schema.singular %>, current_email, update_email_url_fun)
+  def deliver_update_email_instructions(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>, current_email, update_email_url_fun)
       when is_function(update_email_url_fun, 1) do
-    {encoded_token, <%= schema.singular %>_token} = <%= inspect schema.alias %>Token.build_email_token(<%= schema.singular %>, "change:#{current_email}")
+    {encoded_token, <%= @schema.singular %>_token} = <%= inspect @schema.alias %>Token.build_email_token(<%= @schema.singular %>, "change:#{current_email}")
 
-    Repo.insert!(<%= schema.singular %>_token)
-    <%= inspect schema.alias %>Notifier.deliver_update_email_instructions(<%= schema.singular %>, update_email_url_fun.(encoded_token))
+    Repo.insert!(<%= @schema.singular %>_token)
+    <%= inspect @schema.alias %>Notifier.deliver_update_email_instructions(<%= @schema.singular %>, update_email_url_fun.(encoded_token))
   end
 
   @doc """
-  Returns an `%Ecto.Changeset{}` for changing the <%= schema.singular %> password.
+  Returns an `%Ecto.Changeset{}` for changing the <%= @schema.singular %> password.
 
   ## Examples
 
-      iex> change_<%= schema.singular %>_password(<%= schema.singular %>)
-      %Ecto.Changeset{data: %<%= inspect schema.alias %>{}}
+      iex> change_<%= @schema.singular %>_password(<%= @schema.singular %>)
+      %Ecto.Changeset{data: %<%= inspect @schema.alias %>{}}
 
   """
-  def change_<%= schema.singular %>_password(<%= schema.singular %>, attrs \\ %{}) do
-    <%= inspect schema.alias %>.password_changeset(<%= schema.singular %>, attrs, hash_password: false)
+  def change_<%= @schema.singular %>_password(<%= @schema.singular %>, attrs \\ %{}) do
+    <%= inspect @schema.alias %>.password_changeset(<%= @schema.singular %>, attrs, hash_password: false)
   end
 
   @doc """
-  Updates the <%= schema.singular %> password.
+  Updates the <%= @schema.singular %> password.
 
   ## Examples
 
-      iex> update_<%= schema.singular %>_password(<%= schema.singular %>, "valid password", %{password: ...})
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> update_<%= @schema.singular %>_password(<%= @schema.singular %>, "valid password", %{password: ...})
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> update_<%= schema.singular %>_password(<%= schema.singular %>, "invalid password", %{password: ...})
+      iex> update_<%= @schema.singular %>_password(<%= @schema.singular %>, "invalid password", %{password: ...})
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_<%= schema.singular %>_password(<%= schema.singular %>, password, attrs) do
+  def update_<%= @schema.singular %>_password(<%= @schema.singular %>, password, attrs) do
     changeset =
-      <%= schema.singular %>
-      |> <%= inspect schema.alias %>.password_changeset(attrs)
-      |> <%= inspect schema.alias %>.validate_current_password(password)
+      <%= @schema.singular %>
+      |> <%= inspect @schema.alias %>.password_changeset(attrs)
+      |> <%= inspect @schema.alias %>.validate_current_password(password)
 
     Ecto.Multi.new()
-    |> Ecto.Multi.update(:<%= schema.singular %>, changeset)
-    |> Ecto.Multi.delete_all(:tokens, <%= inspect schema.alias %>Token.<%= schema.singular %>_and_contexts_query(<%= schema.singular %>, :all))
+    |> Ecto.Multi.update(:<%= @schema.singular %>, changeset)
+    |> Ecto.Multi.delete_all(:tokens, <%= inspect @schema.alias %>Token.<%= @schema.singular %>_and_contexts_query(<%= @schema.singular %>, :all))
     |> Repo.transaction()
     |> case do
-      {:ok, %{<%= schema.singular %>: <%= schema.singular %>}} -> {:ok, <%= schema.singular %>}
-      {:error, :<%= schema.singular %>, changeset, _} -> {:error, changeset}
+      {:ok, %{<%= @schema.singular %>: <%= @schema.singular %>}} -> {:ok, <%= @schema.singular %>}
+      {:error, :<%= @schema.singular %>, changeset, _} -> {:error, changeset}
     end
   end
 
@@ -209,133 +209,133 @@
   @doc """
   Generates a session token.
   """
-  def generate_<%= schema.singular %>_session_token(<%= schema.singular %>) do
-    {token, <%= schema.singular %>_token} = <%= inspect schema.alias %>Token.build_session_token(<%= schema.singular %>)
-    Repo.insert!(<%= schema.singular %>_token)
+  def generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>) do
+    {token, <%= @schema.singular %>_token} = <%= inspect @schema.alias %>Token.build_session_token(<%= @schema.singular %>)
+    Repo.insert!(<%= @schema.singular %>_token)
     token
   end
 
   @doc """
-  Gets the <%= schema.singular %> with the given signed token.
+  Gets the <%= @schema.singular %> with the given signed token.
   """
-  def get_<%= schema.singular %>_by_session_token(token) do
-    {:ok, query} = <%= inspect schema.alias %>Token.verify_session_token_query(token)
+  def get_<%= @schema.singular %>_by_session_token(token) do
+    {:ok, query} = <%= inspect @schema.alias %>Token.verify_session_token_query(token)
     Repo.one(query)
   end
 
   @doc """
-  Deletes the signed token with the given context.
+  Deletes the signed token with the given @context.
   """
   def delete_session_token(token) do
-    Repo.delete_all(<%= inspect schema.alias %>Token.token_and_context_query(token, "session"))
+    Repo.delete_all(<%= inspect @schema.alias %>Token.token_and_context_query(token, "session"))
     :ok
   end
 
   ## Confirmation
 
   @doc """
-  Delivers the confirmation email instructions to the given <%= schema.singular %>.
+  Delivers the confirmation email instructions to the given <%= @schema.singular %>.
 
   ## Examples
 
-      iex> deliver_<%= schema.singular %>_confirmation_instructions(<%= schema.singular %>, &Routes.<%= schema.singular %>_confirmation_url(conn, :confirm, &1))
+      iex> deliver_<%= @schema.singular %>_confirmation_instructions(<%= @schema.singular %>, &Routes.<%= @schema.singular %>_confirmation_url(conn, :confirm, &1))
       {:ok, %{to: ..., body: ...}}
 
-      iex> deliver_<%= schema.singular %>_confirmation_instructions(confirmed_<%= schema.singular %>, &Routes.<%= schema.singular %>_confirmation_url(conn, :confirm, &1))
+      iex> deliver_<%= @schema.singular %>_confirmation_instructions(confirmed_<%= @schema.singular %>, &Routes.<%= @schema.singular %>_confirmation_url(conn, :confirm, &1))
       {:error, :already_confirmed}
 
   """
-  def deliver_<%= schema.singular %>_confirmation_instructions(%<%= inspect schema.alias %>{} = <%= schema.singular %>, confirmation_url_fun)
+  def deliver_<%= @schema.singular %>_confirmation_instructions(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>, confirmation_url_fun)
       when is_function(confirmation_url_fun, 1) do
-    if <%= schema.singular %>.confirmed_at do
+    if <%= @schema.singular %>.confirmed_at do
       {:error, :already_confirmed}
     else
-      {encoded_token, <%= schema.singular %>_token} = <%= inspect schema.alias %>Token.build_email_token(<%= schema.singular %>, "confirm")
-      Repo.insert!(<%= schema.singular %>_token)
-      <%= inspect schema.alias %>Notifier.deliver_confirmation_instructions(<%= schema.singular %>, confirmation_url_fun.(encoded_token))
+      {encoded_token, <%= @schema.singular %>_token} = <%= inspect @schema.alias %>Token.build_email_token(<%= @schema.singular %>, "confirm")
+      Repo.insert!(<%= @schema.singular %>_token)
+      <%= inspect @schema.alias %>Notifier.deliver_confirmation_instructions(<%= @schema.singular %>, confirmation_url_fun.(encoded_token))
     end
   end
 
   @doc """
-  Confirms a <%= schema.singular %> by the given token.
+  Confirms a <%= @schema.singular %> by the given token.
 
-  If the token matches, the <%= schema.singular %> account is marked as confirmed
+  If the token matches, the <%= @schema.singular %> account is marked as confirmed
   and the token is deleted.
   """
-  def confirm_<%= schema.singular %>(token) do
-    with {:ok, query} <- <%= inspect schema.alias %>Token.verify_email_token_query(token, "confirm"),
-         %<%= inspect schema.alias %>{} = <%= schema.singular %> <- Repo.one(query),
-         {:ok, %{<%= schema.singular %>: <%= schema.singular %>}} <- Repo.transaction(confirm_<%= schema.singular %>_multi(<%= schema.singular %>)) do
-      {:ok, <%= schema.singular %>}
+  def confirm_<%= @schema.singular %>(token) do
+    with {:ok, query} <- <%= inspect @schema.alias %>Token.verify_email_token_query(token, "confirm"),
+         %<%= inspect @schema.alias %>{} = <%= @schema.singular %> <- Repo.one(query),
+         {:ok, %{<%= @schema.singular %>: <%= @schema.singular %>}} <- Repo.transaction(confirm_<%= @schema.singular %>_multi(<%= @schema.singular %>)) do
+      {:ok, <%= @schema.singular %>}
     else
       _ -> :error
     end
   end
 
-  defp confirm_<%= schema.singular %>_multi(<%= schema.singular %>) do
+  defp confirm_<%= @schema.singular %>_multi(<%= @schema.singular %>) do
     Ecto.Multi.new()
-    |> Ecto.Multi.update(:<%= schema.singular %>, <%= inspect schema.alias %>.confirm_changeset(<%= schema.singular %>))
-    |> Ecto.Multi.delete_all(:tokens, <%= inspect schema.alias %>Token.<%= schema.singular %>_and_contexts_query(<%= schema.singular %>, ["confirm"]))
+    |> Ecto.Multi.update(:<%= @schema.singular %>, <%= inspect @schema.alias %>.confirm_changeset(<%= @schema.singular %>))
+    |> Ecto.Multi.delete_all(:tokens, <%= inspect @schema.alias %>Token.<%= @schema.singular %>_and_contexts_query(<%= @schema.singular %>, ["confirm"]))
   end
 
   ## Reset password
 
   @doc """
-  Delivers the reset password email to the given <%= schema.singular %>.
+  Delivers the reset password email to the given <%= @schema.singular %>.
 
   ## Examples
 
-      iex> deliver_<%= schema.singular %>_reset_password_instructions(<%= schema.singular %>, &Routes.<%= schema.singular %>_reset_password_url(conn, :edit, &1))
+      iex> deliver_<%= @schema.singular %>_reset_password_instructions(<%= @schema.singular %>, &Routes.<%= @schema.singular %>_reset_password_url(conn, :edit, &1))
       {:ok, %{to: ..., body: ...}}
 
   """
-  def deliver_<%= schema.singular %>_reset_password_instructions(%<%= inspect schema.alias %>{} = <%= schema.singular %>, reset_password_url_fun)
+  def deliver_<%= @schema.singular %>_reset_password_instructions(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>, reset_password_url_fun)
       when is_function(reset_password_url_fun, 1) do
-    {encoded_token, <%= schema.singular %>_token} = <%= inspect schema.alias %>Token.build_email_token(<%= schema.singular %>, "reset_password")
-    Repo.insert!(<%= schema.singular %>_token)
-    <%= inspect schema.alias %>Notifier.deliver_reset_password_instructions(<%= schema.singular %>, reset_password_url_fun.(encoded_token))
+    {encoded_token, <%= @schema.singular %>_token} = <%= inspect @schema.alias %>Token.build_email_token(<%= @schema.singular %>, "reset_password")
+    Repo.insert!(<%= @schema.singular %>_token)
+    <%= inspect @schema.alias %>Notifier.deliver_reset_password_instructions(<%= @schema.singular %>, reset_password_url_fun.(encoded_token))
   end
 
   @doc """
-  Gets the <%= schema.singular %> by reset password token.
+  Gets the <%= @schema.singular %> by reset password token.
 
   ## Examples
 
-      iex> get_<%= schema.singular %>_by_reset_password_token("validtoken")
-      %<%= inspect schema.alias %>{}
+      iex> get_<%= @schema.singular %>_by_reset_password_token("validtoken")
+      %<%= inspect @schema.alias %>{}
 
-      iex> get_<%= schema.singular %>_by_reset_password_token("invalidtoken")
+      iex> get_<%= @schema.singular %>_by_reset_password_token("invalidtoken")
       nil
 
   """
-  def get_<%= schema.singular %>_by_reset_password_token(token) do
-    with {:ok, query} <- <%= inspect schema.alias %>Token.verify_email_token_query(token, "reset_password"),
-         %<%= inspect schema.alias %>{} = <%= schema.singular %> <- Repo.one(query) do
-      <%= schema.singular %>
+  def get_<%= @schema.singular %>_by_reset_password_token(token) do
+    with {:ok, query} <- <%= inspect @schema.alias %>Token.verify_email_token_query(token, "reset_password"),
+         %<%= inspect @schema.alias %>{} = <%= @schema.singular %> <- Repo.one(query) do
+      <%= @schema.singular %>
     else
       _ -> nil
     end
   end
 
   @doc """
-  Resets the <%= schema.singular %> password.
+  Resets the <%= @schema.singular %> password.
 
   ## Examples
 
-      iex> reset_<%= schema.singular %>_password(<%= schema.singular %>, %{password: "new long password", password_confirmation: "new long password"})
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> reset_<%= @schema.singular %>_password(<%= @schema.singular %>, %{password: "new long password", password_confirmation: "new long password"})
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> reset_<%= schema.singular %>_password(<%= schema.singular %>, %{password: "valid", password_confirmation: "not the same"})
+      iex> reset_<%= @schema.singular %>_password(<%= @schema.singular %>, %{password: "valid", password_confirmation: "not the same"})
       {:error, %Ecto.Changeset{}}
 
   """
-  def reset_<%= schema.singular %>_password(<%= schema.singular %>, attrs) do
+  def reset_<%= @schema.singular %>_password(<%= @schema.singular %>, attrs) do
     Ecto.Multi.new()
-    |> Ecto.Multi.update(:<%= schema.singular %>, <%= inspect schema.alias %>.password_changeset(<%= schema.singular %>, attrs))
-    |> Ecto.Multi.delete_all(:tokens, <%= inspect schema.alias %>Token.<%= schema.singular %>_and_contexts_query(<%= schema.singular %>, :all))
+    |> Ecto.Multi.update(:<%= @schema.singular %>, <%= inspect @schema.alias %>.password_changeset(<%= @schema.singular %>, attrs))
+    |> Ecto.Multi.delete_all(:tokens, <%= inspect @schema.alias %>Token.<%= @schema.singular %>_and_contexts_query(<%= @schema.singular %>, :all))
     |> Repo.transaction()
     |> case do
-      {:ok, %{<%= schema.singular %>: <%= schema.singular %>}} -> {:ok, <%= schema.singular %>}
-      {:error, :<%= schema.singular %>, changeset, _} -> {:error, changeset}
+      {:ok, %{<%= @schema.singular %>: <%= @schema.singular %>}} -> {:ok, <%= @schema.singular %>}
+      {:error, :<%= @schema.singular %>, changeset, _} -> {:error, changeset}
     end
   end

--- a/priv/templates/phx.gen.auth/migration.ex
+++ b/priv/templates/phx.gen.auth/migration.ex
@@ -1,29 +1,29 @@
-defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.table) %>AuthTables do
+defmodule <%= inspect @schema.repo %>.Migrations.Create<%= Macro.camelize(@schema.table) %>AuthTables do
   use Ecto.Migration
 
-  def change do<%= if Enum.any?(migration.extensions) do %><%= for extension <- migration.extensions do %>
+  def change do<%= if Enum.any?(@migration.extensions) do %><%= for extension <- @migration.extensions do %>
     <%= extension %><% end %>
 <% end %>
-    create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %>) do
-<%= if schema.binary_id do %>      add :id, :binary_id, primary_key: true
-<% end %>      <%= migration.column_definitions[:email] %>
+    create table(:<%= @schema.table %><%= if @schema.binary_id do %>, primary_key: false<% end %>) do
+<%= if @schema.binary_id do %>      add :id, :binary_id, primary_key: true
+<% end %>      <%= @migration.column_definitions[:email] %>
       add :hashed_password, :string, null: false
       add :confirmed_at, :naive_datetime
       timestamps()
     end
 
-    create unique_index(:<%= schema.table %>, [:email])
+    create unique_index(:<%= @schema.table %>, [:email])
 
-    create table(:<%= schema.table %>_tokens<%= if schema.binary_id do %>, primary_key: false<% end %>) do
-<%= if schema.binary_id do %>      add :id, :binary_id, primary_key: true
-<% end %>      add :<%= schema.singular %>_id, references(:<%= schema.table %>, <%= if schema.binary_id do %>type: :binary_id, <% end %>on_delete: :delete_all), null: false
-      <%= migration.column_definitions[:token] %>
+    create table(:<%= @schema.table %>_tokens<%= if @schema.binary_id do %>, primary_key: false<% end %>) do
+<%= if @schema.binary_id do %>      add :id, :binary_id, primary_key: true
+<% end %>      add :<%= @schema.singular %>_id, references(:<%= @schema.table %>, <%= if @schema.binary_id do %>type: :binary_id, <% end %>on_delete: :delete_all), null: false
+      <%= @migration.column_definitions[:token] %>
       add :context, :string, null: false
       add :sent_to, :string
       timestamps(updated_at: false)
     end
 
-    create index(:<%= schema.table %>_tokens, [:<%= schema.singular %>_id])
-    create unique_index(:<%= schema.table %>_tokens, [:context, :token])
+    create index(:<%= @schema.table %>_tokens, [:<%= @schema.singular %>_id])
+    create unique_index(:<%= @schema.table %>_tokens, [:context, :token])
   end
 end

--- a/priv/templates/phx.gen.auth/notifier.ex
+++ b/priv/templates/phx.gen.auth/notifier.ex
@@ -1,4 +1,4 @@
-defmodule <%= inspect context.module %>.<%= inspect schema.alias %>Notifier do
+defmodule <%= inspect @context.module %>.<%= inspect @schema.alias %>Notifier do
   # For simplicity, this module simply logs messages to the terminal.
   # You should replace it by a proper email or notification tool, such as:
   #
@@ -14,12 +14,12 @@ defmodule <%= inspect context.module %>.<%= inspect schema.alias %>Notifier do
   @doc """
   Deliver instructions to confirm account.
   """
-  def deliver_confirmation_instructions(<%= schema.singular %>, url) do
-    deliver(<%= schema.singular %>.email, """
+  def deliver_confirmation_instructions(<%= @schema.singular %>, url) do
+    deliver(<%= @schema.singular %>.email, """
 
     ==============================
 
-    Hi #{<%= schema.singular %>.email},
+    Hi #{<%= @schema.singular %>.email},
 
     You can confirm your account by visiting the URL below:
 
@@ -32,14 +32,14 @@ defmodule <%= inspect context.module %>.<%= inspect schema.alias %>Notifier do
   end
 
   @doc """
-  Deliver instructions to reset a <%= schema.singular %> password.
+  Deliver instructions to reset a <%= @schema.singular %> password.
   """
-  def deliver_reset_password_instructions(<%= schema.singular %>, url) do
-    deliver(<%= schema.singular %>.email, """
+  def deliver_reset_password_instructions(<%= @schema.singular %>, url) do
+    deliver(<%= @schema.singular %>.email, """
 
     ==============================
 
-    Hi #{<%= schema.singular %>.email},
+    Hi #{<%= @schema.singular %>.email},
 
     You can reset your password by visiting the URL below:
 
@@ -52,14 +52,14 @@ defmodule <%= inspect context.module %>.<%= inspect schema.alias %>Notifier do
   end
 
   @doc """
-  Deliver instructions to update a <%= schema.singular %> email.
+  Deliver instructions to update a <%= @schema.singular %> email.
   """
-  def deliver_update_email_instructions(<%= schema.singular %>, url) do
-    deliver(<%= schema.singular %>.email, """
+  def deliver_update_email_instructions(<%= @schema.singular %>, url) do
+    deliver(<%= @schema.singular %>.email, """
 
     ==============================
 
-    Hi #{<%= schema.singular %>.email},
+    Hi #{<%= @schema.singular %>.email},
 
     You can change your email by visiting the URL below:
 

--- a/priv/templates/phx.gen.auth/registration_controller.ex
+++ b/priv/templates/phx.gen.auth/registration_controller.ex
@@ -1,27 +1,27 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>RegistrationController do
-  use <%= inspect context.web_module %>, :controller
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>RegistrationController do
+  use <%= inspect @context.web_module %>, :controller
 
-  alias <%= inspect context.module %>
-  alias <%= inspect schema.module %>
-  alias <%= inspect auth_module %>
+  alias <%= inspect @context.module %>
+  alias <%= inspect @schema.module %>
+  alias <%= inspect @auth_module %>
 
   def new(conn, _params) do
-    changeset = <%= inspect context.alias %>.change_<%= schema.singular %>_registration(%<%= inspect schema.alias %>{})
+    changeset = <%= inspect @context.alias %>.change_<%= @schema.singular %>_registration(%<%= inspect @schema.alias %>{})
     render(conn, "new.html", changeset: changeset)
   end
 
-  def create(conn, %{"<%= schema.singular %>" => <%= schema.singular %>_params}) do
-    case <%= inspect context.alias %>.register_<%= schema.singular %>(<%= schema.singular %>_params) do
-      {:ok, <%= schema.singular %>} ->
+  def create(conn, %{"<%= @schema.singular %>" => <%= @schema.singular %>_params}) do
+    case <%= inspect @context.alias %>.register_<%= @schema.singular %>(<%= @schema.singular %>_params) do
+      {:ok, <%= @schema.singular %>} ->
         {:ok, _} =
-          <%= inspect context.alias %>.deliver_<%= schema.singular %>_confirmation_instructions(
-            <%= schema.singular %>,
-            &Routes.<%= schema.route_helper %>_confirmation_url(conn, :confirm, &1)
+          <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_confirmation_instructions(
+            <%= @schema.singular %>,
+            &Routes.<%= @schema.route_helper %>_confirmation_url(conn, :confirm, &1)
           )
 
         conn
-        |> put_flash(:info, "<%= schema.human_singular %> created successfully.")
-        |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
+        |> put_flash(:info, "<%= @schema.human_singular %> created successfully.")
+        |> <%= inspect @schema.alias %>Auth.log_in_<%= @schema.singular %>(<%= @schema.singular %>)
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)

--- a/priv/templates/phx.gen.auth/registration_controller_test.exs
+++ b/priv/templates/phx.gen.auth/registration_controller_test.exs
@@ -1,11 +1,11 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>RegistrationControllerTest do
-  use <%= inspect context.web_module %>.ConnCase<%= test_case_options %>
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>RegistrationControllerTest do
+  use <%= inspect @context.web_module %>.ConnCase<%= @test_case_options %>
 
-  import <%= inspect context.module %>Fixtures
+  import <%= inspect @context.module %>Fixtures
 
-  describe "GET <%= web_path_prefix %>/<%= schema.plural %>/register" do
+  describe "GET <%= @web_path_prefix %>/<%= @schema.plural %>/register" do
     test "renders registration page", %{conn: conn} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_registration_path(conn, :new))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_registration_path(conn, :new))
       response = html_response(conn, 200)
       assert response =~ "<h1>Register</h1>"
       assert response =~ "Log in</a>"
@@ -13,22 +13,22 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
 
     test "redirects if already logged in", %{conn: conn} do
-      conn = conn |> log_in_<%= schema.singular %>(<%= schema.singular %>_fixture()) |> get(Routes.<%= schema.route_helper %>_registration_path(conn, :new))
+      conn = conn |> log_in_<%= @schema.singular %>(<%= @schema.singular %>_fixture()) |> get(Routes.<%= @schema.route_helper %>_registration_path(conn, :new))
       assert redirected_to(conn) == "/"
     end
   end
 
-  describe "POST <%= web_path_prefix %>/<%= schema.plural %>/register" do
+  describe "POST <%= @web_path_prefix %>/<%= @schema.plural %>/register" do
     @tag :capture_log
-    test "creates account and logs the <%= schema.singular %> in", %{conn: conn} do
-      email = unique_<%= schema.singular %>_email()
+    test "creates account and logs the <%= @schema.singular %> in", %{conn: conn} do
+      email = unique_<%= @schema.singular %>_email()
 
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_registration_path(conn, :create), %{
-          "<%= schema.singular %>" => %{"email" => email, "password" => valid_<%= schema.singular %>_password()}
+        post(conn, Routes.<%= @schema.route_helper %>_registration_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{"email" => email, "password" => valid_<%= @schema.singular %>_password()}
         })
 
-      assert get_session(conn, :<%= schema.singular %>_token)
+      assert get_session(conn, :<%= @schema.singular %>_token)
       assert redirected_to(conn) =~ "/"
 
       # Now do a logged in request and assert on the menu
@@ -41,8 +41,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
     test "render errors for invalid data", %{conn: conn} do
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_registration_path(conn, :create), %{
-          "<%= schema.singular %>" => %{"email" => "with spaces", "password" => "too short"}
+        post(conn, Routes.<%= @schema.route_helper %>_registration_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{"email" => "with spaces", "password" => "too short"}
         })
 
       response = html_response(conn, 200)

--- a/priv/templates/phx.gen.auth/registration_new.html.eex
+++ b/priv/templates/phx.gen.auth/registration_new.html.eex
@@ -1,6 +1,6 @@
 <h1>Register</h1>
 
-<%%= form_for @changeset, Routes.<%= schema.route_helper %>_registration_path(@conn, :create), fn f -> %>
+<%%= form_for @changeset, Routes.<%= @schema.route_helper %>_registration_path(@conn, :create), fn f -> %>
   <%%= if @changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong! Please check the errors below.</p>
@@ -21,6 +21,6 @@
 <%% end %>
 
 <p>
-  <%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %> |
-  <%%= link "Forgot your password?", to: Routes.<%= schema.route_helper %>_reset_password_path(@conn, :new) %>
+  <%%= link "Log in", to: Routes.<%= @schema.route_helper %>_session_path(@conn, :new) %> |
+  <%%= link "Forgot your password?", to: Routes.<%= @schema.route_helper %>_reset_password_path(@conn, :new) %>
 </p>

--- a/priv/templates/phx.gen.auth/registration_view.ex
+++ b/priv/templates/phx.gen.auth/registration_view.ex
@@ -1,3 +1,3 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>RegistrationView do
-  use <%= inspect context.web_module %>, :view
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>RegistrationView do
+  use <%= inspect @context.web_module %>, :view
 end

--- a/priv/templates/phx.gen.auth/reset_password_controller.ex
+++ b/priv/templates/phx.gen.auth/reset_password_controller.ex
@@ -1,19 +1,19 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ResetPasswordController do
-  use <%= inspect context.web_module %>, :controller
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>ResetPasswordController do
+  use <%= inspect @context.web_module %>, :controller
 
-  alias <%= inspect context.module %>
+  alias <%= inspect @context.module %>
 
-  plug :get_<%= schema.singular %>_by_reset_password_token when action in [:edit, :update]
+  plug :get_<%= @schema.singular %>_by_reset_password_token when action in [:edit, :update]
 
   def new(conn, _params) do
     render(conn, "new.html")
   end
 
-  def create(conn, %{"<%= schema.singular %>" => %{"email" => email}}) do
-    if <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(email) do
-      <%= inspect context.alias %>.deliver_<%= schema.singular %>_reset_password_instructions(
-        <%= schema.singular %>,
-        &Routes.<%= schema.route_helper %>_reset_password_url(conn, :edit, &1)
+  def create(conn, %{"<%= @schema.singular %>" => %{"email" => email}}) do
+    if <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email(email) do
+      <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_reset_password_instructions(
+        <%= @schema.singular %>,
+        &Routes.<%= @schema.route_helper %>_reset_password_url(conn, :edit, &1)
       )
     end
 
@@ -27,28 +27,28 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def edit(conn, _params) do
-    render(conn, "edit.html", changeset: <%= inspect context.alias %>.change_<%= schema.singular %>_password(conn.assigns.<%= schema.singular %>))
+    render(conn, "edit.html", changeset: <%= inspect @context.alias %>.change_<%= @schema.singular %>_password(conn.assigns.<%= @schema.singular %>))
   end
 
-  # Do not log in the <%= schema.singular %> after reset password to avoid a
-  # leaked token giving the <%= schema.singular %> access to the account.
-  def update(conn, %{"<%= schema.singular %>" => <%= schema.singular %>_params}) do
-    case <%= inspect context.alias %>.reset_<%= schema.singular %>_password(conn.assigns.<%= schema.singular %>, <%= schema.singular %>_params) do
+  # Do not log in the <%= @schema.singular %> after reset password to avoid a
+  # leaked token giving the <%= @schema.singular %> access to the account.
+  def update(conn, %{"<%= @schema.singular %>" => <%= @schema.singular %>_params}) do
+    case <%= inspect @context.alias %>.reset_<%= @schema.singular %>_password(conn.assigns.<%= @schema.singular %>, <%= @schema.singular %>_params) do
       {:ok, _} ->
         conn
         |> put_flash(:info, "Password reset successfully.")
-        |> redirect(to: Routes.<%= schema.route_helper %>_session_path(conn, :new))
+        |> redirect(to: Routes.<%= @schema.route_helper %>_session_path(conn, :new))
 
       {:error, changeset} ->
         render(conn, "edit.html", changeset: changeset)
     end
   end
 
-  defp get_<%= schema.singular %>_by_reset_password_token(conn, _opts) do
+  defp get_<%= @schema.singular %>_by_reset_password_token(conn, _opts) do
     %{"token" => token} = conn.params
 
-    if <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>_by_reset_password_token(token) do
-      conn |> assign(:<%= schema.singular %>, <%= schema.singular %>) |> assign(:token, token)
+    if <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_reset_password_token(token) do
+      conn |> assign(:<%= @schema.singular %>, <%= @schema.singular %>) |> assign(:token, token)
     else
       conn
       |> put_flash(:error, "Reset password link is invalid or it has expired.")

--- a/priv/templates/phx.gen.auth/reset_password_controller_test.exs
+++ b/priv/templates/phx.gen.auth/reset_password_controller_test.exs
@@ -1,98 +1,98 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ResetPasswordControllerTest do
-  use <%= inspect context.web_module %>.ConnCase<%= test_case_options %>
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>ResetPasswordControllerTest do
+  use <%= inspect @context.web_module %>.ConnCase<%= @test_case_options %>
 
-  alias <%= inspect context.module %>
-  alias <%= inspect schema.repo %>
-  import <%= inspect context.module %>Fixtures
+  alias <%= inspect @context.module %>
+  alias <%= inspect @schema.repo %>
+  import <%= inspect @context.module %>Fixtures
 
   setup do
-    %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+    %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
   end
 
-  describe "GET <%= web_path_prefix %>/<%= schema.plural %>/reset_password" do
+  describe "GET <%= @web_path_prefix %>/<%= @schema.plural %>/reset_password" do
     test "renders the reset password page", %{conn: conn} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_reset_password_path(conn, :new))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_reset_password_path(conn, :new))
       response = html_response(conn, 200)
       assert response =~ "<h1>Forgot your password?</h1>"
     end
   end
 
-  describe "POST <%= web_path_prefix %>/<%= schema.plural %>/reset_password" do
+  describe "POST <%= @web_path_prefix %>/<%= @schema.plural %>/reset_password" do
     @tag :capture_log
-    test "sends a new reset password token", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+    test "sends a new reset password token", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_reset_password_path(conn, :create), %{
-          "<%= schema.singular %>" => %{"email" => <%= schema.singular %>.email}
+        post(conn, Routes.<%= @schema.route_helper %>_reset_password_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{"email" => <%= @schema.singular %>.email}
         })
 
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :info) =~ "If your email is in our system"
-      assert Repo.get_by!(<%= inspect context.alias %>.<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id).context == "reset_password"
+      assert Repo.get_by!(<%= inspect @context.alias %>.<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id).context == "reset_password"
     end
 
     test "does not send reset password token if email is invalid", %{conn: conn} do
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_reset_password_path(conn, :create), %{
-          "<%= schema.singular %>" => %{"email" => "unknown@example.com"}
+        post(conn, Routes.<%= @schema.route_helper %>_reset_password_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{"email" => "unknown@example.com"}
         })
 
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :info) =~ "If your email is in our system"
-      assert Repo.all(<%= inspect context.alias %>.<%= inspect schema.alias %>Token) == []
+      assert Repo.all(<%= inspect @context.alias %>.<%= inspect @schema.alias %>Token) == []
     end
   end
 
-  describe "GET <%= web_path_prefix %>/<%= schema.plural %>/reset_password/:token" do
-    setup %{<%= schema.singular %>: <%= schema.singular %>} do
+  describe "GET <%= @web_path_prefix %>/<%= @schema.plural %>/reset_password/:token" do
+    setup %{<%= @schema.singular %>: <%= @schema.singular %>} do
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_<%= schema.singular %>_reset_password_instructions(<%= schema.singular %>, url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_reset_password_instructions(<%= @schema.singular %>, url)
         end)
 
       %{token: token}
     end
 
     test "renders reset password", %{conn: conn, token: token} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_reset_password_path(conn, :edit, token))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_reset_password_path(conn, :edit, token))
       assert html_response(conn, 200) =~ "<h1>Reset password</h1>"
     end
 
     test "does not render reset password with invalid token", %{conn: conn} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_reset_password_path(conn, :edit, "oops"))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_reset_password_path(conn, :edit, "oops"))
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :error) =~ "Reset password link is invalid or it has expired"
     end
   end
 
-  describe "PUT <%= web_path_prefix %>/<%= schema.plural %>/reset_password/:token" do
-    setup %{<%= schema.singular %>: <%= schema.singular %>} do
+  describe "PUT <%= @web_path_prefix %>/<%= @schema.plural %>/reset_password/:token" do
+    setup %{<%= @schema.singular %>: <%= @schema.singular %>} do
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_<%= schema.singular %>_reset_password_instructions(<%= schema.singular %>, url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_reset_password_instructions(<%= @schema.singular %>, url)
         end)
 
       %{token: token}
     end
 
-    test "resets password once", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>, token: token} do
+    test "resets password once", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>, token: token} do
       conn =
-        put(conn, Routes.<%= schema.route_helper %>_reset_password_path(conn, :update, token), %{
-          "<%= schema.singular %>" => %{
+        put(conn, Routes.<%= @schema.route_helper %>_reset_password_path(conn, :update, token), %{
+          "<%= @schema.singular %>" => %{
             "password" => "new valid password",
             "password_confirmation" => "new valid password"
           }
         })
 
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_session_path(conn, :new)
-      refute get_session(conn, :<%= schema.singular %>_token)
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_session_path(conn, :new)
+      refute get_session(conn, :<%= @schema.singular %>_token)
       assert get_flash(conn, :info) =~ "Password reset successfully"
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(<%= schema.singular %>.email, "new valid password")
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email_and_password(<%= @schema.singular %>.email, "new valid password")
     end
 
     test "does not reset password on invalid data", %{conn: conn, token: token} do
       conn =
-        put(conn, Routes.<%= schema.route_helper %>_reset_password_path(conn, :update, token), %{
-          "<%= schema.singular %>" => %{
+        put(conn, Routes.<%= @schema.route_helper %>_reset_password_path(conn, :update, token), %{
+          "<%= @schema.singular %>" => %{
             "password" => "too short",
             "password_confirmation" => "does not match"
           }
@@ -105,7 +105,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
 
     test "does not reset password with invalid token", %{conn: conn} do
-      conn = put(conn, Routes.<%= schema.route_helper %>_reset_password_path(conn, :update, "oops"))
+      conn = put(conn, Routes.<%= @schema.route_helper %>_reset_password_path(conn, :update, "oops"))
       assert redirected_to(conn) == "/"
       assert get_flash(conn, :error) =~ "Reset password link is invalid or it has expired"
     end

--- a/priv/templates/phx.gen.auth/reset_password_edit.html.eex
+++ b/priv/templates/phx.gen.auth/reset_password_edit.html.eex
@@ -1,6 +1,6 @@
 <h1>Reset password</h1>
 
-<%%= form_for @changeset, Routes.<%= schema.route_helper %>_reset_password_path(@conn, :update, @token), fn f -> %>
+<%%= form_for @changeset, Routes.<%= @schema.route_helper %>_reset_password_path(@conn, :update, @token), fn f -> %>
   <%%= if @changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong! Please check the errors below.</p>
@@ -21,6 +21,6 @@
 <%% end %>
 
 <p>
-  <%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %> |
-  <%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %>
+  <%%= link "Register", to: Routes.<%= @schema.route_helper %>_registration_path(@conn, :new) %> |
+  <%%= link "Log in", to: Routes.<%= @schema.route_helper %>_session_path(@conn, :new) %>
 </p>

--- a/priv/templates/phx.gen.auth/reset_password_new.html.eex
+++ b/priv/templates/phx.gen.auth/reset_password_new.html.eex
@@ -1,6 +1,6 @@
 <h1>Forgot your password?</h1>
 
-<%%= form_for :<%= schema.singular %>, Routes.<%= schema.route_helper %>_reset_password_path(@conn, :create), fn f -> %>
+<%%= form_for :<%= @schema.singular %>, Routes.<%= @schema.route_helper %>_reset_password_path(@conn, :create), fn f -> %>
   <%%= label f, :email %>
   <%%= email_input f, :email, required: true %>
 
@@ -10,6 +10,6 @@
 <%% end %>
 
 <p>
-  <%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %> |
-  <%%= link "Log in", to: Routes.<%= schema.route_helper %>_session_path(@conn, :new) %>
+  <%%= link "Register", to: Routes.<%= @schema.route_helper %>_registration_path(@conn, :new) %> |
+  <%%= link "Log in", to: Routes.<%= @schema.route_helper %>_session_path(@conn, :new) %>
 </p>

--- a/priv/templates/phx.gen.auth/reset_password_view.ex
+++ b/priv/templates/phx.gen.auth/reset_password_view.ex
@@ -1,3 +1,3 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ResetPasswordView do
-  use <%= inspect context.web_module %>, :view
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>ResetPasswordView do
+  use <%= inspect @context.web_module %>, :view
 end

--- a/priv/templates/phx.gen.auth/routes.ex
+++ b/priv/templates/phx.gen.auth/routes.ex
@@ -1,32 +1,32 @@
 
   ## Authentication routes
 
-  scope <%= router_scope %> do
-    pipe_through [:browser, :redirect_if_<%= schema.singular %>_is_authenticated]
+  scope <%= @router_scope %> do
+    pipe_through [:browser, :redirect_if_<%= @schema.singular %>_is_authenticated]
 
-    get "/<%= schema.plural %>/register", <%= inspect schema.alias %>RegistrationController, :new
-    post "/<%= schema.plural %>/register", <%= inspect schema.alias %>RegistrationController, :create
-    get "/<%= schema.plural %>/log_in", <%= inspect schema.alias %>SessionController, :new
-    post "/<%= schema.plural %>/log_in", <%= inspect schema.alias %>SessionController, :create
-    get "/<%= schema.plural %>/reset_password", <%= inspect schema.alias %>ResetPasswordController, :new
-    post "/<%= schema.plural %>/reset_password", <%= inspect schema.alias %>ResetPasswordController, :create
-    get "/<%= schema.plural %>/reset_password/:token", <%= inspect schema.alias %>ResetPasswordController, :edit
-    put "/<%= schema.plural %>/reset_password/:token", <%= inspect schema.alias %>ResetPasswordController, :update
+    get "/<%= @schema.plural %>/register", <%= inspect @schema.alias %>RegistrationController, :new
+    post "/<%= @schema.plural %>/register", <%= inspect @schema.alias %>RegistrationController, :create
+    get "/<%= @schema.plural %>/log_in", <%= inspect @schema.alias %>SessionController, :new
+    post "/<%= @schema.plural %>/log_in", <%= inspect @schema.alias %>SessionController, :create
+    get "/<%= @schema.plural %>/reset_password", <%= inspect @schema.alias %>ResetPasswordController, :new
+    post "/<%= @schema.plural %>/reset_password", <%= inspect @schema.alias %>ResetPasswordController, :create
+    get "/<%= @schema.plural %>/reset_password/:token", <%= inspect @schema.alias %>ResetPasswordController, :edit
+    put "/<%= @schema.plural %>/reset_password/:token", <%= inspect @schema.alias %>ResetPasswordController, :update
   end
 
-  scope <%= router_scope %> do
-    pipe_through [:browser, :require_authenticated_<%= schema.singular %>]
+  scope <%= @router_scope %> do
+    pipe_through [:browser, :require_authenticated_<%= @schema.singular %>]
 
-    get "/<%= schema.plural %>/settings", <%= inspect schema.alias %>SettingsController, :edit
-    put "/<%= schema.plural %>/settings", <%= inspect schema.alias %>SettingsController, :update
-    get "/<%= schema.plural %>/settings/confirm_email/:token", <%= inspect schema.alias %>SettingsController, :confirm_email
+    get "/<%= @schema.plural %>/settings", <%= inspect @schema.alias %>SettingsController, :edit
+    put "/<%= @schema.plural %>/settings", <%= inspect @schema.alias %>SettingsController, :update
+    get "/<%= @schema.plural %>/settings/confirm_email/:token", <%= inspect @schema.alias %>SettingsController, :confirm_email
   end
 
-  scope <%= router_scope %> do
+  scope <%= @router_scope %> do
     pipe_through [:browser]
 
-    delete "/<%= schema.plural %>/log_out", <%= inspect schema.alias %>SessionController, :delete
-    get "/<%= schema.plural %>/confirm", <%= inspect schema.alias %>ConfirmationController, :new
-    post "/<%= schema.plural %>/confirm", <%= inspect schema.alias %>ConfirmationController, :create
-    get "/<%= schema.plural %>/confirm/:token", <%= inspect schema.alias %>ConfirmationController, :confirm
+    delete "/<%= @schema.plural %>/log_out", <%= inspect @schema.alias %>SessionController, :delete
+    get "/<%= @schema.plural %>/confirm", <%= inspect @schema.alias %>ConfirmationController, :new
+    post "/<%= @schema.plural %>/confirm", <%= inspect @schema.alias %>ConfirmationController, :create
+    get "/<%= @schema.plural %>/confirm/:token", <%= inspect @schema.alias %>ConfirmationController, :confirm
   end

--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -1,9 +1,9 @@
-defmodule <%= inspect schema.module %> do
+defmodule <%= inspect @schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
-<%= if schema.binary_id do %>  @primary_key {:id, :binary_id, autogenerate: true}
+<%= if @schema.binary_id do %>  @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id<% end %>
-  schema <%= inspect schema.table %> do
+  schema <%= inspect @schema.table %> do
     field :email, :string
     field :password, :string, virtual: true, redact: true
     field :hashed_password, :string, redact: true
@@ -13,7 +13,7 @@ defmodule <%= inspect schema.module %> do
   end
 
   @doc """
-  A <%= schema.singular %> changeset for registration.
+  A <%= @schema.singular %> changeset for registration.
 
   It is important to validate the length of both email and password.
   Otherwise databases may truncate the email without warnings, which
@@ -29,8 +29,8 @@ defmodule <%= inspect schema.module %> do
       validations on a LiveView form), this option can be set to `false`.
       Defaults to `true`.
   """
-  def registration_changeset(<%= schema.singular %>, attrs, opts \\ []) do
-    <%= schema.singular %>
+  def registration_changeset(<%= @schema.singular %>, attrs, opts \\ []) do
+    <%= @schema.singular %>
     |> cast(attrs, [:email, :password])
     |> validate_email()
     |> validate_password(opts)
@@ -41,7 +41,7 @@ defmodule <%= inspect schema.module %> do
     |> validate_required([:email])
     |> validate_format(:email, ~r/^[^\s]+@[^\s]+$/, message: "must have the @ sign and no spaces")
     |> validate_length(:email, max: 160)
-    |> unsafe_validate_unique(:email, <%= inspect schema.repo %>)
+    |> unsafe_validate_unique(:email, <%= inspect @schema.repo %>)
     |> unique_constraint(:email)
   end
 
@@ -61,7 +61,7 @@ defmodule <%= inspect schema.module %> do
 
     if hash_password? && password && changeset.valid? do
       changeset
-      |> put_change(:hashed_password, <%= inspect hashing_library.module %>.hash_pwd_salt(password))
+      |> put_change(:hashed_password, <%= inspect @hashing_library.module %>.hash_pwd_salt(password))
       |> delete_change(:password)
     else
       changeset
@@ -69,12 +69,12 @@ defmodule <%= inspect schema.module %> do
   end
 
   @doc """
-  A <%= schema.singular %> changeset for changing the email.
+  A <%= @schema.singular %> changeset for changing the email.
 
   It requires the email to change otherwise an error is added.
   """
-  def email_changeset(<%= schema.singular %>, attrs) do
-    <%= schema.singular %>
+  def email_changeset(<%= @schema.singular %>, attrs) do
+    <%= @schema.singular %>
     |> cast(attrs, [:email])
     |> validate_email()
     |> case do
@@ -84,7 +84,7 @@ defmodule <%= inspect schema.module %> do
   end
 
   @doc """
-  A <%= schema.singular %> changeset for changing the password.
+  A <%= @schema.singular %> changeset for changing the password.
 
   ## Options
 
@@ -95,8 +95,8 @@ defmodule <%= inspect schema.module %> do
       validations on a LiveView form), this option can be set to `false`.
       Defaults to `true`.
   """
-  def password_changeset(<%= schema.singular %>, attrs, opts \\ []) do
-    <%= schema.singular %>
+  def password_changeset(<%= @schema.singular %>, attrs, opts \\ []) do
+    <%= @schema.singular %>
     |> cast(attrs, [:password])
     |> validate_confirmation(:password, message: "does not match password")
     |> validate_password(opts)
@@ -105,24 +105,24 @@ defmodule <%= inspect schema.module %> do
   @doc """
   Confirms the account by setting `confirmed_at`.
   """
-  def confirm_changeset(<%= schema.singular %>) do
+  def confirm_changeset(<%= @schema.singular %>) do
     now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-    change(<%= schema.singular %>, confirmed_at: now)
+    change(<%= @schema.singular %>, confirmed_at: now)
   end
 
   @doc """
   Verifies the password.
 
-  If there is no <%= schema.singular %> or the <%= schema.singular %> doesn't have a password, we call
-  `<%= inspect hashing_library.module %>.no_user_verify/0` to avoid timing attacks.
+  If there is no <%= @schema.singular %> or the <%= @schema.singular %> doesn't have a password, we call
+  `<%= inspect @hashing_library.module %>.no_user_verify/0` to avoid timing attacks.
   """
-  def valid_password?(%<%= inspect schema.module %>{hashed_password: hashed_password}, password)
+  def valid_password?(%<%= inspect @schema.module %>{hashed_password: hashed_password}, password)
       when is_binary(hashed_password) and byte_size(password) > 0 do
-    <%= inspect hashing_library.module %>.verify_pass(password, hashed_password)
+    <%= inspect @hashing_library.module %>.verify_pass(password, hashed_password)
   end
 
   def valid_password?(_, _) do
-    <%= inspect hashing_library.module %>.no_user_verify()
+    <%= inspect @hashing_library.module %>.no_user_verify()
     false
   end
 

--- a/priv/templates/phx.gen.auth/schema_token.ex
+++ b/priv/templates/phx.gen.auth/schema_token.ex
@@ -1,4 +1,4 @@
-defmodule <%= inspect schema.module %>Token do
+defmodule <%= inspect @schema.module %>Token do
   use Ecto.Schema
   import Ecto.Query
 
@@ -11,14 +11,14 @@ defmodule <%= inspect schema.module %>Token do
   @confirm_validity_in_days 7
   @change_email_validity_in_days 7
   @session_validity_in_days 60
-<%= if schema.binary_id do %>
+<%= if @schema.binary_id do %>
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id<% end %>
-  schema "<%= schema.table %>_tokens" do
+  schema "<%= @schema.table %>_tokens" do
     field :token, :binary
     field :context, :string
     field :sent_to, :string
-    belongs_to :<%= schema.singular %>, <%= inspect schema.module %>
+    belongs_to :<%= @schema.singular %>, <%= inspect @schema.module %>
 
     timestamps(updated_at: false)
   end
@@ -28,22 +28,22 @@ defmodule <%= inspect schema.module %>Token do
   such as session or cookie. As they are signed, those
   tokens do not need to be hashed.
   """
-  def build_session_token(<%= schema.singular %>) do
+  def build_session_token(<%= @schema.singular %>) do
     token = :crypto.strong_rand_bytes(@rand_size)
-    {token, %<%= inspect schema.module %>Token{token: token, context: "session", <%= schema.singular %>_id: <%= schema.singular %>.id}}
+    {token, %<%= inspect @schema.module %>Token{token: token, context: "session", <%= @schema.singular %>_id: <%= @schema.singular %>.id}}
   end
 
   @doc """
   Checks if the token is valid and returns its underlying lookup query.
 
-  The query returns the <%= schema.singular %> found by the token.
+  The query returns the <%= @schema.singular %> found by the token.
   """
   def verify_session_token_query(token) do
     query =
       from token in token_and_context_query(token, "session"),
-        join: <%= schema.singular %> in assoc(token, :<%= schema.singular %>),
+        join: <%= @schema.singular %> in assoc(token, :<%= @schema.singular %>),
         where: token.inserted_at > ago(@session_validity_in_days, "day"),
-        select: <%= schema.singular %>
+        select: <%= @schema.singular %>
 
     {:ok, query}
   end
@@ -51,32 +51,32 @@ defmodule <%= inspect schema.module %>Token do
   @doc """
   Builds a token with a hashed counter part.
 
-  The non-hashed token is sent to the <%= schema.singular %> email while the
+  The non-hashed token is sent to the <%= @schema.singular %> email while the
   hashed part is stored in the database, to avoid reconstruction.
-  The token is valid for a week as long as <%= schema.singular %>s don't change
+  The token is valid for a week as long as <%= @schema.singular %>s don't change
   their email.
   """
-  def build_email_token(<%= schema.singular %>, context) do
-    build_hashed_token(<%= schema.singular %>, context, <%= schema.singular %>.email)
+  def build_email_token(<%= @schema.singular %>, context) do
+    build_hashed_token(<%= @schema.singular %>, context, <%= @schema.singular %>.email)
   end
 
-  defp build_hashed_token(<%= schema.singular %>, context, sent_to) do
+  defp build_hashed_token(<%= @schema.singular %>, context, sent_to) do
     token = :crypto.strong_rand_bytes(@rand_size)
     hashed_token = :crypto.hash(@hash_algorithm, token)
 
     {Base.url_encode64(token, padding: false),
-     %<%= inspect schema.module %>Token{
+     %<%= inspect @schema.module %>Token{
        token: hashed_token,
        context: context,
        sent_to: sent_to,
-       <%= schema.singular %>_id: <%= schema.singular %>.id
+       <%= @schema.singular %>_id: <%= @schema.singular %>.id
      }}
   end
 
   @doc """
   Checks if the token is valid and returns its underlying lookup query.
 
-  The query returns the <%= schema.singular %> found by the token.
+  The query returns the <%= @schema.singular %> found by the token.
   """
   def verify_email_token_query(token, context) do
     case Base.url_decode64(token, padding: false) do
@@ -86,9 +86,9 @@ defmodule <%= inspect schema.module %>Token do
 
         query =
           from token in token_and_context_query(hashed_token, context),
-            join: <%= schema.singular %> in assoc(token, :<%= schema.singular %>),
-            where: token.inserted_at > ago(^days, "day") and token.sent_to == <%= schema.singular %>.email,
-            select: <%= schema.singular %>
+            join: <%= @schema.singular %> in assoc(token, :<%= @schema.singular %>),
+            where: token.inserted_at > ago(^days, "day") and token.sent_to == <%= @schema.singular %>.email,
+            select: <%= @schema.singular %>
 
         {:ok, query}
 
@@ -103,7 +103,7 @@ defmodule <%= inspect schema.module %>Token do
   @doc """
   Checks if the token is valid and returns its underlying lookup query.
 
-  The query returns the <%= schema.singular %> token record.
+  The query returns the <%= @schema.singular %> token record.
   """
   def verify_change_email_token_query(token, context) do
     case Base.url_decode64(token, padding: false) do
@@ -125,17 +125,17 @@ defmodule <%= inspect schema.module %>Token do
   Returns the given token with the given context.
   """
   def token_and_context_query(token, context) do
-    from <%= inspect schema.module %>Token, where: [token: ^token, context: ^context]
+    from <%= inspect @schema.module %>Token, where: [token: ^token, context: ^context]
   end
 
   @doc """
-  Gets all tokens for the given <%= schema.singular %> for the given contexts.
+  Gets all tokens for the given <%= @schema.singular %> for the given contexts.
   """
-  def <%= schema.singular %>_and_contexts_query(<%= schema.singular %>, :all) do
-    from t in <%= inspect schema.module %>Token, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id
+  def <%= @schema.singular %>_and_contexts_query(<%= @schema.singular %>, :all) do
+    from t in <%= inspect @schema.module %>Token, where: t.<%= @schema.singular %>_id == ^<%= @schema.singular %>.id
   end
 
-  def <%= schema.singular %>_and_contexts_query(<%= schema.singular %>, [_ | _] = contexts) do
-    from t in <%= inspect schema.module %>Token, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id and t.context in ^contexts
+  def <%= @schema.singular %>_and_contexts_query(<%= @schema.singular %>, [_ | _] = contexts) do
+    from t in <%= inspect @schema.module %>Token, where: t.<%= @schema.singular %>_id == ^<%= @schema.singular %>.id and t.context in ^contexts
   end
 end

--- a/priv/templates/phx.gen.auth/session_controller.ex
+++ b/priv/templates/phx.gen.auth/session_controller.ex
@@ -1,18 +1,18 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>SessionController do
-  use <%= inspect context.web_module %>, :controller
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>SessionController do
+  use <%= inspect @context.web_module %>, :controller
 
-  alias <%= inspect context.module %>
-  alias <%= inspect auth_module %>
+  alias <%= inspect @context.module %>
+  alias <%= inspect @auth_module %>
 
   def new(conn, _params) do
     render(conn, "new.html", error_message: nil)
   end
 
-  def create(conn, %{"<%= schema.singular %>" => <%= schema.singular %>_params}) do
-    %{"email" => email, "password" => password} = <%= schema.singular %>_params
+  def create(conn, %{"<%= @schema.singular %>" => <%= @schema.singular %>_params}) do
+    %{"email" => email, "password" => password} = <%= @schema.singular %>_params
 
-    if <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(email, password) do
-      <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(conn, <%= schema.singular %>, <%= schema.singular %>_params)
+    if <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email_and_password(email, password) do
+      <%= inspect @schema.alias %>Auth.log_in_<%= @schema.singular %>(conn, <%= @schema.singular %>, <%= @schema.singular %>_params)
     else
       render(conn, "new.html", error_message: "Invalid email or password")
     end
@@ -21,6 +21,6 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   def delete(conn, _params) do
     conn
     |> put_flash(:info, "Logged out successfully.")
-    |> <%= inspect schema.alias %>Auth.log_out_<%= schema.singular %>()
+    |> <%= inspect @schema.alias %>Auth.log_out_<%= @schema.singular %>()
   end
 end

--- a/priv/templates/phx.gen.auth/session_controller_test.exs
+++ b/priv/templates/phx.gen.auth/session_controller_test.exs
@@ -1,77 +1,77 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>SessionControllerTest do
-  use <%= inspect context.web_module %>.ConnCase<%= test_case_options %>
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>SessionControllerTest do
+  use <%= inspect @context.web_module %>.ConnCase<%= @test_case_options %>
 
-  import <%= inspect context.module %>Fixtures
+  import <%= inspect @context.module %>Fixtures
 
   setup do
-    %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+    %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
   end
 
-  describe "GET <%= web_path_prefix %>/<%= schema.plural %>/log_in" do
+  describe "GET <%= @web_path_prefix %>/<%= @schema.plural %>/log_in" do
     test "renders log in page", %{conn: conn} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_session_path(conn, :new))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_session_path(conn, :new))
       response = html_response(conn, 200)
       assert response =~ "<h1>Log in</h1>"
       assert response =~ "Log in</a>"
       assert response =~ "Register</a>"
     end
 
-    test "redirects if already logged in", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> log_in_<%= schema.singular %>(<%= schema.singular %>) |> get(Routes.<%= schema.route_helper %>_session_path(conn, :new))
+    test "redirects if already logged in", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = conn |> log_in_<%= @schema.singular %>(<%= @schema.singular %>) |> get(Routes.<%= @schema.route_helper %>_session_path(conn, :new))
       assert redirected_to(conn) == "/"
     end
   end
 
-  describe "POST <%= web_path_prefix %>/<%= schema.plural %>/log_in" do
-    test "logs the <%= schema.singular %> in", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+  describe "POST <%= @web_path_prefix %>/<%= @schema.plural %>/log_in" do
+    test "logs the <%= @schema.singular %> in", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_session_path(conn, :create), %{
-          "<%= schema.singular %>" => %{"email" => <%= schema.singular %>.email, "password" => valid_<%= schema.singular %>_password()}
+        post(conn, Routes.<%= @schema.route_helper %>_session_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{"email" => <%= @schema.singular %>.email, "password" => valid_<%= @schema.singular %>_password()}
         })
 
-      assert get_session(conn, :<%= schema.singular %>_token)
+      assert get_session(conn, :<%= @schema.singular %>_token)
       assert redirected_to(conn) =~ "/"
 
       # Now do a logged in request and assert on the menu
       conn = get(conn, "/")
       response = html_response(conn, 200)
-      assert response =~ <%= schema.singular %>.email
+      assert response =~ <%= @schema.singular %>.email
       assert response =~ "Settings</a>"
       assert response =~ "Log out</a>"
     end
 
-    test "logs the <%= schema.singular %> in with remember me", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+    test "logs the <%= @schema.singular %> in with remember me", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_session_path(conn, :create), %{
-          "<%= schema.singular %>" => %{
-            "email" => <%= schema.singular %>.email,
-            "password" => valid_<%= schema.singular %>_password(),
+        post(conn, Routes.<%= @schema.route_helper %>_session_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{
+            "email" => <%= @schema.singular %>.email,
+            "password" => valid_<%= @schema.singular %>_password(),
             "remember_me" => "true"
           }
         })
 
-      assert conn.resp_cookies["_<%= web_app_name %>_<%= schema.singular %>_remember_me"]
+      assert conn.resp_cookies["_<%= @web_app_name %>_<%= @schema.singular %>_remember_me"]
       assert redirected_to(conn) =~ "/"
     end
 
-    test "logs the <%= schema.singular %> in with return to", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+    test "logs the <%= @schema.singular %> in with return to", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       conn =
         conn
-        |> init_test_session(<%= schema.singular %>_return_to: "/foo/bar")
-        |> post(Routes.<%= schema.route_helper %>_session_path(conn, :create), %{
-          "<%= schema.singular %>" => %{
-            "email" => <%= schema.singular %>.email,
-            "password" => valid_<%= schema.singular %>_password()
+        |> init_test_session(<%= @schema.singular %>_return_to: "/foo/bar")
+        |> post(Routes.<%= @schema.route_helper %>_session_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{
+            "email" => <%= @schema.singular %>.email,
+            "password" => valid_<%= @schema.singular %>_password()
           }
         })
 
       assert redirected_to(conn) == "/foo/bar"
     end
 
-    test "emits error message with invalid credentials", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+    test "emits error message with invalid credentials", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       conn =
-        post(conn, Routes.<%= schema.route_helper %>_session_path(conn, :create), %{
-          "<%= schema.singular %>" => %{"email" => <%= schema.singular %>.email, "password" => "invalid_password"}
+        post(conn, Routes.<%= @schema.route_helper %>_session_path(conn, :create), %{
+          "<%= @schema.singular %>" => %{"email" => <%= @schema.singular %>.email, "password" => "invalid_password"}
         })
 
       response = html_response(conn, 200)
@@ -80,18 +80,18 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
   end
 
-  describe "DELETE <%= web_path_prefix %>/<%= schema.plural %>/log_out" do
-    test "logs the <%= schema.singular %> out", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = conn |> log_in_<%= schema.singular %>(<%= schema.singular %>) |> delete(Routes.<%= schema.route_helper %>_session_path(conn, :delete))
+  describe "DELETE <%= @web_path_prefix %>/<%= @schema.plural %>/log_out" do
+    test "logs the <%= @schema.singular %> out", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = conn |> log_in_<%= @schema.singular %>(<%= @schema.singular %>) |> delete(Routes.<%= @schema.route_helper %>_session_path(conn, :delete))
       assert redirected_to(conn) == "/"
-      refute get_session(conn, :<%= schema.singular %>_token)
+      refute get_session(conn, :<%= @schema.singular %>_token)
       assert get_flash(conn, :info) =~ "Logged out successfully"
     end
 
-    test "succeeds even if the <%= schema.singular %> is not logged in", %{conn: conn} do
-      conn = delete(conn, Routes.<%= schema.route_helper %>_session_path(conn, :delete))
+    test "succeeds even if the <%= @schema.singular %> is not logged in", %{conn: conn} do
+      conn = delete(conn, Routes.<%= @schema.route_helper %>_session_path(conn, :delete))
       assert redirected_to(conn) == "/"
-      refute get_session(conn, :<%= schema.singular %>_token)
+      refute get_session(conn, :<%= @schema.singular %>_token)
       assert get_flash(conn, :info) =~ "Logged out successfully"
     end
   end

--- a/priv/templates/phx.gen.auth/session_new.html.eex
+++ b/priv/templates/phx.gen.auth/session_new.html.eex
@@ -1,6 +1,6 @@
 <h1>Log in</h1>
 
-<%%= form_for @conn, Routes.<%= schema.route_helper %>_session_path(@conn, :create), [as: :<%= schema.singular %>], fn f -> %>
+<%%= form_for @conn, Routes.<%= @schema.route_helper %>_session_path(@conn, :create), [as: :<%= @schema.singular %>], fn f -> %>
   <%%= if @error_message do %>
     <div class="alert alert-danger">
       <p><%%= @error_message %></p>
@@ -22,6 +22,6 @@
 <%% end %>
 
 <p>
-  <%%= link "Register", to: Routes.<%= schema.route_helper %>_registration_path(@conn, :new) %> |
-  <%%= link "Forgot your password?", to: Routes.<%= schema.route_helper %>_reset_password_path(@conn, :new) %>
+  <%%= link "Register", to: Routes.<%= @schema.route_helper %>_registration_path(@conn, :new) %> |
+  <%%= link "Forgot your password?", to: Routes.<%= @schema.route_helper %>_reset_password_path(@conn, :new) %>
 </p>

--- a/priv/templates/phx.gen.auth/session_view.ex
+++ b/priv/templates/phx.gen.auth/session_view.ex
@@ -1,3 +1,3 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>SessionView do
-  use <%= inspect context.web_module %>, :view
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>SessionView do
+  use <%= inspect @context.web_module %>, :view
 end

--- a/priv/templates/phx.gen.auth/settings_controller.ex
+++ b/priv/templates/phx.gen.auth/settings_controller.ex
@@ -1,8 +1,8 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>SettingsController do
-  use <%= inspect context.web_module %>, :controller
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>SettingsController do
+  use <%= inspect @context.web_module %>, :controller
 
-  alias <%= inspect context.module %>
-  alias <%= inspect auth_module %>
+  alias <%= inspect @context.module %>
+  alias <%= inspect @auth_module %>
 
   plug :assign_email_and_password_changesets
 
@@ -11,15 +11,15 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def update(conn, %{"action" => "update_email"} = params) do
-    %{"current_password" => password, "<%= schema.singular %>" => <%= schema.singular %>_params} = params
-    <%= schema.singular %> = conn.assigns.current_<%= schema.singular %>
+    %{"current_password" => password, "<%= @schema.singular %>" => <%= @schema.singular %>_params} = params
+    <%= @schema.singular %> = conn.assigns.current_<%= @schema.singular %>
 
-    case <%= inspect context.alias %>.apply_<%= schema.singular %>_email(<%= schema.singular %>, password, <%= schema.singular %>_params) do
-      {:ok, applied_<%= schema.singular %>} ->
-        <%= inspect context.alias %>.deliver_update_email_instructions(
-          applied_<%= schema.singular %>,
-          <%= schema.singular %>.email,
-          &Routes.<%= schema.route_helper %>_settings_url(conn, :confirm_email, &1)
+    case <%= inspect @context.alias %>.apply_<%= @schema.singular %>_email(<%= @schema.singular %>, password, <%= @schema.singular %>_params) do
+      {:ok, applied_<%= @schema.singular %>} ->
+        <%= inspect @context.alias %>.deliver_update_email_instructions(
+          applied_<%= @schema.singular %>,
+          <%= @schema.singular %>.email,
+          &Routes.<%= @schema.route_helper %>_settings_url(conn, :confirm_email, &1)
         )
 
         conn
@@ -27,7 +27,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           :info,
           "A link to confirm your email change has been sent to the new address."
         )
-        |> redirect(to: Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
+        |> redirect(to: Routes.<%= @schema.route_helper %>_settings_path(conn, :edit))
 
       {:error, changeset} ->
         render(conn, "edit.html", email_changeset: changeset)
@@ -35,15 +35,15 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def update(conn, %{"action" => "update_password"} = params) do
-    %{"current_password" => password, "<%= schema.singular %>" => <%= schema.singular %>_params} = params
-    <%= schema.singular %> = conn.assigns.current_<%= schema.singular %>
+    %{"current_password" => password, "<%= @schema.singular %>" => <%= @schema.singular %>_params} = params
+    <%= @schema.singular %> = conn.assigns.current_<%= @schema.singular %>
 
-    case <%= inspect context.alias %>.update_<%= schema.singular %>_password(<%= schema.singular %>, password, <%= schema.singular %>_params) do
-      {:ok, <%= schema.singular %>} ->
+    case <%= inspect @context.alias %>.update_<%= @schema.singular %>_password(<%= @schema.singular %>, password, <%= @schema.singular %>_params) do
+      {:ok, <%= @schema.singular %>} ->
         conn
         |> put_flash(:info, "Password updated successfully.")
-        |> put_session(:<%= schema.singular %>_return_to, Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
-        |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
+        |> put_session(:<%= @schema.singular %>_return_to, Routes.<%= @schema.route_helper %>_settings_path(conn, :edit))
+        |> <%= inspect @schema.alias %>Auth.log_in_<%= @schema.singular %>(<%= @schema.singular %>)
 
       {:error, changeset} ->
         render(conn, "edit.html", password_changeset: changeset)
@@ -51,24 +51,24 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def confirm_email(conn, %{"token" => token}) do
-    case <%= inspect context.alias %>.update_<%= schema.singular %>_email(conn.assigns.current_<%= schema.singular %>, token) do
+    case <%= inspect @context.alias %>.update_<%= @schema.singular %>_email(conn.assigns.current_<%= @schema.singular %>, token) do
       :ok ->
         conn
         |> put_flash(:info, "Email changed successfully.")
-        |> redirect(to: Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
+        |> redirect(to: Routes.<%= @schema.route_helper %>_settings_path(conn, :edit))
 
       :error ->
         conn
         |> put_flash(:error, "Email change link is invalid or it has expired.")
-        |> redirect(to: Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
+        |> redirect(to: Routes.<%= @schema.route_helper %>_settings_path(conn, :edit))
     end
   end
 
   defp assign_email_and_password_changesets(conn, _opts) do
-    <%= schema.singular %> = conn.assigns.current_<%= schema.singular %>
+    <%= @schema.singular %> = conn.assigns.current_<%= @schema.singular %>
 
     conn
-    |> assign(:email_changeset, <%= inspect context.alias %>.change_<%= schema.singular %>_email(<%= schema.singular %>))
-    |> assign(:password_changeset, <%= inspect context.alias %>.change_<%= schema.singular %>_password(<%= schema.singular %>))
+    |> assign(:email_changeset, <%= inspect @context.alias %>.change_<%= @schema.singular %>_email(<%= @schema.singular %>))
+    |> assign(:password_changeset, <%= inspect @context.alias %>.change_<%= @schema.singular %>_password(<%= @schema.singular %>))
   end
 end

--- a/priv/templates/phx.gen.auth/settings_controller_test.exs
+++ b/priv/templates/phx.gen.auth/settings_controller_test.exs
@@ -1,49 +1,49 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>SettingsControllerTest do
-  use <%= inspect context.web_module %>.ConnCase<%= test_case_options %>
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>SettingsControllerTest do
+  use <%= inspect @context.web_module %>.ConnCase<%= @test_case_options %>
 
-  alias <%= inspect context.module %>
-  import <%= inspect context.module %>Fixtures
+  alias <%= inspect @context.module %>
+  import <%= inspect @context.module %>Fixtures
 
-  setup :register_and_log_in_<%= schema.singular %>
+  setup :register_and_log_in_<%= @schema.singular %>
 
-  describe "GET <%= web_path_prefix %>/<%= schema.plural %>/settings" do
+  describe "GET <%= @web_path_prefix %>/<%= @schema.plural %>/settings" do
     test "renders settings page", %{conn: conn} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :edit))
       response = html_response(conn, 200)
       assert response =~ "<h1>Settings</h1>"
     end
 
-    test "redirects if <%= schema.singular %> is not logged in" do
+    test "redirects if <%= @schema.singular %> is not logged in" do
       conn = build_conn()
-      conn = get(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :edit))
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_session_path(conn, :new)
+      conn = get(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :edit))
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_session_path(conn, :new)
     end
   end
 
-  describe "PUT <%= web_path_prefix %>/<%= schema.plural %>/settings (change password form)" do
-    test "updates the <%= schema.singular %> password and resets tokens", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+  describe "PUT <%= @web_path_prefix %>/<%= @schema.plural %>/settings (change password form)" do
+    test "updates the <%= @schema.singular %> password and resets tokens", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       new_password_conn =
-        put(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :update), %{
+        put(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :update), %{
           "action" => "update_password",
-          "current_password" => valid_<%= schema.singular %>_password(),
-          "<%= schema.singular %>" => %{
+          "current_password" => valid_<%= @schema.singular %>_password(),
+          "<%= @schema.singular %>" => %{
             "password" => "new valid password",
             "password_confirmation" => "new valid password"
           }
         })
 
-      assert redirected_to(new_password_conn) == Routes.<%= schema.route_helper %>_settings_path(conn, :edit)
-      assert get_session(new_password_conn, :<%= schema.singular %>_token) != get_session(conn, :<%= schema.singular %>_token)
+      assert redirected_to(new_password_conn) == Routes.<%= @schema.route_helper %>_settings_path(conn, :edit)
+      assert get_session(new_password_conn, :<%= @schema.singular %>_token) != get_session(conn, :<%= @schema.singular %>_token)
       assert get_flash(new_password_conn, :info) =~ "Password updated successfully"
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(<%= schema.singular %>.email, "new valid password")
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email_and_password(<%= @schema.singular %>.email, "new valid password")
     end
 
     test "does not update password on invalid data", %{conn: conn} do
       old_password_conn =
-        put(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :update), %{
+        put(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :update), %{
           "action" => "update_password",
           "current_password" => "invalid",
-          "<%= schema.singular %>" => %{
+          "<%= @schema.singular %>" => %{
             "password" => "too short",
             "password_confirmation" => "does not match"
           }
@@ -55,31 +55,31 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       assert response =~ "does not match password"
       assert response =~ "is not valid"
 
-      assert get_session(old_password_conn, :<%= schema.singular %>_token) == get_session(conn, :<%= schema.singular %>_token)
+      assert get_session(old_password_conn, :<%= @schema.singular %>_token) == get_session(conn, :<%= @schema.singular %>_token)
     end
   end
 
-  describe "PUT <%= web_path_prefix %>/<%= schema.plural %>/settings (change email form)" do
+  describe "PUT <%= @web_path_prefix %>/<%= @schema.plural %>/settings (change email form)" do
     @tag :capture_log
-    test "updates the <%= schema.singular %> email", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+    test "updates the <%= @schema.singular %> email", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
       conn =
-        put(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :update), %{
+        put(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :update), %{
           "action" => "update_email",
-          "current_password" => valid_<%= schema.singular %>_password(),
-          "<%= schema.singular %>" => %{"email" => unique_<%= schema.singular %>_email()}
+          "current_password" => valid_<%= @schema.singular %>_password(),
+          "<%= @schema.singular %>" => %{"email" => unique_<%= @schema.singular %>_email()}
         })
 
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_settings_path(conn, :edit)
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_settings_path(conn, :edit)
       assert get_flash(conn, :info) =~ "A link to confirm your email"
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(<%= schema.singular %>.email)
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email(<%= @schema.singular %>.email)
     end
 
     test "does not update email on invalid data", %{conn: conn} do
       conn =
-        put(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :update), %{
+        put(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :update), %{
           "action" => "update_email",
           "current_password" => "invalid",
-          "<%= schema.singular %>" => %{"email" => "with spaces"}
+          "<%= @schema.singular %>" => %{"email" => "with spaces"}
         })
 
       response = html_response(conn, 200)
@@ -89,41 +89,41 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
   end
 
-  describe "GET <%= web_path_prefix %>/<%= schema.plural %>/settings/confirm_email/:token" do
-    setup %{<%= schema.singular %>: <%= schema.singular %>} do
-      email = unique_<%= schema.singular %>_email()
+  describe "GET <%= @web_path_prefix %>/<%= @schema.plural %>/settings/confirm_email/:token" do
+    setup %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      email = unique_<%= @schema.singular %>_email()
 
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_update_email_instructions(%{<%= schema.singular %> | email: email}, <%= schema.singular %>.email, url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_update_email_instructions(%{<%= @schema.singular %> | email: email}, <%= @schema.singular %>.email, url)
         end)
 
       %{token: token, email: email}
     end
 
-    test "updates the <%= schema.singular %> email once", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>, token: token, email: email} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :confirm_email, token))
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_settings_path(conn, :edit)
+    test "updates the <%= @schema.singular %> email once", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>, token: token, email: email} do
+      conn = get(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :confirm_email, token))
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_settings_path(conn, :edit)
       assert get_flash(conn, :info) =~ "Email changed successfully"
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(<%= schema.singular %>.email)
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(email)
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email(<%= @schema.singular %>.email)
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email(email)
 
-      conn = get(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :confirm_email, token))
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_settings_path(conn, :edit)
+      conn = get(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :confirm_email, token))
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_settings_path(conn, :edit)
       assert get_flash(conn, :error) =~ "Email change link is invalid or it has expired"
     end
 
-    test "does not update email with invalid token", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :confirm_email, "oops"))
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_settings_path(conn, :edit)
+    test "does not update email with invalid token", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = get(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :confirm_email, "oops"))
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_settings_path(conn, :edit)
       assert get_flash(conn, :error) =~ "Email change link is invalid or it has expired"
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(<%= schema.singular %>.email)
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email(<%= @schema.singular %>.email)
     end
 
-    test "redirects if <%= schema.singular %> is not logged in", %{token: token} do
+    test "redirects if <%= @schema.singular %> is not logged in", %{token: token} do
       conn = build_conn()
-      conn = get(conn, Routes.<%= schema.route_helper %>_settings_path(conn, :confirm_email, token))
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_session_path(conn, :new)
+      conn = get(conn, Routes.<%= @schema.route_helper %>_settings_path(conn, :confirm_email, token))
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_session_path(conn, :new)
     end
   end
 end

--- a/priv/templates/phx.gen.auth/settings_edit.html.eex
+++ b/priv/templates/phx.gen.auth/settings_edit.html.eex
@@ -2,7 +2,7 @@
 
 <h3>Change email</h3>
 
-<%%= form_for @email_changeset, Routes.<%= schema.route_helper %>_settings_path(@conn, :update), fn f -> %>
+<%%= form_for @email_changeset, Routes.<%= @schema.route_helper %>_settings_path(@conn, :update), fn f -> %>
   <%%= if @email_changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong! Please check the errors below.</p>
@@ -26,7 +26,7 @@
 
 <h3>Change password</h3>
 
-<%%= form_for @password_changeset, Routes.<%= schema.route_helper %>_settings_path(@conn, :update), fn f -> %>
+<%%= form_for @password_changeset, Routes.<%= @schema.route_helper %>_settings_path(@conn, :update), fn f -> %>
   <%%= if @password_changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong! Please check the errors below.</p>

--- a/priv/templates/phx.gen.auth/settings_view.ex
+++ b/priv/templates/phx.gen.auth/settings_view.ex
@@ -1,3 +1,3 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>SettingsView do
-  use <%= inspect context.web_module %>, :view
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>SettingsView do
+  use <%= inspect @context.web_module %>, :view
 end

--- a/priv/templates/phx.gen.auth/test_cases.exs
+++ b/priv/templates/phx.gen.auth/test_cases.exs
@@ -1,51 +1,51 @@
-  import <%= inspect context.module %>Fixtures
-  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Token}
+  import <%= inspect @context.module %>Fixtures
+  alias <%= inspect @context.module %>.{<%= inspect @schema.alias %>, <%= inspect @schema.alias %>Token}
 
-  describe "get_<%= schema.singular %>_by_email/1" do
-    test "does not return the <%= schema.singular %> if the email does not exist" do
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_email("unknown@example.com")
+  describe "get_<%= @schema.singular %>_by_email/1" do
+    test "does not return the <%= @schema.singular %> if the email does not exist" do
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email("unknown@example.com")
     end
 
-    test "returns the <%= schema.singular %> if the email exists" do
-      %{id: id} = <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert %<%= inspect schema.alias %>{id: ^id} = <%= inspect context.alias %>.get_<%= schema.singular %>_by_email(<%= schema.singular %>.email)
-    end
-  end
-
-  describe "get_<%= schema.singular %>_by_email_and_password/2" do
-    test "does not return the <%= schema.singular %> if the email does not exist" do
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password("unknown@example.com", "hello world!")
-    end
-
-    test "does not return the <%= schema.singular %> if the password is not valid" do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(<%= schema.singular %>.email, "invalid")
-    end
-
-    test "returns the <%= schema.singular %> if the email and password are valid" do
-      %{id: id} = <%= schema.singular %> = <%= schema.singular %>_fixture()
-
-      assert %<%= inspect schema.alias %>{id: ^id} =
-               <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(<%= schema.singular %>.email, valid_<%= schema.singular %>_password())
+    test "returns the <%= @schema.singular %> if the email exists" do
+      %{id: id} = <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      assert %<%= inspect @schema.alias %>{id: ^id} = <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email(<%= @schema.singular %>.email)
     end
   end
 
-  describe "get_<%= schema.singular %>!/1" do
+  describe "get_<%= @schema.singular %>_by_email_and_password/2" do
+    test "does not return the <%= @schema.singular %> if the email does not exist" do
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email_and_password("unknown@example.com", "hello world!")
+    end
+
+    test "does not return the <%= @schema.singular %> if the password is not valid" do
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email_and_password(<%= @schema.singular %>.email, "invalid")
+    end
+
+    test "returns the <%= @schema.singular %> if the email and password are valid" do
+      %{id: id} = <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+
+      assert %<%= inspect @schema.alias %>{id: ^id} =
+               <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email_and_password(<%= @schema.singular %>.email, valid_<%= @schema.singular %>_password())
+    end
+  end
+
+  describe "get_<%= @schema.singular %>!/1" do
     test "raises if id is invalid" do
       assert_raise Ecto.NoResultsError, fn ->
-        <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= inspect schema.sample_id %>)
+        <%= inspect @context.alias %>.get_<%= @schema.singular %>!(<%= inspect @schema.sample_id %>)
       end
     end
 
-    test "returns the <%= schema.singular %> with the given id" do
-      %{id: id} = <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert %<%= inspect schema.alias %>{id: ^id} = <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id)
+    test "returns the <%= @schema.singular %> with the given id" do
+      %{id: id} = <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      assert %<%= inspect @schema.alias %>{id: ^id} = <%= inspect @context.alias %>.get_<%= @schema.singular %>!(<%= @schema.singular %>.id)
     end
   end
 
-  describe "register_<%= schema.singular %>/1" do
+  describe "register_<%= @schema.singular %>/1" do
     test "requires email and password to be set" do
-      {:error, changeset} = <%= inspect context.alias %>.register_<%= schema.singular %>(%{})
+      {:error, changeset} = <%= inspect @context.alias %>.register_<%= @schema.singular %>(%{})
 
       assert %{
                password: ["can't be blank"],
@@ -54,7 +54,7 @@
     end
 
     test "validates email and password when given" do
-      {:error, changeset} = <%= inspect context.alias %>.register_<%= schema.singular %>(%{email: "not valid", password: "not valid"})
+      {:error, changeset} = <%= inspect @context.alias %>.register_<%= @schema.singular %>(%{email: "not valid", password: "not valid"})
 
       assert %{
                email: ["must have the @ sign and no spaces"],
@@ -64,43 +64,43 @@
 
     test "validates maximum values for email and password for security" do
       too_long = String.duplicate("db", 100)
-      {:error, changeset} = <%= inspect context.alias %>.register_<%= schema.singular %>(%{email: too_long, password: too_long})
+      {:error, changeset} = <%= inspect @context.alias %>.register_<%= @schema.singular %>(%{email: too_long, password: too_long})
       assert "should be at most 160 character(s)" in errors_on(changeset).email
       assert "should be at most 80 character(s)" in errors_on(changeset).password
     end
 
     test "validates email uniqueness" do
-      %{email: email} = <%= schema.singular %>_fixture()
-      {:error, changeset} = <%= inspect context.alias %>.register_<%= schema.singular %>(%{email: email})
+      %{email: email} = <%= @schema.singular %>_fixture()
+      {:error, changeset} = <%= inspect @context.alias %>.register_<%= @schema.singular %>(%{email: email})
       assert "has already been taken" in errors_on(changeset).email
 
       # Now try with the upper cased email too, to check that email case is ignored.
-      {:error, changeset} = <%= inspect context.alias %>.register_<%= schema.singular %>(%{email: String.upcase(email)})
+      {:error, changeset} = <%= inspect @context.alias %>.register_<%= @schema.singular %>(%{email: String.upcase(email)})
       assert "has already been taken" in errors_on(changeset).email
     end
 
-    test "registers <%= schema.plural %> with a hashed password" do
-      email = unique_<%= schema.singular %>_email()
-      {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.register_<%= schema.singular %>(%{email: email, password: valid_<%= schema.singular %>_password()})
-      assert <%= schema.singular %>.email == email
-      assert is_binary(<%= schema.singular %>.hashed_password)
-      assert is_nil(<%= schema.singular %>.confirmed_at)
-      assert is_nil(<%= schema.singular %>.password)
+    test "registers <%= @schema.plural %> with a hashed password" do
+      email = unique_<%= @schema.singular %>_email()
+      {:ok, <%= @schema.singular %>} = <%= inspect @context.alias %>.register_<%= @schema.singular %>(%{email: email, password: valid_<%= @schema.singular %>_password()})
+      assert <%= @schema.singular %>.email == email
+      assert is_binary(<%= @schema.singular %>.hashed_password)
+      assert is_nil(<%= @schema.singular %>.confirmed_at)
+      assert is_nil(<%= @schema.singular %>.password)
     end
   end
 
-  describe "change_<%= schema.singular %>_registration/2" do
+  describe "change_<%= @schema.singular %>_registration/2" do
     test "returns a changeset" do
-      assert %Ecto.Changeset{} = changeset = <%= inspect context.alias %>.change_<%= schema.singular %>_registration(%<%= inspect schema.alias %>{})
+      assert %Ecto.Changeset{} = changeset = <%= inspect @context.alias %>.change_<%= @schema.singular %>_registration(%<%= inspect @schema.alias %>{})
       assert changeset.required == [:password, :email]
     end
 
     test "allows fields to be set" do
-      email = unique_<%= schema.singular %>_email()
-      password = valid_<%= schema.singular %>_password()
+      email = unique_<%= @schema.singular %>_email()
+      password = valid_<%= @schema.singular %>_password()
 
       changeset =
-        <%= inspect context.alias %>.change_<%= schema.singular %>_registration(%<%= inspect schema.alias %>{}, %{"email" => email, "password" => password})
+        <%= inspect @context.alias %>.change_<%= @schema.singular %>_registration(%<%= inspect @schema.alias %>{}, %{"email" => email, "password" => password})
 
       assert changeset.valid?
       assert get_change(changeset, :email) == email
@@ -109,134 +109,134 @@
     end
   end
 
-  describe "change_<%= schema.singular %>_email/2" do
-    test "returns a <%= schema.singular %> changeset" do
-      assert %Ecto.Changeset{} = changeset = <%= inspect context.alias %>.change_<%= schema.singular %>_email(%<%= inspect schema.alias %>{})
+  describe "change_<%= @schema.singular %>_email/2" do
+    test "returns a <%= @schema.singular %> changeset" do
+      assert %Ecto.Changeset{} = changeset = <%= inspect @context.alias %>.change_<%= @schema.singular %>_email(%<%= inspect @schema.alias %>{})
       assert changeset.required == [:email]
     end
   end
 
-  describe "apply_<%= schema.singular %>_email/3" do
+  describe "apply_<%= @schema.singular %>_email/3" do
     setup do
-      %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+      %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
     end
 
-    test "requires email to change", %{<%= schema.singular %>: <%= schema.singular %>} do
-      {:error, changeset} = <%= inspect context.alias %>.apply_<%= schema.singular %>_email(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{})
+    test "requires email to change", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      {:error, changeset} = <%= inspect @context.alias %>.apply_<%= @schema.singular %>_email(<%= @schema.singular %>, valid_<%= @schema.singular %>_password(), %{})
       assert %{email: ["did not change"]} = errors_on(changeset)
     end
 
-    test "validates email", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates email", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       {:error, changeset} =
-        <%= inspect context.alias %>.apply_<%= schema.singular %>_email(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{email: "not valid"})
+        <%= inspect @context.alias %>.apply_<%= @schema.singular %>_email(<%= @schema.singular %>, valid_<%= @schema.singular %>_password(), %{email: "not valid"})
 
       assert %{email: ["must have the @ sign and no spaces"]} = errors_on(changeset)
     end
 
-    test "validates maximum value for email for security", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates maximum value for email for security", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       too_long = String.duplicate("db", 100)
 
       {:error, changeset} =
-        <%= inspect context.alias %>.apply_<%= schema.singular %>_email(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{email: too_long})
+        <%= inspect @context.alias %>.apply_<%= @schema.singular %>_email(<%= @schema.singular %>, valid_<%= @schema.singular %>_password(), %{email: too_long})
 
       assert "should be at most 160 character(s)" in errors_on(changeset).email
     end
 
-    test "validates email uniqueness", %{<%= schema.singular %>: <%= schema.singular %>} do
-      %{email: email} = <%= schema.singular %>_fixture()
+    test "validates email uniqueness", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      %{email: email} = <%= @schema.singular %>_fixture()
 
       {:error, changeset} =
-        <%= inspect context.alias %>.apply_<%= schema.singular %>_email(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{email: email})
+        <%= inspect @context.alias %>.apply_<%= @schema.singular %>_email(<%= @schema.singular %>, valid_<%= @schema.singular %>_password(), %{email: email})
 
       assert "has already been taken" in errors_on(changeset).email
     end
 
-    test "validates current password", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates current password", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       {:error, changeset} =
-        <%= inspect context.alias %>.apply_<%= schema.singular %>_email(<%= schema.singular %>, "invalid", %{email: unique_<%= schema.singular %>_email()})
+        <%= inspect @context.alias %>.apply_<%= @schema.singular %>_email(<%= @schema.singular %>, "invalid", %{email: unique_<%= @schema.singular %>_email()})
 
       assert %{current_password: ["is not valid"]} = errors_on(changeset)
     end
 
-    test "applies the email without persisting it", %{<%= schema.singular %>: <%= schema.singular %>} do
-      email = unique_<%= schema.singular %>_email()
-      {:ok, <%= schema.singular %>} = <%= inspect context.alias %>.apply_<%= schema.singular %>_email(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{email: email})
-      assert <%= schema.singular %>.email == email
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id).email != email
+    test "applies the email without persisting it", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      email = unique_<%= @schema.singular %>_email()
+      {:ok, <%= @schema.singular %>} = <%= inspect @context.alias %>.apply_<%= @schema.singular %>_email(<%= @schema.singular %>, valid_<%= @schema.singular %>_password(), %{email: email})
+      assert <%= @schema.singular %>.email == email
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>!(<%= @schema.singular %>.id).email != email
     end
   end
 
   describe "deliver_update_email_instructions/3" do
     setup do
-      %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+      %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
     end
 
-    test "sends token through notification", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "sends token through notification", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_update_email_instructions(<%= schema.singular %>, "current@example.com", url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_update_email_instructions(<%= @schema.singular %>, "current@example.com", url)
         end)
 
       {:ok, token} = Base.url_decode64(token, padding: false)
-      assert <%= schema.singular %>_token = Repo.get_by(<%= inspect schema.alias %>Token, token: :crypto.hash(:sha256, token))
-      assert <%= schema.singular %>_token.<%= schema.singular %>_id == <%= schema.singular %>.id
-      assert <%= schema.singular %>_token.sent_to == <%= schema.singular %>.email
-      assert <%= schema.singular %>_token.context == "change:current@example.com"
+      assert <%= @schema.singular %>_token = Repo.get_by(<%= inspect @schema.alias %>Token, token: :crypto.hash(:sha256, token))
+      assert <%= @schema.singular %>_token.<%= @schema.singular %>_id == <%= @schema.singular %>.id
+      assert <%= @schema.singular %>_token.sent_to == <%= @schema.singular %>.email
+      assert <%= @schema.singular %>_token.context == "change:current@example.com"
     end
   end
 
-  describe "update_<%= schema.singular %>_email/2" do
+  describe "update_<%= @schema.singular %>_email/2" do
     setup do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      email = unique_<%= schema.singular %>_email()
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      email = unique_<%= @schema.singular %>_email()
 
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_update_email_instructions(%{<%= schema.singular %> | email: email}, <%= schema.singular %>.email, url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_update_email_instructions(%{<%= @schema.singular %> | email: email}, <%= @schema.singular %>.email, url)
         end)
 
-      %{<%= schema.singular %>: <%= schema.singular %>, token: token, email: email}
+      %{<%= @schema.singular %>: <%= @schema.singular %>, token: token, email: email}
     end
 
-    test "updates the email with a valid token", %{<%= schema.singular %>: <%= schema.singular %>, token: token, email: email} do
-      assert <%= inspect context.alias %>.update_<%= schema.singular %>_email(<%= schema.singular %>, token) == :ok
-      changed_<%= schema.singular %> = Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id)
-      assert changed_<%= schema.singular %>.email != <%= schema.singular %>.email
-      assert changed_<%= schema.singular %>.email == email
-      assert changed_<%= schema.singular %>.confirmed_at
-      assert changed_<%= schema.singular %>.confirmed_at != <%= schema.singular %>.confirmed_at
-      refute Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "updates the email with a valid token", %{<%= @schema.singular %>: <%= @schema.singular %>, token: token, email: email} do
+      assert <%= inspect @context.alias %>.update_<%= @schema.singular %>_email(<%= @schema.singular %>, token) == :ok
+      changed_<%= @schema.singular %> = Repo.get!(<%= inspect @schema.alias %>, <%= @schema.singular %>.id)
+      assert changed_<%= @schema.singular %>.email != <%= @schema.singular %>.email
+      assert changed_<%= @schema.singular %>.email == email
+      assert changed_<%= @schema.singular %>.confirmed_at
+      assert changed_<%= @schema.singular %>.confirmed_at != <%= @schema.singular %>.confirmed_at
+      refute Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
 
-    test "does not update email with invalid token", %{<%= schema.singular %>: <%= schema.singular %>} do
-      assert <%= inspect context.alias %>.update_<%= schema.singular %>_email(<%= schema.singular %>, "oops") == :error
-      assert Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).email == <%= schema.singular %>.email
-      assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "does not update email with invalid token", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      assert <%= inspect @context.alias %>.update_<%= @schema.singular %>_email(<%= @schema.singular %>, "oops") == :error
+      assert Repo.get!(<%= inspect @schema.alias %>, <%= @schema.singular %>.id).email == <%= @schema.singular %>.email
+      assert Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
 
-    test "does not update email if <%= schema.singular %> email changed", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
-      assert <%= inspect context.alias %>.update_<%= schema.singular %>_email(%{<%= schema.singular %> | email: "current@example.com"}, token) == :error
-      assert Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).email == <%= schema.singular %>.email
-      assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "does not update email if <%= @schema.singular %> email changed", %{<%= @schema.singular %>: <%= @schema.singular %>, token: token} do
+      assert <%= inspect @context.alias %>.update_<%= @schema.singular %>_email(%{<%= @schema.singular %> | email: "current@example.com"}, token) == :error
+      assert Repo.get!(<%= inspect @schema.alias %>, <%= @schema.singular %>.id).email == <%= @schema.singular %>.email
+      assert Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
 
-    test "does not update email if token expired", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
-      {1, nil} = Repo.update_all(<%= inspect schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
-      assert <%= inspect context.alias %>.update_<%= schema.singular %>_email(<%= schema.singular %>, token) == :error
-      assert Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).email == <%= schema.singular %>.email
-      assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "does not update email if token expired", %{<%= @schema.singular %>: <%= @schema.singular %>, token: token} do
+      {1, nil} = Repo.update_all(<%= inspect @schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+      assert <%= inspect @context.alias %>.update_<%= @schema.singular %>_email(<%= @schema.singular %>, token) == :error
+      assert Repo.get!(<%= inspect @schema.alias %>, <%= @schema.singular %>.id).email == <%= @schema.singular %>.email
+      assert Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
   end
 
-  describe "change_<%= schema.singular %>_password/2" do
-    test "returns a <%= schema.singular %> changeset" do
-      assert %Ecto.Changeset{} = changeset = <%= inspect context.alias %>.change_<%= schema.singular %>_password(%<%= inspect schema.alias %>{})
+  describe "change_<%= @schema.singular %>_password/2" do
+    test "returns a <%= @schema.singular %> changeset" do
+      assert %Ecto.Changeset{} = changeset = <%= inspect @context.alias %>.change_<%= @schema.singular %>_password(%<%= inspect @schema.alias %>{})
       assert changeset.required == [:password]
     end
 
     test "allows fields to be set" do
       changeset =
-        <%= inspect context.alias %>.change_<%= schema.singular %>_password(%<%= inspect schema.alias %>{}, %{
+        <%= inspect @context.alias %>.change_<%= @schema.singular %>_password(%<%= inspect @schema.alias %>{}, %{
           "password" => "new valid password"
         })
 
@@ -246,14 +246,14 @@
     end
   end
 
-  describe "update_<%= schema.singular %>_password/3" do
+  describe "update_<%= @schema.singular %>_password/3" do
     setup do
-      %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+      %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
     end
 
-    test "validates password", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates password", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       {:error, changeset} =
-        <%= inspect context.alias %>.update_<%= schema.singular %>_password(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{
+        <%= inspect @context.alias %>.update_<%= @schema.singular %>_password(<%= @schema.singular %>, valid_<%= @schema.singular %>_password(), %{
           password: "not valid",
           password_confirmation: "another"
         })
@@ -264,205 +264,205 @@
              } = errors_on(changeset)
     end
 
-    test "validates maximum values for password for security", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates maximum values for password for security", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       too_long = String.duplicate("db", 100)
 
       {:error, changeset} =
-        <%= inspect context.alias %>.update_<%= schema.singular %>_password(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{password: too_long})
+        <%= inspect @context.alias %>.update_<%= @schema.singular %>_password(<%= @schema.singular %>, valid_<%= @schema.singular %>_password(), %{password: too_long})
 
       assert "should be at most 80 character(s)" in errors_on(changeset).password
     end
 
-    test "validates current password", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates current password", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       {:error, changeset} =
-        <%= inspect context.alias %>.update_<%= schema.singular %>_password(<%= schema.singular %>, "invalid", %{password: valid_<%= schema.singular %>_password()})
+        <%= inspect @context.alias %>.update_<%= @schema.singular %>_password(<%= @schema.singular %>, "invalid", %{password: valid_<%= @schema.singular %>_password()})
 
       assert %{current_password: ["is not valid"]} = errors_on(changeset)
     end
 
-    test "updates the password", %{<%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, <%= schema.singular %>} =
-        <%= inspect context.alias %>.update_<%= schema.singular %>_password(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{
+    test "updates the password", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      {:ok, <%= @schema.singular %>} =
+        <%= inspect @context.alias %>.update_<%= @schema.singular %>_password(<%= @schema.singular %>, valid_<%= @schema.singular %>_password(), %{
           password: "new valid password"
         })
 
-      assert is_nil(<%= schema.singular %>.password)
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(<%= schema.singular %>.email, "new valid password")
+      assert is_nil(<%= @schema.singular %>.password)
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email_and_password(<%= @schema.singular %>.email, "new valid password")
     end
 
-    test "deletes all tokens for the given <%= schema.singular %>", %{<%= schema.singular %>: <%= schema.singular %>} do
-      _ = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+    test "deletes all tokens for the given <%= @schema.singular %>", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      _ = <%= inspect @context.alias %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
 
       {:ok, _} =
-        <%= inspect context.alias %>.update_<%= schema.singular %>_password(<%= schema.singular %>, valid_<%= schema.singular %>_password(), %{
+        <%= inspect @context.alias %>.update_<%= @schema.singular %>_password(<%= @schema.singular %>, valid_<%= @schema.singular %>_password(), %{
           password: "new valid password"
         })
 
-      refute Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+      refute Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
   end
 
-  describe "generate_<%= schema.singular %>_session_token/1" do
+  describe "generate_<%= @schema.singular %>_session_token/1" do
     setup do
-      %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+      %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
     end
 
-    test "generates a token", %{<%= schema.singular %>: <%= schema.singular %>} do
-      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
-      assert <%= schema.singular %>_token = Repo.get_by(<%= inspect schema.alias %>Token, token: token)
-      assert <%= schema.singular %>_token.context == "session"
+    test "generates a token", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      token = <%= inspect @context.alias %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
+      assert <%= @schema.singular %>_token = Repo.get_by(<%= inspect @schema.alias %>Token, token: token)
+      assert <%= @schema.singular %>_token.context == "session"
 
-      # Creating the same token for another <%= schema.singular %> should fail
+      # Creating the same token for another <%= @schema.singular %> should fail
       assert_raise Ecto.ConstraintError, fn ->
-        Repo.insert!(%<%= inspect schema.alias %>Token{
-          token: <%= schema.singular %>_token.token,
-          <%= schema.singular %>_id: <%= schema.singular %>_fixture().id,
+        Repo.insert!(%<%= inspect @schema.alias %>Token{
+          token: <%= @schema.singular %>_token.token,
+          <%= @schema.singular %>_id: <%= @schema.singular %>_fixture().id,
           context: "session"
         })
       end
     end
   end
 
-  describe "get_<%= schema.singular %>_by_session_token/1" do
+  describe "get_<%= @schema.singular %>_by_session_token/1" do
     setup do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
-      %{<%= schema.singular %>: <%= schema.singular %>, token: token}
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      token = <%= inspect @context.alias %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
+      %{<%= @schema.singular %>: <%= @schema.singular %>, token: token}
     end
 
-    test "returns <%= schema.singular %> by token", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
-      assert session_<%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token)
-      assert session_<%= schema.singular %>.id == <%= schema.singular %>.id
+    test "returns <%= @schema.singular %> by token", %{<%= @schema.singular %>: <%= @schema.singular %>, token: token} do
+      assert session_<%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_session_token(token)
+      assert session_<%= @schema.singular %>.id == <%= @schema.singular %>.id
     end
 
-    test "does not return <%= schema.singular %> for invalid token" do
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token("oops")
+    test "does not return <%= @schema.singular %> for invalid token" do
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_session_token("oops")
     end
 
-    test "does not return <%= schema.singular %> for expired token", %{token: token} do
-      {1, nil} = Repo.update_all(<%= inspect schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token)
+    test "does not return <%= @schema.singular %> for expired token", %{token: token} do
+      {1, nil} = Repo.update_all(<%= inspect @schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_session_token(token)
     end
   end
 
   describe "delete_session_token/1" do
     test "deletes the token" do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
-      assert <%= inspect context.alias %>.delete_session_token(token) == :ok
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token)
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      token = <%= inspect @context.alias %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
+      assert <%= inspect @context.alias %>.delete_session_token(token) == :ok
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_session_token(token)
     end
   end
 
-  describe "deliver_<%= schema.singular %>_confirmation_instructions/2" do
+  describe "deliver_<%= @schema.singular %>_confirmation_instructions/2" do
     setup do
-      %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+      %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
     end
 
-    test "sends token through notification", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "sends token through notification", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_<%= schema.singular %>_confirmation_instructions(<%= schema.singular %>, url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_confirmation_instructions(<%= @schema.singular %>, url)
         end)
 
       {:ok, token} = Base.url_decode64(token, padding: false)
-      assert <%= schema.singular %>_token = Repo.get_by(<%= inspect schema.alias %>Token, token: :crypto.hash(:sha256, token))
-      assert <%= schema.singular %>_token.<%= schema.singular %>_id == <%= schema.singular %>.id
-      assert <%= schema.singular %>_token.sent_to == <%= schema.singular %>.email
-      assert <%= schema.singular %>_token.context == "confirm"
+      assert <%= @schema.singular %>_token = Repo.get_by(<%= inspect @schema.alias %>Token, token: :crypto.hash(:sha256, token))
+      assert <%= @schema.singular %>_token.<%= @schema.singular %>_id == <%= @schema.singular %>.id
+      assert <%= @schema.singular %>_token.sent_to == <%= @schema.singular %>.email
+      assert <%= @schema.singular %>_token.context == "confirm"
     end
   end
 
-  describe "confirm_<%= schema.singular %>/1" do
+  describe "confirm_<%= @schema.singular %>/1" do
     setup do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
 
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_<%= schema.singular %>_confirmation_instructions(<%= schema.singular %>, url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_confirmation_instructions(<%= @schema.singular %>, url)
         end)
 
-      %{<%= schema.singular %>: <%= schema.singular %>, token: token}
+      %{<%= @schema.singular %>: <%= @schema.singular %>, token: token}
     end
 
-    test "confirms the email with a valid token", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
-      assert {:ok, confirmed_<%= schema.singular %>} = <%= inspect context.alias %>.confirm_<%= schema.singular %>(token)
-      assert confirmed_<%= schema.singular %>.confirmed_at
-      assert confirmed_<%= schema.singular %>.confirmed_at != <%= schema.singular %>.confirmed_at
-      assert Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).confirmed_at
-      refute Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "confirms the email with a valid token", %{<%= @schema.singular %>: <%= @schema.singular %>, token: token} do
+      assert {:ok, confirmed_<%= @schema.singular %>} = <%= inspect @context.alias %>.confirm_<%= @schema.singular %>(token)
+      assert confirmed_<%= @schema.singular %>.confirmed_at
+      assert confirmed_<%= @schema.singular %>.confirmed_at != <%= @schema.singular %>.confirmed_at
+      assert Repo.get!(<%= inspect @schema.alias %>, <%= @schema.singular %>.id).confirmed_at
+      refute Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
 
-    test "does not confirm with invalid token", %{<%= schema.singular %>: <%= schema.singular %>} do
-      assert <%= inspect context.alias %>.confirm_<%= schema.singular %>("oops") == :error
-      refute Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).confirmed_at
-      assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "does not confirm with invalid token", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      assert <%= inspect @context.alias %>.confirm_<%= @schema.singular %>("oops") == :error
+      refute Repo.get!(<%= inspect @schema.alias %>, <%= @schema.singular %>.id).confirmed_at
+      assert Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
 
-    test "does not confirm email if token expired", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
-      {1, nil} = Repo.update_all(<%= inspect schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
-      assert <%= inspect context.alias %>.confirm_<%= schema.singular %>(token) == :error
-      refute Repo.get!(<%= inspect schema.alias %>, <%= schema.singular %>.id).confirmed_at
-      assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "does not confirm email if token expired", %{<%= @schema.singular %>: <%= @schema.singular %>, token: token} do
+      {1, nil} = Repo.update_all(<%= inspect @schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+      assert <%= inspect @context.alias %>.confirm_<%= @schema.singular %>(token) == :error
+      refute Repo.get!(<%= inspect @schema.alias %>, <%= @schema.singular %>.id).confirmed_at
+      assert Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
   end
 
-  describe "deliver_<%= schema.singular %>_reset_password_instructions/2" do
+  describe "deliver_<%= @schema.singular %>_reset_password_instructions/2" do
     setup do
-      %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+      %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
     end
 
-    test "sends token through notification", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "sends token through notification", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_<%= schema.singular %>_reset_password_instructions(<%= schema.singular %>, url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_reset_password_instructions(<%= @schema.singular %>, url)
         end)
 
       {:ok, token} = Base.url_decode64(token, padding: false)
-      assert <%= schema.singular %>_token = Repo.get_by(<%= inspect schema.alias %>Token, token: :crypto.hash(:sha256, token))
-      assert <%= schema.singular %>_token.<%= schema.singular %>_id == <%= schema.singular %>.id
-      assert <%= schema.singular %>_token.sent_to == <%= schema.singular %>.email
-      assert <%= schema.singular %>_token.context == "reset_password"
+      assert <%= @schema.singular %>_token = Repo.get_by(<%= inspect @schema.alias %>Token, token: :crypto.hash(:sha256, token))
+      assert <%= @schema.singular %>_token.<%= @schema.singular %>_id == <%= @schema.singular %>.id
+      assert <%= @schema.singular %>_token.sent_to == <%= @schema.singular %>.email
+      assert <%= @schema.singular %>_token.context == "reset_password"
     end
   end
 
-  describe "get_<%= schema.singular %>_by_reset_password_token/1" do
+  describe "get_<%= @schema.singular %>_by_reset_password_token/1" do
     setup do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
 
       token =
-        extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_<%= schema.singular %>_reset_password_instructions(<%= schema.singular %>, url)
+        extract_<%= @schema.singular %>_token(fn url ->
+          <%= inspect @context.alias %>.deliver_<%= @schema.singular %>_reset_password_instructions(<%= @schema.singular %>, url)
         end)
 
-      %{<%= schema.singular %>: <%= schema.singular %>, token: token}
+      %{<%= @schema.singular %>: <%= @schema.singular %>, token: token}
     end
 
-    test "returns the <%= schema.singular %> with valid token", %{<%= schema.singular %>: %{id: id}, token: token} do
-      assert %<%= inspect schema.alias %>{id: ^id} = <%= inspect context.alias %>.get_<%= schema.singular %>_by_reset_password_token(token)
-      assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: id)
+    test "returns the <%= @schema.singular %> with valid token", %{<%= @schema.singular %>: %{id: id}, token: token} do
+      assert %<%= inspect @schema.alias %>{id: ^id} = <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_reset_password_token(token)
+      assert Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: id)
     end
 
-    test "does not return the <%= schema.singular %> with invalid token", %{<%= schema.singular %>: <%= schema.singular %>} do
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_reset_password_token("oops")
-      assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "does not return the <%= @schema.singular %> with invalid token", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_reset_password_token("oops")
+      assert Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
 
-    test "does not return the <%= schema.singular %> if token expired", %{<%= schema.singular %>: <%= schema.singular %>, token: token} do
-      {1, nil} = Repo.update_all(<%= inspect schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
-      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_reset_password_token(token)
-      assert Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "does not return the <%= @schema.singular %> if token expired", %{<%= @schema.singular %>: <%= @schema.singular %>, token: token} do
+      {1, nil} = Repo.update_all(<%= inspect @schema.alias %>Token, set: [inserted_at: ~N[2020-01-01 00:00:00]])
+      refute <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_reset_password_token(token)
+      assert Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
   end
 
-  describe "reset_<%= schema.singular %>_password/2" do
+  describe "reset_<%= @schema.singular %>_password/2" do
     setup do
-      %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
+      %{<%= @schema.singular %>: <%= @schema.singular %>_fixture()}
     end
 
-    test "validates password", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates password", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       {:error, changeset} =
-        <%= inspect context.alias %>.reset_<%= schema.singular %>_password(<%= schema.singular %>, %{
+        <%= inspect @context.alias %>.reset_<%= @schema.singular %>_password(<%= @schema.singular %>, %{
           password: "not valid",
           password_confirmation: "another"
         })
@@ -473,27 +473,27 @@
              } = errors_on(changeset)
     end
 
-    test "validates maximum values for password for security", %{<%= schema.singular %>: <%= schema.singular %>} do
+    test "validates maximum values for password for security", %{<%= @schema.singular %>: <%= @schema.singular %>} do
       too_long = String.duplicate("db", 100)
-      {:error, changeset} = <%= inspect context.alias %>.reset_<%= schema.singular %>_password(<%= schema.singular %>, %{password: too_long})
+      {:error, changeset} = <%= inspect @context.alias %>.reset_<%= @schema.singular %>_password(<%= @schema.singular %>, %{password: too_long})
       assert "should be at most 80 character(s)" in errors_on(changeset).password
     end
 
-    test "updates the password", %{<%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, updated_<%= schema.singular %>} = <%= inspect context.alias %>.reset_<%= schema.singular %>_password(<%= schema.singular %>, %{password: "new valid password"})
-      assert is_nil(updated_<%= schema.singular %>.password)
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>_by_email_and_password(<%= schema.singular %>.email, "new valid password")
+    test "updates the password", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      {:ok, updated_<%= @schema.singular %>} = <%= inspect @context.alias %>.reset_<%= @schema.singular %>_password(<%= @schema.singular %>, %{password: "new valid password"})
+      assert is_nil(updated_<%= @schema.singular %>.password)
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>_by_email_and_password(<%= @schema.singular %>.email, "new valid password")
     end
 
-    test "deletes all tokens for the given <%= schema.singular %>", %{<%= schema.singular %>: <%= schema.singular %>} do
-      _ = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
-      {:ok, _} = <%= inspect context.alias %>.reset_<%= schema.singular %>_password(<%= schema.singular %>, %{password: "new valid password"})
-      refute Repo.get_by(<%= inspect schema.alias %>Token, <%= schema.singular %>_id: <%= schema.singular %>.id)
+    test "deletes all tokens for the given <%= @schema.singular %>", %{<%= @schema.singular %>: <%= @schema.singular %>} do
+      _ = <%= inspect @context.alias %>.generate_<%= @schema.singular %>_session_token(<%= @schema.singular %>)
+      {:ok, _} = <%= inspect @context.alias %>.reset_<%= @schema.singular %>_password(<%= @schema.singular %>, %{password: "new valid password"})
+      refute Repo.get_by(<%= inspect @schema.alias %>Token, <%= @schema.singular %>_id: <%= @schema.singular %>.id)
     end
   end
 
   describe "inspect/2" do
     test "does not include password" do
-      refute inspect(%<%= inspect schema.alias %>{password: "123456"}) =~ "password: \"123456\""
+      refute inspect(%<%= inspect @schema.alias %>{password: "123456"}) =~ "password: \"123456\""
     end
   end

--- a/priv/templates/phx.gen.channel/channel.ex
+++ b/priv/templates/phx.gen.channel/channel.ex
@@ -1,8 +1,8 @@
-defmodule <%= module %>Channel do
-  use <%= web_module %>, :channel
+defmodule <%= @module %>Channel do
+  use <%= @web_module %>, :channel
 
   @impl true
-  def join("<%= singular %>:lobby", payload, socket) do
+  def join("<%= @singular %>:lobby", payload, socket) do
     if authorized?(payload) do
       {:ok, socket}
     else
@@ -18,7 +18,7 @@ defmodule <%= module %>Channel do
   end
 
   # It is also common to receive messages from the client and
-  # broadcast to everyone in the current topic (<%= singular %>:lobby).
+  # broadcast to everyone in the current topic (<%= @singular %>:lobby).
   @impl true
   def handle_in("shout", payload, socket) do
     broadcast socket, "shout", payload

--- a/priv/templates/phx.gen.channel/channel_test.exs
+++ b/priv/templates/phx.gen.channel/channel_test.exs
@@ -1,11 +1,11 @@
-defmodule <%= module %>ChannelTest do
-  use <%= web_module %>.ChannelCase
+defmodule <%= @module %>ChannelTest do
+  use <%= @web_module %>.ChannelCase
 
   setup do
     {:ok, _, socket} =
-      <%= web_module %>.UserSocket
+      <%= @web_module %>.UserSocket
       |> socket("user_id", %{some: :assign})
-      |> subscribe_and_join(<%= module %>Channel, "<%= singular %>:lobby")
+      |> subscribe_and_join(<%= @module %>Channel, "<%= @singular %>:lobby")
 
     %{socket: socket}
   end
@@ -15,7 +15,7 @@ defmodule <%= module %>ChannelTest do
     assert_reply ref, :ok, %{"hello" => "there"}
   end
 
-  test "shout broadcasts to <%= singular %>:lobby", %{socket: socket} do
+  test "shout broadcasts to <%= @singular %>:lobby", %{socket: socket} do
     push socket, "shout", %{"hello" => "all"}
     assert_broadcast "shout", %{"hello" => "all"}
   end

--- a/priv/templates/phx.gen.context/access_no_schema.ex
+++ b/priv/templates/phx.gen.context/access_no_schema.ex
@@ -1,89 +1,89 @@
 
-  alias <%= inspect schema.module %>
+  alias <%= inspect @schema.module %>
 
   @doc """
-  Returns the list of <%= schema.plural %>.
+  Returns the list of <%= @schema.plural %>.
 
   ## Examples
 
-      iex> list_<%= schema.plural %>()
-      [%<%= inspect schema.alias %>{}, ...]
+      iex> list_<%= @schema.plural %>()
+      [%<%= inspect @schema.alias %>{}, ...]
 
   """
-  def list_<%= schema.plural %> do
+  def list_<%= @schema.plural %> do
     raise "TODO"
   end
 
   @doc """
-  Gets a single <%= schema.singular %>.
+  Gets a single <%= @schema.singular %>.
 
-  Raises if the <%= schema.human_singular %> does not exist.
+  Raises if the <%= @schema.human_singular %> does not exist.
 
   ## Examples
 
-      iex> get_<%= schema.singular %>!(123)
-      %<%= inspect schema.alias %>{}
+      iex> get_<%= @schema.singular %>!(123)
+      %<%= inspect @schema.alias %>{}
 
   """
-  def get_<%= schema.singular %>!(id), do: raise "TODO"
+  def get_<%= @schema.singular %>!(id), do: raise "TODO"
 
   @doc """
-  Creates a <%= schema.singular %>.
+  Creates a <%= @schema.singular %>.
 
   ## Examples
 
-      iex> create_<%= schema.singular %>(%{field: value})
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> create_<%= @schema.singular %>(%{field: value})
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> create_<%= schema.singular %>(%{field: bad_value})
+      iex> create_<%= @schema.singular %>(%{field: bad_value})
       {:error, ...}
 
   """
-  def create_<%= schema.singular %>(attrs \\ %{}) do
+  def create_<%= @schema.singular %>(attrs \\ %{}) do
     raise "TODO"
   end
 
   @doc """
-  Updates a <%= schema.singular %>.
+  Updates a <%= @schema.singular %>.
 
   ## Examples
 
-      iex> update_<%= schema.singular %>(<%= schema.singular %>, %{field: new_value})
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> update_<%= @schema.singular %>(<%= @schema.singular %>, %{field: new_value})
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> update_<%= schema.singular %>(<%= schema.singular %>, %{field: bad_value})
+      iex> update_<%= @schema.singular %>(<%= @schema.singular %>, %{field: bad_value})
       {:error, ...}
 
   """
-  def update_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
+  def update_<%= @schema.singular %>(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>, attrs) do
     raise "TODO"
   end
 
   @doc """
-  Deletes a <%= inspect schema.alias %>.
+  Deletes a <%= inspect @schema.alias %>.
 
   ## Examples
 
-      iex> delete_<%= schema.singular %>(<%= schema.singular %>)
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> delete_<%= @schema.singular %>(<%= @schema.singular %>)
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> delete_<%= schema.singular %>(<%= schema.singular %>)
+      iex> delete_<%= @schema.singular %>(<%= @schema.singular %>)
       {:error, ...}
 
   """
-  def delete_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do
+  def delete_<%= @schema.singular %>(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>) do
     raise "TODO"
   end
 
   @doc """
-  Returns a data structure for tracking <%= schema.singular %> changes.
+  Returns a data structure for tracking <%= @schema.singular %> changes.
 
   ## Examples
 
-      iex> change_<%= schema.singular %>(<%= schema.singular %>)
+      iex> change_<%= @schema.singular %>(<%= @schema.singular %>)
       %Todo{...}
 
   """
-  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, _attrs \\ %{}) do
+  def change_<%= @schema.singular %>(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>, _attrs \\ %{}) do
     raise "TODO"
   end

--- a/priv/templates/phx.gen.context/context.ex
+++ b/priv/templates/phx.gen.context/context.ex
@@ -1,8 +1,8 @@
-defmodule <%= inspect context.module %> do
+defmodule <%= inspect @context.module %> do
   @moduledoc """
-  The <%= context.name %> context.
+  The <%= @context.name %> @context.
   """
 
   import Ecto.Query, warn: false
-  alias <%= inspect schema.repo %>
+  alias <%= inspect @schema.repo %>
 end

--- a/priv/templates/phx.gen.context/context_test.exs
+++ b/priv/templates/phx.gen.context/context_test.exs
@@ -1,5 +1,5 @@
-defmodule <%= inspect context.module %>Test do
-  use <%= inspect context.base_module %>.DataCase
+defmodule <%= inspect @context.module %>Test do
+  use <%= inspect @context.base_module %>.DataCase
 
-  alias <%= inspect context.module %>
+  alias <%= inspect @context.module %>
 end

--- a/priv/templates/phx.gen.context/fixtures.ex
+++ b/priv/templates/phx.gen.context/fixtures.ex
@@ -1,11 +1,11 @@
 
-  def <%= schema.singular %>_fixture(attrs \\ %{}) do
-    {:ok, <%= schema.singular %>} =
+  def <%= @schema.singular %>_fixture(attrs \\ %{}) do
+    {:ok, <%= @schema.singular %>} =
       attrs
       |> Enum.into(%{
-<%= schema.params.create |> Enum.map(fn {key, val} -> "        #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
+<%= @schema.params.create |> Enum.map(fn {key, val} -> "        #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
       })
-      |> <%= inspect context.module %>.create_<%= schema.singular %>()
+      |> <%= inspect @context.module %>.create_<%= @schema.singular %>()
 
-    <%= schema.singular %>
+    <%= @schema.singular %>
   end

--- a/priv/templates/phx.gen.context/fixtures_module.ex
+++ b/priv/templates/phx.gen.context/fixtures_module.ex
@@ -1,6 +1,6 @@
-defmodule <%= inspect context.module %>Fixtures do
+defmodule <%= inspect @context.module %>Fixtures do
   @moduledoc """
   This module defines test helpers for creating
-  entities via the `<%= inspect context.module %>` context.
+  entities via the `<%= inspect @context.module %>` context.
   """
 end

--- a/priv/templates/phx.gen.context/schema_access.ex
+++ b/priv/templates/phx.gen.context/schema_access.ex
@@ -1,96 +1,96 @@
 
-  alias <%= inspect schema.module %>
+  alias <%= inspect @schema.module %>
 
   @doc """
-  Returns the list of <%= schema.plural %>.
+  Returns the list of <%= @schema.plural %>.
 
   ## Examples
 
-      iex> list_<%= schema.plural %>()
-      [%<%= inspect schema.alias %>{}, ...]
+      iex> list_<%= @schema.plural %>()
+      [%<%= inspect @schema.alias %>{}, ...]
 
   """
-  def list_<%= schema.plural %> do
-    Repo.all(<%= inspect schema.alias %>)
+  def list_<%= @schema.plural %> do
+    Repo.all(<%= inspect @schema.alias %>)
   end
 
   @doc """
-  Gets a single <%= schema.singular %>.
+  Gets a single <%= @schema.singular %>.
 
-  Raises `Ecto.NoResultsError` if the <%= schema.human_singular %> does not exist.
+  Raises `Ecto.NoResultsError` if the <%= @schema.human_singular %> does not exist.
 
   ## Examples
 
-      iex> get_<%= schema.singular %>!(123)
-      %<%= inspect schema.alias %>{}
+      iex> get_<%= @schema.singular %>!(123)
+      %<%= inspect @schema.alias %>{}
 
-      iex> get_<%= schema.singular %>!(456)
+      iex> get_<%= @schema.singular %>!(456)
       ** (Ecto.NoResultsError)
 
   """
-  def get_<%= schema.singular %>!(id), do: Repo.get!(<%= inspect schema.alias %>, id)
+  def get_<%= @schema.singular %>!(id), do: Repo.get!(<%= inspect @schema.alias %>, id)
 
   @doc """
-  Creates a <%= schema.singular %>.
+  Creates a <%= @schema.singular %>.
 
   ## Examples
 
-      iex> create_<%= schema.singular %>(%{field: value})
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> create_<%= @schema.singular %>(%{field: value})
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> create_<%= schema.singular %>(%{field: bad_value})
+      iex> create_<%= @schema.singular %>(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_<%= schema.singular %>(attrs \\ %{}) do
-    %<%= inspect schema.alias %>{}
-    |> <%= inspect schema.alias %>.changeset(attrs)
+  def create_<%= @schema.singular %>(attrs \\ %{}) do
+    %<%= inspect @schema.alias %>{}
+    |> <%= inspect @schema.alias %>.changeset(attrs)
     |> Repo.insert()
   end
 
   @doc """
-  Updates a <%= schema.singular %>.
+  Updates a <%= @schema.singular %>.
 
   ## Examples
 
-      iex> update_<%= schema.singular %>(<%= schema.singular %>, %{field: new_value})
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> update_<%= @schema.singular %>(<%= @schema.singular %>, %{field: new_value})
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> update_<%= schema.singular %>(<%= schema.singular %>, %{field: bad_value})
+      iex> update_<%= @schema.singular %>(<%= @schema.singular %>, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
-    <%= schema.singular %>
-    |> <%= inspect schema.alias %>.changeset(attrs)
+  def update_<%= @schema.singular %>(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>, attrs) do
+    <%= @schema.singular %>
+    |> <%= inspect @schema.alias %>.changeset(attrs)
     |> Repo.update()
   end
 
   @doc """
-  Deletes a <%= schema.singular %>.
+  Deletes a <%= @schema.singular %>.
 
   ## Examples
 
-      iex> delete_<%= schema.singular %>(<%= schema.singular %>)
-      {:ok, %<%= inspect schema.alias %>{}}
+      iex> delete_<%= @schema.singular %>(<%= @schema.singular %>)
+      {:ok, %<%= inspect @schema.alias %>{}}
 
-      iex> delete_<%= schema.singular %>(<%= schema.singular %>)
+      iex> delete_<%= @schema.singular %>(<%= @schema.singular %>)
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do
-    Repo.delete(<%= schema.singular %>)
+  def delete_<%= @schema.singular %>(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>) do
+    Repo.delete(<%= @schema.singular %>)
   end
 
   @doc """
-  Returns an `%Ecto.Changeset{}` for tracking <%= schema.singular %> changes.
+  Returns an `%Ecto.Changeset{}` for tracking <%= @schema.singular %> changes.
 
   ## Examples
 
-      iex> change_<%= schema.singular %>(<%= schema.singular %>)
-      %Ecto.Changeset{data: %<%= inspect schema.alias %>{}}
+      iex> change_<%= @schema.singular %>(<%= @schema.singular %>)
+      %Ecto.Changeset{data: %<%= inspect @schema.alias %>{}}
 
   """
-  def change_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs \\ %{}) do
-    <%= inspect schema.alias %>.changeset(<%= schema.singular %>, attrs)
+  def change_<%= @schema.singular %>(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>, attrs \\ %{}) do
+    <%= inspect @schema.alias %>.changeset(<%= @schema.singular %>, attrs)
   end

--- a/priv/templates/phx.gen.context/test_cases.exs
+++ b/priv/templates/phx.gen.context/test_cases.exs
@@ -1,54 +1,54 @@
 
-  describe "<%= schema.plural %>" do
-    alias <%= inspect schema.module %>
+  describe "<%= @schema.plural %>" do
+    alias <%= inspect @schema.module %>
 
-    import <%= inspect context.module %>Fixtures
+    import <%= inspect @context.module %>Fixtures
 
-    @invalid_attrs <%= Mix.Phoenix.to_text for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
+    @invalid_attrs <%= Mix.Phoenix.to_text for {key, _} <- @schema.params.create, into: %{}, do: {key, nil} %>
 
-    test "list_<%= schema.plural %>/0 returns all <%= schema.plural %>" do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert <%= inspect context.alias %>.list_<%= schema.plural %>() == [<%= schema.singular %>]
+    test "list_<%= @schema.plural %>/0 returns all <%= @schema.plural %>" do
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      assert <%= inspect @context.alias %>.list_<%= @schema.plural %>() == [<%= @schema.singular %>]
     end
 
-    test "get_<%= schema.singular %>!/1 returns the <%= schema.singular %> with given id" do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id) == <%= schema.singular %>
+    test "get_<%= @schema.singular %>!/1 returns the <%= @schema.singular %> with given id" do
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      assert <%= inspect @context.alias %>.get_<%= @schema.singular %>!(<%= @schema.singular %>.id) == <%= @schema.singular %>
     end
 
-    test "create_<%= schema.singular %>/1 with valid data creates a <%= schema.singular %>" do
-      valid_attrs = <%= Mix.Phoenix.to_text schema.params.create %>
+    test "create_<%= @schema.singular %>/1 with valid data creates a <%= @schema.singular %>" do
+      valid_attrs = <%= Mix.Phoenix.to_text @schema.params.create %>
 
-      assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.create_<%= schema.singular %>(valid_attrs)<%= for {field, value} <- schema.params.create do %>
-      assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>
+      assert {:ok, %<%= inspect @schema.alias %>{} = <%= @schema.singular %>} = <%= inspect @context.alias %>.create_<%= @schema.singular %>(valid_attrs)<%= for {field, value} <- @schema.params.create do %>
+      assert <%= @schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(@schema, field, value) %><% end %>
     end
 
-    test "create_<%= schema.singular %>/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = <%= inspect context.alias %>.create_<%= schema.singular %>(@invalid_attrs)
+    test "create_<%= @schema.singular %>/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = <%= inspect @context.alias %>.create_<%= @schema.singular %>(@invalid_attrs)
     end
 
-    test "update_<%= schema.singular %>/2 with valid data updates the <%= schema.singular %>" do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      update_attrs = <%= Mix.Phoenix.to_text schema.params.update%>
+    test "update_<%= @schema.singular %>/2 with valid data updates the <%= @schema.singular %>" do
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      update_attrs = <%= Mix.Phoenix.to_text @schema.params.update%>
 
-      assert {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, update_attrs)<%= for {field, value} <- schema.params.update do %>
-      assert <%= schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(schema, field, value) %><% end %>
+      assert {:ok, %<%= inspect @schema.alias %>{} = <%= @schema.singular %>} = <%= inspect @context.alias %>.update_<%= @schema.singular %>(<%= @schema.singular %>, update_attrs)<%= for {field, value} <- @schema.params.update do %>
+      assert <%= @schema.singular %>.<%= field %> == <%= Mix.Phoenix.Schema.value(@schema, field, value) %><% end %>
     end
 
-    test "update_<%= schema.singular %>/2 with invalid data returns error changeset" do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert {:error, %Ecto.Changeset{}} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, @invalid_attrs)
-      assert <%= schema.singular %> == <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id)
+    test "update_<%= @schema.singular %>/2 with invalid data returns error changeset" do
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      assert {:error, %Ecto.Changeset{}} = <%= inspect @context.alias %>.update_<%= @schema.singular %>(<%= @schema.singular %>, @invalid_attrs)
+      assert <%= @schema.singular %> == <%= inspect @context.alias %>.get_<%= @schema.singular %>!(<%= @schema.singular %>.id)
     end
 
-    test "delete_<%= schema.singular %>/1 deletes the <%= schema.singular %>" do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert {:ok, %<%= inspect schema.alias %>{}} = <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>)
-      assert_raise Ecto.NoResultsError, fn -> <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id) end
+    test "delete_<%= @schema.singular %>/1 deletes the <%= @schema.singular %>" do
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      assert {:ok, %<%= inspect @schema.alias %>{}} = <%= inspect @context.alias %>.delete_<%= @schema.singular %>(<%= @schema.singular %>)
+      assert_raise Ecto.NoResultsError, fn -> <%= inspect @context.alias %>.get_<%= @schema.singular %>!(<%= @schema.singular %>.id) end
     end
 
-    test "change_<%= schema.singular %>/1 returns a <%= schema.singular %> changeset" do
-      <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert %Ecto.Changeset{} = <%= inspect context.alias %>.change_<%= schema.singular %>(<%= schema.singular %>)
+    test "change_<%= @schema.singular %>/1 returns a <%= @schema.singular %> changeset" do
+      <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+      assert %Ecto.Changeset{} = <%= inspect @context.alias %>.change_<%= @schema.singular %>(<%= @schema.singular %>)
     end
   end

--- a/priv/templates/phx.gen.embedded/embedded_schema.ex
+++ b/priv/templates/phx.gen.embedded/embedded_schema.ex
@@ -1,16 +1,16 @@
-defmodule <%= inspect schema.module %> do
+defmodule <%= inspect @schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
-  alias <%= inspect schema.module %>
+  alias <%= inspect @schema.module %>
 
   embedded_schema do
-<%= for {k, v} <- schema.types do %>    field <%= inspect k %>, <%= inspect v %><%= schema.defaults[k] %>
+<%= for {k, v} <- @schema.types do %>    field <%= inspect k %>, <%= inspect v %><%= @schema.defaults[k] %>
 <% end %>  end
 
   @doc false
-  def changeset(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do
-    <%= schema.singular %>
-    |> cast(attrs, [<%= Enum.map_join(schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
-    |> validate_required([<%= Enum.map_join(schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
+  def changeset(%<%= inspect @schema.alias %>{} = <%= @schema.singular %>, attrs) do
+    <%= @schema.singular %>
+    |> cast(attrs, [<%= Enum.map_join(@schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
+    |> validate_required([<%= Enum.map_join(@schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
   end
 end

--- a/priv/templates/phx.gen.html/controller.ex
+++ b/priv/templates/phx.gen.html/controller.ex
@@ -1,25 +1,25 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Controller do
-  use <%= inspect context.web_module %>, :controller
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>Controller do
+  use <%= inspect @context.web_module %>, :controller
 
-  alias <%= inspect context.module %>
-  alias <%= inspect schema.module %>
+  alias <%= inspect @context.module %>
+  alias <%= inspect @schema.module %>
 
   def index(conn, _params) do
-    <%= schema.plural %> = <%= inspect context.alias %>.list_<%= schema.plural %>()
-    render(conn, "index.html", <%= schema.plural %>: <%= schema.plural %>)
+    <%= @schema.plural %> = <%= inspect @context.alias %>.list_<%= @schema.plural %>()
+    render(conn, "index.html", <%= @schema.plural %>: <%= @schema.plural %>)
   end
 
   def new(conn, _params) do
-    changeset = <%= inspect context.alias %>.change_<%= schema.singular %>(%<%= inspect schema.alias %>{})
+    changeset = <%= inspect @context.alias %>.change_<%= @schema.singular %>(%<%= inspect @schema.alias %>{})
     render(conn, "new.html", changeset: changeset)
   end
 
-  def create(conn, %{<%= inspect schema.singular %> => <%= schema.singular %>_params}) do
-    case <%= inspect context.alias %>.create_<%= schema.singular %>(<%= schema.singular %>_params) do
-      {:ok, <%= schema.singular %>} ->
+  def create(conn, %{<%= inspect @schema.singular %> => <%= @schema.singular %>_params}) do
+    case <%= inspect @context.alias %>.create_<%= @schema.singular %>(<%= @schema.singular %>_params) do
+      {:ok, <%= @schema.singular %>} ->
         conn
-        |> put_flash(:info, "<%= schema.human_singular %> created successfully.")
-        |> redirect(to: Routes.<%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>))
+        |> put_flash(:info, "<%= @schema.human_singular %> created successfully.")
+        |> redirect(to: Routes.<%= @schema.route_helper %>_path(conn, :show, <%= @schema.singular %>))
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
@@ -27,36 +27,36 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def show(conn, %{"id" => id}) do
-    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
-    render(conn, "show.html", <%= schema.singular %>: <%= schema.singular %>)
+    <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id)
+    render(conn, "show.html", <%= @schema.singular %>: <%= @schema.singular %>)
   end
 
   def edit(conn, %{"id" => id}) do
-    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
-    changeset = <%= inspect context.alias %>.change_<%= schema.singular %>(<%= schema.singular %>)
-    render(conn, "edit.html", <%= schema.singular %>: <%= schema.singular %>, changeset: changeset)
+    <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id)
+    changeset = <%= inspect @context.alias %>.change_<%= @schema.singular %>(<%= @schema.singular %>)
+    render(conn, "edit.html", <%= @schema.singular %>: <%= @schema.singular %>, changeset: changeset)
   end
 
-  def update(conn, %{"id" => id, <%= inspect schema.singular %> => <%= schema.singular %>_params}) do
-    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
+  def update(conn, %{"id" => id, <%= inspect @schema.singular %> => <%= @schema.singular %>_params}) do
+    <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id)
 
-    case <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, <%= schema.singular %>_params) do
-      {:ok, <%= schema.singular %>} ->
+    case <%= inspect @context.alias %>.update_<%= @schema.singular %>(<%= @schema.singular %>, <%= @schema.singular %>_params) do
+      {:ok, <%= @schema.singular %>} ->
         conn
-        |> put_flash(:info, "<%= schema.human_singular %> updated successfully.")
-        |> redirect(to: Routes.<%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>))
+        |> put_flash(:info, "<%= @schema.human_singular %> updated successfully.")
+        |> redirect(to: Routes.<%= @schema.route_helper %>_path(conn, :show, <%= @schema.singular %>))
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, "edit.html", <%= schema.singular %>: <%= schema.singular %>, changeset: changeset)
+        render(conn, "edit.html", <%= @schema.singular %>: <%= @schema.singular %>, changeset: changeset)
     end
   end
 
   def delete(conn, %{"id" => id}) do
-    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
-    {:ok, _<%= schema.singular %>} = <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>)
+    <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id)
+    {:ok, _<%= @schema.singular %>} = <%= inspect @context.alias %>.delete_<%= @schema.singular %>(<%= @schema.singular %>)
 
     conn
-    |> put_flash(:info, "<%= schema.human_singular %> deleted successfully.")
-    |> redirect(to: Routes.<%= schema.route_helper %>_path(conn, :index))
+    |> put_flash(:info, "<%= @schema.human_singular %> deleted successfully.")
+    |> redirect(to: Routes.<%= @schema.route_helper %>_path(conn, :index))
   end
 end

--- a/priv/templates/phx.gen.html/controller_test.exs
+++ b/priv/templates/phx.gen.html/controller_test.exs
@@ -1,85 +1,85 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ControllerTest do
-  use <%= inspect context.web_module %>.ConnCase
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>ControllerTest do
+  use <%= inspect @context.web_module %>.ConnCase
 
-  import <%= inspect context.module %>Fixtures
+  import <%= inspect @context.module %>Fixtures
 
-  @create_attrs <%= Mix.Phoenix.to_text schema.params.create %>
-  @update_attrs <%= Mix.Phoenix.to_text schema.params.update %>
-  @invalid_attrs <%= Mix.Phoenix.to_text (for {key, _} <- schema.params.create, into: %{}, do: {key, nil}) %>
+  @create_attrs <%= Mix.Phoenix.to_text @schema.params.create %>
+  @update_attrs <%= Mix.Phoenix.to_text @schema.params.update %>
+  @invalid_attrs <%= Mix.Phoenix.to_text (for {key, _} <- @schema.params.create, into: %{}, do: {key, nil}) %>
 
   describe "index" do
-    test "lists all <%= schema.plural %>", %{conn: conn} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_path(conn, :index))
-      assert html_response(conn, 200) =~ "Listing <%= schema.human_plural %>"
+    test "lists all <%= @schema.plural %>", %{conn: conn} do
+      conn = get(conn, Routes.<%= @schema.route_helper %>_path(conn, :index))
+      assert html_response(conn, 200) =~ "Listing <%= @schema.human_plural %>"
     end
   end
 
-  describe "new <%= schema.singular %>" do
+  describe "new <%= @schema.singular %>" do
     test "renders form", %{conn: conn} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_path(conn, :new))
-      assert html_response(conn, 200) =~ "New <%= schema.human_singular %>"
+      conn = get(conn, Routes.<%= @schema.route_helper %>_path(conn, :new))
+      assert html_response(conn, 200) =~ "New <%= @schema.human_singular %>"
     end
   end
 
-  describe "create <%= schema.singular %>" do
+  describe "create <%= @schema.singular %>" do
     test "redirects to show when data is valid", %{conn: conn} do
-      conn = post(conn, Routes.<%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @create_attrs)
+      conn = post(conn, Routes.<%= @schema.route_helper %>_path(conn, :create), <%= @schema.singular %>: @create_attrs)
 
       assert %{id: id} = redirected_params(conn)
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_path(conn, :show, id)
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_path(conn, :show, id)
 
-      conn = get(conn, Routes.<%= schema.route_helper %>_path(conn, :show, id))
-      assert html_response(conn, 200) =~ "Show <%= schema.human_singular %>"
+      conn = get(conn, Routes.<%= @schema.route_helper %>_path(conn, :show, id))
+      assert html_response(conn, 200) =~ "Show <%= @schema.human_singular %>"
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, Routes.<%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @invalid_attrs)
-      assert html_response(conn, 200) =~ "New <%= schema.human_singular %>"
+      conn = post(conn, Routes.<%= @schema.route_helper %>_path(conn, :create), <%= @schema.singular %>: @invalid_attrs)
+      assert html_response(conn, 200) =~ "New <%= @schema.human_singular %>"
     end
   end
 
-  describe "edit <%= schema.singular %>" do
-    setup [:create_<%= schema.singular %>]
+  describe "edit <%= @schema.singular %>" do
+    setup [:create_<%= @schema.singular %>]
 
-    test "renders form for editing chosen <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_path(conn, :edit, <%= schema.singular %>))
-      assert html_response(conn, 200) =~ "Edit <%= schema.human_singular %>"
+    test "renders form for editing chosen <%= @schema.singular %>", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = get(conn, Routes.<%= @schema.route_helper %>_path(conn, :edit, <%= @schema.singular %>))
+      assert html_response(conn, 200) =~ "Edit <%= @schema.human_singular %>"
     end
   end
 
-  describe "update <%= schema.singular %>" do
-    setup [:create_<%= schema.singular %>]
+  describe "update <%= @schema.singular %>" do
+    setup [:create_<%= @schema.singular %>]
 
-    test "redirects when data is valid", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = put(conn, Routes.<%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @update_attrs)
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>)
+    test "redirects when data is valid", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = put(conn, Routes.<%= @schema.route_helper %>_path(conn, :update, <%= @schema.singular %>), <%= @schema.singular %>: @update_attrs)
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_path(conn, :show, <%= @schema.singular %>)
 
-      conn = get(conn, Routes.<%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>))<%= if schema.string_attr do %>
-      assert html_response(conn, 200) =~ <%= inspect Mix.Phoenix.Schema.default_param(schema, :update) %><% else %>
+      conn = get(conn, Routes.<%= @schema.route_helper %>_path(conn, :show, <%= @schema.singular %>))<%= if @schema.string_attr do %>
+      assert html_response(conn, 200) =~ <%= inspect Mix.Phoenix.Schema.default_param(@schema, :update) %><% else %>
       assert html_response(conn, 200)<% end %>
     end
 
-    test "renders errors when data is invalid", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = put(conn, Routes.<%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @invalid_attrs)
-      assert html_response(conn, 200) =~ "Edit <%= schema.human_singular %>"
+    test "renders errors when data is invalid", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = put(conn, Routes.<%= @schema.route_helper %>_path(conn, :update, <%= @schema.singular %>), <%= @schema.singular %>: @invalid_attrs)
+      assert html_response(conn, 200) =~ "Edit <%= @schema.human_singular %>"
     end
   end
 
-  describe "delete <%= schema.singular %>" do
-    setup [:create_<%= schema.singular %>]
+  describe "delete <%= @schema.singular %>" do
+    setup [:create_<%= @schema.singular %>]
 
-    test "deletes chosen <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = delete(conn, Routes.<%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>))
-      assert redirected_to(conn) == Routes.<%= schema.route_helper %>_path(conn, :index)
+    test "deletes chosen <%= @schema.singular %>", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = delete(conn, Routes.<%= @schema.route_helper %>_path(conn, :delete, <%= @schema.singular %>))
+      assert redirected_to(conn) == Routes.<%= @schema.route_helper %>_path(conn, :index)
 
       assert_error_sent 404, fn ->
-        get(conn, Routes.<%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>))
+        get(conn, Routes.<%= @schema.route_helper %>_path(conn, :show, <%= @schema.singular %>))
       end
     end
   end
 
-  defp create_<%= schema.singular %>(_) do
-    <%= schema.singular %> = <%= schema.singular %>_fixture()
-    %{<%= schema.singular %>: <%= schema.singular %>}
+  defp create_<%= @schema.singular %>(_) do
+    <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+    %{<%= @schema.singular %>: <%= @schema.singular %>}
   end
 end

--- a/priv/templates/phx.gen.html/edit.html.eex
+++ b/priv/templates/phx.gen.html/edit.html.eex
@@ -1,5 +1,5 @@
-<h1>Edit <%= schema.human_singular %></h1>
+<h1>Edit <%= @schema.human_singular %></h1>
 
-<%%= render "form.html", Map.put(assigns, :action, Routes.<%= schema.route_helper %>_path(@conn, :update, @<%= schema.singular %>)) %>
+<%%= render "form.html", Map.put(assigns, :action, Routes.<%= @schema.route_helper %>_path(@conn, :update, @<%= @schema.singular %>)) %>
 
-<span><%%= link "Back", to: Routes.<%= schema.route_helper %>_path(@conn, :index) %></span>
+<span><%%= link "Back", to: Routes.<%= @schema.route_helper %>_path(@conn, :index) %></span>

--- a/priv/templates/phx.gen.html/form.html.eex
+++ b/priv/templates/phx.gen.html/form.html.eex
@@ -4,7 +4,7 @@
       <p>Oops, something went wrong! Please check the errors below.</p>
     </div>
   <%% end %>
-<%= for {label, input, error} <- inputs, input do %>
+<%= for {label, input, error} <- @inputs, input do %>
   <%= label %>
   <%= input %>
   <%= error %>

--- a/priv/templates/phx.gen.html/index.html.eex
+++ b/priv/templates/phx.gen.html/index.html.eex
@@ -1,26 +1,26 @@
-<h1>Listing <%= schema.human_plural %></h1>
+<h1>Listing <%= @schema.human_plural %></h1>
 
 <table>
   <thead>
     <tr>
-<%= for {k, _} <- schema.attrs do %>      <th><%= Phoenix.Naming.humanize(Atom.to_string(k)) %></th>
+<%= for {k, _} <- @schema.attrs do %>      <th><%= Phoenix.Naming.humanize(Atom.to_string(k)) %></th>
 <% end %>
       <th></th>
     </tr>
   </thead>
   <tbody>
-<%%= for <%= schema.singular %> <- @<%= schema.plural %> do %>
+<%%= for <%= @schema.singular %> <- @<%= @schema.plural %> do %>
     <tr>
-<%= for {k, _} <- schema.attrs do %>      <td><%%= <%= schema.singular %>.<%= k %> %></td>
+<%= for {k, _} <- @schema.attrs do %>      <td><%%= <%= @schema.singular %>.<%= k %> %></td>
 <% end %>
       <td>
-        <span><%%= link "Show", to: Routes.<%= schema.route_helper %>_path(@conn, :show, <%= schema.singular %>) %></span>
-        <span><%%= link "Edit", to: Routes.<%= schema.route_helper %>_path(@conn, :edit, <%= schema.singular %>) %></span>
-        <span><%%= link "Delete", to: Routes.<%= schema.route_helper %>_path(@conn, :delete, <%= schema.singular %>), method: :delete, data: [confirm: "Are you sure?"] %></span>
+        <span><%%= link "Show", to: Routes.<%= @schema.route_helper %>_path(@conn, :show, <%= @schema.singular %>) %></span>
+        <span><%%= link "Edit", to: Routes.<%= @schema.route_helper %>_path(@conn, :edit, <%= @schema.singular %>) %></span>
+        <span><%%= link "Delete", to: Routes.<%= @schema.route_helper %>_path(@conn, :delete, <%= @schema.singular %>), method: :delete, data: [confirm: "Are you sure?"] %></span>
       </td>
     </tr>
 <%% end %>
   </tbody>
 </table>
 
-<span><%%= link "New <%= schema.human_singular %>", to: Routes.<%= schema.route_helper %>_path(@conn, :new) %></span>
+<span><%%= link "New <%= @schema.human_singular %>", to: Routes.<%= @schema.route_helper %>_path(@conn, :new) %></span>

--- a/priv/templates/phx.gen.html/new.html.eex
+++ b/priv/templates/phx.gen.html/new.html.eex
@@ -1,5 +1,5 @@
-<h1>New <%= schema.human_singular %></h1>
+<h1>New <%= @schema.human_singular %></h1>
 
-<%%= render "form.html", Map.put(assigns, :action, Routes.<%= schema.route_helper %>_path(@conn, :create)) %>
+<%%= render "form.html", Map.put(assigns, :action, Routes.<%= @schema.route_helper %>_path(@conn, :create)) %>
 
-<span><%%= link "Back", to: Routes.<%= schema.route_helper %>_path(@conn, :index) %></span>
+<span><%%= link "Back", to: Routes.<%= @schema.route_helper %>_path(@conn, :index) %></span>

--- a/priv/templates/phx.gen.html/show.html.eex
+++ b/priv/templates/phx.gen.html/show.html.eex
@@ -1,13 +1,13 @@
-<h1>Show <%= schema.human_singular %></h1>
+<h1>Show <%= @schema.human_singular %></h1>
 
 <ul>
-<%= for {k, _} <- schema.attrs do %>
+<%= for {k, _} <- @schema.attrs do %>
   <li>
     <strong><%= Phoenix.Naming.humanize(Atom.to_string(k)) %>:</strong>
-    <%%= @<%= schema.singular %>.<%= k %> %>
+    <%%= @<%= @schema.singular %>.<%= k %> %>
   </li>
 <% end %>
 </ul>
 
-<span><%%= link "Edit", to: Routes.<%= schema.route_helper %>_path(@conn, :edit, @<%= schema.singular %>) %></span>
-<span><%%= link "Back", to: Routes.<%= schema.route_helper %>_path(@conn, :index) %></span>
+<span><%%= link "Edit", to: Routes.<%= @schema.route_helper %>_path(@conn, :edit, @<%= @schema.singular %>) %></span>
+<span><%%= link "Back", to: Routes.<%= @schema.route_helper %>_path(@conn, :index) %></span>

--- a/priv/templates/phx.gen.html/view.ex
+++ b/priv/templates/phx.gen.html/view.ex
@@ -1,3 +1,3 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>View do
-  use <%= inspect context.web_module %>, :view
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>View do
+  use <%= inspect @context.web_module %>, :view
 end

--- a/priv/templates/phx.gen.json/changeset_view.ex
+++ b/priv/templates/phx.gen.json/changeset_view.ex
@@ -1,11 +1,11 @@
-defmodule <%= inspect context.web_module %>.ChangesetView do
-  use <%= inspect context.web_module %>, :view
+defmodule <%= inspect @context.web_module %>.ChangesetView do
+  use <%= inspect @context.web_module %>, :view
 
   @doc """
   Traverses and translates changeset errors.
 
   See `Ecto.Changeset.traverse_errors/2` and
-  `<%= inspect context.web_module %>.ErrorHelpers.translate_error/1` for more details.
+  `<%= inspect @context.web_module %>.ErrorHelpers.translate_error/1` for more details.
   """
   def translate_errors(changeset) do
     Ecto.Changeset.traverse_errors(changeset, &translate_error/1)

--- a/priv/templates/phx.gen.json/controller.ex
+++ b/priv/templates/phx.gen.json/controller.ex
@@ -1,42 +1,42 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Controller do
-  use <%= inspect context.web_module %>, :controller
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>Controller do
+  use <%= inspect @context.web_module %>, :controller
 
-  alias <%= inspect context.module %>
-  alias <%= inspect schema.module %>
+  alias <%= inspect @context.module %>
+  alias <%= inspect @schema.module %>
 
-  action_fallback <%= inspect context.web_module %>.FallbackController
+  action_fallback <%= inspect @context.web_module %>.FallbackController
 
   def index(conn, _params) do
-    <%= schema.plural %> = <%= inspect context.alias %>.list_<%= schema.plural %>()
-    render(conn, "index.json", <%= schema.plural %>: <%= schema.plural %>)
+    <%= @schema.plural %> = <%= inspect @context.alias %>.list_<%= @schema.plural %>()
+    render(conn, "index.json", <%= @schema.plural %>: <%= @schema.plural %>)
   end
 
-  def create(conn, %{<%= inspect schema.singular %> => <%= schema.singular %>_params}) do
-    with {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} <- <%= inspect context.alias %>.create_<%= schema.singular %>(<%= schema.singular %>_params) do
+  def create(conn, %{<%= inspect @schema.singular %> => <%= @schema.singular %>_params}) do
+    with {:ok, %<%= inspect @schema.alias %>{} = <%= @schema.singular %>} <- <%= inspect @context.alias %>.create_<%= @schema.singular %>(<%= @schema.singular %>_params) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", Routes.<%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>))
-      |> render("show.json", <%= schema.singular %>: <%= schema.singular %>)
+      |> put_resp_header("location", Routes.<%= @schema.route_helper %>_path(conn, :show, <%= @schema.singular %>))
+      |> render("show.json", <%= @schema.singular %>: <%= @schema.singular %>)
     end
   end
 
   def show(conn, %{"id" => id}) do
-    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
-    render(conn, "show.json", <%= schema.singular %>: <%= schema.singular %>)
+    <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id)
+    render(conn, "show.json", <%= @schema.singular %>: <%= @schema.singular %>)
   end
 
-  def update(conn, %{"id" => id, <%= inspect schema.singular %> => <%= schema.singular %>_params}) do
-    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
+  def update(conn, %{"id" => id, <%= inspect @schema.singular %> => <%= @schema.singular %>_params}) do
+    <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id)
 
-    with {:ok, %<%= inspect schema.alias %>{} = <%= schema.singular %>} <- <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, <%= schema.singular %>_params) do
-      render(conn, "show.json", <%= schema.singular %>: <%= schema.singular %>)
+    with {:ok, %<%= inspect @schema.alias %>{} = <%= @schema.singular %>} <- <%= inspect @context.alias %>.update_<%= @schema.singular %>(<%= @schema.singular %>, <%= @schema.singular %>_params) do
+      render(conn, "show.json", <%= @schema.singular %>: <%= @schema.singular %>)
     end
   end
 
   def delete(conn, %{"id" => id}) do
-    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
+    <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id)
 
-    with {:ok, %<%= inspect schema.alias %>{}} <- <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>) do
+    with {:ok, %<%= inspect @schema.alias %>{}} <- <%= inspect @context.alias %>.delete_<%= @schema.singular %>(<%= @schema.singular %>) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/priv/templates/phx.gen.json/controller_test.exs
+++ b/priv/templates/phx.gen.json/controller_test.exs
@@ -1,84 +1,84 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ControllerTest do
-  use <%= inspect context.web_module %>.ConnCase
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>ControllerTest do
+  use <%= inspect @context.web_module %>.ConnCase
 
-  import <%= inspect context.module %>Fixtures
+  import <%= inspect @context.module %>Fixtures
 
-  alias <%= inspect schema.module %>
+  alias <%= inspect @schema.module %>
 
   @create_attrs %{
-<%= schema.params.create |> Enum.map(fn {key, val} -> "    #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
+<%= @schema.params.create |> Enum.map(fn {key, val} -> "    #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
   }
   @update_attrs %{
-<%= schema.params.update |> Enum.map(fn {key, val} -> "    #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
+<%= @schema.params.update |> Enum.map(fn {key, val} -> "    #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
   }
-  @invalid_attrs <%= Mix.Phoenix.to_text for {key, _} <- schema.params.create, into: %{}, do: {key, nil} %>
+  @invalid_attrs <%= Mix.Phoenix.to_text for {key, _} <- @schema.params.create, into: %{}, do: {key, nil} %>
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 
   describe "index" do
-    test "lists all <%= schema.plural %>", %{conn: conn} do
-      conn = get(conn, Routes.<%= schema.route_helper %>_path(conn, :index))
+    test "lists all <%= @schema.plural %>", %{conn: conn} do
+      conn = get(conn, Routes.<%= @schema.route_helper %>_path(conn, :index))
       assert json_response(conn, 200)["data"] == []
     end
   end
 
-  describe "create <%= schema.singular %>" do
-    test "renders <%= schema.singular %> when data is valid", %{conn: conn} do
-      conn = post(conn, Routes.<%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @create_attrs)
+  describe "create <%= @schema.singular %>" do
+    test "renders <%= @schema.singular %> when data is valid", %{conn: conn} do
+      conn = post(conn, Routes.<%= @schema.route_helper %>_path(conn, :create), <%= @schema.singular %>: @create_attrs)
       assert %{"id" => id} = json_response(conn, 201)["data"]
 
-      conn = get(conn, Routes.<%= schema.route_helper %>_path(conn, :show, id))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_path(conn, :show, id))
 
       assert %{
-               "id" => ^id<%= for {key, val} <- schema.params.create |> Phoenix.json_library().encode!() |> Phoenix.json_library().decode!() do %>,
+               "id" => ^id<%= for {key, val} <- @schema.params.create |> Phoenix.json_library().encode!() |> Phoenix.json_library().decode!() do %>,
                "<%= key %>" => <%= inspect(val) %><% end %>
              } = json_response(conn, 200)["data"]
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post(conn, Routes.<%= schema.route_helper %>_path(conn, :create), <%= schema.singular %>: @invalid_attrs)
+      conn = post(conn, Routes.<%= @schema.route_helper %>_path(conn, :create), <%= @schema.singular %>: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
 
-  describe "update <%= schema.singular %>" do
-    setup [:create_<%= schema.singular %>]
+  describe "update <%= @schema.singular %>" do
+    setup [:create_<%= @schema.singular %>]
 
-    test "renders <%= schema.singular %> when data is valid", %{conn: conn, <%= schema.singular %>: %<%= inspect schema.alias %>{id: id} = <%= schema.singular %>} do
-      conn = put(conn, Routes.<%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @update_attrs)
+    test "renders <%= @schema.singular %> when data is valid", %{conn: conn, <%= @schema.singular %>: %<%= inspect @schema.alias %>{id: id} = <%= @schema.singular %>} do
+      conn = put(conn, Routes.<%= @schema.route_helper %>_path(conn, :update, <%= @schema.singular %>), <%= @schema.singular %>: @update_attrs)
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
-      conn = get(conn, Routes.<%= schema.route_helper %>_path(conn, :show, id))
+      conn = get(conn, Routes.<%= @schema.route_helper %>_path(conn, :show, id))
 
       assert %{
-               "id" => ^id<%= for {key, val} <- schema.params.update |> Phoenix.json_library().encode!() |> Phoenix.json_library().decode!() do %>,
+               "id" => ^id<%= for {key, val} <- @schema.params.update |> Phoenix.json_library().encode!() |> Phoenix.json_library().decode!() do %>,
                "<%= key %>" => <%= inspect(val) %><% end %>
              } = json_response(conn, 200)["data"]
     end
 
-    test "renders errors when data is invalid", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = put(conn, Routes.<%= schema.route_helper %>_path(conn, :update, <%= schema.singular %>), <%= schema.singular %>: @invalid_attrs)
+    test "renders errors when data is invalid", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = put(conn, Routes.<%= @schema.route_helper %>_path(conn, :update, <%= @schema.singular %>), <%= @schema.singular %>: @invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
 
-  describe "delete <%= schema.singular %>" do
-    setup [:create_<%= schema.singular %>]
+  describe "delete <%= @schema.singular %>" do
+    setup [:create_<%= @schema.singular %>]
 
-    test "deletes chosen <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      conn = delete(conn, Routes.<%= schema.route_helper %>_path(conn, :delete, <%= schema.singular %>))
+    test "deletes chosen <%= @schema.singular %>", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      conn = delete(conn, Routes.<%= @schema.route_helper %>_path(conn, :delete, <%= @schema.singular %>))
       assert response(conn, 204)
 
       assert_error_sent 404, fn ->
-        get(conn, Routes.<%= schema.route_helper %>_path(conn, :show, <%= schema.singular %>))
+        get(conn, Routes.<%= @schema.route_helper %>_path(conn, :show, <%= @schema.singular %>))
       end
     end
   end
 
-  defp create_<%= schema.singular %>(_) do
-    <%= schema.singular %> = <%= schema.singular %>_fixture()
-    %{<%= schema.singular %>: <%= schema.singular %>}
+  defp create_<%= @schema.singular %>(_) do
+    <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+    %{<%= @schema.singular %>: <%= @schema.singular %>}
   end
 end

--- a/priv/templates/phx.gen.json/fallback_controller.ex
+++ b/priv/templates/phx.gen.json/fallback_controller.ex
@@ -1,16 +1,16 @@
-defmodule <%= inspect context.web_module %>.FallbackController do
+defmodule <%= inspect @context.web_module %>.FallbackController do
   @moduledoc """
   Translates controller action results into valid `Plug.Conn` responses.
 
   See `Phoenix.Controller.action_fallback/1` for more details.
   """
-  use <%= inspect context.web_module %>, :controller
+  use <%= inspect @context.web_module %>, :controller
 
-  <%= if schema.generate? do %># This clause handles errors returned by Ecto's insert/update/delete.
+  <%= if @schema.generate? do %># This clause handles errors returned by Ecto's insert/update/delete.
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)
-    |> put_view(<%= inspect context.web_module %>.ChangesetView)
+    |> put_view(<%= inspect @context.web_module %>.ChangesetView)
     |> render("error.json", changeset: changeset)
   end
 
@@ -18,7 +18,7 @@ defmodule <%= inspect context.web_module %>.FallbackController do
   def call(conn, {:error, :not_found}) do
     conn
     |> put_status(:not_found)
-    |> put_view(<%= inspect context.web_module %>.ErrorView)
+    |> put_view(<%= inspect @context.web_module %>.ErrorView)
     |> render(:"404")
   end
 end

--- a/priv/templates/phx.gen.json/view.ex
+++ b/priv/templates/phx.gen.json/view.ex
@@ -1,18 +1,18 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>View do
-  use <%= inspect context.web_module %>, :view
-  alias <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>View
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>View do
+  use <%= inspect @context.web_module %>, :view
+  alias <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>View
 
-  def render("index.json", %{<%= schema.plural %>: <%= schema.plural %>}) do
-    %{data: render_many(<%= schema.plural %>, <%= inspect schema.alias %>View, "<%= schema.singular %>.json")}
+  def render("index.json", %{<%= @schema.plural %>: <%= @schema.plural %>}) do
+    %{data: render_many(<%= @schema.plural %>, <%= inspect @schema.alias %>View, "<%= @schema.singular %>.json")}
   end
 
-  def render("show.json", %{<%= schema.singular %>: <%= schema.singular %>}) do
-    %{data: render_one(<%= schema.singular %>, <%= inspect schema.alias %>View, "<%= schema.singular %>.json")}
+  def render("show.json", %{<%= @schema.singular %>: <%= @schema.singular %>}) do
+    %{data: render_one(<%= @schema.singular %>, <%= inspect @schema.alias %>View, "<%= @schema.singular %>.json")}
   end
 
-  def render("<%= schema.singular %>.json", %{<%= schema.singular %>: <%= schema.singular %>}) do
+  def render("<%= @schema.singular %>.json", %{<%= @schema.singular %>: <%= @schema.singular %>}) do
     %{
-<%= [{:id, :id} | schema.attrs] |> Enum.map(fn {k, _} -> "      #{k}: #{schema.singular}.#{k}" end) |> Enum.join(",\n")  %>
+<%= [{:id, :id} | @schema.attrs] |> Enum.map(fn {k, _} -> "      #{k}: #{@schema.singular}.#{k}" end) |> Enum.join(",\n")  %>
     }
   end
 end

--- a/priv/templates/phx.gen.live/form_component.ex
+++ b/priv/templates/phx.gen.live/form_component.ex
@@ -1,11 +1,11 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent do
-  use <%= inspect context.web_module %>, :live_component
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>Live.FormComponent do
+  use <%= inspect @context.web_module %>, :live_component
 
-  alias <%= inspect context.module %>
+  alias <%= inspect @context.module %>
 
   @impl true
-  def update(%{<%= schema.singular %>: <%= schema.singular %>} = assigns, socket) do
-    changeset = <%= inspect context.alias %>.change_<%= schema.singular %>(<%= schema.singular %>)
+  def update(%{<%= @schema.singular %>: <%= @schema.singular %>} = assigns, socket) do
+    changeset = <%= inspect @context.alias %>.change_<%= @schema.singular %>(<%= @schema.singular %>)
 
     {:ok,
      socket
@@ -14,25 +14,25 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   @impl true
-  def handle_event("validate", %{"<%= schema.singular %>" => <%= schema.singular %>_params}, socket) do
+  def handle_event("validate", %{"<%= @schema.singular %>" => <%= @schema.singular %>_params}, socket) do
     changeset =
-      socket.assigns.<%= schema.singular %>
-      |> <%= inspect context.alias %>.change_<%= schema.singular %>(<%= schema.singular %>_params)
+      socket.assigns.<%= @schema.singular %>
+      |> <%= inspect @context.alias %>.change_<%= @schema.singular %>(<%= @schema.singular %>_params)
       |> Map.put(:action, :validate)
 
     {:noreply, assign(socket, :changeset, changeset)}
   end
 
-  def handle_event("save", %{"<%= schema.singular %>" => <%= schema.singular %>_params}, socket) do
-    save_<%= schema.singular %>(socket, socket.assigns.action, <%= schema.singular %>_params)
+  def handle_event("save", %{"<%= @schema.singular %>" => <%= @schema.singular %>_params}, socket) do
+    save_<%= @schema.singular %>(socket, socket.assigns.action, <%= @schema.singular %>_params)
   end
 
-  defp save_<%= schema.singular %>(socket, :edit, <%= schema.singular %>_params) do
-    case <%= inspect context.alias %>.update_<%= schema.singular %>(socket.assigns.<%= schema.singular %>, <%= schema.singular %>_params) do
-      {:ok, _<%= schema.singular %>} ->
+  defp save_<%= @schema.singular %>(socket, :edit, <%= @schema.singular %>_params) do
+    case <%= inspect @context.alias %>.update_<%= @schema.singular %>(socket.assigns.<%= @schema.singular %>, <%= @schema.singular %>_params) do
+      {:ok, _<%= @schema.singular %>} ->
         {:noreply,
          socket
-         |> put_flash(:info, "<%= schema.human_singular %> updated successfully")
+         |> put_flash(:info, "<%= @schema.human_singular %> updated successfully")
          |> push_redirect(to: socket.assigns.return_to)}
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -40,12 +40,12 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     end
   end
 
-  defp save_<%= schema.singular %>(socket, :new, <%= schema.singular %>_params) do
-    case <%= inspect context.alias %>.create_<%= schema.singular %>(<%= schema.singular %>_params) do
-      {:ok, _<%= schema.singular %>} ->
+  defp save_<%= @schema.singular %>(socket, :new, <%= @schema.singular %>_params) do
+    case <%= inspect @context.alias %>.create_<%= @schema.singular %>(<%= @schema.singular %>_params) do
+      {:ok, _<%= @schema.singular %>} ->
         {:noreply,
          socket
-         |> put_flash(:info, "<%= schema.human_singular %> created successfully")
+         |> put_flash(:info, "<%= @schema.human_singular %> created successfully")
          |> push_redirect(to: socket.assigns.return_to)}
 
       {:error, %Ecto.Changeset{} = changeset} ->

--- a/priv/templates/phx.gen.live/form_component.html.leex
+++ b/priv/templates/phx.gen.live/form_component.html.leex
@@ -1,11 +1,11 @@
 <h2><%%= @title %></h2>
 
 <%%= f = form_for @changeset, "#",
-  id: "<%= schema.singular %>-form",
+  id: "<%= @schema.singular %>-form",
   phx_target: @myself,
   phx_change: "validate",
   phx_submit: "save" %>
-<%= for {label, input, error} <- inputs, input do %>
+<%= for {label, input, error} <- @inputs, input do %>
   <%= label %>
   <%= input %>
   <%= error %>

--- a/priv/templates/phx.gen.live/index.ex
+++ b/priv/templates/phx.gen.live/index.ex
@@ -1,12 +1,12 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.Index do
-  use <%= inspect context.web_module %>, :live_view
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>Live.Index do
+  use <%= inspect @context.web_module %>, :live_view
 
-  alias <%= inspect context.module %>
-  alias <%= inspect schema.module %>
+  alias <%= inspect @context.module %>
+  alias <%= inspect @schema.module %>
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :<%= schema.collection %>, list_<%= schema.plural %>())}
+    {:ok, assign(socket, :<%= @schema.collection %>, list_<%= @schema.plural %>())}
   end
 
   @impl true
@@ -16,31 +16,31 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   defp apply_action(socket, :edit, %{"id" => id}) do
     socket
-    |> assign(:page_title, "Edit <%= schema.human_singular %>")
-    |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))
+    |> assign(:page_title, "Edit <%= @schema.human_singular %>")
+    |> assign(:<%= @schema.singular %>, <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id))
   end
 
   defp apply_action(socket, :new, _params) do
     socket
-    |> assign(:page_title, "New <%= schema.human_singular %>")
-    |> assign(:<%= schema.singular %>, %<%= inspect schema.alias %>{})
+    |> assign(:page_title, "New <%= @schema.human_singular %>")
+    |> assign(:<%= @schema.singular %>, %<%= inspect @schema.alias %>{})
   end
 
   defp apply_action(socket, :index, _params) do
     socket
-    |> assign(:page_title, "Listing <%= schema.human_plural %>")
-    |> assign(:<%= schema.singular %>, nil)
+    |> assign(:page_title, "Listing <%= @schema.human_plural %>")
+    |> assign(:<%= @schema.singular %>, nil)
   end
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    <%= schema.singular %> = <%= inspect context.alias %>.get_<%= schema.singular %>!(id)
-    {:ok, _} = <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>)
+    <%= @schema.singular %> = <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id)
+    {:ok, _} = <%= inspect @context.alias %>.delete_<%= @schema.singular %>(<%= @schema.singular %>)
 
-    {:noreply, assign(socket, :<%= schema.collection %>, list_<%=schema.plural %>())}
+    {:noreply, assign(socket, :<%= @schema.collection %>, list_<%=@schema.plural %>())}
   end
 
-  defp list_<%= schema.plural %> do
-    <%= inspect context.alias %>.list_<%= schema.plural %>()
+  defp list_<%= @schema.plural %> do
+    <%= inspect @context.alias %>.list_<%= @schema.plural %>()
   end
 end

--- a/priv/templates/phx.gen.live/index.html.leex
+++ b/priv/templates/phx.gen.live/index.html.leex
@@ -1,35 +1,35 @@
-<h1>Listing <%= schema.human_plural %></h1>
+<h1>Listing <%= @schema.human_plural %></h1>
 
 <%%= if @live_action in [:new, :edit] do %>
-  <%%= live_modal @socket, <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent,
-    id: @<%= schema.singular %>.id || :new,
+  <%%= live_modal @socket, <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>Live.FormComponent,
+    id: @<%= @schema.singular %>.id || :new,
     title: @page_title,
     action: @live_action,
-    <%= schema.singular %>: @<%= schema.singular %>,
-    return_to: Routes.<%= schema.route_helper %>_index_path(@socket, :index) %>
+    <%= @schema.singular %>: @<%= @schema.singular %>,
+    return_to: Routes.<%= @schema.route_helper %>_index_path(@socket, :index) %>
 <%% end %>
 
 <table>
   <thead>
     <tr>
-<%= for {k, _} <- schema.attrs do %>      <th><%= Phoenix.Naming.humanize(Atom.to_string(k)) %></th>
+<%= for {k, _} <- @schema.attrs do %>      <th><%= Phoenix.Naming.humanize(Atom.to_string(k)) %></th>
 <% end %>
       <th></th>
     </tr>
   </thead>
-  <tbody id="<%= schema.plural %>">
-    <%%= for <%= schema.singular %> <- @<%= schema.collection %> do %>
-      <tr id="<%= schema.singular %>-<%%= <%= schema.singular %>.id %>">
-<%= for {k, _} <- schema.attrs do %>        <td><%%= <%= schema.singular %>.<%= k %> %></td>
+  <tbody id="<%= @schema.plural %>">
+    <%%= for <%= @schema.singular %> <- @<%= @schema.collection %> do %>
+      <tr id="<%= @schema.singular %>-<%%= <%= @schema.singular %>.id %>">
+<%= for {k, _} <- @schema.attrs do %>        <td><%%= <%= @schema.singular %>.<%= k %> %></td>
 <% end %>
         <td>
-          <span><%%= live_redirect "Show", to: Routes.<%= schema.route_helper %>_show_path(@socket, :show, <%= schema.singular %>) %></span>
-          <span><%%= live_patch "Edit", to: Routes.<%= schema.route_helper %>_index_path(@socket, :edit, <%= schema.singular %>) %></span>
-          <span><%%= link "Delete", to: "#", phx_click: "delete", phx_value_id: <%= schema.singular %>.id, data: [confirm: "Are you sure?"] %></span>
+          <span><%%= live_redirect "Show", to: Routes.<%= @schema.route_helper %>_show_path(@socket, :show, <%= @schema.singular %>) %></span>
+          <span><%%= live_patch "Edit", to: Routes.<%= @schema.route_helper %>_index_path(@socket, :edit, <%= @schema.singular %>) %></span>
+          <span><%%= link "Delete", to: "#", phx_click: "delete", phx_value_id: <%= @schema.singular %>.id, data: [confirm: "Are you sure?"] %></span>
         </td>
       </tr>
     <%% end %>
   </tbody>
 </table>
 
-<span><%%= live_patch "New <%= schema.human_singular %>", to: Routes.<%= schema.route_helper %>_index_path(@socket, :new) %></span>
+<span><%%= live_patch "New <%= @schema.human_singular %>", to: Routes.<%= @schema.route_helper %>_index_path(@socket, :new) %></span>

--- a/priv/templates/phx.gen.live/live_helpers.ex
+++ b/priv/templates/phx.gen.live/live_helpers.ex
@@ -1,23 +1,23 @@
-defmodule <%= inspect context.web_module %>.LiveHelpers do
+defmodule <%= inspect @context.web_module %>.LiveHelpers do
   import Phoenix.LiveView.Helpers
 
   @doc """
-  Renders a component inside the `<%= inspect context.web_module %>.ModalComponent` component.
+  Renders a component inside the `<%= inspect @context.web_module %>.ModalComponent` component.
 
   The rendered modal receives a `:return_to` option to properly update
   the URL when the modal is closed.
 
   ## Examples
 
-      <%%= live_modal @socket, <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent,
-        id: @<%= schema.singular %>.id || :new,
+      <%%= live_modal @socket, <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>Live.FormComponent,
+        id: @<%= @schema.singular %>.id || :new,
         action: @live_action,
-        <%= schema.singular %>: @<%= schema.singular %>,
-        return_to: Routes.<%= schema.singular %>_index_path(@socket, :index) %>
+        <%= @schema.singular %>: @<%= @schema.singular %>,
+        return_to: Routes.<%= @schema.singular %>_index_path(@socket, :index) %>
   """
   def live_modal(socket, component, opts) do
     path = Keyword.fetch!(opts, :return_to)
     modal_opts = [id: :modal, return_to: path, component: component, opts: opts]
-    live_component(socket, <%= inspect context.web_module %>.ModalComponent, modal_opts)
+    live_component(socket, <%= inspect @context.web_module %>.ModalComponent, modal_opts)
   end
 end

--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -1,110 +1,110 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>LiveTest do
-  use <%= inspect context.web_module %>.ConnCase
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>LiveTest do
+  use <%= inspect @context.web_module %>.ConnCase
 
   import Phoenix.LiveViewTest
-  import <%= inspect context.module %>Fixtures
+  import <%= inspect @context.module %>Fixtures
 
-  @create_attrs <%= Mix.Phoenix.to_text for {key, value} <- schema.params.create, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
-  @update_attrs <%= Mix.Phoenix.to_text for {key, value} <- schema.params.update, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
-  @invalid_attrs <%= Mix.Phoenix.to_text for {key, value} <- schema.params.create, into: %{}, do: {key, value |> Mix.Phoenix.Schema.live_form_value() |> Mix.Phoenix.Schema.invalid_form_value()} %>
+  @create_attrs <%= Mix.Phoenix.to_text for {key, value} <- @schema.params.create, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
+  @update_attrs <%= Mix.Phoenix.to_text for {key, value} <- @schema.params.update, into: %{}, do: {key, Mix.Phoenix.Schema.live_form_value(value)} %>
+  @invalid_attrs <%= Mix.Phoenix.to_text for {key, value} <- @schema.params.create, into: %{}, do: {key, value |> Mix.Phoenix.Schema.live_form_value() |> Mix.Phoenix.Schema.invalid_form_value()} %>
 
-  defp create_<%= schema.singular %>(_) do
-    <%= schema.singular %> = <%= schema.singular %>_fixture()
-    %{<%= schema.singular %>: <%= schema.singular %>}
+  defp create_<%= @schema.singular %>(_) do
+    <%= @schema.singular %> = <%= @schema.singular %>_fixture()
+    %{<%= @schema.singular %>: <%= @schema.singular %>}
   end
 
   describe "Index" do
-    setup [:create_<%= schema.singular %>]
+    setup [:create_<%= @schema.singular %>]
 
-    test "lists all <%= schema.plural %>", <%= if schema.string_attr do %>%{conn: conn, <%= schema.singular %>: <%= schema.singular %>}<% else %>%{conn: conn}<% end %> do
-      {:ok, _index_live, html} = live(conn, Routes.<%= schema.route_helper %>_index_path(conn, :index))
+    test "lists all <%= @schema.plural %>", <%= if @schema.string_attr do %>%{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>}<% else %>%{conn: conn}<% end %> do
+      {:ok, _index_live, html} = live(conn, Routes.<%= @schema.route_helper %>_index_path(conn, :index))
 
-      assert html =~ "Listing <%= schema.human_plural %>"<%= if schema.string_attr do %>
-      assert html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
+      assert html =~ "Listing <%= @schema.human_plural %>"<%= if @schema.string_attr do %>
+      assert html =~ <%= @schema.singular %>.<%= @schema.string_attr %><% end %>
     end
 
-    test "saves new <%= schema.singular %>", %{conn: conn} do
-      {:ok, index_live, _html} = live(conn, Routes.<%= schema.route_helper %>_index_path(conn, :index))
+    test "saves new <%= @schema.singular %>", %{conn: conn} do
+      {:ok, index_live, _html} = live(conn, Routes.<%= @schema.route_helper %>_index_path(conn, :index))
 
-      assert index_live |> element("a", "New <%= schema.human_singular %>") |> render_click() =~
-               "New <%= schema.human_singular %>"
+      assert index_live |> element("a", "New <%= @schema.human_singular %>") |> render_click() =~
+               "New <%= @schema.human_singular %>"
 
-      assert_patch(index_live, Routes.<%= schema.route_helper %>_index_path(conn, :new))
+      assert_patch(index_live, Routes.<%= @schema.route_helper %>_index_path(conn, :new))
 
       assert index_live
-             |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @invalid_attrs)
-             |> render_change() =~ "<%= Mix.Phoenix.Schema.failed_render_change_message(schema) %>"
+             |> form("#<%= @schema.singular %>-form", <%= @schema.singular %>: @invalid_attrs)
+             |> render_change() =~ "<%= Mix.Phoenix.Schema.failed_render_change_message(@schema) %>"
 
       {:ok, _, html} =
         index_live
-        |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @create_attrs)
+        |> form("#<%= @schema.singular %>-form", <%= @schema.singular %>: @create_attrs)
         |> render_submit()
-        |> follow_redirect(conn, Routes.<%= schema.route_helper %>_index_path(conn, :index))
+        |> follow_redirect(conn, Routes.<%= @schema.route_helper %>_index_path(conn, :index))
 
-      assert html =~ "<%= schema.human_singular %> created successfully"<%= if schema.string_attr do %>
-      assert html =~ "some <%= schema.string_attr %>"<% end %>
+      assert html =~ "<%= @schema.human_singular %> created successfully"<%= if @schema.string_attr do %>
+      assert html =~ "some <%= @schema.string_attr %>"<% end %>
     end
 
-    test "updates <%= schema.singular %> in listing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, index_live, _html} = live(conn, Routes.<%= schema.route_helper %>_index_path(conn, :index))
+    test "updates <%= @schema.singular %> in listing", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      {:ok, index_live, _html} = live(conn, Routes.<%= @schema.route_helper %>_index_path(conn, :index))
 
-      assert index_live |> element("#<%= schema.singular %>-#{<%= schema.singular %>.id} a", "Edit") |> render_click() =~
-               "Edit <%= schema.human_singular %>"
+      assert index_live |> element("#<%= @schema.singular %>-#{<%= @schema.singular %>.id} a", "Edit") |> render_click() =~
+               "Edit <%= @schema.human_singular %>"
 
-      assert_patch(index_live, Routes.<%= schema.route_helper %>_index_path(conn, :edit, <%= schema.singular %>))
+      assert_patch(index_live, Routes.<%= @schema.route_helper %>_index_path(conn, :edit, <%= @schema.singular %>))
 
       assert index_live
-             |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @invalid_attrs)
-             |> render_change() =~ "<%= Mix.Phoenix.Schema.failed_render_change_message(schema) %>"
+             |> form("#<%= @schema.singular %>-form", <%= @schema.singular %>: @invalid_attrs)
+             |> render_change() =~ "<%= Mix.Phoenix.Schema.failed_render_change_message(@schema) %>"
 
       {:ok, _, html} =
         index_live
-        |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @update_attrs)
+        |> form("#<%= @schema.singular %>-form", <%= @schema.singular %>: @update_attrs)
         |> render_submit()
-        |> follow_redirect(conn, Routes.<%= schema.route_helper %>_index_path(conn, :index))
+        |> follow_redirect(conn, Routes.<%= @schema.route_helper %>_index_path(conn, :index))
 
-      assert html =~ "<%= schema.human_singular %> updated successfully"<%= if schema.string_attr do %>
-      assert html =~ "some updated <%= schema.string_attr %>"<% end %>
+      assert html =~ "<%= @schema.human_singular %> updated successfully"<%= if @schema.string_attr do %>
+      assert html =~ "some updated <%= @schema.string_attr %>"<% end %>
     end
 
-    test "deletes <%= schema.singular %> in listing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, index_live, _html} = live(conn, Routes.<%= schema.route_helper %>_index_path(conn, :index))
+    test "deletes <%= @schema.singular %> in listing", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      {:ok, index_live, _html} = live(conn, Routes.<%= @schema.route_helper %>_index_path(conn, :index))
 
-      assert index_live |> element("#<%= schema.singular %>-#{<%= schema.singular %>.id} a", "Delete") |> render_click()
-      refute has_element?(index_live, "#<%= schema.singular %>-#{<%= schema.singular %>.id}")
+      assert index_live |> element("#<%= @schema.singular %>-#{<%= @schema.singular %>.id} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#<%= @schema.singular %>-#{<%= @schema.singular %>.id}")
     end
   end
 
   describe "Show" do
-    setup [:create_<%= schema.singular %>]
+    setup [:create_<%= @schema.singular %>]
 
-    test "displays <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, _show_live, html} = live(conn, Routes.<%= schema.route_helper %>_show_path(conn, :show, <%= schema.singular %>))
+    test "displays <%= @schema.singular %>", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      {:ok, _show_live, html} = live(conn, Routes.<%= @schema.route_helper %>_show_path(conn, :show, <%= @schema.singular %>))
 
-      assert html =~ "Show <%= schema.human_singular %>"<%= if schema.string_attr do %>
-      assert html =~ <%= schema.singular %>.<%= schema.string_attr %><% end %>
+      assert html =~ "Show <%= @schema.human_singular %>"<%= if @schema.string_attr do %>
+      assert html =~ <%= @schema.singular %>.<%= @schema.string_attr %><% end %>
     end
 
-    test "updates <%= schema.singular %> within modal", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      {:ok, show_live, _html} = live(conn, Routes.<%= schema.route_helper %>_show_path(conn, :show, <%= schema.singular %>))
+    test "updates <%= @schema.singular %> within modal", %{conn: conn, <%= @schema.singular %>: <%= @schema.singular %>} do
+      {:ok, show_live, _html} = live(conn, Routes.<%= @schema.route_helper %>_show_path(conn, :show, <%= @schema.singular %>))
 
       assert show_live |> element("a", "Edit") |> render_click() =~
-               "Edit <%= schema.human_singular %>"
+               "Edit <%= @schema.human_singular %>"
 
-      assert_patch(show_live, Routes.<%= schema.route_helper %>_show_path(conn, :edit, <%= schema.singular %>))
+      assert_patch(show_live, Routes.<%= @schema.route_helper %>_show_path(conn, :edit, <%= @schema.singular %>))
 
       assert show_live
-             |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @invalid_attrs)
-             |> render_change() =~ "<%= Mix.Phoenix.Schema.failed_render_change_message(schema) %>"
+             |> form("#<%= @schema.singular %>-form", <%= @schema.singular %>: @invalid_attrs)
+             |> render_change() =~ "<%= Mix.Phoenix.Schema.failed_render_change_message(@schema) %>"
 
       {:ok, _, html} =
         show_live
-        |> form("#<%= schema.singular %>-form", <%= schema.singular %>: @update_attrs)
+        |> form("#<%= @schema.singular %>-form", <%= @schema.singular %>: @update_attrs)
         |> render_submit()
-        |> follow_redirect(conn, Routes.<%= schema.route_helper %>_show_path(conn, :show, <%= schema.singular %>))
+        |> follow_redirect(conn, Routes.<%= @schema.route_helper %>_show_path(conn, :show, <%= @schema.singular %>))
 
-      assert html =~ "<%= schema.human_singular %> updated successfully"<%= if schema.string_attr do %>
-      assert html =~ "some updated <%= schema.string_attr %>"<% end %>
+      assert html =~ "<%= @schema.human_singular %> updated successfully"<%= if @schema.string_attr do %>
+      assert html =~ "some updated <%= @schema.string_attr %>"<% end %>
     end
   end
 end

--- a/priv/templates/phx.gen.live/modal_component.ex
+++ b/priv/templates/phx.gen.live/modal_component.ex
@@ -1,5 +1,5 @@
-defmodule <%= inspect context.web_module %>.ModalComponent do
-  use <%= inspect context.web_module %>, :live_component
+defmodule <%= inspect @context.web_module %>.ModalComponent do
+  use <%= inspect @context.web_module %>, :live_component
 
   @impl true
   def render(assigns) do

--- a/priv/templates/phx.gen.live/show.ex
+++ b/priv/templates/phx.gen.live/show.ex
@@ -1,7 +1,7 @@
-defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.Show do
-  use <%= inspect context.web_module %>, :live_view
+defmodule <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>Live.Show do
+  use <%= inspect @context.web_module %>, :live_view
 
-  alias <%= inspect context.module %>
+  alias <%= inspect @context.module %>
 
   @impl true
   def mount(_params, _session, socket) do
@@ -13,9 +13,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     {:noreply,
      socket
      |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:<%= schema.singular %>, <%= inspect context.alias %>.get_<%= schema.singular %>!(id))}
+     |> assign(:<%= @schema.singular %>, <%= inspect @context.alias %>.get_<%= @schema.singular %>!(id))}
   end
 
-  defp page_title(:show), do: "Show <%= schema.human_singular %>"
-  defp page_title(:edit), do: "Edit <%= schema.human_singular %>"
+  defp page_title(:show), do: "Show <%= @schema.human_singular %>"
+  defp page_title(:edit), do: "Edit <%= @schema.human_singular %>"
 end

--- a/priv/templates/phx.gen.live/show.html.leex
+++ b/priv/templates/phx.gen.live/show.html.leex
@@ -1,22 +1,22 @@
-<h1>Show <%= schema.human_singular %></h1>
+<h1>Show <%= @schema.human_singular %></h1>
 
 <%%= if @live_action in [:edit] do %>
-  <%%= live_modal @socket, <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent,
-    id: @<%= schema.singular %>.id,
+  <%%= live_modal @socket, <%= inspect @context.web_module %>.<%= inspect Module.concat(@schema.web_namespace, @schema.alias) %>Live.FormComponent,
+    id: @<%= @schema.singular %>.id,
     title: @page_title,
     action: @live_action,
-    <%= schema.singular %>: @<%= schema.singular %>,
-    return_to: Routes.<%= schema.route_helper %>_show_path(@socket, :show, @<%= schema.singular %>) %>
+    <%= @schema.singular %>: @<%= @schema.singular %>,
+    return_to: Routes.<%= @schema.route_helper %>_show_path(@socket, :show, @<%= @schema.singular %>) %>
 <%% end %>
 
 <ul>
-<%= for {k, _} <- schema.attrs do %>
+<%= for {k, _} <- @schema.attrs do %>
   <li>
     <strong><%= Phoenix.Naming.humanize(Atom.to_string(k)) %>:</strong>
-    <%%= @<%= schema.singular %>.<%= k %> %>
+    <%%= @<%= @schema.singular %>.<%= k %> %>
   </li>
 <% end %>
 </ul>
 
-<span><%%= live_patch "Edit", to: Routes.<%= schema.route_helper %>_show_path(@socket, :edit, @<%= schema.singular %>), class: "button" %></span>
-<span><%%= live_redirect "Back", to: Routes.<%= schema.route_helper %>_index_path(@socket, :index) %></span>
+<span><%%= live_patch "Edit", to: Routes.<%= @schema.route_helper %>_show_path(@socket, :edit, @<%= @schema.singular %>), class: "button" %></span>
+<span><%%= live_redirect "Back", to: Routes.<%= @schema.route_helper %>_index_path(@socket, :index) %></span>

--- a/priv/templates/phx.gen.presence/presence.ex
+++ b/priv/templates/phx.gen.presence/presence.ex
@@ -1,10 +1,10 @@
-defmodule <%= module %> do
+defmodule <%= @module %> do
   @moduledoc """
   Provides presence tracking to channels and processes.
 
   See the [`Phoenix.Presence`](http://hexdocs.pm/phoenix/Phoenix.Presence.html)
   docs for more details.
   """
-  use Phoenix.Presence, otp_app: <%= inspect otp_app %>,
-                        pubsub_server: <%= inspect pubsub_server %>
+  use Phoenix.Presence, otp_app: <%= inspect @otp_app %>,
+                        pubsub_server: <%= inspect @pubsub_server %>
 end

--- a/priv/templates/phx.gen.schema/migration.exs
+++ b/priv/templates/phx.gen.schema/migration.exs
@@ -1,15 +1,15 @@
-defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.table) %> do
-  use <%= inspect schema.migration_module %>
+defmodule <%= inspect @schema.repo %>.Migrations.Create<%= Macro.camelize(@schema.table) %> do
+  use <%= inspect @schema.migration_module %>
 
   def change do
-    create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %>) do
-<%= if schema.binary_id do %>      add :id, :binary_id, primary_key: true
-<% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect Mix.Phoenix.Schema.type_for_migration(v) %><%= schema.migration_defaults[k] %>
-<% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= inspect(i) %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)
+    create table(:<%= @schema.table %><%= if @schema.binary_id do %>, primary_key: false<% end %>) do
+<%= if @schema.binary_id do %>      add :id, :binary_id, primary_key: true
+<% end %><%= for {k, v} <- @schema.attrs do %>      add <%= inspect k %>, <%= inspect Mix.Phoenix.Schema.type_for_migration(v) %><%= @schema.migration_defaults[k] %>
+<% end %><%= for {_, i, _, s} <- @schema.assocs do %>      add <%= inspect(i) %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if @schema.binary_id do %>, type: :binary_id<% end %>)
 <% end %>
       timestamps()
     end
-<%= if Enum.any?(schema.indexes) do %><%= for index <- schema.indexes do %>
+<%= if Enum.any?(@schema.indexes) do %><%= for index <- @schema.indexes do %>
     <%= index %><% end %>
 <% end %>  end
 end

--- a/priv/templates/phx.gen.schema/schema.ex
+++ b/priv/templates/phx.gen.schema/schema.ex
@@ -1,21 +1,21 @@
-defmodule <%= inspect schema.module %> do
+defmodule <%= inspect @schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
-<%= if schema.binary_id do %>
+<%= if @schema.binary_id do %>
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id<% end %>
-  schema <%= inspect schema.table %> do
-<%= for {k, v} <- schema.types do %>    field <%= inspect k %>, <%= Mix.Phoenix.Schema.type_and_opts_for_schema(v) %><%= schema.defaults[k] %><%= Mix.Phoenix.Schema.maybe_redact_field(k in schema.redacts) %>
-<% end %><%= for {_, k, _, _} <- schema.assocs do %>    field <%= inspect k %>, <%= if schema.binary_id do %>:binary_id<% else %>:id<% end %>
+  schema <%= inspect @schema.table %> do
+<%= for {k, v} <- @schema.types do %>    field <%= inspect k %>, <%= Mix.Phoenix.Schema.type_and_opts_for_schema(v) %><%= @schema.defaults[k] %><%= Mix.Phoenix.Schema.maybe_redact_field(k in @schema.redacts) %>
+<% end %><%= for {_, k, _, _} <- @schema.assocs do %>    field <%= inspect k %>, <%= if @schema.binary_id do %>:binary_id<% else %>:id<% end %>
 <% end %>
     timestamps()
   end
 
   @doc false
-  def changeset(<%= schema.singular %>, attrs) do
-    <%= schema.singular %>
-    |> cast(attrs, [<%= Enum.map_join(schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
-    |> validate_required([<%= Enum.map_join(schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
-<%= for k <- schema.uniques do %>    |> unique_constraint(<%= inspect k %>)
+  def changeset(<%= @schema.singular %>, attrs) do
+    <%= @schema.singular %>
+    |> cast(attrs, [<%= Enum.map_join(@schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
+    |> validate_required([<%= Enum.map_join(@schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
+<%= for k <- @schema.uniques do %>    |> unique_constraint(<%= inspect k %>)
 <% end %>  end
 end

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -854,7 +854,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       File.mkdir_p!("priv/templates/phx.gen.auth")
       File.write!("priv/templates/phx.gen.auth/_menu.html.eex", """
       <ul>
-        <%%= if @current_<%= schema.singular %> do %>
+        <%%= if @current_<%= @schema.singular %> do %>
           You're logged in
         <%% end %>
       </ul>


### PR DESCRIPTION
This PR precompiles all of the `phx.gen.*` templates making the generators much faster to run. For example, the `phx.gen.auth` test suite went from 30 seconds to 0.7 seconds. This also adds multiple template sources (`LocalApp`, `PhoenixCompiled` and `Phoenix`) so we can still override templates by placing files in `priv/templates`.

However there are a couple drawbacks with the current implementation
* Compilation time goes from 3 seconds to 13 seconds.
* Any time we change a template, `Mix.Phoenix.TemplateSources.PhoenixCompiled` must recompile all of its templates

I'm trying to figure out if we can improve performance by compiling these templates in parallel. I've compiling the eex with `Task.async_stream/1`, but that doesn't help. I've also tried partitioning the templates into multiple modules (using `:erlang.phash_2` to split them into 4 modules, and then calling `Module.create/3`) in hopes that we can take advantage of Elixir's parallel compiler, but `Module.create/3` seems to create the module sequentially. I'm curious if partitioning would still be good so if one template changed, we would only have to recompile that partition (maybe even so far as 1 module per template).

There's a ton of changes here, so it's broken into 2 commits. The first one switches all of the templates over to use assigns so it's compatible with precompiled templates. The second has the new TemplateSource idea including the precompilation logic.

I'm really curious what approaches I could take to make precompilation more efficient. And if it ends up not making sense, that's cool too. Thanks!