### PR TITLE
allow `node -r ...` in watchers

### DIFF
--- a/lib/phoenix/endpoint/watcher.ex
+++ b/lib/phoenix/endpoint/watcher.ex
@@ -59,6 +59,12 @@ defmodule Phoenix.Endpoint.Watcher do
 
   # We specially handle Node.js to make sure we
   # provide a good getting started experience.
+  # Although we assume folks know what they're doing
+  # if they are calling `node -r some_required.js ...`
+  defp validate("node", ["-r" | _], _opts) do
+    :ok
+  end
+
   defp validate("node", [script | _], merged_opts) do
     script_path = Path.expand(script, cd(merged_opts))
 


### PR DESCRIPTION
This allows watchers that want to require a file inline, such as you might do if you are using `yarn`'s "Plug'n'Play" approach.