### PR TITLE
Add .map to gzippable extensions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule Phoenix.MixProject do
         stacktrace_depth: nil,
         filter_parameters: ["password"],
         serve_endpoints: false,
-        gzippable_exts: ~w(.js .css .txt .text .html .json .svg .eot .ttf),
+        gzippable_exts: ~w(.js .map .css .txt .text .html .json .svg .eot .ttf),
         static_compressors: [Phoenix.Digester.Gzip]
       ]
     ]

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -24,6 +24,8 @@ defmodule Phoenix.DigesterTest do
       refute "phoenix.png.gz" in output_files
       assert "app.js" in output_files
       assert "app.js.gz" in output_files
+      assert "app.js.map" in output_files
+      assert "app.js.map.gz" in output_files
       assert "css/app.css" in output_files
       assert "css/app.css.gz" in output_files
       assert "manifest.json" in output_files


### PR DESCRIPTION
This pull request adds the `.map` extension to the list of _gzippable extensions_.

This is mostly a matter of consistency rather than performance.

### Before running `mix phx.digest`

```
priv/static
├── css
│  └── app.css
├── js
│  ├── app.js
│  └── app.js.map
```

### After running `mix phx.digest`

```
priv/static
├── cache_manifest.json
├── css
│  ├── app-c60f329d5f7165fe3b7016ba48b7252f.css
│  ├── app-c60f329d5f7165fe3b7016ba48b7252f.css.gz
│  ├── app.css
│  └── app.css.gz
├── js
│  ├── app-a3f59890277c10a37e518d3f4e19fb7e.js
│  ├── app-a3f59890277c10a37e518d3f4e19fb7e.js.gz
│  ├── app.js
│  ├── app.js-1d02813ec397c786ae3c97473218f5e0.map # ← Not gzipped
│  ├── app.js.gz
│  └── app.js.map # ← Also not gzipped
```

I think it would be a safe default to assume that if Phoenix generates source maps by default, that they should also be included in the _gzipping_ process.

Let me know if this is a good idea or not 🙂
