### PR TITLE
Opinionated change regarding webpack

### DIFF
--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -8,14 +8,13 @@
     "phoenix": "file:<%= @phoenix_webpack_path %>"<%= if @html do %>,
     "phoenix_html": "file:<%= @phoenix_html_webpack_path %>"<% end %><%= if @live do %>,
     "phoenix_live_view": "file:<%= @phoenix_live_view_webpack_path %>",
-    "topbar": "^1.0.0"<% end %>
+    "topbar": "^1.x"<% end %>
   },
   "devDependencies": {
-    "copy-webpack-plugin": "^9.0.0",
+    "copy-webpack-plugin": "^9.x",
     "css-loader": "^5.2.6",
-    "css-minimizer-webpack-plugin": "^3.0.0",
-    "glob": "7.1.7",
-    "mini-css-extract-plugin": "^1.6.0",
+    "css-minimizer-webpack-plugin": "^3.x",
+    "mini-css-extract-plugin": "^2.x",
     "webpack": "5.37.1",
     "webpack-cli": "^4.7.0"
   },

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require('path');
-const glob = require('glob');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -8,39 +7,39 @@ module.exports = (env, options) => {
   const devMode = options.mode !== 'production';
 
   return {
-    resolve: {
-      modules: ['node_modules']
-    },
-    optimization: {
-      minimizer: [
-        '...',
-        new CssMinimizerPlugin()
-      ]
-    },
     entry: {
-      'app': glob.sync('./vendor/**/*.js').concat(['./js/app.js'])
+      'app': './js/app.js'
     },
     output: {
       filename: '[name].js',
       path: path.resolve(__dirname, '../priv/static/js'),
       publicPath: '/js/'
     },
-    devtool: devMode ? 'source-map' : undefined,
     module: {
       rules: [
         {
           test: /\.css$/,
-          use: [MiniCssExtractPlugin.loader, 'css-loader'],
+          use: [
+            MiniCssExtractPlugin.loader,
+            'css-loader'
+          ],
         }
       ]
     },
     plugins: [
-      new MiniCssExtractPlugin({ filename: '../css/app.css' }),
+      new MiniCssExtractPlugin({ filename: '../css/[name].css' }),
       new CopyPlugin({
         patterns: [
           { from: 'static/', to: '../' }
         ]
       })
-    ]
+    ],
+    optimization: {
+      minimizer: [
+        '...',
+        new CssMinimizerPlugin()
+      ]
+    },
+    devtool: devMode ? 'source-map' : undefined
   }
 };


### PR DESCRIPTION
- Update of mini-css-extract-plugin to v2.
- Reordered the webpack.config.js in a more "logical" order.?!
- Removed the entry point of `./vendor/**/*.js` but I'm unsure about it.
  Will phx.new created project have in any way a non empty "assets/vendor" directory?
  So I will probably also suggest to remove the creation of this directory.
  What are your thought about that?
- Again used 1.x version annotation where totally clear
