### PR TITLE
tolerate `mix fromat` typo

### DIFF
--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -62,6 +62,7 @@ defmodule <%= @app_module %>.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
+      fromat: ["format"],
       setup: ["deps.get"<%= if @ecto do %>, "ecto.setup"<% end %><%= if @webpack do %>, "cmd npm install --prefix assets"<% end %>]<%= if @ecto do %>,
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],


### PR DESCRIPTION
Most common typo. A small improvement can make a developer's life just a little better while saving a bit of time.