### PR TITLE
Use Regex to extract token

### DIFF
--- a/priv/templates/phx.gen.auth/context_fixtures_functions.ex
+++ b/priv/templates/phx.gen.auth/context_fixtures_functions.ex
@@ -19,6 +19,6 @@
 
   def extract_<%= schema.singular %>_token(fun) do
     {:ok, captured} = fun.(&"[TOKEN]#{&1}[TOKEN]")
-    [_, token, _] = String.split(captured.body, "[TOKEN]")
+    [_, token] = Regex.run(~r/(?:\[TOKEN])([\w_-]*)(?:\[TOKEN])/, captured.body)
     token
   end


### PR DESCRIPTION
The current token extraction method for the tests generated by `mix phx.gen.auth` fails if there is more than one occurrence of the token in the captured content. By using Regex to extract only the first occurrence of a token, the tests would still pass in the above case.

Using Regex seems a sensible default as the tests will now pass if the captured notification body is in either plain text or a HTML format requiring two occurrences of the token, like in a link for example. `<a href="[TOKEN]">[TOKEN]</a>`