### PR TITLE
Add phx.gen.socket to generate a socket file

### DIFF
--- a/lib/mix/tasks/phx.gen.channel.ex
+++ b/lib/mix/tasks/phx.gen.channel.ex
@@ -42,12 +42,31 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
       {:eex, "channel_test.exs", Path.join(test_prefix, "channels/#{binding[:path]}_channel_test.exs")},
     ]
 
-    Mix.shell().info """
+    user_socket_path = Mix.Phoenix.web_path(context_app, "channels/user_socket.ex")
 
-    Add the channel to your `#{Mix.Phoenix.web_path(context_app, "channels/user_socket.ex")}` handler, for example:
+    instructions =
+      if File.exists?(user_socket_path) do
+        """
 
-        channel "#{binding[:singular]}:lobby", #{binding[:module]}Channel
-    """
+        Add the channel to your `#{user_socket_path}` handler, for example:
+
+            channel "#{binding[:singular]}:lobby", #{binding[:module]}Channel
+        """
+      else
+        """
+
+        The default socket handler - `#{binding[:web_module]}.UserSocket` - was not found
+        in its default location. To create it, please run the mix task:
+
+            mix phx.gen.socket User
+
+        Then add the channel to the newly created file, at `#{user_socket_path}`:
+
+            channel "#{binding[:singular]}:lobby", #{binding[:module]}Channel
+        """
+      end
+
+    Mix.shell().info(instructions)
   end
 
   @spec raise_with_help() :: no_return()

