### PR TITLE
emit [:phoenix, :router_dispatch, :stop] on halted Plug.Conn

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -346,6 +346,9 @@ defmodule Phoenix.Router do
 
     case pipeline.(conn) do
       %Plug.Conn{halted: true} = halted_conn ->
+        measurements = %{duration: System.monotonic_time() - start}
+        metadata = %{metadata | conn: halted_conn}
+        :telemetry.execute([:phoenix, :router_dispatch, :stop], measurements, metadata)
         halted_conn
       %Plug.Conn{} = piped_conn ->
         try do


### PR DESCRIPTION
Ensures the `[:phoenix, :router_dispatch, :stop]` event is emitted when either a plug in the router or a controller halts a conn using `Plug.Conn.halt/2`.

Fixes [#4216][1]

[1]: https://github.com/phoenixframework/phoenix/issues/4216