### PR TITLE
Fix incorrect webpack devTool value

### DIFF
--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = (env, options) => {
       path: path.resolve(__dirname, '../priv/static/js'),
       publicPath: '/js/'
     },
-    devtool: devMode ? 'eval-cheap-module-source-map' : undefined,
+    devtool: devMode ? 'eval-source-map' : undefined,
     module: {
       rules: [
         {


### PR DESCRIPTION
I have been trying to get source maps to work with Phoenix, and I noticed that the default `devTool` option is incorrect, _I think?_

https://github.com/phoenixframework/phoenix/blob/c8883af5582a38496e4b7e45e05d3a4d759a6caa/installer/templates/phx_assets/webpack.config.js#L27

It seems that it's set to a webpack 5 value, while Phoenix still uses webpack 4.

WP5: https://webpack.js.org/configuration/devtool/#devtool, has `eval-cheap-module-source-map`.

WP4: https://v4.webpack.js.org/configuration/devtool/#devtool, no `eval-cheap-module-source-map` option, perhaps intended to use `cheap-module-eval-source-map`?

The weird thing is that I was still seeing source maps like behaviour in the browser, maybe webpack defaults to a safe value if it doesn't recognise the key?

At any rate, I wasn't actually able to click though to code lines without setting the value to `eval-source-map` (that is, setting it to the maybe-intended value, `cheap-module-eval-source-map`, didn't seem useful).

The webpack docs listed as "fast", vs "faster", but no real indication of exactly *how much faster*. I certainly couldn't tell between them but I don't have multi MB of JS.

`eval-source-map` seems like a good pick by the docs:

> https://v4.webpack.js.org/configuration/devtool/#development
> 
> eval-source-map - Each module is executed with eval() and a SourceMap is added as a DataUrl to the eval(). Initially it is slow, but it provides fast rebuild speed and yields real files. Line numbers are correctly mapped since it gets mapped to the original code. _It yields the best quality SourceMaps for development_.