--- a/lib/mix/tasks/phx.gen.channel.ex
+++ b/lib/mix/tasks/phx.gen.channel.ex
@@ -22,12 +22,16 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
 
   """
   use Mix.Task
+  alias Mix.Tasks.Phx.Gen
 
   @doc false
   def run(args) do
     if Mix.Project.umbrella?() do
-      Mix.raise "mix phx.gen.channel must be invoked from within your *_web application root directory"
+      Mix.raise(
+        "mix phx.gen.channel must be invoked from within your *_web application root directory"
+      )
     end
+
     [channel_name] = validate_args!(args)
     context_app = Mix.Phoenix.context_app()
     web_prefix = Mix.Phoenix.web_path(context_app)
@@ -37,52 +41,60 @@ defmodule Mix.Tasks.Phx.Gen.Channel do
 
     Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Channel")
 
-    Mix.Phoenix.copy_from paths(), "priv/templates/phx.gen.channel", binding, [
-      {:eex, "channel.ex",       Path.join(web_prefix, "channels/#{binding[:path]}_channel.ex")},
-      {:eex, "channel_test.exs", Path.join(test_prefix, "channels/#{binding[:path]}_channel_test.exs")},
-    ]
+    Mix.Phoenix.copy_from(paths(), "priv/templates/phx.gen.channel", binding, [
+      {:eex, "channel.ex", Path.join(web_prefix, "channels/#{binding[:path]}_channel.ex")},
+      {:eex, "channel_test.exs",
+       Path.join(test_prefix, "channels/#{binding[:path]}_channel_test.exs")}
+    ])
 
     user_socket_path = Mix.Phoenix.web_path(context_app, "channels/user_socket.ex")
 
-    instructions =
-      if File.exists?(user_socket_path) do
-        """
+    if File.exists?(user_socket_path) do
+      Mix.shell().info("""
 
-        Add the channel to your `#{user_socket_path}` handler, for example:
+      Add the channel to your `#{user_socket_path}` handler, for example:
 
-            channel "#{binding[:singular]}:lobby", #{binding[:module]}Channel
-        """
+          channel "#{binding[:singular]}:lobby", #{binding[:module]}Channel
+      """)
+    else
+      Mix.shell().info("""
+
+      The default socket handler - `#{binding[:web_module]}.UserSocket` - was not found
+      in its default location.
+      """)
+
+      if Mix.shell().yes?("Do you want to create it?") do
+        Gen.Socket.run(~w(User #{channel_name}))
       else
-        """
+        Mix.shell().info("""
 
-        The default socket handler - `#{binding[:web_module]}.UserSocket` - was not found
-        in its default location. To create it, please run the mix task:
+        To create it, please run the mix task:
 
             mix phx.gen.socket User
 
         Then add the channel to the newly created file, at `#{user_socket_path}`:
 
             channel "#{binding[:singular]}:lobby", #{binding[:module]}Channel
-        """
+        """)
       end
-
-    Mix.shell().info(instructions)
+    end
   end
 
   @spec raise_with_help() :: no_return()
   defp raise_with_help do
-    Mix.raise """
+    Mix.raise("""
     mix phx.gen.channel expects just the module name:
 
         mix phx.gen.channel Room
 
-    """
+    """)
   end
 
   defp validate_args!(args) do
     unless length(args) == 1 do
       raise_with_help()
     end
+
     args
   end
 

--- a/lib/mix/tasks/phx.gen.socket.ex
+++ b/lib/mix/tasks/phx.gen.socket.ex
@@ -1,0 +1,94 @@
+defmodule Mix.Tasks.Phx.Gen.Socket do
+  @shortdoc "Generates a Phoenix socket handler"
+
+  @moduledoc """
+  Generates a Phoenix socket handler.
+
+      mix phx.gen.socket User
+
+  Accepts the module name for the socket
+
+  The generated files will contain:
+
+  For a regular application:
+
+    * a socket in `lib/my_app_web/channels`
+    * a socket test in `test/my_app_web/channels`
+
+  For an umbrella application:
+
+    * a socket in `apps/my_app_web/lib/app_name_web/channels`
+    * a socket test in `apps/my_app_web/test/my_app_web/channels`
+
+  """
+  use Mix.Task
+
+  @doc false
+  def run(args) do
+    if Mix.Project.umbrella?() do
+      Mix.raise(
+        "mix phx.gen.socket must be invoked from within your *_web application root directory"
+      )
+    end
+
+    [socket_name] = validate_args!(args)
+
+    context_app = Mix.Phoenix.context_app()
+    web_prefix = Mix.Phoenix.web_path(context_app)
+    binding = Mix.Phoenix.inflect(socket_name)
+
+    binding =
+      binding
+      |> Keyword.put(:module, "#{binding[:web_module]}.#{binding[:scoped]}")
+      |> Keyword.put(:endpoint_module, Module.concat([binding[:web_module], Endpoint]))
+      |> Keyword.put(:web_prefix, web_prefix)
+
+    Mix.Phoenix.check_module_name_availability!(binding[:module] <> "Socket")
+
+    Mix.Phoenix.copy_from(paths(), "priv/templates/phx.gen.socket", binding, [
+      {:eex, "socket.ex", Path.join(web_prefix, "channels/#{binding[:path]}_socket.ex")},
+      {:eex, "socket.js", "assets/js/#{binding[:path]}_socket.js"}
+    ])
+
+    Mix.shell().info("""
+
+    Add the socket handler to your `#{Mix.Phoenix.web_path(context_app, "endpoint.ex")}`, for example:
+
+        socket "/socket", #{binding[:module]}Socket,
+          websocket: true,
+          longpoll: false
+
+    After that you can define your `channel` topic in the newly created socket file.
+    In order to create new channel files, you can use channel generator:
+
+        mix phx.gen.channel Room
+
+    For the front-end integration, you need to import the `#{binding[:path]}_socket.js`
+    in your `app.js` file:
+
+        import "./#{binding[:path]}_socket.js"
+    """)
+  end
+
+  @spec raise_with_help() :: no_return()
+  defp raise_with_help do
+    Mix.raise("""
+    mix phx.gen.socket expects just the module name:
+
+        mix phx.gen.socket User
+
+    """)
+  end
+
+  defp validate_args!(args) do
+    unless length(args) == 1 do
+      raise_with_help()
+    end
+
+    args
+  end
+
+  defp paths do
+    [".", :phoenix]
+  end
+end

--- a/priv/templates/phx.gen.socket/socket.ex
+++ b/priv/templates/phx.gen.socket/socket.ex
@@ -14,7 +14,7 @@ defmodule <%= module %>Socket do
   # pointing to the `<%= web_module %>.RoomChannel`:
   #
   # channel "room:*", <%= web_module %>.RoomChannel
-  #<% end %>
+  #
   # To create a channel file, use the mix task:
   #
   #     mix phx.gen.channel Room
@@ -22,6 +22,7 @@ defmodule <%= module %>Socket do
   # See the [`Channels guide`](https://hexdocs.pm/phoenix/channels.html)
   # for futher details.
 
+<% end %>
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After
   # verification, you can put default assigns into

--- a/priv/templates/phx.gen.socket/socket.ex
+++ b/priv/templates/phx.gen.socket/socket.ex
@@ -1,0 +1,50 @@
+defmodule <%= module %>Socket do
+  use Phoenix.Socket
+
+  # A Socket handler
+  #
+  # It's possible to control the websocket connection and
+  # assign values that can be accessed by your channel topics.
+
+  ## Channels
+  # Uncomment the following line to define a "room:*" topic
+  # pointing to the `<%= web_module %>.RoomChannel`:
+  #
+  # channel "room:*", <%= web_module %>.RoomChannel
+  #
+  # To create a channel file, use the mix task:
+  #
+  #     mix phx.gen.channel Room
+  #
+  # See the [`Channels guide`](https://hexdocs.pm/phoenix/channels.html)
+  # for futher details.
+
+  # Socket params are passed from the client and can
+  # be used to verify and authenticate a user. After
+  # verification, you can put default assigns into
+  # the socket that will be set for all channels, ie
+  #
+  #     {:ok, assign(socket, :user_id, verified_user_id)}
+  #
+  # To deny connection, return `:error`.
+  #
+  # See `Phoenix.Token` documentation for examples in
+  # performing token verification on connect.
+  @impl true
+  def connect(_params, socket, _connect_info) do
+    {:ok, socket}
+  end
+
+  # Socket id's are topics that allow you to identify all sockets for a given user:
+  #
+  #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
+  #
+  # Would allow you to broadcast a "disconnect" event and terminate
+  # all active sockets and channels for a given user:
+  #
+  #     <%= endpoint_module %>.broadcast("user_socket:#{user.id}", "disconnect", %{})
+  #
+  # Returning `nil` makes this socket anonymous.
+  @impl true
+  def id(_socket), do: nil
+end

--- a/priv/templates/phx.gen.socket/socket.ex
+++ b/priv/templates/phx.gen.socket/socket.ex
@@ -6,12 +6,15 @@ defmodule <%= module %>Socket do
   # It's possible to control the websocket connection and
   # assign values that can be accessed by your channel topics.
 
-  ## Channels
+  ## Channels<%= if existing_channel do %>
+
+  channel "<%= existing_channel[:singular] %>:*", <%= existing_channel[:module] %>Channel
+<% else %>
   # Uncomment the following line to define a "room:*" topic
   # pointing to the `<%= web_module %>.RoomChannel`:
   #
   # channel "room:*", <%= web_module %>.RoomChannel
-  #
+  #<% end %>
   # To create a channel file, use the mix task:
   #
   #     mix phx.gen.channel Room

--- a/priv/templates/phx.gen.socket/socket.js
+++ b/priv/templates/phx.gen.socket/socket.js
@@ -4,7 +4,7 @@
 // Bring in Phoenix channels client library:
 import {Socket} from "phoenix"
 
-// And connect to the path in "lib/web/endpoint.ex". We pass the
+// And connect to the path in "<%= web_prefix %>/endpoint.ex". We pass the
 // token for authentication. Read below how it should be used.
 let socket = new Socket("/socket", {params: {token: window.userToken}})
 

--- a/priv/templates/phx.gen.socket/socket.js
+++ b/priv/templates/phx.gen.socket/socket.js
@@ -1,13 +1,11 @@
 // NOTE: The contents of this file will only be executed if
 // you uncomment its entry in "assets/js/app.js".
 
-// To use Phoenix channels, the first step is to import Socket,
-// and connect at the socket path in "<%= web_prefix %>/endpoint.ex".
-//
-// Pass the token on params as below. Or remove it
-// from the params if you are not using authentication.
+// Bring in Phoenix channels client library:
 import {Socket} from "phoenix"
 
+// And connect to the path in "lib/web/endpoint.ex". We pass the
+// token for authentication. Read below how it should be used.
 let socket = new Socket("/socket", {params: {token: window.userToken}})
 
 // When you connect, you'll often need to authenticate the client.

--- a/priv/templates/phx.gen.socket/socket.js
+++ b/priv/templates/phx.gen.socket/socket.js
@@ -1,0 +1,66 @@
+// NOTE: The contents of this file will only be executed if
+// you uncomment its entry in "assets/js/app.js".
+
+// To use Phoenix channels, the first step is to import Socket,
+// and connect at the socket path in "<%= web_prefix %>/endpoint.ex".
+//
+// Pass the token on params as below. Or remove it
+// from the params if you are not using authentication.
+import {Socket} from "phoenix"
+
+let socket = new Socket("/socket", {params: {token: window.userToken}})
+
+// When you connect, you'll often need to authenticate the client.
+// For example, imagine you have an authentication plug, `MyAuth`,
+// which authenticates the session and assigns a `:current_user`.
+// If the current user exists you can assign the user's token in
+// the connection for use in the layout.
+//
+// In your "<%= web_prefix %>/router.ex":
+//
+//     pipeline :browser do
+//       ...
+//       plug MyAuth
+//       plug :put_user_token
+//     end
+//
+//     defp put_user_token(conn, _) do
+//       if current_user = conn.assigns[:current_user] do
+//         token = Phoenix.Token.sign(conn, "user socket", current_user.id)
+//         assign(conn, :user_token, token)
+//       else
+//         conn
+//       end
+//     end
+//
+// Now you need to pass this token to JavaScript. You can do so
+// inside a script tag in "<%= web_prefix %>/templates/layout/app.html.eex":
+//
+//     <script>window.userToken = "<%%= assigns[:user_token] %>";</script>
+//
+// You will need to verify the user token in the "connect/3" function
+// in "<%= web_prefix %>/channels/user_socket.ex":
+//
+//     def connect(%{"token" => token}, socket, _connect_info) do
+//       # max_age: 1209600 is equivalent to two weeks in seconds
+//       case Phoenix.Token.verify(socket, "user socket", token, max_age: 1_209_600) do
+//         {:ok, user_id} ->
+//           {:ok, assign(socket, :user, user_id)}
+//
+//         {:error, reason} ->
+//           :error
+//       end
+//     end
+//
+// Finally, connect to the socket:
+socket.connect()
+
+// Now that you are connected, you can join channels with a topic.
+// Let's assume you have a channel with a topic named `room` and the
+// subtopic is its id - in this case 42:
+let channel = socket.channel("room:42", {})
+channel.join()
+  .receive("ok", resp => { console.log("Joined successfully", resp) })
+  .receive("error", resp => { console.log("Unable to join", resp) })
+
+export default socket

--- a/test/mix/tasks/phx.gen.channel_test.exs
+++ b/test/mix/tasks/phx.gen.channel_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "../../../installer/test/mix_helper.exs", __DIR__
+Code.require_file("../../../installer/test/mix_helper.exs", __DIR__)
 
 defmodule PhoenixWeb.DupChannel do
 end
@@ -14,12 +14,12 @@ defmodule Mix.Tasks.Phx.Gen.ChannelTest do
   end
 
   test "generates channel" do
-    in_tmp_project "generates channel", fn ->
+    in_tmp_project("generates channel", fn ->
       # Ensure the `user_socket.ex` exists first.
-      Gen.Socket.run ["User"]
-      Gen.Channel.run ["Room"]
+      Gen.Socket.run(["User"])
+      Gen.Channel.run(["Room"])
 
-      assert_file "lib/phoenix_web/channels/room_channel.ex", fn file ->
+      assert_file("lib/phoenix_web/channels/room_channel.ex", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.RoomChannel do|
         assert file =~ ~S|use PhoenixWeb, :channel|
         assert file =~ ~S|def join("room:lobby", payload, socket) do|
@@ -29,9 +29,9 @@ defmodule Mix.Tasks.Phx.Gen.ChannelTest do
         assert file =~ ~S|def handle_in("shout", payload, socket) do|
         assert file =~ ~S|broadcast socket, "shout", payload|
         assert file =~ ~S|{:noreply, socket}|
-      end
+      end)
 
-      assert_file "test/phoenix_web/channels/room_channel_test.exs", fn file ->
+      assert_file("test/phoenix_web/channels/room_channel_test.exs", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.RoomChannelTest|
         assert file =~ ~S|use PhoenixWeb.ChannelCase|
         assert file =~ ~S|> socket("user_id", %{some: :assign}|
@@ -48,117 +48,223 @@ defmodule Mix.Tasks.Phx.Gen.ChannelTest do
         assert file =~ ~S|test "broadcasts are pushed to the client"|
         assert file =~ ~S|broadcast_from! socket, "broadcast", %{"some" => "data"}|
         assert file =~ ~S|assert_push "broadcast", %{"some" => "data"}|
-      end
-    end
+      end)
+    end)
 
-    assert_received {:mix_shell, :info, ["""
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-    Add the channel to your `lib/phoenix_web/channels/user_socket.ex` handler, for example:
+                       Add the channel to your `lib/phoenix_web/channels/user_socket.ex` handler, for example:
 
-        channel "room:lobby", PhoenixWeb.RoomChannel
-    """]}
+                           channel "room:lobby", PhoenixWeb.RoomChannel
+                       """
+                     ]}
+  end
+
+  test "generates channel and ask to create UserSocket" do
+    in_tmp_project("generates channel", fn ->
+      # Accepts creation of the UserSocket
+      send(self(), {:mix_shell_input, :yes?, true})
+      Gen.Channel.run(["Room"])
+
+      assert_file("lib/phoenix_web/channels/room_channel.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.RoomChannel do|
+        assert file =~ ~S|use PhoenixWeb, :channel|
+      end)
+
+      assert_file("test/phoenix_web/channels/room_channel_test.exs", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.RoomChannelTest|
+        assert file =~ ~S|use PhoenixWeb.ChannelCase|
+      end)
+
+      assert_received {:mix_shell, :info,
+                       [
+                         """
+
+                         The default socket handler - `PhoenixWeb.UserSocket` - was not found
+                         in its default location.
+                         """
+                       ]}
+
+      assert_received {:mix_shell, :yes?, [question]}
+      assert question =~ "Do you want to create it?"
+
+      assert_received {:mix_shell, :info,
+                       [
+                         """
+
+                         Add the socket handler to your `lib/phoenix_web/endpoint.ex`, for example:
+
+                             socket "/socket", PhoenixWeb.UserSocket,
+                               websocket: true,
+                               longpoll: false
+
+                         After that you can define your `channel` topic in the newly created socket file.
+                         In order to create new channel files, you can use channel generator:
+
+                             mix phx.gen.channel Room
+
+                         For the front-end integration, you need to import the `user_socket.js`
+                         in your `app.js` file:
+
+                             import "./user_socket.js"
+                         """
+                       ]}
+
+      assert_file("lib/phoenix_web/channels/user_socket.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.UserSocket do|
+        assert file =~ ~S|channel "room:*", PhoenixWeb.RoomChannel|
+      end)
+    end)
   end
 
   test "generates channel and give instructions when UserSocket does not exist" do
-    in_tmp_project "generates channel", fn ->
-      Gen.Channel.run ["Room"]
+    in_tmp_project("generates channel", fn ->
+      send(self(), {:mix_shell_input, :yes?, false})
+      Gen.Channel.run(["Room"])
 
-      assert_file "lib/phoenix_web/channels/room_channel.ex", fn file ->
+      assert_file("lib/phoenix_web/channels/room_channel.ex", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.RoomChannel do|
         assert file =~ ~S|use PhoenixWeb, :channel|
-      end
+      end)
 
-      assert_file "test/phoenix_web/channels/room_channel_test.exs", fn file ->
+      assert_file("test/phoenix_web/channels/room_channel_test.exs", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.RoomChannelTest|
         assert file =~ ~S|use PhoenixWeb.ChannelCase|
-      end
-    end
+      end)
+    end)
 
-    assert_received {:mix_shell, :info, ["""
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-    The default socket handler - `PhoenixWeb.UserSocket` - was not found
-    in its default location. To create it, please run the mix task:
+                       The default socket handler - `PhoenixWeb.UserSocket` - was not found
+                       in its default location.
+                       """
+                     ]}
 
-        mix phx.gen.socket User
+    assert_received {:mix_shell, :yes?, [question]}
+    assert question =~ "Do you want to create it?"
 
-    Then add the channel to the newly created file, at `lib/phoenix_web/channels/user_socket.ex`:
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-        channel "room:lobby", PhoenixWeb.RoomChannel
-    """]}
+                       To create it, please run the mix task:
+
+                           mix phx.gen.socket User
+
+                       Then add the channel to the newly created file, at `lib/phoenix_web/channels/user_socket.ex`:
+
+                           channel "room:lobby", PhoenixWeb.RoomChannel
+                       """
+                     ]}
   end
 
   test "in an umbrella with a context_app, generates the files" do
