### PR TITLE
Fix indentation in Markdown list.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,8 +3,8 @@
   1. Check related deps for required version bumps and compatibility (`phoenix_ecto`, `phoenix_pubsub_redis`, `phoenix_html`)
   2. Bump version in related files below
   3. Run tests:
-    - `mix test` in the root folder
-    - `mix test` in the `installer/` folder
+      - `mix test` in the root folder
+      - `mix test` in the `installer/` folder
   4. Commit, push code
   5. Publish `phx_new` and `phoenix` packages and docs after pruning any extraneous uncommitted files
   6. Test installer by generating a new app, running `mix deps.get`, and compiling


### PR DESCRIPTION
Fix indentation in Markdown list.
Since it was already inside a list, it was looking as one line item.