### PR TITLE
Implement LiveAuth module for phx.gen.auth generator

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -125,6 +125,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
       web_app_name: web_app_name(context),
       endpoint_module: Module.concat([context.web_module, Endpoint]),
       auth_module: Module.concat([context.web_module, schema.web_namespace, "#{inspect(schema.alias)}Auth"]),
+      live_auth_module: Module.concat([context.web_module, schema.web_namespace, "#{inspect(schema.alias)}LiveAuth"]),
       router_scope: router_scope(context),
       web_path_prefix: web_path_prefix(schema),
       test_case_options: test_case_options(ecto_adapter)
@@ -219,6 +220,8 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
       {:eex, "schema_token.ex", Path.join([context.dir, "#{schema.singular}_token.ex"])},
       {:eex, "auth.ex", Path.join([web_prefix, "controllers", web_path, "#{schema.singular}_auth.ex"])},
       {:eex, "auth_test.exs", Path.join([web_test_prefix, "controllers", web_path, "#{schema.singular}_auth_test.exs"])},
+      {:eex, "live_auth.ex", Path.join([web_prefix, "live", web_path, "#{schema.singular}_live_auth.ex"])},
+      {:eex, "live_auth_test.exs", Path.join([web_test_prefix, "live", web_path, "#{schema.singular}_live_auth_test.exs"])},
       {:eex, "confirmation_view.ex", Path.join([web_prefix, "views", web_path, "#{schema.singular}_confirmation_view.ex"])},
       {:eex, "confirmation_new.html.eex", Path.join([web_prefix, "templates", web_path, "#{schema.singular}_confirmation", "new.html.eex"])},
       {:eex, "confirmation_controller.ex", Path.join([web_prefix, "controllers", web_path, "#{schema.singular}_confirmation_controller.ex"])},

--- a/priv/templates/phx.gen.auth/live_auth.ex
+++ b/priv/templates/phx.gen.auth/live_auth.ex
@@ -1,0 +1,53 @@
+defmodule <%= inspect live_auth_module %> do
+  import Phoenix.LiveView, only: [assign_new: 3, push_redirect: 2, put_flash: 3]
+  alias <%= inspect context.web_module %>.Router.Helpers, as: Routes
+
+  @doc """
+  Mounts current_<%= schema.singular %> to `socket` assigns based on <%= schema.singular %>_token or nil if it doesn't.
+
+  ## Example
+
+      defmodule DemoWeb.PageLive do
+        use Phoenix.LiveView, :live_view
+
+        import DemoWeb.<%= inspect live_auth_module %>
+
+        on_mount {DemoWeb.LiveAuth, :mount_current_<%= schema.singular %>}
+      end
+  """
+  def mount_current_<%= schema.singular %>(_params, %{"<%=schema.singular %>_token" => <%= schema.singular %>_token}, socket) do
+    assign_new(socket, :current_<%= schema.singular %>, fn ->
+      <%= inspect context.module %>.get_<%= schema.singular %>_by_session_token(<%= schema.singular %>_token)
+    end)
+  end
+
+  def mount_current_<%= schema.singular %>(_params, _session, socket) do
+    assign_new(socket, :current_<%= schema.singular %>, fn -> nil end)
+  end
+
+  @doc """
+  This function should be used in conjunction with mount_current_<%= schema.singular %>
+  Requires that current_<%= schema.singular %> is mounted to `socket`.
+  Otherwise it will flash an error message and redirect the user to log in.
+
+  ## Example
+
+      defmodule DemoWeb.PageLive do
+        use Phoenix.LiveView, :live_view
+
+        import DemoWeb.<%= inspect live_auth_module %>
+
+        on_mount {DemoWeb.LiveAuth, :mount_current_<%= schema.singular %>}
+        on_mount {DemoWeb.LiveAuth, :require_mounted_<%= schema.singular %>}
+      end
+  """
+  def require_mounted_<%= schema.singular %>(_params, _session, socket) do
+    if socket.assigns[:current_<%= schema.singular %>] do
+      socket
+    else
+      socket
+      |> put_flash(:error, "You must log in to access this page.")
+      |> push_redirect(to: Routes.<%= schema.route_helper %>_session_path(socket, :new))
+    end
+  end
+end

