### PR TITLE
Add 'ecto.drop' to generated 'mix test' command

### DIFF
--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -65,7 +65,7 @@ defmodule <%= @app_module %>.MixProject do
       setup: ["deps.get"<%= if @ecto do %>, "ecto.setup"<% end %><%= if @webpack do %>, "cmd npm install --prefix assets"<% end %>]<%= if @ecto do %>,
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %>
+      test: ["ecto.drop --quiet", "ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %>
     ]
   end
 end


### PR DESCRIPTION
In development process, schema are always updated and created. The current generated 'mix test' command did not drop repo and create new repo. If the repo has been updated and migration scripts have been updated, it would not run migration scripts again. There are many times that I would forget to run migration scripts again on test db. I propose to first drop the repo and create the new one, then apply all migrations every time when the tests are run.