### PR TITLE
Include route information in router_dispatch exception telemetry

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -359,13 +359,13 @@ defmodule Phoenix.Router do
         rescue
           e in Plug.Conn.WrapperError ->
             measurements = %{duration: System.monotonic_time() - start}
-            metadata = %{conn: conn, kind: :error, reason: e, stacktrace: __STACKTRACE__}
+            metadata = Map.merge(metadata, %{conn: conn, kind: :error, reason: e, stacktrace: __STACKTRACE__})
             :telemetry.execute([:phoenix, :router_dispatch, :exception], measurements, metadata)
             Plug.Conn.WrapperError.reraise(e)
         catch
           kind, reason ->
             measurements = %{duration: System.monotonic_time() - start}
-            metadata = %{conn: conn, kind: kind, reason: reason, stacktrace: __STACKTRACE__}
+            metadata = Map.merge(metadata, %{conn: conn, kind: kind, reason: reason, stacktrace: __STACKTRACE__})
             :telemetry.execute([:phoenix, :router_dispatch, :exception], measurements, metadata)
             Plug.Conn.WrapperError.reraise(piped_conn, kind, reason, __STACKTRACE__)
         end


### PR DESCRIPTION
## The goal

@keathley and I were working on standardized metrics around our web requests on a per-route basis. We were able to do that using the `[:phoenix, :router_dispatch, :stop]` Telemetry event for requests that complete successfully, because this event includes things like the `:plug`, `:plug_opts`, and `:route` in the metadata.

## The problem

Unfortunately, for requests that crash or exit for some reason while in the application code, we got a `[:phoenix, :router_dispatch, :exception]` instead of `:stop`, which we expected, but we were surprised that some of the metadata was missing, which meant that we couldn't attribute this failure to a particular route / controller action like we wanted to.

## The workaround

We didn't like the idea, but we were able to work around this issue by capturing this metadata from the `:start` event, store it in the PDict, and pull it out later if we get the `:exception` event instead of `:stop`.

## The fix

In this PR, I've corrected what I believe was an oversight, since I see a similar pattern of `metadata = %{metadata | conn: conn}` in a few other places nearby. I didn't use this same short-hand in this case because the `:kind` and `:reason` keys don't already exist in the Map, so it raises and exception.

In the tests that I added to verify the change, I was unsure about whether we should assert that the `:log` and `:access` keys are present, because I can't tell what they even mean, but I believe the rest should be there because they can all be useful in different situations. Please let me know if you'd like me to remove those two from the tests or even filter them out from the actual metadata.