### PR TITLE
Don't put /priv/static/ into .gitignore with --no-webpack

### DIFF
--- a/installer/templates/phx_single/gitignore
+++ b/installer/templates/phx_single/gitignore
@@ -27,8 +27,9 @@ npm-debug.log
 
 # The directory NPM downloads your dependencies sources to.
 /assets/node_modules/
-<% end %>
+
 # Since we are building assets from assets/,
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/gitignore
+++ b/installer/templates/phx_umbrella/apps/app_name_web/gitignore
@@ -27,8 +27,9 @@ npm-debug.log
 
 # The directory NPM downloads your dependencies sources to.
 /assets/node_modules/
-<% end %>
+
 # Since we are building assets from assets/,
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+<% end %>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -106,6 +106,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       # webpack
       assert_file "phx_blog/.gitignore", "/assets/node_modules/"
+      assert_file "phx_blog/.gitignore", "/priv/static/"
       assert_file "phx_blog/.gitignore", "phx_blog-*.tar"
       assert_file "phx_blog/.gitignore", ~r/\n$/
       assert_file "phx_blog/assets/webpack.config.js", "js/app.js"
@@ -221,6 +222,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       # No webpack
       refute File.read!("phx_blog/.gitignore") |> String.contains?("/assets/node_modules/")
+      refute File.read!("phx_blog/.gitignore") |> String.contains?("/priv/static/")
       assert_file "phx_blog/.gitignore", ~r/\n$/
       assert_file "phx_blog/config/dev.exs", ~r/watchers: \[\]/
 

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -128,6 +128,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       # webpack
       assert_file web_path(@app, ".gitignore"), "/assets/node_modules/"
+      assert_file web_path(@app, ".gitignore"), "/priv/static/"
       assert_file web_path(@app, ".gitignore"), "#{@app}_web-*.tar"
       assert_file( web_path(@app, ".gitignore"),  ~r/\n$/)
       assert_file web_path(@app, "assets/webpack.config.js"), "js/app.js"
@@ -235,6 +236,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file web_path(@app, ".gitignore"), fn file ->
         assert file =~ ~r/\n$/
         refute file =~ "/assets/node_modules/"
+        refute file =~ "/priv/static/"
       end
 
       assert_file root_path(@app, "config/dev.exs"), ~r/watchers: \[\]/
@@ -666,7 +668,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
                     "<title>Another · Phoenix Framework</title>"
 
         # webpack
-        assert_file "another/.gitignore", "/assets/node_modules"
+        assert_file "another/.gitignore", "/assets/node_modules/"
+        assert_file "another/.gitignore", "/static/priv/"
         assert_file "another/.gitignore",  ~r/\n$/
         assert_file "another/assets/webpack.config.js", "js/app.js"
         assert_file "another/assets/.babelrc", "env"


### PR DESCRIPTION
When using `--no-webpack`, all of the static assets are generated *only* in `/static/priv/`, `/assets/` does not get created. Therefore, to persist static assets when not using Webpack, `/static/priv/` should not be ignored. 