### PR TITLE
Generate fixture functions for unique attributes

### DIFF
--- a/integration_test/test/code_generation/app_with_defaults_test.exs
+++ b/integration_test/test/code_generation/app_with_defaults_test.exs
@@ -8,19 +8,6 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithDefaultsTest do
 
         assert_no_compilation_warnings(app_root_path)
         assert_passes_formatter_check(app_root_path)
-
-        # Test unique fixture generators
-        mix_run!(
-          ~w(
-            phx.gen.context Blog Post posts
-            title:string:unique
-            body:text:unique
-          ),
-          app_root_path
-        )
-
-        assert_no_compilation_warnings(app_root_path)
-        assert_passes_formatter_check(app_root_path)
       end)
     end
 
@@ -30,30 +17,6 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithDefaultsTest do
         {app_root_path, _} = generate_phoenix_app(tmp_dir, "default_app")
 
         drop_test_database(app_root_path)
-        assert_tests_pass(app_root_path)
-
-        # Test unique fixture generators
-        mix_run!(
-          ~w(
-            phx.gen.context Blog Post posts
-            title:string:unique
-            body:text:unique
-            author_name:string
-            order:integer:unique
-            score:float:unique
-            previous_post:references:posts:unique
-            publish_on:naive_datetime:unique
-            publish_at:utc_datetime:unique
-            publish_on_usec:naive_datetime_usec:unique
-            publish_at_usec:utc_datetime_usec:unique
-            publish_time:time:unique
-            publish_time_usec:time_usec:unique
-            status:enum:draft:published:deleted:unique
-            tags:array:string:unique
-          ),
-          app_root_path
-        )
-
         assert_tests_pass(app_root_path)
       end)
     end