--- a/priv/templates/phx.gen.auth/live_auth_test.exs
+++ b/priv/templates/phx.gen.auth/live_auth_test.exs
@@ -1,0 +1,47 @@
+defmodule <%= inspect live_auth_module %>Test do
+  use <%= inspect context.web_module %>.ChannelCase
+
+  alias <%= inspect context.module %>
+  alias <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>LiveAuth
+  alias <%= inspect context.web_module %>.Router.Helpers, as: Routes
+  import <%= inspect context.module %>Fixtures
+
+  setup do
+    socket = %Phoenix.LiveView.Socket{
+      assigns: %{flash: %{}},
+      endpoint: <%= inspect context.web_module %>.Endpoint
+    }
+
+    %{<%= schema.singular %>: <%= schema.singular %>_fixture(), socket: socket}
+  end
+
+  describe "mount_current_<%= schema.singular %>/2" do
+    test "authenticates <%= schema.singular %> from session", %{socket: socket, <%= schema.singular %>: <%= schema.singular %>} do
+      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      session = %{"<%= schema.singular %>_token" => <%= schema.singular %>_token}
+      socket = <%= inspect schema.alias %>LiveAuth.mount_current_<%= schema.singular %>(%{}, session, socket)
+      assert socket.assigns.current_<%= schema.singular %>.id == <%= schema.singular %>.id
+    end
+
+    test "does not authenticate if data is missing", %{socket: socket, <%= schema.singular %>: <%= schema.singular %>} do
+      _ = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      socket = <%= inspect schema.alias %>LiveAuth.mount_current_<%= schema.singular %>(%{}, %{}, socket)
+      refute socket.assigns.current_<%= schema.singular %>
+    end
+  end
+
+  describe "require_mounted_<%= schema.singular %>/2" do
+    test "redirects if <%= schema.singular %> is not authenticated", %{socket: socket} do
+      socket = <%= inspect schema.alias %>LiveAuth.require_mounted_<%= schema.singular %>(%{}, %{}, socket)
+      assert {:live, :redirect, %{kind: :push, to: path}} = socket.redirected
+      assert path == Routes.<%= schema.route_helper %>_session_path(socket, :new)
+      assert socket.assigns.flash["error"] == "You must log in to access this page."
+    end
+
+    test "does not redirect if <%= schema.singular %> is authenticated", %{socket: socket, <%= schema.singular %>: <%= schema.singular %>} do
+      socket = socket |> Phoenix.LiveView.assign(:current_<%= schema.singular %>, <%= schema.singular %>)
+      socket = <%= inspect schema.alias %>LiveAuth.require_mounted_<%= schema.singular %>(%{}, %{}, socket)
+      refute socket.redirected
+    end
+  end
+end

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -101,6 +101,8 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       assert_file "test/support/fixtures/accounts_fixtures.ex"
       assert_file "lib/my_app_web/controllers/user_auth.ex"
       assert_file "test/my_app_web/controllers/user_auth_test.exs"
+      assert_file "lib/my_app_web/live/user_live_auth.ex"
+      assert_file "test/my_app_web/live/user_live_auth_test.exs"
       assert_file "lib/my_app_web/views/user_confirmation_view.ex"
       assert_file "lib/my_app_web/templates/user_confirmation/new.html.eex"
       assert_file "lib/my_app_web/controllers/user_confirmation_controller.ex"
@@ -245,6 +247,10 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file "test/my_app_web/controllers/warehouse/user_auth_test.exs", fn file ->
         assert file =~ "defmodule MyAppWeb.Warehouse.UserAuthTest do"
+      end
+
+      assert_file "lib/my_app_web/live/warehouse/user_live_auth.ex", fn file ->
+        assert file =~ "defmodule MyAppWeb.Warehouse.UserLiveAuth do"
       end
 
       assert_file "lib/my_app_web/views/warehouse/user_confirmation_view.ex", fn file ->
@@ -417,6 +423,10 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
           assert file =~ ~r/use MyAppWeb\.ConnCase, async: true$/m
         end
 