-    in_tmp_umbrella_project "generates channels", fn ->
+    in_tmp_umbrella_project("generates channels", fn ->
+      send(self(), {:mix_shell_input, :yes?, false})
       Application.put_env(:phoenix, :generators, context_app: {:another_app, "another_app"})
-      Gen.Channel.run ["room"]
-      assert_file "lib/phoenix/channels/room_channel.ex", fn file ->
+      Gen.Channel.run(["room"])
+
+      assert_file("lib/phoenix/channels/room_channel.ex", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.RoomChannel do|
         assert file =~ ~S|use PhoenixWeb, :channel|
-      end
+      end)
 
-      assert_file "test/phoenix/channels/room_channel_test.exs", fn file ->
+      assert_file("test/phoenix/channels/room_channel_test.exs", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.RoomChannelTest|
         assert file =~ ~S|subscribe_and_join(PhoenixWeb.RoomChannel|
-      end
-    end
+      end)
+    end)
 
-    assert_received {:mix_shell, :info, ["""
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-    The default socket handler - `PhoenixWeb.UserSocket` - was not found
-    in its default location. To create it, please run the mix task:
+                       The default socket handler - `PhoenixWeb.UserSocket` - was not found
+                       in its default location.
+                       """
+                     ]}
 
-        mix phx.gen.socket User
+    assert_received {:mix_shell, :yes?, [question]}
+    assert question =~ "Do you want to create it?"
 
-    Then add the channel to the newly created file, at `lib/phoenix/channels/user_socket.ex`:
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-        channel "room:lobby", PhoenixWeb.RoomChannel
-    """]}
+                       To create it, please run the mix task:
+
+                           mix phx.gen.socket User
+
+                       Then add the channel to the newly created file, at `lib/phoenix/channels/user_socket.ex`:
+
+                           channel "room:lobby", PhoenixWeb.RoomChannel
+                       """
+                     ]}
   end
 
   test "generates nested channel" do
