### PR TITLE
Fix default Swoosh adapter for mailer generator

### DIFF
--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -21,8 +21,13 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
   live_view: [signing_salt: "<%= @lv_signing_salt %>"]<%= if @mailer do %>
 
 # Configures the mailer.
-# Check https://hexdocs.pm/swoosh for different adapters.
-config :<%= @app_name %>, <%= @web_namespace %>.Mailer, adapter: Swoosh.Adapters.SMTP
+#
+# By default it uses the "Local" adapter which stores the emails
+# locally. You can see the emails in your browser, at "/dev/mailbox".
+#
+# For production it's recommended to configure a different adapter
+# at the `config/runtime.exs`.
+config :<%= @app_name %>, <%= @app_module %>.Mailer, adapter: Swoosh.Adapters.Local
 
 # Swoosh API client is needed for adapters other than SMTP.
 config :swoosh, :api_client, false<% end %>

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -57,13 +57,7 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
       ~r"lib/<%= @lib_web_name %>/(live|views)/.*(ex)$",
       ~r"lib/<%= @lib_web_name %>/templates/.*(eex)$"
     ]
-  ]<% end %><%= if @mailer do %>
-
-# By default, emails will not be sent in localhost.
-# Instead they are available at "/dev/mailbox".
-# Check the application router for details.
-config :<%= @app_name %>, <%= @web_namespace %>.Mailer,
-  adapter: Swoosh.Adapters.Local<% end %>
+  ]<% end %>
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"

--- a/installer/templates/phx_single/config/runtime.exs
+++ b/installer/templates/phx_single/config/runtime.exs
@@ -33,5 +33,27 @@ if config_env() == :prod do
   #     config :<%= @web_app_name %>, <%= @endpoint_module %>, server: true
   #
   # Then you can assemble a release by calling `mix release`.
-  # See `mix help release` for more information.
+  # See `mix help release` for more information.<%= if @mailer do %>
+
+  # ## Configuring the mailer
+  #
+  # In production you need to configure the mailer to use a different adapter.
+  # Also, you may need to configure the Swoosh API client of your choice if you
+  # are not using SMTP.
+  #
+  # Additionally you may need to add more dependencies required by your adapter.
+  # Here is an example of the configuration:
+  #
+  #     config :<%= @app_name %>, <%= @app_module %>.Mailer,
+  #       adapter: Swoosh.Adapters.Mailgun,
+  #       api_key: System.get_env("MAILGUN_API_KEY"),
+  #       domain: System.get_env("MAILGUN_DOMAIN")
+  #
+  # For this example you need include a HTTP client required by Swoosh API client.
+  # Swoosh supports Hackney and Finch, but you can write your own if you need.
+  # Finally configure Swoosh to use the given adapter:
+  #
+  #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
+  #
+  # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.<% end %>
 end

--- a/installer/templates/phx_single/config/runtime.exs
+++ b/installer/templates/phx_single/config/runtime.exs
@@ -39,10 +39,7 @@ if config_env() == :prod do
   #
   # In production you need to configure the mailer to use a different adapter.
   # Also, you may need to configure the Swoosh API client of your choice if you
-  # are not using SMTP.
-  #
-  # Additionally you may need to add more dependencies required by your adapter.
-  # Here is an example of the configuration:
+  # are not using SMTP. Here is an example of the configuration:
   #
   #     config :<%= @app_name %>, <%= @app_module %>.Mailer,
   #       adapter: Swoosh.Adapters.Mailgun,
@@ -50,8 +47,7 @@ if config_env() == :prod do
   #       domain: System.get_env("MAILGUN_DOMAIN")
   #
   # For this example you need include a HTTP client required by Swoosh API client.
-  # Swoosh supports Hackney and Finch, but you can write your own if you need.
-  # Finally configure Swoosh to use the given adapter:
+  # Swoosh supports Hackney and Finch out of the box:
   #
   #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
   #

--- a/installer/templates/phx_single/config/test.exs
+++ b/installer/templates/phx_single/config/test.exs
@@ -7,7 +7,7 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
   server: false<%= if @mailer do %>
 
 # In test we don't send emails.
-config :<%= @app_name %>, <%= @web_namespace %>.Mailer,
+config :<%= @app_name %>, <%= @app_module %>.Mailer,
   adapter: Swoosh.Adapters.Test<% end %>
 
 # Print only warnings and errors during test

--- a/installer/templates/phx_umbrella/apps/app_name/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/config/config.exs
@@ -4,8 +4,13 @@ config :<%= @app_name %><%= if @namespaced? do %>,
   ecto_repos: [<%= @app_module %>.Repo]<% end %><% end %><%= if @mailer do %>
 
 # Configures the mailer.
-# Check https://hexdocs.pm/swoosh for different adapters.
-config :<%= @app_name %>, <%= @app_module %>.Mailer, adapter: Swoosh.Adapters.SMTP
+#
+# By default it uses the "Local" adapter which stores the emails
+# locally. You can see the emails in your browser, at "/dev/mailbox".
+#
+# For production it's recommended to configure a different adapter
+# at the `config/runtime.exs`.
+config :<%= @app_name %>, <%= @app_module %>.Mailer, adapter: Swoosh.Adapters.Local
 
 # Swoosh API client is needed for adapters other than SMTP.
 config :swoosh, :api_client, false<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/runtime.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/runtime.exs
