### PR TITLE
Add inputs key to .formatter.exs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -72,6 +72,7 @@ locals_without_parens = [
 ]
 
 [
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   locals_without_parens: locals_without_parens,
   export: [locals_without_parens: locals_without_parens]
 ]


### PR DESCRIPTION
Current version of Elixir requires either :inputs or :subdirectories fields

    $ mix format
    ** (Mix) Expected one or more files/patterns to be given to mix format or for a .formatter.exs to exist with an :inputs or :subdirectories key

The values in this commits are the default ones when a newly generated project is created by latest stable version of Elixir.