### PR TITLE
Improve asset pipline docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ Phoenix v1.6 requires Elixir v1.9+.
   * [Endpoint] Do not require a pubsub server in the socket (only inside channels)
   * [mix phx.gen.auth] Add `mix phx.gen.auth` generator
   * [mix phx.gen.context] Support `enum` types and the `redact` option when declaring fields
-  * [mix phx.new] Replace deprecated `node-sass` with `sass` library
   * [mix phx.new] Update `mix phx.new` to require Elixir v1.11 and use the new `config/runtime.exs`
   * [mix phx.new] Add description to Ecto telemetry metrics
   * [mix phx.new] Use `Ecto.Adapters.SQL.Sandbox.start_owner!/2` in generators - this approach provides proper shutdown semantics for apps using LiveView and Presence
   * [mix phx.new] Add `--install` and `--no-install` options to `phx.new`
   * [mix phx.new] Add `--database sqlite3` option to `phx.new`
   * [View] Extracted `Phoenix.View` into its own project to facilitate reuse
+  * [mix phx.new] Remove usage of Sass
 
 ### JavaScript Client Enhancements
   * Fire each event in a separate task for the LongPoll transport to fix ordering

--- a/guides/introduction/installation.md
+++ b/guides/introduction/installation.md
@@ -50,12 +50,11 @@ The `phx.new` generator is now available to generate new applications in the nex
 
 ## Node.js
 
-Node.js is an optional dependency. Phoenix will use [webpack](https://webpack.js.org/) to compile static assets (JavaScript, CSS, etc), by default. Webpack uses the node package manager (npm) to install its dependencies, and npm requires Node.js.
+Node.js is an optional dependency. Phoenix will use [webpack](https://webpack.js.org) to compile static assets (JavaScript, CSS, etc), by default. Webpack uses the node package manager (npm) to install its dependencies, and npm requires Node.js.
 
 If we don't have any static assets, or we want to use another build tool, we can pass the `--no-webpack` flag when creating a new application and Node.js won't be required at all.
 
-We can get Node.js from the [download page](https://nodejs.org/en/download/). When selecting a package to download, it's important to note that Phoenix requires version 5.0.0 or greater.
-
+We can get Node.js from [nodejs.org](https://nodejs.org).  
 macOS users can also install Node.js via [homebrew](https://brew.sh/).
 
 ## PostgreSQL

--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -8,16 +8,18 @@
     "phoenix": "file:<%= @phoenix_webpack_path %>"<%= if @html do %>,
     "phoenix_html": "file:<%= @phoenix_html_webpack_path %>"<% end %><%= if @live do %>,
     "phoenix_live_view": "file:<%= @phoenix_live_view_webpack_path %>",
-    "topbar": "^0.1.4"<% end %>
+    "topbar": "^1.0.0"<% end %>
   },
   "devDependencies": {
     "copy-webpack-plugin": "^9.0.0",
     "css-loader": "^5.2.6",
     "css-minimizer-webpack-plugin": "^3.0.0",
-    "expose-loader": "3.0.0",
     "glob": "7.1.7",
     "mini-css-extract-plugin": "^1.6.0",
     "webpack": "5.37.1",
     "webpack-cli": "^4.7.0"
+  },
+  "engines": {
+    "node": ">=14.x"
   }
 }

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -163,14 +163,14 @@ defmodule Phoenix.Endpoint do
       You can configure it to whatever build tool or command you want:
 
           [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development",
-              "--watch-stdin"]]
+              "--watch", "--watch-options-stdin"]]
 
       The `:cd` option can be used on a watcher to override the folder from
       which the watcher will run. By default this will be the project's root:
       `File.cwd!()`
 
           [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development",
-              "--watch-stdin", cd: "my_frontend"]]
+              "--watch", "--watch-options-stdin" cd: "my_frontend"]]
 
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -170,7 +170,7 @@ defmodule Phoenix.Endpoint do
       `File.cwd!()`
 
           [node: ["node_modules/webpack/bin/webpack.js", "--mode", "development",
-              "--watch", "--watch-options-stdin" cd: "my_frontend"]]
+              "--watch", "--watch-options-stdin", cd: "my_frontend"]]
 
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of


### PR DESCRIPTION
This is a complementation of https://github.com/phoenixframework/phoenix/pull/4337.

Things done:
- Removed the Node.js version requirement from the installation guide
- Added instead the "engines" field with node >=14.x to the `package.json`  
  This should at least warn if an older Node.js version is used.
  But theoretically we still would support older versions.
  (webpack says it support 10.x - but you never really know with all the other dependencies)
- Changed the Node.js download page directly to the nodejs.org landing site (probably quicker for first time node users)