### PR TITLE
Update README.md with new IRC address

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ npm run watch
 
 ## Important links
 
-* [#elixir-lang][1] on [Freenode][2] IRC
+* [#elixir-lang][1] on [Libera][2] IRC
 * [elixir-lang Slack channel][3]
 * [Issue tracker][4]
 * [Phoenix Forum (questions)][5]
@@ -81,8 +81,8 @@ $ npm run watch
 * Visit Phoenix's sponsor, DockYard, for expert [phoenix consulting](https://dockyard.com/phoenix-consulting)
 * Privately disclose security vulnerabilities to phoenix-security@googlegroups.com
 
-  [1]: https://webchat.freenode.net/?channels=#elixir-lang
-  [2]: http://www.freenode.net/
+  [1]: https://web.libera.chat/?channels=#elixir-lang
+  [2]: https://libera.chat/
   [3]: https://elixir-slackin.herokuapp.com/
   [4]: https://github.com/phoenixframework/phoenix/issues
   [5]: https://elixirforum.com/c/phoenix-forum


### PR DESCRIPTION
Updated the `README` links to point to the new Elixir IRC channel on [libera.chat](https://libera.chat).