### PR TITLE
add option `--prefix` to schema and migration generators

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -106,7 +106,8 @@ defmodule Mix.Tasks.Phx.New do
              app: :string, module: :string, web_module: :string,
              database: :string, binary_id: :boolean, html: :boolean,
              gettext: :boolean, umbrella: :boolean, verbose: :boolean,
-             live: :boolean, dashboard: :boolean, install: :boolean]
+             live: :boolean, dashboard: :boolean, install: :boolean,
+             prefix: :string]
 
   @impl true
   def run([version]) when version in ~w(-v --version) do

--- a/lib/mix/phoenix/schema.ex
+++ b/lib/mix/phoenix/schema.ex
@@ -35,7 +35,8 @@ defmodule Mix.Phoenix.Schema do
             route_helper: nil,
             migration_module: nil,
             fixture_unique_functions: %{},
-            fixture_params: %{}
+            fixture_params: %{},
+            prefix: nil
 
   @valid_types [
     :integer,
@@ -136,7 +137,9 @@ defmodule Mix.Phoenix.Schema do
       generate?: generate?,
       migration_module: migration_module(),
       fixture_unique_functions: fixture_unique_functions,
-      fixture_params: fixture_params(attrs, fixture_unique_functions)}
+      fixture_params: fixture_params(attrs, fixture_unique_functions),
+      prefix: opts[:prefix]
+    }
   end
 
   @doc """

--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -82,7 +82,8 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
   alias Mix.Tasks.Phx.Gen.Auth.{HashingLibrary, Injector, Migration}
 
   @switches [web: :string, binary_id: :boolean, hashing_lib: :string,
-             table: :string, merge_with_existing_context: :boolean]
+             table: :string, merge_with_existing_context: :boolean,
+             prefix: :string]
 
   @doc false
   def run(args, test_opts \\ []) do

--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -80,7 +80,7 @@ defmodule Mix.Tasks.Phx.Gen.Context do
 
   @switches [binary_id: :boolean, table: :string, web: :string,
              schema: :boolean, context: :boolean, context_app: :string,
-             merge_with_existing_context: :boolean]
+             merge_with_existing_context: :boolean, prefix: :string]
 
   @default_opts [schema: true, context: true]
 

--- a/lib/mix/tasks/phx.gen.schema.ex
+++ b/lib/mix/tasks/phx.gen.schema.ex
@@ -103,7 +103,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   alias Mix.Phoenix.Schema
 
   @switches [migration: :boolean, binary_id: :boolean, table: :string,
-             web: :string, context_app: :string]
+             web: :string, context_app: :string, prefix: :string]
 
   @doc false
   def run(args) do

--- a/priv/templates/phx.gen.schema/migration.exs
+++ b/priv/templates/phx.gen.schema/migration.exs
@@ -2,7 +2,7 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.
   use <%= inspect schema.migration_module %>
 
   def change do
-    create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %>) do
+    create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %><%= if schema.prefix do %>, prefix: :<%= schema.prefix %><% end %>) do
 <%= if schema.binary_id do %>      add :id, :binary_id, primary_key: true
 <% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect Mix.Phoenix.Schema.type_for_migration(v) %><%= schema.migration_defaults[k] %>
 <% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= inspect(i) %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)

--- a/priv/templates/phx.gen.schema/schema.ex
+++ b/priv/templates/phx.gen.schema/schema.ex
@@ -1,7 +1,8 @@
 defmodule <%= inspect schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
-<%= if schema.binary_id do %>
+<%= if schema.prefix do %>
+  @schema_prefix :<%= schema.prefix %><% end %><%= if schema.binary_id do %>
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id<% end %>
   schema <%= inspect schema.table %> do

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -258,6 +258,21 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
     end
   end
 
+  test "generates schema and migration with prefix", config do
+    in_tmp_project config.test, fn ->
+      Gen.Schema.run(~w(Blog.Post posts title --prefix cms))
+
+      assert_file "lib/phoenix/blog/post.ex", fn file ->
+        assert file =~ "@schema_prefix :cms"
+      end
+
+      assert [migration] = Path.wildcard("priv/repo/migrations/*_create_posts.exs")
+      assert_file migration, fn file ->
+        assert file =~ "create table(:posts, prefix: :cms) do"
+      end
+    end
+  end
+
   test "skips migration with --no-migration option", config do
     in_tmp_project config.test, fn ->
       Gen.Schema.run(~w(Blog.Post posts --no-migration))


### PR DESCRIPTION
I added a new option `--prefix` to the `mix phx.gen.schema` task and to the all related tasks: `phx.new`, `phx.gen.context`, `phx.gen.auth`. So it would be possible to generate files with pre-installed `prefix` option in the `table/2` function in migrations and `@schema_prefix` module attribute in schemas.