### PR TITLE
Disable FLoC by default when creating a new project

### DIFF
--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -50,6 +50,6 @@ defmodule <%= @endpoint_module %> do
   plug Plug.MethodOverride
   plug Plug.Head
   plug Plug.Session, @session_options
-  plug :set_floc, false
+  plug :disable_floc, false
   plug <%= @web_namespace %>.Router
 end

--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -50,5 +50,6 @@ defmodule <%= @endpoint_module %> do
   plug Plug.MethodOverride
   plug Plug.Head
   plug Plug.Session, @session_options
+  plug :set_floc, false
   plug <%= @web_namespace %>.Router
 end

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -905,4 +905,15 @@ defmodule Phoenix.Endpoint do
   def server?(otp_app, endpoint) when is_atom(otp_app) and is_atom(endpoint) do
     Phoenix.Endpoint.Supervisor.server?(otp_app, endpoint)
   end
+
+  @doc """
+  Disables FLoC on Google Chrome browsers.
+
+  This function adds the HTTP-header `Permission-Policy: interest-cohort=()` to the response,
+  which tells the browser to exclude the page from the the FLoC calculation.
+
+  For more information regarding FLoC, please visit https://web.dev/floc.
+  """
+  def disable_floc(conn, true), do: Plug.Conn.put_resp_header(conn, "permissions-policy", "interest-cohort=()")
+  def disable_floc(conn, false), do: conn
 end


### PR DESCRIPTION
As the title says, this pull request tries to disable [FLoC](https://web.dev/floc/) on Google Chrome by default when creating a new project. I didn't add any tests yet, because I was ensure whether defining the function to disable this feature would fit into the `Phoenix.Endpoint` module and would appreciate further feedback. Thanks in advance!