-    in_tmp_project "generates nested channel", fn ->
-      Gen.Channel.run ["Admin.Room"]
+    in_tmp_project("generates nested channel", fn ->
+      send(self(), {:mix_shell_input, :yes?, false})
+      Gen.Channel.run(["Admin.Room"])
 
-      assert_file "lib/phoenix_web/channels/admin/room_channel.ex", fn file ->
+      assert_file("lib/phoenix_web/channels/admin/room_channel.ex", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.Admin.RoomChannel do|
         assert file =~ ~S|use PhoenixWeb, :channel|
-      end
+      end)
 
-      assert_file "test/phoenix_web/channels/admin/room_channel_test.exs", fn file ->
+      assert_file("test/phoenix_web/channels/admin/room_channel_test.exs", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.Admin.RoomChannelTest|
         assert file =~ ~S|use PhoenixWeb.ChannelCase|
         assert file =~ ~S|subscribe_and_join(PhoenixWeb.Admin.RoomChannel|
-      end
-    end
+      end)
+    end)
 
-    assert_received {:mix_shell, :info, ["""
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-    The default socket handler - `PhoenixWeb.UserSocket` - was not found
-    in its default location. To create it, please run the mix task:
+                       The default socket handler - `PhoenixWeb.UserSocket` - was not found
+                       in its default location.
+                       """
+                     ]}
 
-        mix phx.gen.socket User
+    assert_received {:mix_shell, :yes?, [question]}
+    assert question =~ "Do you want to create it?"
 
-    Then add the channel to the newly created file, at `lib/phoenix_web/channels/user_socket.ex`:
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-        channel "room:lobby", PhoenixWeb.Admin.RoomChannel
-    """]}
+                       To create it, please run the mix task:
+
+                           mix phx.gen.socket User
+
+                       Then add the channel to the newly created file, at `lib/phoenix_web/channels/user_socket.ex`:
+
+                           channel "room:lobby", PhoenixWeb.Admin.RoomChannel
+                       """
+                     ]}
   end
 
   test "passing no args raises error" do
     assert_raise Mix.Error, fn ->