+        assert_file "test/my_app_web/live/user_live_auth_test.exs", fn file ->
+          assert file =~ ~r/use MyAppWeb\.ChannelCase$/m
+        end
+
         assert_file "test/my_app_web/controllers/user_confirmation_controller_test.exs", fn file ->
           assert file =~ ~r/use MyAppWeb\.ConnCase, async: true$/m
         end
@@ -454,6 +464,10 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
         assert_file "test/my_app_web/controllers/user_auth_test.exs", fn file ->
           assert file =~ ~r/use MyAppWeb\.ConnCase$/m
+        end
+
+        assert_file "test/my_app_web/live/user_live_auth_test.exs", fn file ->
+          assert file =~ ~r/use MyAppWeb\.ChannelCase$/m
         end
 
         assert_file "test/my_app_web/controllers/user_confirmation_controller_test.exs", fn file ->
@@ -495,6 +509,10 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
           assert file =~ ~r/use MyAppWeb\.ConnCase$/m
         end
 
+        assert_file "test/my_app_web/live/user_live_auth_test.exs", fn file ->
+          assert file =~ ~r/use MyAppWeb\.ChannelCase$/m
+        end
+
         assert_file "test/my_app_web/controllers/user_confirmation_controller_test.exs", fn file ->
           assert file =~ ~r/use MyAppWeb\.ConnCase$/m
         end
@@ -532,6 +550,10 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
         assert_file "test/my_app_web/controllers/user_auth_test.exs", fn file ->
           assert file =~ ~r/use MyAppWeb\.ConnCase$/m
+        end
+
+        assert_file "test/my_app_web/live/user_live_auth_test.exs", fn file ->
+          assert file =~ ~r/use MyAppWeb\.ChannelCase$/m
         end
 
         assert_file "test/my_app_web/controllers/user_confirmation_controller_test.exs", fn file ->
@@ -693,6 +715,8 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         assert_file "apps/my_app/test/support/fixtures/accounts_fixtures.ex"
         assert_file "apps/my_app/lib/my_app_web/controllers/user_auth.ex"
         assert_file "apps/my_app/test/my_app_web/controllers/user_auth_test.exs"
+        assert_file "apps/my_app/lib/my_app_web/live/user_live_auth.ex"
+        assert_file "apps/my_app/test/my_app_web/live/user_live_auth_test.exs"
         assert_file "apps/my_app/lib/my_app_web/views/user_confirmation_view.ex"
         assert_file "apps/my_app/lib/my_app_web/templates/user_confirmation/new.html.eex"
         assert_file "apps/my_app/lib/my_app_web/controllers/user_confirmation_controller.ex"
@@ -736,6 +760,8 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         assert_file "apps/my_app/test/support/fixtures/accounts_fixtures.ex"
         assert_file "apps/my_app_web/lib/my_app_web/controllers/user_auth.ex"
         assert_file "apps/my_app_web/test/my_app_web/controllers/user_auth_test.exs"
+        assert_file "apps/my_app_web/lib/my_app_web/live/user_live_auth.ex"
+        assert_file "apps/my_app_web/test/my_app_web/live/user_live_auth_test.exs"
         assert_file "apps/my_app_web/lib/my_app_web/views/user_confirmation_view.ex"
         assert_file "apps/my_app_web/lib/my_app_web/templates/user_confirmation/new.html.eex"
         assert_file "apps/my_app_web/lib/my_app_web/controllers/user_confirmation_controller.ex"


### PR DESCRIPTION
This builds upon what was discussed on #4344 

- Create LiveAuth module with mount_current_[name] and require_mounted_[name] functions.
- Documented the use cases for these function using the on_mount callback
- Create LiveAuthTest module to test the two functions
- Added tests to confirm file creations on many scenarios

I was thinking about injecting the LiveAuth module in the main Web module to be imported in :live_view modules. As I saw that AuthModule did not do it, I was unsure if this was desired.

Also, I believe the tests for require_mounted_[name] function can be improved, but not sure how:
- Did a direct check on socket.redirected to test redirection. Not sure if this is a good way to do it
- Confirming the flash by getting it in socket.assigns.flash. Also not sure this is a good way to do it

Please let me know if there is anything else I can do here.