### PR TITLE
Remove node.js sass dependency from generated projects

### DIFF
--- a/installer/templates/phx_assets/package.json
+++ b/installer/templates/phx_assets/package.json
@@ -18,8 +18,6 @@
     "babel-loader": "^8.0.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.4.2",
-    "sass-loader": "^8.0.2",
-    "node-sass": "^4.13.1",
     "hard-source-webpack-plugin": "^0.13.1",
     "mini-css-extract-plugin": "^0.9.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",

--- a/installer/templates/phx_assets/webpack.config.js
+++ b/installer/templates/phx_assets/webpack.config.js
@@ -39,7 +39,6 @@ module.exports = (env, options) => {
           use: [
             MiniCssExtractPlugin.loader,
             'css-loader',
-            'sass-loader',
           ],
         }
       ]


### PR DESCRIPTION
This is related to #4358 and https://github.com/phoenixframework/phoenix/issues/4359#issuecomment-873135861. For a newcomer, being stopped at the first page of the manual by a node.js dependency nightmare is **really** frustrating.
