### PR TITLE
Dynamic Phoenix.Logger level

### DIFF
--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -97,9 +97,9 @@ defmodule Phoenix.Logger do
 
   When invoked, your function should return one of:
 
-      * a valid [`Logger.level()`](`t:Logger.level()/0`)
-      * `false` to disable logging
-      * `true` to use the event's default log level
+    * a valid [`Logger.level()`](`t:Logger.level()/0`)
+    * `false` to disable logging
+    * `true` to use the event's default log level
 
   For example, in your Endpoint you might do something like this:
 

--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -13,6 +13,7 @@ defmodule Phoenix.Logger do
       * Metadata: `%{conn: Plug.Conn.t, options: Keyword.t}`
       * Options: `%{log: Logger.level | false}`
       * Disable logging: In your endpoint `plug Plug.Telemetry, ..., log: Logger.level | false`
+      * Configure logging per request: `plug Plug.Telemetry, ..., log: (Plug.Conn.t -> Logger.level | false) | (Plug.Conn.t, Keyword.t -> Logger.level | false)`
 
     * `[:phoenix, :endpoint, :stop]` - dispatched by `Plug.Telemetry` in your
       endpoint whenever the response is sent
@@ -20,6 +21,7 @@ defmodule Phoenix.Logger do
       * Metadata: `%{conn: Plug.Conn.t, options: Keyword.t}`
       * Options: `%{log: Logger.level | false}`
       * Disable logging: In your endpoint `plug Plug.Telemetry, ..., log: Logger.level | false`
+      * Configure logging per request: `plug Plug.Telemetry, ..., log: (Plug.Conn.t -> Logger.level | false) | (Plug.Conn.t, Keyword.t -> Logger.level | false)`
 
     * `[:phoenix, :router_dispatch, :start]` - dispatched by `Phoenix.Router`
       before dispatching to a matched route
@@ -170,7 +172,7 @@ defmodule Phoenix.Logger do
   ## Event: [:phoenix, :endpoint, *]
 
   defp phoenix_endpoint_start(_, _, %{conn: conn} = metadata, _) do
-    case metadata[:options][:log] do
+    case endpoint_log_level(metadata) do
       false ->
         :ok
 
@@ -183,7 +185,7 @@ defmodule Phoenix.Logger do
   end
 
   defp phoenix_endpoint_stop(_, %{duration: duration}, %{conn: conn} = metadata, _) do
-    case metadata[:options][:log] do
+    case endpoint_log_level(metadata) do
       false ->
         :ok
 
@@ -198,6 +200,15 @@ defmodule Phoenix.Logger do
 
   defp connection_type(:set_chunked), do: "Chunked"
   defp connection_type(_), do: "Sent"
+
+  defp endpoint_log_level(%{conn: conn, options: options}) do
+    case options[:log] do
+      level when is_atom(level) -> level
+      level when is_function(level, 1) -> level.(conn)
+      level when is_function(level, 2) -> level.(conn, options)
+      _ -> :info
+    end
+  end
 
   ## Event: [:phoenix, :error_rendered]
 

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -124,6 +124,38 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert_receive {^pid, :sample}
   end
 
+  test "invokes log level callback from Plug.Telemetry" do
+    defmodule TelemetryEndpoint do
+      use Phoenix.Endpoint, otp_app: :phoenix
+      plug Plug.Telemetry,
+        event_prefix: [:phoenix, :endpoint],
+        log: &__MODULE__.log_level/1
+
+      def log_level(conn) do
+        case conn.path_info do
+          [] -> :debug
+          ["warn" | _] -> :warn
+          ["error" | _] -> :error
+          _ -> nil
+        end
+      end
+    end
+
+    ExUnit.CaptureLog.capture_log(fn -> start_supervised! TelemetryEndpoint end)
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+      TelemetryEndpoint.call(conn(:get, "/"), [])
+    end) =~ "[debug] GET /"
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+      TelemetryEndpoint.call(conn(:get, "/warn"), [])
+    end) =~ "[warn]  GET /warn"
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+      TelemetryEndpoint.call(conn(:get, "/error/404"), [])
+    end) =~ "[error] GET /error/404"
+  end
+
   @tag :capture_log
   test "uses url configuration for static path" do
     Application.put_env(:phoenix, __MODULE__.UrlEndpoint, url: [path: "/api"])
