### PR TITLE
Change vsn query in assets url to be configurable

### DIFF
--- a/lib/mix/tasks/phx.digest.ex
+++ b/lib/mix/tasks/phx.digest.ex
@@ -33,19 +33,26 @@ defmodule Mix.Tasks.Phx.Digest do
     * app-eb0a5b9302e8d32828d8a73f137cc8f0.js.gz
     * cache_manifest.json
 
+  ## vsn
+
+  It is possible to digest the stylesheet asset references without the query
+  string "?vsn=d" with the option `--no-vsn`.
   """
+
+  @default_opts [vsn: true]
 
   @doc false
   def run(all_args) do
     Mix.Task.run "compile", all_args
-    {opts, args, _} = OptionParser.parse(all_args, switches: [output: :string], aliases: [o: :output])
+    {opts, args, _} = OptionParser.parse(all_args, switches: [output: :string, vsn: :boolean], aliases: [o: :output])
     input_path = List.first(args) || @default_input_path
     output_path = opts[:output] || input_path
+    with_vsn? = Keyword.merge(@default_opts, opts)[:vsn]
 
     Mix.Task.run "deps.loadpaths", all_args
     {:ok, _} = Application.ensure_all_started(:phoenix)
 
-    case Phoenix.Digester.compile(input_path, output_path) do
+    case Phoenix.Digester.compile(input_path, output_path, with_vsn?) do
       :ok ->
         # We need to call build structure so everything we have
         # generated into priv is copied to _build in case we have

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -96,6 +96,13 @@ defmodule Phoenix.Endpoint do
     * `:adapter` - which webserver adapter to use for serving web requests.
       See the "Adapter configuration" section below
 
+    * `:cache_manifest_skip_vsn` - when true, skips the appended query string 
+      "?vsn=d". If set to true it can also be useful to pass the 
+      [`--no-vsn`](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Digest.html#module-vsn).
+      Recommended to be set to `false` because of the cache mechanisms from
+      [`Plug.Static`](https://hexdocs.pm/plug/Plug.Static.html#module-cache-mechanisms).
+      Defaults to false.
+
     * `:cache_static_manifest` - a path to a json manifest file that contains
       static files and their digested version. This is typically set to
       "priv/static/cache_manifest.json" which is the file automatically generated

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -96,13 +96,6 @@ defmodule Phoenix.Endpoint do
     * `:adapter` - which webserver adapter to use for serving web requests.
       See the "Adapter configuration" section below
 
-    * `:cache_manifest_skip_vsn` - when true, skips the appended query string 
-      "?vsn=d". If set to true it can also be useful to pass the 
-      [`--no-vsn`](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Digest.html#module-vsn).
-      Recommended to be set to `false` because of the cache mechanisms from
-      [`Plug.Static`](https://hexdocs.pm/plug/Plug.Static.html#module-cache-mechanisms).
-      Defaults to false.
-
     * `:cache_static_manifest` - a path to a json manifest file that contains
       static files and their digested version. This is typically set to
       "priv/static/cache_manifest.json" which is the file automatically generated
@@ -113,7 +106,15 @@ defmodule Phoenix.Endpoint do
       digest version. This is automatically loaded from `cache_static_manifest` on
       boot. However, if you have your own static handling mechanism, you may want to
       set this value explicitly. This is used by projects such as `LiveView` to
-      detect if the client is running on the latest version of all assets
+      detect if the client is running on the latest version of all assets.
+
+    * `:cache_manifest_skip_vsn` - when true, skips the appended query string 
+      "?vsn=d" when generatic paths to static assets. This query string is used
+      by `Plug.Static` to set long expiry dates, therefore, you should set this
+      option to true only if you are not using `Plug.Static` to serve assets,
+      for example, if you are using a CDN. If you are setting this option, you
+      should also consider passing `--no-vsn` to `mix phx.digest`. Defaults to
+      `false`.
 
     * `:check_origin` - configure the default `:check_origin` setting for
       transports. See `socket/3` for options. Defaults to `true`.


### PR DESCRIPTION
When generating `static_path` or `static_url` as well as when running `mix phx.digest`it would be nice to have the option of the generated urls to have the `vsn=d`query or not.
This PR adds the possibility and maintains the current behavior as the default, being opt-in.
The `vsn` option as added to the runtime configuration `:url` of `Phoenix.Endpoint` as it looked like an expected place for it.
This PR is also related to #1784