### PR TITLE
Enable IPv6 for Ecto

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -264,7 +264,8 @@ defmodule Phx.New.Generator do
     config :#{binding[:app_name]}, #{binding[:app_module]}.Repo,
       # ssl: true,
       url: database_url,
-      pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
+      pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+      socket_options: [:inet6]
     """)
   end
 

--- a/installer/templates/phx_ecto/repo.ex
+++ b/installer/templates/phx_ecto/repo.ex
@@ -1,6 +1,6 @@
 defmodule <%= @app_module %>.Repo do
   use Ecto.Repo,
     otp_app: :<%= @app_name %>,
-    adapter: <%= inspect @adapter_module %>
+    adapter: <%= inspect @adapter_module %>,
     socket_options: [:inet6]
 end

--- a/installer/templates/phx_ecto/repo.ex
+++ b/installer/templates/phx_ecto/repo.ex
@@ -2,4 +2,5 @@ defmodule <%= @app_module %>.Repo do
   use Ecto.Repo,
     otp_app: :<%= @app_name %>,
     adapter: <%= inspect @adapter_module %>
+    socket_options: [:inet6]
 end

--- a/installer/templates/phx_ecto/repo.ex
+++ b/installer/templates/phx_ecto/repo.ex
@@ -1,6 +1,5 @@
 defmodule <%= @app_module %>.Repo do
   use Ecto.Repo,
     otp_app: :<%= @app_name %>,
-    adapter: <%= inspect @adapter_module %>,
-    socket_options: [:inet6]
+    adapter: <%= inspect @adapter_module %>
 end


### PR DESCRIPTION
This is an intentionally small PR. I'm not sure how best to accomplish this, so I made a tiny guess.

It adds a default `socket_options` to allow IPv6 with Ecto. This is backwards compatible, it does not disable IPv4. It is necessary [so Phoenix can talk to databases over IPv6](https://elixirforum.com/t/use-fly-io-internal-dns-for-resolving-database-url/38889) by default.

Tests pass but I'm not sure this change would actually break an existing test.