@@ -177,7 +209,7 @@ defmodule Phoenix.Endpoint.EndpointTest do
 
   test "loads cache manifest from specified application" do
     config = put_in(@config[:cache_static_manifest], {:phoenix, "../../../../test/fixtures/digest/compile/cache_manifest.json"})
-    
+
     assert Endpoint.config_change([{Endpoint, config}], []) == :ok
     assert Endpoint.static_path("/foo.css") == "/foo-d978852bea6530fcd197b5445ed008fd.css?vsn=d"
   end

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -154,6 +154,10 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert ExUnit.CaptureLog.capture_log(fn ->
       TelemetryEndpoint.call(conn(:get, "/error/404"), [])
     end) =~ "[error] GET /error/404"
+
+    assert ExUnit.CaptureLog.capture_log(fn ->
+      TelemetryEndpoint.call(conn(:get, "/any"), [])
+    end) =~ "[info]  GET /any"
   end
 
   @tag :capture_log

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -129,14 +129,14 @@ defmodule Phoenix.Endpoint.EndpointTest do
       use Phoenix.Endpoint, otp_app: :phoenix
       plug Plug.Telemetry,
         event_prefix: [:phoenix, :endpoint],
-        log: &__MODULE__.log_level/1
+        log: {__MODULE__, :log_level, []}
 
       def log_level(conn) do
         case conn.path_info do
           [] -> :debug
           ["warn" | _] -> :warn
           ["error" | _] -> :error
-          _ -> nil
+          _ -> true
         end
       end
     end

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -136,7 +136,7 @@ defmodule Phoenix.Endpoint.EndpointTest do
           [] -> :debug
           ["warn" | _] -> :warn
           ["error" | _] -> :error
-          _ -> true
+          _ -> :info
         end
       end
     end

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -158,27 +158,6 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert ExUnit.CaptureLog.capture_log(fn ->
       TelemetryEndpoint.call(conn(:get, "/any"), [])
     end) =~ "[info]  GET /any"
-
-    stop_supervised!(TelemetryEndpoint)
-
-    defmodule LogOptionsEndpoint do
-      use Phoenix.Endpoint, otp_app: :phoenix
-      plug Plug.Telemetry,
-        event_prefix: [:phoenix, :endpoint],
-        log: &__MODULE__.log_level/2,
-        some_key: :some_value
-
-      def log_level(_conn, opts) do
-        assert opts[:some_key] == :some_value
-        :error
-      end
-    end
-
-    ExUnit.CaptureLog.capture_log(fn -> start_supervised! LogOptionsEndpoint end)
-
-    assert ExUnit.CaptureLog.capture_log(fn ->
-      LogOptionsEndpoint.call(conn(:get, "/"), [])
-    end) =~ "[error] GET /"
   end
 
   @tag :capture_log

--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -23,6 +23,12 @@ defmodule Phoenix.Router.RoutingTest do
     def any(conn, _params), do: text(conn, "users any")
   end
 
+  defmodule LogLevel do
+    def log_level(%{params: %{"level" => "debug"}}), do: :debug
+    def log_level(%{params: %{"level" => "warn"}}), do: :warn
+    def log_level(_), do: nil
+  end
+
   defmodule Router do
     use Phoenix.Router
 
@@ -48,6 +54,8 @@ defmodule Phoenix.Router.RoutingTest do
     end
 
     get "/no_log", SomePlug, [], log: false
+    get "/none_log", SomePlug, [], log: nil
+    get "/fun_log", SomePlug, [], log: &LogLevel.log_level/1
     get "/users/:user_id/files/:id", UserController, :image
     get "/*path", UserController, :not_found
 
@@ -220,6 +228,25 @@ defmodule Phoenix.Router.RoutingTest do
     test "does not log when log is set to false" do
       refute capture_log(fn -> call(Router, :get, "/no_log", foo: "bar") end) =~
                "Processing with Phoenix.Router.RoutingTest.SomePlug"
