### PR TITLE
fix: Include topbar in newly generated umbrella apps

### DIFF
--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -49,6 +49,7 @@ defmodule Phx.New.Web do
   ]
 
   template :live, [
+    {:eex, "phx_live/assets/topbar.js",                :web, "assets/vendor/topbar.js"},
     {:eex, "phx_live/templates/layout/root.html.leex", :web, "lib/:web_app/templates/layout/root.html.leex"},
     {:eex, "phx_live/templates/layout/app.html.leex",  :web, "lib/:web_app/templates/layout/app.html.eex"},
     {:eex, "phx_live/templates/layout/live.html.leex", :web, "lib/:web_app/templates/layout/live.html.leex"},


### PR DESCRIPTION
Topbar is not included in the web part of newly created umbrella application. 

Similar issue was already fixed for single application by @josevalim in:

https://github.com/phoenixframework/phoenix/commit/2c5e39117232dc3456f61b03febdd65caca13ea3

Original issue: https://github.com/phoenixframework/phoenix/issues/4380