-      Gen.Channel.run []
+      Gen.Channel.run([])
     end
   end
 
   test "passing extra args raises error" do
     assert_raise Mix.Error, fn ->
-      Gen.Channel.run ["Admin.Room", "new_message"]
+      Gen.Channel.run(["Admin.Room", "new_message"])
     end
   end
 
   test "name is already defined" do
     assert_raise Mix.Error, ~r/DupChannel is already taken/, fn ->
-      Gen.Channel.run ["Dup"]
+      Gen.Channel.run(["Dup"])
     end
   end
 end

--- a/test/mix/tasks/phx.gen.socket_test.exs
+++ b/test/mix/tasks/phx.gen.socket_test.exs
@@ -19,6 +19,13 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
 
       assert_file("lib/phoenix_web/channels/user_socket.ex", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.UserSocket do|
+
+        assert file =~ ~S|# Uncomment the following line to define a "room:*" topic|
+        assert file =~ ~S|# pointing to the `PhoenixWeb.RoomChannel`:|
+        assert file =~ ~S|# channel "room:*", PhoenixWeb.RoomChannel|
+
+        assert file =~ ~S|def connect(_params, socket, _connect_info) do|
+        assert file =~ ~S|def id(_socket), do: nil|
       end)
 
       assert_file("assets/js/user_socket.js", fn file ->
@@ -30,30 +37,46 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
       end)
     end)
 
