### PR TITLE
Doc:  Dockerfile intructions: copy lib folder before compiling assets.

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -192,12 +192,13 @@ COPY priv priv
 # your Elixir templates, you will need to move the asset compilation step
 # down so that `lib` is available.
 COPY assets assets
+COPY lib lib
 # use webpack to compile npm dependencies - https://www.npmjs.com/package/webpack-deploy
 RUN npm run --prefix ./assets deploy
 RUN mix phx.digest
 
 # compile and build the release
-COPY lib lib
+
 RUN mix compile
 # changes to config/runtime.exs don't require recompiling the code
 COPY config/runtime.exs config/

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -198,7 +198,6 @@ RUN npm run --prefix ./assets deploy
 RUN mix phx.digest
 
 # compile and build the release
-
 RUN mix compile
 # changes to config/runtime.exs don't require recompiling the code
 COPY config/runtime.exs config/


### PR DESCRIPTION
I know that it is going to compile the assets again if we change the lib folder. But, when working with Tailwind(very popular) it needs to see the classes in the live view components before purging it on production.  I see it is a common problem with people trying to deploy tailwind with Live view to containers. https://pragmaticstudio.com/tutorials/adding-tailwind-css-to-phoenix