### PR TITLE
Use so_reuseport to fix eaddrinuse test failures

### DIFF
--- a/test/phoenix/integration/endpoint_test.exs
+++ b/test/phoenix/integration/endpoint_test.exs
@@ -18,15 +18,24 @@ defmodule Phoenix.Integration.EndpointTest do
   @prod_inet6 prod_inet6
 
   Application.put_env(:endpoint_int, ProdEndpoint,
-    http: [port: @prod], url: [host: "example.com"], server: true, drainer: false,
-    render_errors: [accepts: ~w(html json)])
+    http: [port: @prod, transport_options: [socket_opts: so_reuseport()]],
+    url: [host: "example.com"],
+    server: true,
+    drainer: false,
+    render_errors: [accepts: ~w(html json)]
+  )
+
   Application.put_env(:endpoint_int, DevEndpoint,
-    http: [port: @dev], debug_errors: true, drainer: false)
+    http: [port: @dev, transport_options: [socket_opts: so_reuseport()]],
+    debug_errors: true,
+    drainer: false
+  )
 
   Application.put_env(:endpoint_int, ProdInet6Endpoint,
-    http: [port: @prod_inet6, transport_options: [socket_opts: [:inet6]]],
+    http: [port: @prod_inet6, transport_options: [socket_opts: [:inet6] ++ so_reuseport()]],
     url: [host: "example.com"],
-    server: true)
+    server: true
+  )
 
   defmodule Router do
     @moduledoc """

--- a/test/support/endpoint_helper.exs
+++ b/test/support/endpoint_helper.exs
@@ -29,7 +29,15 @@ defmodule Phoenix.Integration.EndpointHelper do
   Socket option to allow a port to be reused.
 
   When provided as a socket option, this allows for a port to be bound to by
-  multiple processes and prevents eaddrinuse errors.
+  multiple processes and prevents `:eaddrinuse` errors. This is useful in
+  Phoenix's integration tests because in order to get an unused port number from
+  the OS in `get_unused_port_numbers/1` we have to open and close a socket,
+  which temporarily makes the port number unavailable to other processes while
+  the OS is shutting it down (the shutdown process continues even after
+  `:gen_tcp.close/1` returns). Trying to reuse the port number before this
+  shutdown process is complete causes `:eaddrinuse` errors, unless the original
+  socket and the new socket that is being opened are opened with the
+  `so_reuseport` option.
   """
   def so_reuseport do
     case :os.type() do

--- a/test/support/endpoint_helper.exs
+++ b/test/support/endpoint_helper.exs
@@ -15,7 +15,7 @@ defmodule Phoenix.Integration.EndpointHelper do
   end
 
   defp listen_on_os_assigned_port(_) do
-    {:ok, socket} = :gen_tcp.listen(0, [])
+    {:ok, socket} = :gen_tcp.listen(0, so_reuseport())
     socket
   end
 
@@ -23,5 +23,19 @@ defmodule Phoenix.Integration.EndpointHelper do
     {:ok, port_number} = :inet.port(socket)
     :gen_tcp.close(socket)
     port_number
+  end
+
+  @doc """
+  Socket option to allow a port to be reused.
+
+  When provided as a socket option, this allows for a port to be bound to by
+  multiple processes and prevents eaddrinuse errors.
+  """
+  def so_reuseport do
+    case :os.type() do
+      {:unix, :linux} -> [{:raw, 1, 15, <<1::32-native>>}]
+      {:unix, :darwin} -> [{:raw, 65_535, 512, <<1::32-native>>}]
+      _ -> []
+    end
   end
 end


### PR DESCRIPTION
This PR is an attempt to fix intermittent test `:eaddrinuse` test failures like these:

https://github.com/phoenixframework/phoenix/runs/2003562379#step:4:509

I first came across this approach with this PR to bypass: https://github.com/PSPDFKit-labs/bypass/pull/77. It appears that it takes a little bit of time for a socket to shut down after a connection is closed. When open up a connection to find an unused port, then close it so we can reopen it for the phoenix endpoint, if the OS hasn't finished closing down the socket we'll receive this error. By opening a port both times with `so_reuseport`, even if the OS isn't finished shutting down the original socket, we shouldn't receive an error.

Here are a few links I found useful about `so_reuseport`
* An in-depth stackoverflow answer about the difference between `SO_REUSEADDR` and `SO_REUSEPORT`: https://stackoverflow.com/a/14388707
* An example of how to configure `so_reuseport` in phoenix: https://stackoverflow.com/a/56952910