### PR TITLE
Fix router helper

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -345,7 +345,7 @@ defmodule Phoenix.Router.Helpers do
   """
   def raise_route_error(mod, fun, arity, action, routes, params) do
     cond do
-      not Keyword.has_key?(routes, action) ->
+      is_atom(action) and not Keyword.has_key?(routes, action) ->
         "no action #{inspect action} for #{inspect mod}.#{fun}/#{arity}"
         |> invalid_route_error(fun, routes)
 


### PR DESCRIPTION
Keyword.has_key?/2 is being passed a non atom key
as described in:
https://github.com/phoenixframework/phoenix/issues/4280

Fixes the issue by checking the type of key

/cc  @conradwt 