### PR TITLE
use Snowpack to get JavaScript debugging in dev

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -30,7 +30,6 @@
   "scripts": {
     "test": "mocha ./test/**/*.js --exit -r @babel/register -r jsdom-global/register",
     "docs": "documentation build js/phoenix.js -f html -o ../doc/js",
-    "build": "webpack --mode production",
-    "watch": "webpack --mode development --watch"
+    "build": "webpack --mode production"
   }
 }

--- a/guides/introduction/up_and_running.md
+++ b/guides/introduction/up_and_running.md
@@ -38,7 +38,7 @@ When it's done, it will ask us if we want it to install our dependencies for us.
 Fetch and install dependencies? [Yn] Y
 * running mix deps.get
 * running mix deps.compile
-* running cd assets && npm install && node node_modules/webpack/bin/webpack.js --mode development
+* running cd assets && npm install
 
 We are almost there! The following steps are missing:
 
@@ -101,7 +101,7 @@ We are almost there! The following steps are missing:
 
     $ cd hello
     $ mix deps.get
-    $ cd assets && npm install && node node_modules/webpack/bin/webpack.js --mode development
+    $ cd assets && npm install
 
 Then configure your database in config/dev.exs and run:
 

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -218,7 +218,7 @@ defmodule Mix.Tasks.Phx.New do
     assets_path = Path.join(project.web_path || project.project_path, "assets")
     webpack_config = Path.join(assets_path, "webpack.config.js")
 
-    maybe_cmd(project, "cd #{relative_app_path(assets_path)} && npm install && node node_modules/webpack/bin/webpack.js --mode development",
+    maybe_cmd(project, "cd #{relative_app_path(assets_path)} && npm install",
               File.exists?(webpack_config), install? && System.find_executable("npm"))
   end
 

--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -74,6 +74,7 @@ defmodule Phx.New.Single do
     {:eex,  "phx_assets/app.scss",          :web, "assets/css/app.scss"},
     {:eex,  "phx_assets/socket.js",         :web, "assets/js/socket.js"},
     {:eex,  "phx_assets/package.json",      :web, "assets/package.json"},
+    {:text, "phx_assets/snowpack.config.js",:web, "assets/snowpack.config.js"},
     {:keep, "phx_assets/vendor",            :web, "assets/vendor"},
   ]
 
@@ -83,6 +84,7 @@ defmodule Phx.New.Single do
     {:eex,  "phx_assets/app.js",            :web, "assets/js/app.js"},
     {:eex,  "phx_assets/app.scss",          :web, "assets/css/app.scss"},
     {:eex,  "phx_assets/package.json",      :web, "assets/package.json"},
+    {:text, "phx_assets/snowpack.config.js",:web, "assets/snowpack.config.js"},
     {:keep, "phx_assets/vendor",            :web, "assets/vendor"},
   ]
 

--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -1,8 +1,3 @@
-// We need to import the CSS so that webpack will load it.
-// The MiniCssExtractPlugin is used to separate it out into
-// its own CSS file.
-import "../css/app.scss"
-
 // webpack automatically bundles all modules in your
 // entry points. Those entry points can be configured
 // in "webpack.config.js".

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -1,8 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "deploy": "webpack --mode production",
-    "watch": "webpack --mode development --watch"
+    "deploy": "webpack --mode production"
   },
   "dependencies": {
     "phoenix": "file:<%= @phoenix_webpack_path %>"<%= if @html do %>,
@@ -13,6 +12,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
+    "@snowpack/plugin-sass": "^1.3.0",
     "babel-loader": "^8.0.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.4.2",
@@ -21,6 +21,7 @@
     "hard-source-webpack-plugin": "^0.13.1",
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
+    "snowpack": "^3.0.13",
     "terser-webpack-plugin": "^2.3.2",
     "webpack": "4.41.5",
     "webpack-cli": "^3.3.2"

--- a/installer/templates/phx_assets/snowpack.config.js
+++ b/installer/templates/phx_assets/snowpack.config.js
@@ -1,0 +1,25 @@
+// Snowpack Configuration File
+// See all supported options: https://www.snowpack.dev/reference/configuration
+
+/** @type {import("snowpack").SnowpackUserConfig } */
+module.exports = {
+  mount: {
+    "static/images": {url: "/images", static: true, resolve: false},
+    "js": {url: "/js"},
+    "css": {url: "/css"}
+  },
+  plugins: [
+    "@snowpack/plugin-sass",
+  ],
+  packageOptions: {
+    /* ... */
+  },
+  devOptions: {
+    /* ... */
+  },
+  buildOptions: {
+      out: "../priv/static",
+      watch: true
+  },
+};
+

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -15,10 +15,8 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
   check_origin: false,
   watchers: <%= if @webpack do %>[
     node: [
-      "node_modules/webpack/bin/webpack.js",
-      "--mode",
-      "development",
-      "--watch-stdin",
+      "node_modules/snowpack/index.bin.js",
+      "build",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]<% else %>[]<% end %>

--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -24,7 +24,7 @@ defmodule <%= @endpoint_module %> do
     at: "/",
     from: :<%= @web_app_name %>,
     gzip: false,
-    only: ~w(css fonts images js favicon.ico robots.txt)
+    only: ~w(css fonts images js favicon.ico robots.txt _snowpack)
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/installer/templates/phx_web/templates/layout/app.html.eex
+++ b/installer/templates/phx_web/templates/layout/app.html.eex
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title><%= @app_module %> · Phoenix Framework</title>
     <link rel="stylesheet" href="<%%= Routes.static_path(@conn, "/css/app.css") %>"/>
-    <script defer type="text/javascript" src="<%%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+    <script defer type="module" src="<%%= Routes.static_path(@conn, "/js/app.js") %>"></script>
   </head>
   <body>
     <header>


### PR DESCRIPTION
This change makes [Snowpack](https://www.snowpack.dev/) the asset builder while developing, so you can use an in-browser JavaScript debugger on non-minified code.

Webpack is still used for `npm run deploy` so you can have minified code in production.