@@ -87,7 +50,7 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithDefaultsTest do
       with_installer_tmp("app_with_defaults", fn tmp_dir ->
         {app_root_path, _} = generate_phoenix_app(tmp_dir, "phx_blog")
 
-        mix_run!(~w(phx.gen.html Blog Post posts title:unique body:string status:enum:unpublished:published:deleted), app_root_path)
+        mix_run!(~w(phx.gen.html Blog Post posts title:unique body:string status:enum:unpublished:published:deleted order:integer:unique), app_root_path)
 
         modify_file(Path.join(app_root_path, "lib/phx_blog_web/router.ex"), fn file ->
           inject_before_final_end(file, """

--- a/integration_test/test/code_generation/app_with_defaults_test.exs
+++ b/integration_test/test/code_generation/app_with_defaults_test.exs
@@ -8,6 +8,19 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithDefaultsTest do
 
         assert_no_compilation_warnings(app_root_path)
         assert_passes_formatter_check(app_root_path)
+
+        # Test unique fixture generators
+        mix_run!(
+          ~w(
+            phx.gen.context Blog Post posts
+            title:string:unique
+            body:text:unique
+          ),
+          app_root_path
+        )
+
+        assert_no_compilation_warnings(app_root_path)
+        assert_passes_formatter_check(app_root_path)
       end)
     end
 
@@ -17,6 +30,30 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithDefaultsTest do
         {app_root_path, _} = generate_phoenix_app(tmp_dir, "default_app")
 
         drop_test_database(app_root_path)
+        assert_tests_pass(app_root_path)
+
+        # Test unique fixture generators
+        mix_run!(
+          ~w(
+            phx.gen.context Blog Post posts
+            title:string:unique
+            body:text:unique
+            author_name:string
+            order:integer:unique
+            score:float:unique
+            previous_post:references:posts:unique
+            publish_on:naive_datetime:unique
+            publish_at:utc_datetime:unique
+            publish_on_usec:naive_datetime_usec:unique
+            publish_at_usec:utc_datetime_usec:unique
+            publish_time:time:unique
+            publish_time_usec:time_usec:unique
+            status:enum:draft:published:deleted:unique
+            tags:array:string:unique
+          ),
+          app_root_path
+        )
+
         assert_tests_pass(app_root_path)
       end)
     end
@@ -50,7 +87,7 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithDefaultsTest do
       with_installer_tmp("app_with_defaults", fn tmp_dir ->
         {app_root_path, _} = generate_phoenix_app(tmp_dir, "phx_blog")
 
-        mix_run!(~w(phx.gen.html Blog Post posts title body:string status:enum:unpublished:published:deleted), app_root_path)
+        mix_run!(~w(phx.gen.html Blog Post posts title:unique body:string status:enum:unpublished:published:deleted), app_root_path)
 
         modify_file(Path.join(app_root_path, "lib/phx_blog_web/router.ex"), fn file ->
           inject_before_final_end(file, """
@@ -86,7 +123,7 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithDefaultsTest do
       with_installer_tmp("app_with_defaults", fn tmp_dir ->
         {app_root_path, _} = generate_phoenix_app(tmp_dir, "phx_blog")
 
-        mix_run!(~w(phx.gen.json Blog Post posts title body:string status:enum:unpublished:published:deleted), app_root_path)
+        mix_run!(~w(phx.gen.json Blog Post posts title:unique body:string status:enum:unpublished:published:deleted), app_root_path)
 
         modify_file(Path.join(app_root_path, "lib/phx_blog_web/router.ex"), fn file ->
           inject_before_final_end(file, """

--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -355,4 +355,8 @@ defmodule Mix.Phoenix do
   def to_text(data) do
     inspect data, limit: :infinity, printable_limit: :infinity
   end
+
+  def prepend_newline(string) do
+    "\n" <> string
+  end
 end

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -217,8 +217,9 @@ defmodule Mix.Tasks.Phx.Gen.Context do
       Mix.shell.info(
         """
 
-        Update the following fixture function(s) in #{context.test_fixtures_file}
-        with new implementations:
+        Some of the generated database columns are unique. Please provide
+        unique implementations for the following fixture function(s) in
+        #{context.test_fixtures_file}:
 
         #{
           fixture_functions_needing_implementations

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -197,6 +197,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
 
     paths
     |> Mix.Phoenix.eval_from("priv/templates/phx.gen.context/fixtures.ex", binding)
+    |> Mix.Phoenix.prepend_newline()
     |> inject_eex_before_final_end(test_fixtures_file, binding)
   end
 

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -199,6 +199,49 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     |> Mix.Phoenix.eval_from("priv/templates/phx.gen.context/fixtures.ex", binding)
     |> Mix.Phoenix.prepend_newline()
     |> inject_eex_before_final_end(test_fixtures_file, binding)
+
+    maybe_print_unimplemented_fixture_functions(context)
+  end
+
+  defp maybe_print_unimplemented_fixture_functions(%Context{} = context) do
+    fixture_functions_needing_implementations =
+      Enum.flat_map(
+        context.schema.fixture_unique_functions,
+        fn
+          {_field, {_function_name, function_def, true}} -> [function_def]
+          {_field, {_function_name, _function_def, false}} -> []
+        end
+      )
+
+    if Enum.any?(fixture_functions_needing_implementations) do
+      Mix.shell.info(
+        """
+
+        Update the following fixture function(s) in #{context.test_fixtures_file}
+        with new implementations:
+
+        #{
+          fixture_functions_needing_implementations
+          |> Enum.map_join(&indent(&1, 2))
+          |> String.trim_trailing()
+        }
+        """
+      )
+    end
+  end
+
+  defp indent(string, spaces) do
+    indent_string = String.duplicate(" ", spaces)
+
+    string
+    |> String.split("\n")
+    |> Enum.map_join(fn line ->
+        if String.trim(line) == "" do
+          "\n"
+        else
+          indent_string <> line <> "\n"
+        end
+    end)
   end
 
   defp inject_eex_before_final_end(content_to_inject, file_path, binding) do

--- a/priv/templates/phx.gen.context/fixtures.ex
+++ b/priv/templates/phx.gen.context/fixtures.ex
@@ -1,9 +1,15 @@
-
+<%= for {attr, {_function_name, function_def}} <- schema.fixture_unique_functions do %>  @doc """
+  Generate a unique <%= schema.singular %> <%= attr %>.
+  """
+<%= function_def %>
+<% end %>  @doc """
+  Generate a <%= schema.singular %>.
+  """
   def <%= schema.singular %>_fixture(attrs \\ %{}) do
     {:ok, <%= schema.singular %>} =
       attrs
       |> Enum.into(%{
-<%= schema.params.create |> Enum.map(fn {key, val} -> "        #{key}: #{inspect(val)}" end) |> Enum.join(",\n") %>
+<%= schema.fixture_params |> Enum.map(fn {key, code} -> "        #{key}: #{code}" end) |> Enum.join(",\n") %>
       })
       |> <%= inspect context.module %>.create_<%= schema.singular %>()
 

--- a/priv/templates/phx.gen.context/fixtures.ex
+++ b/priv/templates/phx.gen.context/fixtures.ex
@@ -1,4 +1,4 @@
-<%= for {attr, {_function_name, function_def}} <- schema.fixture_unique_functions do %>  @doc """
+<%= for {attr, {_function_name, function_def, _needs_impl?}} <- schema.fixture_unique_functions do %>  @doc """
   Generate a unique <%= schema.singular %> <%= attr %>.
   """
 <%= function_def %>

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -226,8 +226,9 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
 
       assert_received {:mix_shell, :info, ["""
 
-        Update the following fixture function(s) in test/support/fixtures/blog_fixtures.ex
-        with new implementations:
+        Some of the generated database columns are unique. Please provide
+        unique implementations for the following fixture function(s) in
+        test/support/fixtures/blog_fixtures.ex:
 
             def unique_post_price do
               raise "implement the logic to generate a unique post price"
@@ -281,10 +282,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
             order:integer:unique
           ))
 
-      refute_received {:mix_shell, :info, ["""
-
-        Update the following fixture function(s) in test/support/fixtures/blog_fixtures.ex
-        """ <> _]}
+      refute_received {:mix_shell, :info, ["\nSome of the generated database columns are unique." <> _]}
     end
   end
 

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -215,41 +215,76 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
     in_tmp_project config.test, fn ->
       Gen.Context.run(~w(Blog Post posts
             slug:string:unique
+            subject:unique
+            body:text:unique
             order:integer:unique
-            my_float:float:unique
-            published?:boolean
             price:decimal:unique
+            published_at:utc_datetime:unique
             author:references:users:unique
+            published?:boolean
           ))
 
+      assert_received {:mix_shell, :info, ["""
+
+        Update the following fixture function(s) in test/support/fixtures/blog_fixtures.ex
+        with new implementations:
+
+            def unique_post_price do
+              raise "implement the logic to generate a unique post price"
+            end
+
+            def unique_post_published_at do
+              raise "implement the logic to generate a unique post published_at"
+            end
+        """]}
+
       assert_file "test/support/fixtures/blog_fixtures.ex", fn file ->
-        assert file =~ ~S|def unique_post_my_float, do: System.unique_integer([:positive]) * 1.0|
-        assert file =~ """
-          def unique_post_price do
-            to_string(System.unique_integer([:positive]) * 1.0)
-          end
-        """
         assert file =~ ~S|def unique_post_order, do: System.unique_integer([:positive])|
         assert file =~ ~S|def unique_post_slug, do: "some slug#{System.unique_integer([:positive])}"|
+        assert file =~ ~S|def unique_post_body, do: "some body#{System.unique_integer([:positive])}"|
+        assert file =~ ~S|def unique_post_subject, do: "some subject#{System.unique_integer([:positive])}"|
         refute file =~ ~S|def unique_post_author|
+        assert file =~ """
+          def unique_post_price do
+            raise "implement the logic to generate a unique post price"
+          end
+        """
 
         assert file =~ """
-                my_float: unique_post_my_float(),
+                body: unique_post_body(),
                 order: unique_post_order(),
                 price: unique_post_price(),
                 published?: true,
-                slug: unique_post_slug()
+                published_at: unique_post_published_at(),
+                slug: unique_post_slug(),
+                subject: unique_post_subject()
         """
       end
 
       assert [path] = Path.wildcard("priv/repo/migrations/*_create_posts.exs")
       assert_file path, fn file ->
         assert file =~ "create table(:posts)"
+        assert file =~ "create unique_index(:posts, [:order])"
         assert file =~ "create unique_index(:posts, [:price])"
         assert file =~ "create unique_index(:posts, [:slug])"
-        assert file =~ "create unique_index(:posts, [:order])"
-        assert file =~ "create unique_index(:posts, [:my_float])"
+        assert file =~ "create unique_index(:posts, [:subject])"
       end
+    end
+  end
+
+  test "does not prompt on unimplemented functions with only string, text and integer unique fields", config do
+    in_tmp_project config.test, fn ->
+      Gen.Context.run(~w(Blog Post posts
+            slug:string:unique
+            subject:unique
+            body:text:unique
+            order:integer:unique
+          ))
+
+      refute_received {:mix_shell, :info, ["""
+
+        Update the following fixture function(s) in test/support/fixtures/blog_fixtures.ex
+        """ <> _]}
     end
   end
 


### PR DESCRIPTION
This PR extends the fixture generator to create functions for generating unique attributes like is done with the email address in `mix phx.gen.auth`. I'm thinking of this as the first step in fixing #4156.

Below is the file generated by the integration test

```elixir
defmodule DefaultApp.BlogFixtures do
  @moduledoc """
  This module defines test helpers for creating
  entities via the `DefaultApp.Blog` context.
  """

  @doc """
  Generate a unique post body.
  """
  def unique_post_body, do: "some body" <> "#{System.unique_integer([:positive])}"

  @doc """
  Generate a unique post order.
  """
  def unique_post_order, do: System.unique_integer([:positive])

  @doc """
  Generate a unique post publish_at.
  """
  def unique_post_publish_at do
    DateTime.add(
      ~U[2021-02-22 04:29:00Z],
      System.unique_integer([:positive])
    )
  end

  @doc """
  Generate a unique post publish_at_usec.
  """
  def unique_post_publish_at_usec do
    DateTime.add(
      ~U[2021-02-22 04:29:00.000000Z],
      System.unique_integer([:positive])
    )
  end

  @doc """
  Generate a unique post publish_on.
  """
  def unique_post_publish_on do
    NaiveDateTime.add(
      ~N[2021-02-22 04:29:00],
      System.unique_integer([:positive])
    )
  end

  @doc """
  Generate a unique post publish_on_usec.
  """
  def unique_post_publish_on_usec do
    NaiveDateTime.add(
      ~N[2021-02-22 04:29:00.000000],
      System.unique_integer([:positive])
    )
  end

  @doc """
  Generate a unique post publish_time.
  """
  def unique_post_publish_time do
    Time.add(
      ~T[14:00:00],
      System.unique_integer([:positive])
    )
  end

  @doc """
  Generate a unique post publish_time_usec.
  """
  def unique_post_publish_time_usec do
    Time.add(
      ~T[14:00:00.000000],
      System.unique_integer([:positive])
    )
  end

  @doc """
  Generate a unique post score.
  """
  def unique_post_score, do: System.unique_integer([:positive]) * 1.0

  @doc """
  Generate a unique post status.
  """
  def unique_post_status, do: :draft

  @doc """
  Generate a unique post tags.
  """
  def unique_post_tags, do: []

  @doc """
  Generate a unique post title.
  """
  def unique_post_title, do: "some title" <> "#{System.unique_integer([:positive])}"

  @doc """
  Generate a post.
  """
  def post_fixture(attrs \\ %{}) do
    {:ok, post} =
      attrs
      |> Enum.into(%{
        author_name: "some author_name",
        body: unique_post_body(),
        order: unique_post_order(),
        publish_at: unique_post_publish_at(),
        publish_at_usec: unique_post_publish_at_usec(),
        publish_on: unique_post_publish_on(),
        publish_on_usec: unique_post_publish_on_usec(),
        publish_time: unique_post_publish_time(),
        publish_time_usec: unique_post_publish_time_usec(),
        score: unique_post_score(),
        status: unique_post_status(),
        tags: unique_post_tags(),
        title: unique_post_title()
      })
      |> DefaultApp.Blog.create_post()

    post
  end
end
```

If a special fixture function isn't defined for a specific type, the unique function will be generated but will just return the default value. These updates also follow existing pattern of not generating attributes for references associations.

## Other notes

This also adds a `Mix.Phoenix.prepend_newline/1` function, so we don't have to keep the leading blank line at the top of this template (which my editor wants to remove automatically). It's also used by the latest `phx.gen.auth` commit that I need to port over to phoenix.