### PR TITLE
Update Dockerfile instructions in releases.md

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -172,7 +172,7 @@ FROM node:15.7.0-alpine3.10 as assets
 
 # install build dependencies
 RUN --mount=type=cache,sharing=locked,target=/var/cache/apk \
-    apk add build-base python
+    apk add build-base python3
 
 # prepare build dir
 WORKDIR /app


### PR DESCRIPTION
Hi 👋 

The package install command `apk add python` no longer seems to work. The solution appears to be to explicitly specify `python2` or `python3` instead. There is some discussion of that here: https://stackoverflow.com/a/62652692/312962