### PR TITLE
Add modern entry point for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "The official JavaScript client for the Phoenix web framework.",
   "license": "MIT",
   "main": "./priv/static/phoenix.js",
+  "module": "./assets/js/phoenix.js",
+  "exports": {
+    "import": "./assets/js/phoenix.js",
+    "require": "./priv/static/phoenix.js"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/phoenixframework/phoenix.git"


### PR DESCRIPTION
Many JavaScript bundlers nowadays support native ES modules syntax. In fact, ES modules syntax is preferred it is easier to statically analyze and allows tree-shaking to reduce bundle size.

Modern native ESM dev servers like [vite](https://vitejs.dev/) or [snowpack](https://www.snowpack.dev/) can also consume the native ESM version of the Phoenix client directly without having to convert it from cjs back to ESM again! However, this is only possible if the Phoenix package specifies the entry point to the file using modern syntax.

This PR adds:
- The `module` field: de-facto standard supported by almost all ESM-supporting bundlers.
- The `exports` field: as specified by [Node.js](https://nodejs.org/api/packages.html#packages_package_entry_points). Many modern bundlers are also converging on using this field to conditionally resolve package entry points.