### PR TITLE
Use scripts defined in package.json for starting Webpack

### DIFF
--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -14,11 +14,10 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
   code_reloader: true,
   check_origin: false,
   watchers: <%= if @webpack do %>[
-    node: [
-      "node_modules/webpack/bin/webpack.js",
-      "--mode",
-      "development",
-      "--watch-stdin",
+    # If using yarn, you can use `yarn watch` instead of `npm run watch`
+    npm: [
+      "run",
+      "watch",
       cd: Path.expand("../assets", __DIR__)
     ]
   ]<% else %>[]<% end %>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/assets/webpack.config.js", "js/app.js"
       assert_file "phx_blog/assets/.babelrc", "env"
       assert_file "phx_blog/config/dev.exs", fn file ->
-        assert file =~ "watchers: [\n    node:"
+        assert file =~ "watchers: [\n    # If using yarn, you can use `yarn watch` instead of `npm run watch`\n    npm:"
         assert file =~ "lib/phx_blog_web/(live|views)/.*(ex)"
         assert file =~ "lib/phx_blog_web/templates/.*(eex)"
       end


### PR DESCRIPTION
I came across this while working with TailwindCSS and trying to get its JIT mode working, and figured it might be beneficial to contribute back.

There's already a `watch` script defined in package.json that starts webpack, so if we use it for the watcher then the command can be more easily tweaked (eg. to add `NODE_ENV=development` which Tailwind needs).

It works for npm (and yarn if using the comment version) - can we assume that users are using npm like this? I think maybe we can, because we use npm for assets if a user starts a new app and elects to install dependencies.