### PR TITLE
Add --all flag to phx.digest.clean

### DIFF
--- a/lib/mix/tasks/phx.digest.clean.ex
+++ b/lib/mix/tasks/phx.digest.clean.ex
@@ -30,19 +30,27 @@ defmodule Mix.Tasks.Phx.Digest.Clean do
     * `--keep` - specifies how many previous versions of assets to keep.
       Defaults to 2 previous versions
 
+    * `--all` - specifies that all compiled assets (including the manifest)
+      will be removed. Specifying `--all` overrides the age and keep options.
   """
 
   @doc false
   def run(args) do
-    switches = [output: :string, age: :integer, keep: :integer]
+    switches = [output: :string, age: :integer, keep: :integer, all: :boolean]
     {opts, _, _} = OptionParser.parse(args, switches: switches, aliases: [o: :output])
     output_path = opts[:output] || @default_output_path
     age = opts[:age] || @default_age
     keep = opts[:keep] || @default_keep
+    all? = opts[:all] || false
 
     {:ok, _} = Application.ensure_all_started(:phoenix)
 
-    case Phoenix.Digester.clean(output_path, age, keep) do
+    result =
+      if all?,
+        do: Phoenix.Digester.clean_all(output_path),
+        else: Phoenix.Digester.clean(output_path, age, keep)
+
+    case result do
       :ok ->
         # We need to call build structure so everything we have cleaned from
         # priv is removed from _build in case we have build_embedded set to

--- a/lib/mix/tasks/phx.digest.clean.ex
+++ b/lib/mix/tasks/phx.digest.clean.ex
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Phx.Digest.Clean do
       Defaults to 2 previous versions
 
     * `--all` - specifies that all compiled assets (including the manifest)
-      will be removed. Specifying `--all` overrides the age and keep options.
+      will be removed. Note this overrides the age and keep switches.
   """
 
   @doc false

--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -95,7 +95,7 @@ defmodule Phoenix.Digester do
   end
 
   defp remove_manifest(output_path) do
-    File.rm!(Path.join(output_path, "cache_manifest.json"))
+    File.rm(Path.join(output_path, "cache_manifest.json"))
   end
 
   defp generate_digests(files) do
@@ -309,24 +309,19 @@ defmodule Phoenix.Digester do
   @spec clean_all(String.t()) :: :ok | {:error, :invalid_path}
   def clean_all(path) do
     if File.exists?(path) do
-      case load_manifest(path) do
-        %{"digests" => digests} when map_size(digests) > 0 ->
-          grouped_digests = group_by_logical_path(digests)
-          logical_paths = Map.keys(grouped_digests)
+      %{"digests" => digests} = load_manifest(path)
+      grouped_digests = group_by_logical_path(digests)
+      logical_paths = Map.keys(grouped_digests)
 
-          files =
-            for {_, versions} <- grouped_digests,
-                file <- Enum.map(versions, fn {path, _attrs} -> path end),
-                do: file
+      files =
+        for {_, versions} <- grouped_digests,
+            file <- Enum.map(versions, fn {path, _attrs} -> path end),
+            do: file
 
-          remove_files(files, path)
-          remove_compressed_files(logical_paths, path)
-          remove_manifest(path)
-          :ok
-
-        _ ->
-          :ok
-      end
+      remove_files(files, path)
+      remove_compressed_files(logical_paths, path)
+      remove_manifest(path)
+      :ok
     else
       {:error, :invalid_path}
     end

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -434,6 +434,42 @@ defmodule Phoenix.DigesterTest do
     end
   end
 
+  describe "clean_all" do
+    test "fails when the given path is invalid" do
+      assert {:error, :invalid_path} = Phoenix.Digester.clean_all("nonexistent path")
+    end
+
+    test "removes all compiled files including latest and manifest" do
+      manifest_path = "test/fixtures/digest/cleaner/cache_manifest.json"
+      File.mkdir_p!(@output_path)
+      File.cp(manifest_path, "#{@output_path}/cache_manifest.json")
+      File.touch("#{@output_path}/app.css")
+      File.touch("#{@output_path}/app-1.css")
+      File.touch("#{@output_path}/app-1.css.gz")
+      File.touch("#{@output_path}/app-2.css")
+      File.touch("#{@output_path}/app-2.css.gz")
+      File.touch("#{@output_path}/app-3.css")
+      File.touch("#{@output_path}/app-3.css.gz")
+      File.touch("#{@output_path}/manifest.json")
+      File.touch("#{@output_path}/manifest.json.gz")
+      File.touch("#{@output_path}/app.css")
+
+      assert :ok = Phoenix.Digester.clean_all(@output_path)
+      output_files = assets_files(@output_path)
+
+      assert "app.css" in output_files
+      refute "app-3.css" in output_files
+      refute "app-3.css.gz" in output_files
+      refute "app-2.css" in output_files
+      refute "app-2.css.gz" in output_files
+      refute "app-1.css" in output_files
+      refute "app-1.css.gz" in output_files
+      assert "manifest.json" in output_files
+      assert "manifest.json.gz" in output_files
+      refute "cache_manifest.json" in output_files
+    end
+  end
+
   defp assets_files(path) do
     path
     |> Path.join("**/*")

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -439,6 +439,13 @@ defmodule Phoenix.DigesterTest do
       assert {:error, :invalid_path} = Phoenix.Digester.clean_all("nonexistent path")
     end
 
+    test "no-op when the given path does not contain cache_manifest.json" do
+      output_path = "test/fixtures/digest/priv/static/css"
+      assert assets_files(output_path) == ["app.css"]
+      assert :ok = Phoenix.Digester.clean_all(output_path)
+      assert assets_files(output_path) == ["app.css"]
+    end
+
     test "removes all compressed/compiled files including latest and manifest" do
       manifest_path = "test/fixtures/digest/cleaner/cache_manifest.json"
       File.mkdir_p!(@output_path)

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -439,11 +439,12 @@ defmodule Phoenix.DigesterTest do
       assert {:error, :invalid_path} = Phoenix.Digester.clean_all("nonexistent path")
     end
 
-    test "removes all compiled files including latest and manifest" do
+    test "removes all compressed/compiled files including latest and manifest" do
       manifest_path = "test/fixtures/digest/cleaner/cache_manifest.json"
       File.mkdir_p!(@output_path)
       File.cp(manifest_path, "#{@output_path}/cache_manifest.json")
       File.touch("#{@output_path}/app.css")
+      File.touch("#{@output_path}/app.css.gz")
       File.touch("#{@output_path}/app-1.css")
       File.touch("#{@output_path}/app-1.css.gz")
       File.touch("#{@output_path}/app-2.css")
@@ -458,6 +459,7 @@ defmodule Phoenix.DigesterTest do
       output_files = assets_files(@output_path)
 
       assert "app.css" in output_files
+      refute "app.css.gz" in output_files
       refute "app-3.css" in output_files
       refute "app-3.css.gz" in output_files
       refute "app-2.css" in output_files


### PR DESCRIPTION
This PR allows `mix phx.digest` to be fully reversed by the `phx.digest.clean` task:

```sh
mix phx.digest.clean --all
```

When run with the `--all` flag, the following files are cleaned:

* All digested versions listed in the `cache_manifest.json` file (including latest).
* All compressed originals (e.g `robots.txt.gz`).
* The `cache_manifest.json` file itself.