### PR TITLE
Fix flaky Phoenix.Config test

### DIFF
--- a/test/phoenix/config_test.exs
+++ b/test/phoenix/config_test.exs
@@ -23,7 +23,8 @@ defmodule Phoenix.ConfigTest do
   end
 
   test "can change configuration", meta do
-    {:ok, _pid} = start_link({meta.test, @all, @defaults, []})
+    {:ok, pid} = start_link({meta.test, @all, @defaults, []})
+    ref = Process.monitor(pid)
 
     # Nothing changed
     config_change(meta.test, [], [])
@@ -39,6 +40,8 @@ defmodule Phoenix.ConfigTest do
 
     # Module removed
     config_change(meta.test, [], [meta.test])
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
     assert :ets.info(meta.test, :name) == :undefined
   end
 


### PR DESCRIPTION
This test is failing intermittently because the assertion to ensure the ETS table has been removed does not wait for the `Phoenix.Config` process to end this flaky test failure can be recreated pretty reliably with the following command:

```
$ mix test test/phoenix/config_test.exs --trace --seed 422381

Phoenix.ConfigTest [test/phoenix/config_test.exs]
  * test can change configuration (2.8ms) [L#25]

  1) test can change configuration (Phoenix.ConfigTest)
     test/phoenix/config_test.exs:25
     Assertion with == failed
     code:  assert :ets.info(meta.test, :name) == :undefined
     left:  :"test can change configuration"
     right: :undefined
     stacktrace:
       test/phoenix/config_test.exs:42: (test)

  * test reads configuration from env (0.01ms) [L#9]
  * test starts an ets table as part of the module (0.03ms) [L#17]
  * test can cache (0.05ms) [L#45]


Finished in 0.06 seconds
4 tests, 1 failure

Randomized with seed 422381
```

This PR monitors the process and uses `assert_receive` to ensure the process has shut down before asserting the ETS table has been removed.