### PR TITLE
Standardize use of key-value pair(s)

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -389,7 +389,7 @@ Using route helpers is actually the preferred approach to link to any page withi
 
 Sometimes we need to communicate with users during the course of an action. Maybe there was an error updating a schema, or maybe we just want to welcome them back to the application. For this, we have flash messages.
 
-The `Phoenix.Controller` module provides the `put_flash/3` and `get_flash/2` functions to help us set and retrieve flash messages as a key value pair. Let's set two flash messages in our `HelloWeb.PageController` to try this out.
+The `Phoenix.Controller` module provides the `put_flash/3` and `get_flash/2` functions to help us set and retrieve flash messages as a key-value pair. Let's set two flash messages in our `HelloWeb.PageController` to try this out.
 
 To do this we modify the `index` action as follows:
 

--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -518,6 +518,6 @@ $ mix ecto.migrate
 
 ## Other options
 
-While Phoenix uses the [Ecto project](https://hexdocs.pm/ecto) to interact with the data access layer, there are many other data access options, some even built into the Erlang standard library. [ETS](http://www.erlang.org/doc/man/ets.html) and [DETS](http://www.erlang.org/doc/man/dets.html) are key value data stores built into [OTP](http://www.erlang.org/doc/). OTP also provides a relational database called [mnesia](http://www.erlang.org/doc/man/mnesia.html) with its own query language called QLC. Both Elixir and Erlang also have a number of libraries for working with a wide range of popular data stores.
+While Phoenix uses the [Ecto project](https://hexdocs.pm/ecto) to interact with the data access layer, there are many other data access options, some even built into the Erlang standard library. [ETS](http://www.erlang.org/doc/man/ets.html) and [DETS](http://www.erlang.org/doc/man/dets.html) are key-value data stores built into [OTP](http://www.erlang.org/doc/). OTP also provides a relational database called [mnesia](http://www.erlang.org/doc/man/mnesia.html) with its own query language called QLC. Both Elixir and Erlang also have a number of libraries for working with a wide range of popular data stores.
 
 The data world is your oyster, but we won't be covering these options in these guides.

--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -454,7 +454,7 @@ event.
 
 ## Periodic measurements
 
-You might want to periodically measure key values within
+You might want to periodically measure key-value pairs within
 your application. Fortunately the
 [`:telemetry_poller`](http://hexdocs.pm/telemetry_poller)
 package provides a mechanism for custom measurements,

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -303,9 +303,9 @@ defmodule Phoenix.Socket do
   ## USER API
 
   @doc """
-  Adds key value pairs to socket assigns.
+  Adds key-value pairs to socket assigns.
 
-  A single key value pair may be passed, a keyword list or map
+  A single key-value pair may be passed, a keyword list or map
   of assigns may be provided to be merged into existing socket
   assigns.
 


### PR DESCRIPTION
In the same vein as 12bd337cfdea7e5a7e38d35ae9c891857c6046d7