### PR TITLE
Implement Phoenix.Param for Float

### DIFF
--- a/lib/phoenix/param.ex
+++ b/lib/phoenix/param.ex
@@ -58,6 +58,10 @@ defimpl Phoenix.Param, for: Integer do
   def to_param(int), do: Integer.to_string(int)
 end
 
+defimpl Phoenix.Param, for: Float do
+  def to_param(float), do: Float.to_string(float)
+end
+
 defimpl Phoenix.Param, for: BitString do
   def to_param(bin) when is_binary(bin), do: bin
 end

--- a/test/phoenix/param_test.exs
+++ b/test/phoenix/param_test.exs
@@ -7,6 +7,10 @@ defmodule Phoenix.ParamTest do
     assert to_param(1) == "1"
   end
 
+  test "to_param for floats" do
+    assert to_param(3.14) == "3.14"
+  end
+
   test "to_param for binaries" do
     assert to_param("foo") == "foo"
   end


### PR DESCRIPTION
I tried to place a float in the query string of a URL using the router helpers like this:

```elixir
latitude = 32.149989
longitude = -110.835842
MyAppWeb.Router.Helpers.page_path(:search, %{latitude: latitude, longitude: longitude})
```

But I get the error

```
** (Protocol.UndefinedError) protocol Phoenix.Param not implemented for 32.149989 of type Float. This protocol is implemented for the following type(s): Any, Map, Integer, BitString, Atom
```

I've implemented this in my own application, but I felt like Float is a common enough data structure that it would make sense for me to add this change back upstream for everyone else too. I'm happy to make any changes necessary.