### PR TITLE
Set plug_init_mode: :runtime in generated config/test.exs

### DIFF
--- a/installer/templates/phx_single/config/test.exs
+++ b/installer/templates/phx_single/config/test.exs
@@ -13,5 +13,5 @@ config :<%= @app_name %>, <%= @app_module %>.Mailer,
 # Print only warnings and errors during test
 config :logger, level: :warn
 
-# Initialize plugs at runtime for faster development compilation
+# Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/installer/templates/phx_single/config/test.exs
+++ b/installer/templates/phx_single/config/test.exs
@@ -12,3 +12,6 @@ config :<%= @app_name %>, <%= @app_module %>.Mailer,
 
 # Print only warnings and errors during test
 config :logger, level: :warn
+
+# Initialize plugs at runtime for faster development compilation
+config :phoenix, :plug_init_mode, :runtime

--- a/installer/templates/phx_umbrella/config/test.exs
+++ b/installer/templates/phx_umbrella/config/test.exs
@@ -7,5 +7,5 @@ config :logger, level: :warn<%= if @mailer do %>
 config :<%= @app_name %>, <%= @app_module %>.Mailer,
   adapter: Swoosh.Adapters.Test<% end %>
 
-# Initialize plugs at runtime for faster development compilation
+# Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/installer/templates/phx_umbrella/config/test.exs
+++ b/installer/templates/phx_umbrella/config/test.exs
@@ -6,3 +6,6 @@ config :logger, level: :warn<%= if @mailer do %>
 # In test we don't send emails.
 config :<%= @app_name %>, <%= @app_module %>.Mailer,
   adapter: Swoosh.Adapters.Test<% end %>
+
+# Initialize plugs at runtime for faster development compilation
+config :phoenix, :plug_init_mode, :runtime


### PR DESCRIPTION
This is to allow unnecessary recompilations when running tests.
