### PR TITLE
Allow webpack > 4.41 but < 5

### DIFF
--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -24,7 +24,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "terser-webpack-plugin": "^2.3.2",
-    "webpack": "4.41.5",
+    "webpack": "^4.41.5",
     "webpack-cli": "^3.3.2"
   }
 }


### PR DESCRIPTION
In case there is another minor release, this fixes Issue #4126