### PR TITLE
Expand the plug only in plug_init_mode :runtime

### DIFF
--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -177,7 +177,12 @@ defmodule Phoenix.Controller.Pipeline do
   defmacro plug(plug, opts), do: plug(plug, opts, true, __CALLER__)
 
   defp plug(plug, opts, guards, caller) do
-    plug = Macro.expand(plug, %{caller | function: {:init, 1}})
+    plug =
+      if Phoenix.plug_init_mode() == :runtime do
+        Macro.expand(plug, %{caller | function: {:init, 1}})
+      else
+        plug
+      end
 
     quote do
       @plugs {unquote(plug), unquote(opts), unquote(escape_guards(guards))}

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -676,7 +676,12 @@ defmodule Phoenix.Router do
   See `pipeline/2` for more information.
   """
   defmacro plug(plug, opts \\ []) do
-    plug = Macro.expand(plug, %{__CALLER__ | function: {:init, 1}})
+    plug =
+      if Phoenix.plug_init_mode() == :runtime do
+        Macro.expand(plug, %{__CALLER__ | function: {:init, 1}})
+      else
+        plug
+      end
 
     quote do
       if pipeline = @phoenix_pipeline do


### PR DESCRIPTION
Otherwise, in the :compile mode, the router is not recompiled if a *module* plug changes.

cc @josevalim 
