### PR TITLE
Explain how to choose an application name in the Gigalixir guide

### DIFF
--- a/guides/deployment/gigalixir.md
+++ b/guides/deployment/gigalixir.md
@@ -66,10 +66,12 @@ There are three different ways to deploy a Phoenix app on Gigalixir: with mix, w
 Let's create a Gigalixir application
 
 ```console
-$ gigalixir create
+$ gigalixir create -n "your_app_name"
 ```
 
-Verify it was created
+Note: the app name cannot be changed afterwards. A random name is used if you do not provide one.
+
+Verify the app was created
 
 ```console
 $ gigalixir apps


### PR DESCRIPTION
When following the Gigalixir deployment guide, I didn't know I could provide an application name because the guide does not mention it. It would have been fine if the name was editable, but it is not. I ended up losing "a lot" of time because I had to destroy my app and create a new one later.

I suggest this small update in the guide since I believe most people would prefer an easy-to-use name, rather than the long random names generated by default.