@@ -22,4 +22,26 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 #     config :<%= @web_app_name %>, <%= @endpoint_module %>, server: true
 #
 # Then you can assemble a release by calling `mix release`.
-# See `mix help release` for more information.
+# See `mix help release` for more information.<%= if @mailer do %>
+
+# ## Configuring the mailer
+#
+# In production you need to configure the mailer to use a different adapter.
+# Also, you may need to configure the Swoosh API client of your choice if you
+# are not using SMTP.
+#
+# Additionally you may need to add more dependencies required by your adapter.
+# Here is an example of the configuration:
+#
+#     config :<%= @app_name %>, <%= @app_module %>.Mailer,
+#       adapter: Swoosh.Adapters.Mailgun,
+#       api_key: System.get_env("MAILGUN_API_KEY"),
+#       domain: System.get_env("MAILGUN_DOMAIN")
+#
+# For this example you need include a HTTP client required by Swoosh API client.
+# Swoosh supports Hackney and Finch, but you can write your own if you need.
+# Finally configure Swoosh to use the given adapter:
+#
+#     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
+#
+# See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/runtime.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/runtime.exs
@@ -28,10 +28,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 #
 # In production you need to configure the mailer to use a different adapter.
 # Also, you may need to configure the Swoosh API client of your choice if you
-# are not using SMTP.
-#
-# Additionally you may need to add more dependencies required by your adapter.
-# Here is an example of the configuration:
+# are not using SMTP. Here is an example of the configuration:
 #
 #     config :<%= @app_name %>, <%= @app_module %>.Mailer,
 #       adapter: Swoosh.Adapters.Mailgun,
@@ -39,8 +36,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 #       domain: System.get_env("MAILGUN_DOMAIN")
 #
 # For this example you need include a HTTP client required by Swoosh API client.
-# Swoosh supports Hackney and Finch, but you can write your own if you need.
-# Finally configure Swoosh to use the given adapter:
+# Swoosh supports Hackney and Finch out of the box:
 #
 #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
 #

--- a/installer/templates/phx_umbrella/config/dev.exs
+++ b/installer/templates/phx_umbrella/config/dev.exs
@@ -8,10 +8,4 @@ config :phoenix, :plug_init_mode, :runtime
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.
-config :phoenix, :stacktrace_depth, 20<%= if @mailer do %>
-
-# By default, emails will not be sent in localhost.
-# Instead they are available at "/dev/mailbox".
-# Check the application router for details.
-config :<%= @app_name %>, <%= @app_module %>.Mailer,
-  adapter: Swoosh.Adapters.Local<% end %>
+config :phoenix, :stacktrace_depth, 20

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -203,15 +203,11 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/config/config.exs", fn file ->
         assert file =~ "config :swoosh"
-        assert file =~ "config :phx_blog, PhxBlogWeb.Mailer, adapter: Swoosh.Adapters.SMTP"
+        assert file =~ "config :phx_blog, PhxBlog.Mailer, adapter: Swoosh.Adapters.Local"
       end
 
       assert_file "phx_blog/config/test.exs", fn file ->
-        assert file =~ "config :phx_blog, PhxBlogWeb.Mailer, adapter: Swoosh.Adapters.Test"
-      end
-
-      assert_file "phx_blog/config/dev.exs", fn file ->
-        assert file =~ "config :phx_blog, PhxBlogWeb.Mailer, adapter: Swoosh.Adapters.Local"
+        assert file =~ "config :phx_blog, PhxBlog.Mailer, adapter: Swoosh.Adapters.Test"
       end
 
       # Install dependencies?
@@ -340,7 +336,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/config/config.exs", fn file ->
         refute file =~ "config :swoosh"
-        refute file =~ "config :phx_blog, PhxBlogWeb.Mailer, adapter: Swoosh.Adapters.SMTP"
+        refute file =~ "config :phx_blog, PhxBlog.Mailer, adapter: Swoosh.Adapters.Local"
       end
     end
   end

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -216,15 +216,11 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file root_path(@app, "config/config.exs"), fn file ->
         assert file =~ "config :swoosh"
-        assert file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.SMTP"
+        assert file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.Local"
       end
 
       assert_file root_path(@app, "config/test.exs"), fn file ->
         assert file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.Test"
-      end
-
-      assert_file root_path(@app, "config/dev.exs"), fn file ->
-        assert file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.Local"
       end
 
       # Install dependencies?
@@ -335,15 +331,11 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file root_path(@app, "config/config.exs"), fn file ->
         refute file =~ "config :swoosh"
-        refute file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.SMTP"
+        refute file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.Local"
       end
 
       assert_file root_path(@app, "config/test.exs"), fn file ->
         refute file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.Test"
-      end
-
-      assert_file root_path(@app, "config/dev.exs"), fn file ->
-        refute file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.Local"
       end
     end
   end


### PR DESCRIPTION
This fix is needed because we don't want to include a new dependency
required for the "SMTP" adapter (gen_smtp). We choose to use the "Local"
adapter by default and mention Swoosh docs for more adapters.