### PR TITLE
Clarify disconnected html in PageLiveTest

### DIFF
--- a/installer/templates/phx_test/live/page_live_test.exs
+++ b/installer/templates/phx_test/live/page_live_test.exs
@@ -4,8 +4,11 @@ defmodule <%= @web_namespace %>.PageLiveTest do
   import Phoenix.LiveViewTest
 
   test "disconnected and connected render", %{conn: conn} do
-    {:ok, page_live, disconnected_html} = live(conn, "/")
+    conn = get(conn, "/")
+    disconnected_html = html_response(conn, 200)
+    {:ok, _live, connected_html} = live(conn)
+
     assert disconnected_html =~ "Welcome to Phoenix!"
-    assert render(page_live) =~ "Welcome to Phoenix!"
+    assert connected_html =~ "Welcome to Phoenix!"
   end
 end


### PR DESCRIPTION
👋 thanks for all the awesome work with Phoenix and LiveView!

What changed?
=============

This commit tries to clarify the "disconnected/connected" concepts in the sample [`page_live_test.exs`][page live test] that is generated when running `phx new --live`.

Why is a change needed?
----

The `PageLiveTest` that is generated with the `phx new --live` installer seems to be either incorrect or uses confusing language.

The [test][page live test] currently shows the `live/2` helper returning a `disconnected_html` as the third element in the three tuple:

```elixir
{:ok, page_live, disconnected_html} = live(conn, "/")
```

The term "disconnected" is confusing because [`LiveViewTest` docs][test docs] use that same term to describe the disconnected HTML returned from the stateless HTTP request.

Take the examples from [`LiveViewTest` docs][test docs]:

```elixir
test "disconnected and connected mount", %{conn: conn} do
  conn = get(conn, "/my-path")
  assert html_response(conn, 200) =~ "<h1>My Disconnected View</h1>"

  {:ok, view, html} = live(conn)
end
```

The disconnected view is the one rendered via the `get/2` + `html_response/2`.

By contrast the `html` returned by `live/2` renders the "Connected View":

```elixir
test "connected mount", %{conn: conn} do
  {:ok, _view, html} = live(conn, "/my-path")
  assert html =~ "<h1>My Connected View</h1>"
end
```

From some independent testing (I'd be happy to provide a sample app if that's helpful), the latter seems to be true: the `html` returned by the `live/2` helper is the connected HTML, not the disconnected one.

So, this commit seeks to clarify that distinction by updating the sample test in the installer to more closely match those shown in the `Phoenix.LiveViewTest` docs.

[test docs]: https://hexdocs.pm/phoenix_live_view/Phoenix.LiveViewTest.html#module-liveview-testing
[page live test]: https://github.com/phoenixframework/phoenix/blob/c11b93ed7da4ef200338dad635be93b31fac2aa8/installer/templates/phx_test/live/page_live_test.exs#L1-L11