### PR TITLE
Introduce `mix phx --version` option and streamline help output format

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -51,6 +51,8 @@ defmodule Mix.Tasks.Phx.New do
 
     * `--verbose` - use verbose output
 
+    * `-v`, `--version` - prints the Phoenix installer version
+
   When passing the `--no-ecto` flag, Phoenix generators such as
   `phx.gen.html`, `phx.gen.json`, `phx.gen.live`, and `phx.gen.context`
   may no longer work as expected as they generate context files that rely
@@ -93,10 +95,6 @@ defmodule Mix.Tasks.Phx.New do
 
   You can read more about umbrella projects using the
   official [Elixir guide](http://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-apps.html#umbrella-projects)
-
-  To print the Phoenix installer version, pass `-v` or `--version`, for example:
-
-      mix phx.new -v
   """
   use Mix.Task
   alias Phx.New.{Generator, Project, Single, Umbrella, Web, Ecto}
@@ -112,7 +110,7 @@ defmodule Mix.Tasks.Phx.New do
 
   @impl true
   def run([version]) when version in ~w(-v --version) do
-    Mix.shell().info("Phoenix v#{@version}")
+    Mix.shell().info("Phoenix installer v#{@version}")
   end
 
   def run(argv) do

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
   test "returns the version" do
     Mix.Tasks.Phx.New.run(["-v"])
-    assert_received {:mix_shell, :info, ["Phoenix v" <> _]}
+    assert_received {:mix_shell, :info, ["Phoenix installer v" <> _]}
   end
 
   test "new with defaults" do

--- a/lib/mix/tasks/phx.ex
+++ b/lib/mix/tasks/phx.ex
@@ -32,8 +32,7 @@ defmodule Mix.Tasks.Phx do
   defp general() do
     Application.ensure_all_started(:phoenix)
     Mix.shell().info "Phoenix v#{Application.spec(:phoenix, :vsn)}"
-    Mix.shell().info "Productive. Reliable. Fast."
-    Mix.shell().info "A productive web framework that does not compromise speed or maintainability."
+    Mix.shell().info "Peace of mind from prototype to production"
     Mix.shell().info "\n## Options\n"
     Mix.shell().info "-v, --version        # Prints Phoenix version\n"
     Mix.Tasks.Help.run(["--search", "phx."])

--- a/lib/mix/tasks/phx.ex
+++ b/lib/mix/tasks/phx.ex
@@ -8,9 +8,20 @@ defmodule Mix.Tasks.Phx do
 
       mix phx
 
+  To print the Phoenix version, pass `-v` or `--version`, for example:
+
+      mix phx --version
+
   """
 
+  @version Mix.Project.config()[:version]
+
+  @impl true
   @doc false
+  def run([version]) when version in ~w(-v --version) do
+    Mix.shell().info("Phoenix v#{@version}")
+  end
+
   def run(args) do
     case args do
       [] -> general()
@@ -23,7 +34,8 @@ defmodule Mix.Tasks.Phx do
     Mix.shell().info "Phoenix v#{Application.spec(:phoenix, :vsn)}"
     Mix.shell().info "Productive. Reliable. Fast."
     Mix.shell().info "A productive web framework that does not compromise speed or maintainability."
-    Mix.shell().info "\nAvailable tasks:\n"
+    Mix.shell().info "\n## Options\n"
+    Mix.shell().info "-v, --version        # Prints Phoenix version\n"
     Mix.Tasks.Help.run(["--search", "phx."])
   end
 end


### PR DESCRIPTION
It gives the --version option the `phx` task.

It also streamline the format of `mix phx` with headers.

It mentions it is the "Phoenix installer" when you run
`mix phx.new --version`

Output now looks like:

    $ mix phx --version
    Phoenix v1.6.0-dev

    $ mix phx.new --version
    Phoenix installer v1.6.0-dev

    $ mix phx
    Phoenix v1.6.0-dev
    Productive. Reliable. Fast.
    A productive web framework that does not compromise speed or maintainability.

    ## Options

    -v, --version        # Prints Phoenix version

    ## Available tasks

    mix phx.digest       # Digests and compresses static files
    mix phx.digest.clean # Removes old versions of static assets.
    ....