-    assert_received {:mix_shell, :info, ["""
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-      Add the socket handler to your `lib/phoenix_web/endpoint.ex`, for example:
+                       Add the socket handler to your `lib/phoenix_web/endpoint.ex`, for example:
 
-          socket "/socket", PhoenixWeb.UserSocket,
-            websocket: true,
-            longpoll: false
+                           socket "/socket", PhoenixWeb.UserSocket,
+                             websocket: true,
+                             longpoll: false
 
-      After that you can define your `channel` topic in the newly created socket file.
-      In order to create new channel files, you can use channel generator:
+                       After that you can define your `channel` topic in the newly created socket file.
+                       In order to create new channel files, you can use channel generator:
 
-          mix phx.gen.channel Room
+                           mix phx.gen.channel Room
 
-      For the front-end integration, you need to import the `user_socket.js`
-      in your `app.js` file:
+                       For the front-end integration, you need to import the `user_socket.js`
+                       in your `app.js` file:
 
-          import "./user_socket.js"
-      """]}
+                           import "./user_socket.js"
+                       """
+                     ]}
+  end
+
+  test "generates socket with channel declaration" do
+    in_tmp_project("generates socket with channel declaration", fn ->
+      Gen.Socket.run(~w(User Chat))
+
+      assert_file("lib/phoenix_web/channels/user_socket.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.UserSocket do|
+
+        refute file =~ ~S|# Uncomment the following line to define a "room:*" topic|
+        assert file =~ ~S|channel "chat:*", PhoenixWeb.ChatChannel|
+      end)
+    end)
   end
 
   test "in an umbrella with a context_app, generates the files" do
     in_tmp_umbrella_project("generates channels", fn ->
       Application.put_env(:phoenix, :generators, context_app: {:another_app, "another_app"})
-      Gen.Socket.run(["room"])
+      Gen.Socket.run(["Room"])
 
       assert_file("lib/phoenix/channels/room_socket.ex", fn file ->
         assert file =~ ~S|defmodule PhoenixWeb.RoomSocket do|
@@ -68,24 +91,27 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
       end)
     end)
 
-    assert_received {:mix_shell, :info, ["""
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-      Add the socket handler to your `lib/phoenix/endpoint.ex`, for example:
+                       Add the socket handler to your `lib/phoenix/endpoint.ex`, for example:
 
-          socket "/socket", PhoenixWeb.RoomSocket,
-            websocket: true,
-            longpoll: false
+                           socket "/socket", PhoenixWeb.RoomSocket,
+                             websocket: true,
+                             longpoll: false
 
-      After that you can define your `channel` topic in the newly created socket file.
-      In order to create new channel files, you can use channel generator:
+                       After that you can define your `channel` topic in the newly created socket file.
+                       In order to create new channel files, you can use channel generator:
 
-          mix phx.gen.channel Room
+                           mix phx.gen.channel Room
 
