### PR TITLE
Schedule heartbeat on reply to avoid intensive throttling

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -1039,9 +1039,11 @@ export class Socket {
    */
 
   heartbeatTimeout(){
-    this.pendingHeartbeatRef = null
-    if (this.hasLogger()) this.log("transport", "heartbeat timeout. Attempting to re-establish connection")
-    this.abnormalClose("heartbeat timeout")
+    if(this.pendingHeartbeatRef){
+      this.pendingHeartbeatRef = null
+      if (this.hasLogger()) this.log("transport", "heartbeat timeout. Attempting to re-establish connection")
+      this.abnormalClose("heartbeat timeout")
+    }
   }
 
   resetHeartbeat(){ if(this.conn && this.conn.skipHeartbeat){ return }

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -1215,7 +1215,7 @@ export class Socket {
 
   abnormalClose(reason){
     this.closeWasClean = false
-    if(this.conn.readyState === SOCKET_STATES.open){ this.conn.close(WS_CLOSE_NORMAL, reason) }
+    if(this.isConnected()){ this.conn.close(WS_CLOSE_NORMAL, reason) }
   }
 
   flushSendBuffer(){

--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -1041,7 +1041,7 @@ export class Socket {
   heartbeatTimeout(){
     if(this.pendingHeartbeatRef){
       this.pendingHeartbeatRef = null
-      if (this.hasLogger()) this.log("transport", "heartbeat timeout. Attempting to re-establish connection")
+      if(this.hasLogger()){ this.log("transport", "heartbeat timeout. Attempting to re-establish connection") }
       this.abnormalClose("heartbeat timeout")
     }
   }

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -467,15 +467,22 @@ describe("with transports", done =>{
       socket.connect()
     })
 
-    it("closes socket when heartbeat is not ack'd within heartbeat window", () => {
+    it("closes socket when heartbeat is not ack'd within heartbeat window", (done) => {
+      let clock = sinon.useFakeTimers()
       let closed = false
       socket.conn.readyState = 1 // open
       socket.conn.close = () => closed = true
       socket.sendHeartbeat()
-      assert.equal(closed, false)
+      assert.strictEqual(closed, false)
 
-      socket.sendHeartbeat()
-      assert.equal(closed, true)
+      clock.tick(10000)
+      assert.strictEqual(closed, false)
+
+      clock.tick(20010)
+      assert.strictEqual(closed, true)
+
+      clock.restore()
+      done()
     })
 
     it("pushes heartbeat data when connected", () => {


### PR DESCRIPTION
Closes #4307 

According to a Chromium bug report, intensive throttling is not applied to timers that are scheduled from a "network response handler". This was in response to Chrome 88 breaking Microsoft SignalR in a similar way to what's been reported.

I refactored our heartbeat based on their reference:
https://bugs.chromium.org/p/chromium/issues/detail?id=1186569#c3

**EDIT:** I am adding the annotated workflow for this change to reduce any confusion about what is going on.

1. First, `resetHeartbeat()` is called from `onConnOpen`
2. `resetHeartbeat` schedules `sendHeartbeat()` to be invoked after the heartbeat interval (default 30s). Note: the returned timer is not tracked.
3. `sendHeartbeat` then...
    1. generates `pendingHeartbeatRef`
    2. pushes the heartbeat message to the channel
    3. schedules `heartbeatTimeout()` to be invoked after the heartbeat interval. Note: this timer is tracked by `heartbeatTimer`
4. Next in `onConnMessage`, if the message ref matches `pendingHeartbeatRef`, then...
    1. `pendingHeartbeatRef` is cleared
    2. `heartbeatTimer` is cancelled
    3. The next invocation of `sendHeartbeat()` is scheduled.
5. If it happens that `heartbeatTimeout()` is ever invoked, the connection will be closed and an timeout error logged.

tl;dr the initial `sendHeartbeat()` is always scheduled and invoked. Subsequent heartbeats are scheduled once the previous heartbeat response has been received.