### PR TITLE
Fix the mime.types url

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -311,7 +311,7 @@ end
 
 We would then need to provide an `index.xml.eex` template which created valid XML, and we would be done.
 
-For a list of valid content mime-types, please see the [mime.types](https://github.com/elixir-plug/mime/blob/master/priv/mime.types) documentation from the mime type library.
+For a list of valid content mime-types, please see the [mime.types](https://github.com/elixir-plug/mime/blob/master/lib/mime.ex) documentation from the mime type library.
 
 ### Setting the HTTP Status
 


### PR DESCRIPTION
This PR fixes the url to the `mime.types` documentation.