-      For the front-end integration, you need to import the `room_socket.js`
-      in your `app.js` file:
+                       For the front-end integration, you need to import the `room_socket.js`
+                       in your `app.js` file:
 
-          import "./room_socket.js"
-      """]}
+                           import "./room_socket.js"
+                       """
+                     ]}
   end
 
   test "generates nested socket" do
@@ -105,29 +131,38 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
       end)
     end)
 
-    assert_received {:mix_shell, :info, ["""
+    assert_received {:mix_shell, :info,
+                     [
+                       """
 
-      Add the socket handler to your `lib/phoenix_web/endpoint.ex`, for example:
+                       Add the socket handler to your `lib/phoenix_web/endpoint.ex`, for example:
 
-          socket "/socket", PhoenixWeb.Admin.UserSocket,
-            websocket: true,
-            longpoll: false
+                           socket "/socket", PhoenixWeb.Admin.UserSocket,
+                             websocket: true,
+                             longpoll: false
 
-      After that you can define your `channel` topic in the newly created socket file.
-      In order to create new channel files, you can use channel generator:
+                       After that you can define your `channel` topic in the newly created socket file.
+                       In order to create new channel files, you can use channel generator:
 
-          mix phx.gen.channel Room
+                           mix phx.gen.channel Room
 
-      For the front-end integration, you need to import the `admin/user_socket.js`
-      in your `app.js` file:
+                       For the front-end integration, you need to import the `admin/user_socket.js`
+                       in your `app.js` file:
 
-          import "./admin/user_socket.js"
-      """]}
+                           import "./admin/user_socket.js"
+                       """
+                     ]}
   end
 
   test "passing no args raises error" do
     assert_raise Mix.Error, fn ->
       Gen.Socket.run([])
+    end
+  end
+
+  test "passing invalid name raises error" do
+    assert_raise Mix.Error, fn ->
+      Gen.Socket.run(["room"])
     end
   end
 

--- a/test/mix/tasks/phx.gen.socket_test.exs
+++ b/test/mix/tasks/phx.gen.socket_test.exs
@@ -1,0 +1,145 @@
+Code.require_file("../../../installer/test/mix_helper.exs", __DIR__)
+
+defmodule PhoenixWeb.DupSocket do
+end
+
+defmodule Mix.Tasks.Phx.Gen.SocketTest do
+  use ExUnit.Case
+  import MixHelper
+  alias Mix.Tasks.Phx.Gen
+
+  setup do
+    Mix.Task.clear()
+    :ok
+  end
+
+  test "generates socket" do
+    in_tmp_project("generates socket", fn ->
+      Gen.Socket.run(["User"])
+
+      assert_file("lib/phoenix_web/channels/user_socket.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.UserSocket do|
+      end)
+
+      assert_file("assets/js/user_socket.js", fn file ->
+        assert file =~ ~S|and connect at the socket path in "lib/phoenix_web/endpoint.ex"|
+        assert file =~ ~S|In your "lib/phoenix_web/router.ex":|
+
+        assert file =~ ~S|let channel = socket.channel("room:42", {})|
+        assert file =~ ~S|channel.join()|
+      end)
+    end)
+
+    assert_received {:mix_shell, :info, ["""
+
+      Add the socket handler to your `lib/phoenix_web/endpoint.ex`, for example:
+
+          socket "/socket", PhoenixWeb.UserSocket,
+            websocket: true,
+            longpoll: false
+
+      After that you can define your `channel` topic in the newly created socket file.
+      In order to create new channel files, you can use channel generator:
+
+          mix phx.gen.channel Room
+
+      For the front-end integration, you need to import the `user_socket.js`
+      in your `app.js` file:
+
+          import "./user_socket.js"
+      """]}
+  end
+
+  test "in an umbrella with a context_app, generates the files" do
+    in_tmp_umbrella_project("generates channels", fn ->
+      Application.put_env(:phoenix, :generators, context_app: {:another_app, "another_app"})
+      Gen.Socket.run(["room"])
+
+      assert_file("lib/phoenix/channels/room_socket.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.RoomSocket do|
+      end)
+
+      assert_file("assets/js/room_socket.js", fn file ->
+        assert file =~ ~S|and connect at the socket path in "lib/phoenix/endpoint.ex"|
+        assert file =~ ~S|In your "lib/phoenix/router.ex":|
+
+        assert file =~ ~S|let channel = socket.channel("room:42", {})|
+        assert file =~ ~S|channel.join()|
+      end)
+    end)
+
+    assert_received {:mix_shell, :info, ["""
+
+      Add the socket handler to your `lib/phoenix/endpoint.ex`, for example:
+
+          socket "/socket", PhoenixWeb.RoomSocket,
+            websocket: true,
+            longpoll: false
+
+      After that you can define your `channel` topic in the newly created socket file.
+      In order to create new channel files, you can use channel generator:
+
+          mix phx.gen.channel Room
+
+      For the front-end integration, you need to import the `room_socket.js`
+      in your `app.js` file:
+
+          import "./room_socket.js"
+      """]}
+  end
+
+  test "generates nested socket" do
+    in_tmp_project("generates nested socket", fn ->
+      Gen.Socket.run(["Admin.User"])
+
+      assert_file("lib/phoenix_web/channels/admin/user_socket.ex", fn file ->
+        assert file =~ ~S|defmodule PhoenixWeb.Admin.UserSocket do|
+      end)
+
+      assert_file("assets/js/admin/user_socket.js", fn file ->
+        assert file =~ ~S|and connect at the socket path in "lib/phoenix_web/endpoint.ex"|
+        assert file =~ ~S|In your "lib/phoenix_web/router.ex":|
+
+        assert file =~ ~S|let channel = socket.channel("room:42", {})|
+        assert file =~ ~S|channel.join()|
+      end)
+    end)
+
+    assert_received {:mix_shell, :info, ["""
+
+      Add the socket handler to your `lib/phoenix_web/endpoint.ex`, for example:
+
+          socket "/socket", PhoenixWeb.Admin.UserSocket,
+            websocket: true,
+            longpoll: false
+
+      After that you can define your `channel` topic in the newly created socket file.
+      In order to create new channel files, you can use channel generator:
+
+          mix phx.gen.channel Room
+
+      For the front-end integration, you need to import the `admin/user_socket.js`
+      in your `app.js` file:
+
+          import "./admin/user_socket.js"
+      """]}
+  end
+
+  test "passing no args raises error" do
+    assert_raise Mix.Error, fn ->
+      Gen.Socket.run([])
+    end
+  end
+
+  test "passing extra args raises error" do
+    assert_raise Mix.Error, fn ->
+      Gen.Socket.run(["Admin.User", "new_message"])
+    end
+  end
+
+  test "name is already defined" do
+    assert_raise Mix.Error, ~r/DupSocket is already taken/, fn ->
+      Gen.Socket.run(["Dup"])
+    end
+  end
+end

