### PR TITLE
Simplify release automatically determining phoenix_dep in generator

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,12 @@
 # Release Instructions
 
   1. Check related deps for required version bumps and compatibility (`phoenix_ecto`, `phoenix_pubsub_redis`, `phoenix_html`)
-  2. Update `phoenix_dep` in `installer/lib/phx_new/generator.ex` to release
-  3. Bump version in related files below
-  4. Run tests, commit, push code
-  5. Publish `phx_new` and `phoenix` packages and docs after pruning any extraneous uncommitted files
-  6. Test installer by generating a new app, running `mix deps.get`, and compiling
-  7. Publish to `npm` with `npm publish`
-  8. Start -dev version in related files below
-  9. Update `phoenix_dep` in `installer/lib/phx_new/generator.ex` back to git
+  2. Bump version in related files below
+  3. Run tests, commit, push code
+  4. Publish `phx_new` and `phoenix` packages and docs after pruning any extraneous uncommitted files
+  5. Test installer by generating a new app, running `mix deps.get`, and compiling
+  6. Publish to `npm` with `npm publish`
+  7. Start -dev version in related files below
 
 ## Files with version
 

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -200,7 +200,7 @@ defmodule Phx.New.Generator do
       endpoint_module: inspect(Module.concat(project.web_namespace, Endpoint)),
       web_namespace: inspect(project.web_namespace),
       phoenix_github_version_tag: "v#{version.major}.#{version.minor}",
-      phoenix_dep: phoenix_dep(phoenix_path),
+      phoenix_dep: phoenix_dep(phoenix_path, version),
       phoenix_path: phoenix_path,
       phoenix_webpack_path: phoenix_webpack_path(project, dev),
       phoenix_html_webpack_path: phoenix_html_webpack_path(project),
@@ -240,9 +240,7 @@ defmodule Phx.New.Generator do
 
     config_inject(project_path, "config/dev.exs", """
     # Configure your database
-    config :#{binding[:app_name]}, #{binding[:app_module]}.Repo#{
-      kw_to_config(adapter_config[:dev])
-    },
+    config :#{binding[:app_name]}, #{binding[:app_module]}.Repo#{kw_to_config(adapter_config[:dev])},
       pool_size: 10
     """)
 
@@ -252,9 +250,7 @@ defmodule Phx.New.Generator do
     # The MIX_TEST_PARTITION environment variable can be used
     # to provide built-in test partitioning in CI environment.
     # Run `mix help test` for more information.
-    config :#{binding[:app_name]}, #{binding[:app_module]}.Repo#{
-      kw_to_config(adapter_config[:test])
-    }
+    config :#{binding[:app_name]}, #{binding[:app_module]}.Repo#{kw_to_config(adapter_config[:test])}
     """)
 
     prod_only_config_inject(project_path, "config/runtime.exs", """
@@ -382,10 +378,14 @@ defmodule Phx.New.Generator do
   defp phoenix_live_view_webpack_path(%Project{in_umbrella?: false}),
     do: "../deps/phoenix_live_view"
 
-  defp phoenix_dep("deps/phoenix"), do: ~s[{:phoenix, "~> #{@phoenix_version}"}]
+  defp phoenix_dep("deps/phoenix", %{pre: ["dev"]}),
+    do: ~s[{:phoenix, github: "phoenixframework/phoenix", override: true}]
 
-  # defp phoenix_dep("deps/phoenix"), do: ~s[{:phoenix, github: "phoenixframework/phoenix", override: true}]
-  defp phoenix_dep(path), do: ~s[{:phoenix, path: #{inspect(path)}, override: true}]
+  defp phoenix_dep("deps/phoenix", version),
+    do: ~s[{:phoenix, "~> #{version}"}]
+
+  defp phoenix_dep(path, _version),
+    do: ~s[{:phoenix, path: #{inspect(path)}, override: true}]
 
   defp phoenix_static_path("deps/phoenix"), do: "deps/phoenix"
   defp phoenix_static_path(path), do: Path.join("..", path)

--- a/installer/mix.exs
+++ b/installer/mix.exs
@@ -1,4 +1,4 @@
-for path <- :code.get_path,
+for path <- :code.get_path(),
     Regex.match?(~r/phx_new\-\d+\.\d+\.\d\/ebin$/, List.to_string(path)) do
   Code.delete_path(path)
 end
@@ -6,7 +6,7 @@ end
 defmodule Phx.New.MixProject do
   use Mix.Project
 
-  @version "1.5.0"
+  @version "1.6.0-dev"
   @github_path "phoenixframework/phoenix"
   @url "https://github.com/#{@github_path}"
 


### PR DESCRIPTION
It relies on whether the version number is a -dev or not.

It also fixes the current state, as it hasn't been reverted after latest release.