### PR TITLE
Update Elixir IRC channel references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please **do not** use the issue tracker for personal support requests nor featur
 
 * The [phoenix-talk mailing list](http://groups.google.com/group/phoenix-talk) (closed in favor of forum, but archive is still online)
 * [The Phoenix subforum on the Elixir forum](https://elixirforum.com/c/phoenix-forum)
-* **[#elixir](irc://irc.libera.chat/elixir)** IRC channel on [irc.libera.chat](https://libera.chat/)
+* **[#elixir](irc://irc.libera.chat/elixir)** on [Libera](https://libera.chat/) IRC
 
 Development issues can be discussed on the [phoenix-core mailing list](http://groups.google.com/group/phoenix-core).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Please **do not** use the issue tracker for personal support requests nor featur
 
 * The [phoenix-talk mailing list](http://groups.google.com/group/phoenix-talk) (closed in favor of forum, but archive is still online)
 * [The Phoenix subforum on the Elixir forum](https://elixirforum.com/c/phoenix-forum)
-* **[#elixir-lang](irc://chat.freenode.net/elixir-lang)** IRC channel on [chat.freenode.net](http://www.freenode.net/)
+* **[#elixir](irc://irc.libera.chat/elixir)** IRC channel on [irc.libera.chat](https://libera.chat/)
 
 Development issues can be discussed on the [phoenix-core mailing list](http://groups.google.com/group/phoenix-core).
 

--- a/installer/templates/phx_web/templates/page/index.html.eex
+++ b/installer/templates/phx_web/templates/page/index.html.eex
@@ -36,7 +36,7 @@
         <a href="https://elixirforum.com/c/phoenix-forum">Forum</a>
       </li>
       <li>
-        <a href="https://webchat.freenode.net/?channels=elixir-lang">#elixir-lang on Freenode IRC</a>
+        <a href="https://web.libera.chat/#elixir">#elixir on Libera Chat (IRC)</a>
       </li>
       <li>
         <a href="https://twitter.com/elixirphoenix">Twitter @elixirphoenix</a>


### PR DESCRIPTION
Spotted this when creating a new project: the initial template still references the old Freenode channel #elixir-lang.

Update this to #elixir on Libera, which is the [new official IRC channel](https://github.com/elixir-lang/elixir-lang.github.com/commit/1434d99966abe6ce50765e07fa9a6addb1e8355f).