+    end
+
+    test "logs info level when log is set to nil" do
+      assert capture_log(fn -> call(Router, :get, "/none_log") end) =~
+               "[info]  Processing with Phoenix.Router.RoutingTest.SomePlug"
+    end
+
+    test "logs custom level when log is set to a 1-arity function" do
+      assert capture_log(fn -> call(Router, :get, "/fun_log", level: "debug") end) =~
+               "[debug] Processing with Phoenix.Router.RoutingTest.SomePlug"
+
+      assert capture_log(fn -> call(Router, :get, "/fun_log", level: "warn") end) =~
+               "[warn]  Processing with Phoenix.Router.RoutingTest.SomePlug"
+
+      assert capture_log(fn -> call(Router, :get, "/fun_log", level: "yelling") end) =~
+               "[info]  Processing with Phoenix.Router.RoutingTest.SomePlug"
+
+      assert capture_log(fn -> call(Router, :get, "/fun_log") end) =~
+               "[info]  Processing with Phoenix.Router.RoutingTest.SomePlug"
     end
   end
 

--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -24,9 +24,9 @@ defmodule Phoenix.Router.RoutingTest do
   end
 
   defmodule LogLevel do
-    def log_level(%{params: %{"level" => "debug"}}), do: :debug
+    def log_level(%{params: %{"level" => "info"}}), do: :info
     def log_level(%{params: %{"level" => "warn"}}), do: :warn
-    def log_level(_), do: nil
+    def log_level(_), do: true
   end
 
   defmodule Router do
@@ -54,8 +54,7 @@ defmodule Phoenix.Router.RoutingTest do
     end
 
     get "/no_log", SomePlug, [], log: false
-    get "/none_log", SomePlug, [], log: nil
-    get "/fun_log", SomePlug, [], log: &LogLevel.log_level/1
+    get "/fun_log", SomePlug, [], log: {LogLevel, :log_level, []}
     get "/users/:user_id/files/:id", UserController, :image
     get "/*path", UserController, :not_found
 
@@ -230,23 +229,18 @@ defmodule Phoenix.Router.RoutingTest do
                "Processing with Phoenix.Router.RoutingTest.SomePlug"
     end
 
-    test "logs info level when log is set to nil" do
-      assert capture_log(fn -> call(Router, :get, "/none_log") end) =~
-               "[info]  Processing with Phoenix.Router.RoutingTest.SomePlug"
-    end
-
     test "logs custom level when log is set to a 1-arity function" do
-      assert capture_log(fn -> call(Router, :get, "/fun_log", level: "debug") end) =~
-               "[debug] Processing with Phoenix.Router.RoutingTest.SomePlug"
+      assert capture_log(fn -> call(Router, :get, "/fun_log", level: "info") end) =~
+               "[info]  Processing with Phoenix.Router.RoutingTest.SomePlug"
 
       assert capture_log(fn -> call(Router, :get, "/fun_log", level: "warn") end) =~
                "[warn]  Processing with Phoenix.Router.RoutingTest.SomePlug"
 
       assert capture_log(fn -> call(Router, :get, "/fun_log", level: "yelling") end) =~
-               "[info]  Processing with Phoenix.Router.RoutingTest.SomePlug"
+               "[debug] Processing with Phoenix.Router.RoutingTest.SomePlug"
 
       assert capture_log(fn -> call(Router, :get, "/fun_log") end) =~
-               "[info]  Processing with Phoenix.Router.RoutingTest.SomePlug"
+               "[debug] Processing with Phoenix.Router.RoutingTest.SomePlug"
     end
   end
 

--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -26,7 +26,7 @@ defmodule Phoenix.Router.RoutingTest do
   defmodule LogLevel do
     def log_level(%{params: %{"level" => "info"}}), do: :info
     def log_level(%{params: %{"level" => "warn"}}), do: :warn
-    def log_level(_), do: true
+    def log_level(_), do: :debug
   end
 
   defmodule Router do


### PR DESCRIPTION
Related to #4194, this change would let us remove a wrapper that needs to know too much about Plug.Telemetry internals and replace it with this:

```ex
# lib/my_app_web/endpoint.ex

plug Plug.Telemetry,
  event_prefix: [:phoenix, :endpoint],
  log: &__MODULE__.log_level/1

@quiet_paths ["alive", "health", "ready", "favicon.ico"]
def log_level(%{path_info: [head | _]}) when head in @quiet_paths, do: false
def log_level(_), do: :info
```

Incidentally, deploying the wrapper reduced our production log output by a non-insignificant amount (screenshot below) :)

![image](https://user-images.githubusercontent.com/168677/106706342-68123e00-65a4-11eb-9c74-6ff4e9d9317a.png)

Wdyt?