### PR TITLE
Add libstdc++ package to docker release image in the docs

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -206,7 +206,7 @@ RUN mix release
 # Start a new build stage so that the final image will only contain
 # the compiled release and other runtime necessities
 FROM alpine:3.12.1 AS app
-RUN apk add --no-cache openssl ncurses-libs
+RUN apk add --no-cache libstdc++ openssl ncurses-libs
 
 ENV USER="elixir"
 


### PR DESCRIPTION
I initially prepared the Dockerfile for my project according to the Phoenix docs and it worked great without modifications.
After updating to Elixir 1.12 and Erlang/OTP 24, the app crashes at startup complaining about missing `libstdc++` and `libgcc`.

The [OTP 24.0 release announcement](https://www.erlang.org/downloads/24.0) doesn't explicitly mention the new dependencies, but it does say this:
```
The JIT-compiler is enabled by default on most x86 64-bit platforms that have a C++ compiler that can compile C++17.
```

Since [`libstdc++`](https://pkgs.alpinelinux.org/package/edge/main/ppc64le/libstdc++) depends on `libgcc`, it's enough to add the `libstdc++` package to the docker release image.

For anyone who runs into this issue, this is the full error log without `libstdc++` installed:
<details>
  <summary>Full error log</summary>
  

```
Error loading shared library libstdc++.so.6: No such file or directory (needed by /app/erts-12.0/bin/beam.smp)
Error loading shared library libgcc_s.so.1: No such file or directory (needed by /app/erts-12.0/bin/beam.smp)
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_begin_catch: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZSt24__throw_out_of_range_fmtPKcz: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _Znwm: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZSt20__throw_length_errorPKc: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_guard_release: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZNKSt8__detail20_Prime_rehash_policy11_M_next_bktEm: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __popcountdi2: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZSt29_Rb_tree_insert_and_rebalancebPSt18_Rb_tree_node_baseS0_RS_: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZSt17__throw_bad_allocv: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_appendEPKcm: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE9_M_createERmm: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZSt18_Rb_tree_incrementPKSt18_Rb_tree_node_base: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_end_catch: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_guard_acquire: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZNKSt8__detail20_Prime_rehash_policy14_M_need_rehashEmmm: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZSt19__throw_logic_errorPKc: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZSt18_Rb_tree_decrementPSt18_Rb_tree_node_base: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE7reserveEm: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_rethrow: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _Unwind_Resume: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZdlPvm: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv120__si_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __cxa_pure_virtual: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv117__class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv117__class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv117__class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv117__class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv117__class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv117__class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: _ZTVN10__cxxabiv121__vmi_class_type_infoE: symbol not found
Error relocating /app/erts-12.0/bin/beam.smp: __gxx_personality_v0: symbol not found
```
</details>