### PR TITLE
Add onJoin method and trigger join event for channel

### DIFF
--- a/assets/js/phoenix.js
+++ b/assets/js/phoenix.js
@@ -390,11 +390,12 @@ export class Channel {
         if(this.isErrored()){ this.rejoin() }
       })
     )
-    this.joinPush.receive("ok", () => {
+    this.joinPush.receive("ok", (payload) => {
       this.state = CHANNEL_STATES.joined
       this.rejoinTimer.reset()
       this.pushBuffer.forEach( pushEvent => pushEvent.send() )
       this.pushBuffer = []
+      this.trigger(CHANNEL_EVENTS.join, payload)
     })
     this.joinPush.receive("error", () => {
       this.state = CHANNEL_STATES.errored
@@ -440,6 +441,15 @@ export class Channel {
       return this.joinPush
     }
   }
+
+  /**
+   * Hook into channel join
+   * @param {Function} callback
+   */
+  onJoin(callback){
+    this.on(CHANNEL_EVENTS.join, callback)
+  }
+
 
   /**
    * Hook into channel close


### PR DESCRIPTION
There isn't possible to use the join event. After the channel joined there isn't possible to use the on method with the `phx_join` event name, but in the source, this event exists.

This pull request contains a new method `onJoin` and triggers the `phx_join` event when the channel joined.