### PR TITLE
Remove implicit aria roles for navigation and main elements

### DIFF
--- a/guides/howto/custom_error_pages.md
+++ b/guides/howto/custom_error_pages.md
@@ -77,7 +77,7 @@ Phoenix generates an `ErrorView` for us, but it doesn't give us a `lib/hello_web
   <body>
     <header>
       <section class="container">
-        <nav role="navigation">
+        <nav>
           <ul>
             <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
           </ul>
@@ -87,7 +87,7 @@ Phoenix generates an `ErrorView` for us, but it doesn't give us a `lib/hello_web
         </a>
       </section>
     </header>
-    <main role="main" class="container">
+    <main class="container">
       <section class="phx-hero">
         <p>Sorry, the page you are looking for does not exist.</p>
       </section>

--- a/guides/plug.md
+++ b/guides/plug.md
@@ -118,7 +118,7 @@ In the [`init/1`] callback, we pass a default locale to use if none is present i
 To see the assign in action, go to the layout in `lib/hello_web/templates/layout/app.html.eex` and add the following close to the main container:
 
 ```html
-<main role="main" class="container">
+<main class="container">
   <p>Locale: <%= @locale %></p>
 ```
 

--- a/installer/templates/phx_live/templates/layout/app.html.leex
+++ b/installer/templates/phx_live/templates/layout/app.html.leex
@@ -1,4 +1,4 @@
-<main role="main" class="container">
+<main class="container">
   <p class="alert alert-info" role="alert"><%%= get_flash(@conn, :info) %></p>
   <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
   <%%= @inner_content %>

--- a/installer/templates/phx_live/templates/layout/live.html.leex
+++ b/installer/templates/phx_live/templates/layout/live.html.leex
@@ -1,4 +1,4 @@
-<main role="main" class="container">
+<main class="container">
   <p class="alert alert-info" role="alert"
     phx-click="lv:clear-flash"
     phx-value-key="info"><%%= live_flash(@flash, :info) %></p>

--- a/installer/templates/phx_live/templates/layout/root.html.leex
+++ b/installer/templates/phx_live/templates/layout/root.html.leex
@@ -12,7 +12,7 @@
   <body>
     <header>
       <section class="container">
-        <nav role="navigation">
+        <nav>
           <ul>
             <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
             <%= if @dashboard do %><%%= if function_exported?(Routes, :live_dashboard_path, 2) do %>

--- a/installer/templates/phx_web/templates/layout/app.html.eex
+++ b/installer/templates/phx_web/templates/layout/app.html.eex
@@ -11,7 +11,7 @@
   <body>
     <header>
       <section class="container">
-        <nav role="navigation">
+        <nav>
           <ul>
             <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
             <%= if @dashboard do %><%%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
@@ -24,7 +24,7 @@
         </a>
       </section>
     </header>
-    <main role="main" class="container">
+    <main class="container">
       <p class="alert alert-info" role="alert"><%%= get_flash(@conn, :info) %></p>
       <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
       <%%= @inner_content %>

--- a/lib/mix/tasks/phx.gen.auth/injector.ex
+++ b/lib/mix/tasks/phx.gen.auth/injector.ex
@@ -141,7 +141,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.Injector do
     """
     Add a render call for #{inspect(app_layout_menu_template_name(schema))} to #{Path.relative_to_cwd(file_path)}:
 
-      <nav role="navigation">
+      <nav>
         #{app_layout_menu_code_to_inject(schema)}
       </nav>
     """

--- a/test/mix/tasks/phx.gen.auth/injector_test.exs
+++ b/test/mix/tasks/phx.gen.auth/injector_test.exs
@@ -248,7 +248,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
       existing_code = """
       <html>
         <body>
-          <nav role="navigation">
+          <nav>
             <%= render "_user_menu.html" %>
           </nav>
           <h1>My App</h1>
@@ -632,7 +632,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
         <body>
           <header>
             <section class="container">
-              <nav role="navigation">
+              <nav>
                 <ul>
                   <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
                   <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
@@ -658,7 +658,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                  <body>
                    <header>
                      <section class="container">
-                       <nav role="navigation">
+                       <nav>
                          <ul>
                            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
                            <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
@@ -686,7 +686,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
         <body>\r
           <header>\r
             <section class="container">\r
-              <nav role="navigation">\r
+              <nav>\r
                 <ul>\r
                   <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>\r
                   <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>\r
@@ -712,7 +712,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                  <body>\r
                    <header>\r
                      <section class="container">\r
-                       <nav role="navigation">\r
+                       <nav>\r
                          <ul>\r
                            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>\r
                            <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>\r
@@ -738,7 +738,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
           <title>Demo · Phoenix Framework</title>
         </head>
         <body>
-          <main role="main" class="container">
+          <main class="container">
             <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
             <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
             <%= @inner_content %>
@@ -758,7 +758,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                  </head>
                  <body>
                    <%= render "_user_menu.html", assigns %>
-                   <main role="main" class="container">
+                   <main class="container">
                      <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
                      <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
                      <%= @inner_content %>
@@ -778,7 +778,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
           <title>Demo · Phoenix Framework</title>\r
         </head>\r
         <body>\r
-          <main role="main" class="container">\r
+          <main class="container">\r
             <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>\r
             <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>\r
             <%= @inner_content %>\r
@@ -798,7 +798,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                  </head>\r
                  <body>\r
                    <%= render "_user_menu.html", assigns %>\r
-                   <main role="main" class="container">\r
+                   <main class="container">\r
                      <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>\r
                      <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>\r
                      <%= @inner_content %>\r
@@ -821,7 +821,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
           <div class="my-header">
             <%= render "_user_menu.html", assigns %>
           </div>
-          <main role="main" class="container">
+          <main class="container">
             <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
             <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
             <%= @inner_content %>
@@ -852,7 +852,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                """
                Add a render call for "_user_menu.html" to foo.ex:
 
-                 <nav role="navigation">
+                 <nav>
                    <%= render "_user_menu.html", assigns %>
                  </nav>
                """

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -897,7 +897,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
         Add a render call for "_user_menu.html" to lib/my_app_web/templates/layout/app.html.eex:
 
-          <nav role="navigation">
+          <nav>
             <%= render "_user_menu.html", assigns %>
           </nav>
 


### PR DESCRIPTION
Closes issue #4347

# Background

In the html templates the aria roles of `main` and `nav` are explicitly set. According to the spec both `main` and `nav` elements have an implicit aria role and you should not set any role. Explicitly setting the role used to be a workaround for older browsers (released before 2013, most notably IE11).

In the PR I basically make the following change for main and nav elements:

```diff
-   <main role="main" class="container">
+   <main class="container">
      <p class="alert alert-info" role="alert"><%%= get_flash(@conn, :info) %></p>
      <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
      <%%= @inner_content %>
    </main>
```

Further reading on explicitly setting role="main" can be found in the MDN article: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main#browser_compatibility