### PR TITLE
Correcting divergence between description and code example in channels guide

### DIFF
--- a/guides/realtime/channels.md
+++ b/guides/realtime/channels.md
@@ -347,7 +347,7 @@ defmodule HelloWeb.RoomChannel do
 end
 ```
 
-`broadcast!/3` will notify all joined clients on this `socket`'s topic and invoke their `handle_out/3` callbacks. `handle_out/3` isn't a required callback, but it allows us to customize and filter broadcasts before they reach each client. By default, `handle_out/3` is implemented for us and simply pushes the message on to the client, just like our definition. We included it here because hooking into outgoing events allows for powerful message customization and filtering. Let's see how.
+`broadcast!/3` will notify all joined clients on this `socket`'s topic and invoke their `handle_out/3` callbacks. `handle_out/3` isn't a required callback, but it allows us to customize and filter broadcasts before they reach each client. By default, `handle_out/3` is implemented for us and simply pushes the message on to the client. Hooking into outgoing events allows for powerful message customization and filtering. Let's see how.
 
 ### Intercepting Outgoing Events
 


### PR DESCRIPTION
It appears as though the code example and the written documentation relating to [Incoming Events]( https://hexdocs.pm/phoenix/channels.html#incoming-events) has diverged slightly. The documentation makes reference to `handle_out/3` and explains the default behaviour, even stipulating the following:

> We included it here because hooking into outgoing events allows for powerful message customization and filtering. 

The code example does not contain a definition for `handle_out/3`.

This change updates the description to ensure it is consistent with the code example.