--- a/test/mix/tasks/phx.gen.socket_test.exs
+++ b/test/mix/tasks/phx.gen.socket_test.exs
@@ -29,7 +29,15 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
       end)
 
       assert_file("assets/js/user_socket.js", fn file ->
-        assert file =~ ~S|and connect at the socket path in "lib/phoenix_web/endpoint.ex"|
+        assert file =~ ~S|// NOTE: The contents of this file will only be executed if|
+        assert file =~ ~S|// you uncomment its entry in "assets/js/app.js".|
+
+        assert file =~ ~S|// Bring in Phoenix channels client library:|
+        assert file =~ ~S|import {Socket} from "phoenix"|
+
+        assert file =~ ~S|// And connect to the path in "lib/phoenix_web/endpoint.ex".|
+        assert file =~ ~S|let socket = new Socket("/socket", {params: {token: window.userToken}})|
+
         assert file =~ ~S|In your "lib/phoenix_web/router.ex":|
 
         assert file =~ ~S|let channel = socket.channel("room:42", {})|
@@ -83,7 +91,13 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
       end)
 
       assert_file("assets/js/room_socket.js", fn file ->
-        assert file =~ ~S|and connect at the socket path in "lib/phoenix/endpoint.ex"|
+        assert file =~ ~S|// NOTE: The contents of this file will only be executed if|
+        assert file =~ ~S|// you uncomment its entry in "assets/js/app.js".|
+
+        assert file =~ ~S|// Bring in Phoenix channels client library:|
+        assert file =~ ~S|import {Socket} from "phoenix"|
+
+        assert file =~ ~S|// And connect to the path in "lib/phoenix/endpoint.ex".|
         assert file =~ ~S|In your "lib/phoenix/router.ex":|
 
         assert file =~ ~S|let channel = socket.channel("room:42", {})|
@@ -123,7 +137,15 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
       end)
 
       assert_file("assets/js/admin/user_socket.js", fn file ->
-        assert file =~ ~S|and connect at the socket path in "lib/phoenix_web/endpoint.ex"|
+        assert file =~ ~S|// NOTE: The contents of this file will only be executed if|
+        assert file =~ ~S|// you uncomment its entry in "assets/js/app.js".|
+
+        assert file =~ ~S|// Bring in Phoenix channels client library:|
+        assert file =~ ~S|import {Socket} from "phoenix"|
+
+        assert file =~ ~S|// And connect to the path in "lib/phoenix_web/endpoint.ex".|
+        assert file =~ ~S|let socket = new Socket("/socket", {params: {token: window.userToken}})|
+
         assert file =~ ~S|In your "lib/phoenix_web/router.ex":|
 
         assert file =~ ~S|let channel = socket.channel("room:42", {})|


### PR DESCRIPTION
The socket generation was removed from the installer, so this task is needed
when the user wants to work with _websockets_ outside LiveView.

This also changes the `mix phx.gen.channel` task to include instructions regarding
this new task when the default socket - `user_socket.ex` does not exist under `/channels`.

Closes https://github.com/phoenixframework/phoenix/issues/4376.