### PR TITLE
interface npm scripts 

### DIFF
--- a/guides/introduction/up_and_running.md
+++ b/guides/introduction/up_and_running.md
@@ -38,7 +38,7 @@ When it's done, it will ask us if we want it to install our dependencies for us.
 Fetch and install dependencies? [Yn] Y
 * running mix deps.get
 * running mix deps.compile
-* running cd assets && npm install && node node_modules/webpack/bin/webpack.js --mode development
+* running cd assets && npm install && npm run dev
 
 We are almost there! The following steps are missing:
 
@@ -101,7 +101,7 @@ We are almost there! The following steps are missing:
 
     $ cd hello
     $ mix deps.get
-    $ cd assets && npm install && node node_modules/webpack/bin/webpack.js --mode development
+    $ cd assets && npm install && npm run dev
 
 Then configure your database in config/dev.exs and run:
 
@@ -127,4 +127,3 @@ To stop it, we hit `ctrl-c` twice.
 Now you are ready to explore the world provided by Phoenix! See [our community page](community.html) for books, screencasts, courses, and more.
 
 Alternatively, you can continue reading these guides to have a quick introduction into all the parts that make your Phoenix application. If that's the case, you can read the guides in any order or start with our guide that explains the [Phoenix directory structure](directory_structure.html).
-

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -216,7 +216,7 @@ defmodule Mix.Tasks.Phx.New do
     assets_path = Path.join(project.web_path || project.project_path, "assets")
     webpack_config = Path.join(assets_path, "webpack.config.js")
 
-    maybe_cmd(project, "cd #{relative_app_path(assets_path)} && npm install && node node_modules/webpack/bin/webpack.js --mode development",
+    maybe_cmd(project, "cd #{relative_app_path(assets_path)} && npm install && npm run dev",
               File.exists?(webpack_config), install? && System.find_executable("npm"))
   end
 

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "deploy": "webpack --mode production",
-    "watch": "webpack --mode development --watch"
+    "dev": "webpack --mode development",
+    "watch": "webpack --mode development --watch-stdin"
   },
   "dependencies": {
     "phoenix": "file:<%= @phoenix_webpack_path %>"<%= if @html do %>,

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -14,11 +14,9 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
   code_reloader: true,
   check_origin: false,
   watchers: <%= if @webpack do %>[
-    node: [
-      "node_modules/webpack/bin/webpack.js",
-      "--mode",
-      "development",
-      "--watch-stdin",
+    npm: [
+      "run",
+      "watch",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]<% else %>[]<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -12,11 +12,9 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
   code_reloader: true,
   check_origin: false,
   watchers: <%= if @webpack do %>[
-    node: [
-      "node_modules/webpack/bin/webpack.js",
-      "--mode",
-      "development",
-      "--watch-stdin",
+    npm: [
+      "run",
+      "watch",
       cd: Path.expand("../apps/<%= @web_app_name %>/assets", __DIR__)
     ]
   ]<% else %>[]<% end %>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/assets/webpack.config.js", "js/app.js"
       assert_file "phx_blog/assets/.babelrc", "env"
       assert_file "phx_blog/config/dev.exs", fn file ->
-        assert file =~ "watchers: [\n    node:"
+        assert file =~ "watchers: [\n    npm:"
         assert file =~ "lib/phx_blog_web/(live|views)/.*(ex)"
         assert file =~ "lib/phx_blog_web/templates/.*(eex)"
       end

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -63,7 +63,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       end
 
       assert_file root_path(@app, "config/dev.exs"), fn file ->
-        assert file =~ ~r{watchers: \[\s+node:}
+        assert file =~ ~r{watchers: \[\s+npm:}
         assert file =~ "cd: Path.expand(\"../apps/phx_umb_web/assets\", __DIR__)"
         assert file =~ "lib/#{@app}_web/(live|views)/.*(ex)"
         assert file =~ "lib/#{@app}_web/templates/.*(eex)"

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -148,15 +148,13 @@ defmodule Phoenix.Endpoint do
       the "watch" mode of the webpack build tool when the server starts.
       You can configure it to whatever build tool or command you want:
 
-          [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development",
-              "--watch-stdin"]]
+          [npm: ["run", "watch"]]
 
       The `:cd` option can be used on a watcher to override the folder from
       which the watcher will run. By default this will be the project's root:
       `File.cwd!()`
 
-          [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development",
-              "--watch-stdin", cd: "my_frontend"]]
+          [npm: ["run", "watch", cd: "my_frontend"]]
 
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of


### PR DESCRIPTION
`scripts` section of `package.json` is a good place to provide commands which are used by Phoenix.

If we abstract the long commands into short npm scripts, we will:
+ have a unified interface to call node.js related commands.
+ avoid the long commands(such as `node node_modules/webpack/bin/webpack.js --mode development`) spreading in the code

And, there are two more advantage:
+ The developers who want to implement his own `assets` dir will have a better view on what they should implement - `just provides necessary NPM scripts, no need to touch the Phoenix code`.
+ When Phoenix Team decide to upgrade to Webpack 5, just update the npm scripts, there's nothing need to do with the Elixir code.
