### PR TITLE
Include Phoenix as an external to the esbuild args

### DIFF
--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -24,7 +24,7 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
 config :esbuild,
   version: "0.12.18",
   default: [
-    args: ~w(js/app.js --bundle --target=es2016 --outdir=../priv/static/assets),
+    args: ~w(js/app.js --bundle --target=es2016 --outdir=../priv/static/assets --external:phoenix),
     cd: Path.expand("../assets", __DIR__),
     env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
   ]<% end %><%= if @mailer do %>


### PR DESCRIPTION
When creating a new project with the current `master` I was having an issue with the `--live` flag working as expected. The initial install / build would complete, and then on the first run of `mix phx.server` a dependency error would occur inside esbuild. 

```
 > js/app.js:26:21: error: Could not resolve "phoenix" (mark it as external to exclude it from the bundle)
    26 │ import {Socket} from "phoenix"
       ╵                      ~~~~~~~~~
```

My assumption here is that this is caused because Phoenix is a library, and is not natively included in the phoenix install. Adding this command line argument immediately fixed it.

If my assumption is incorrect, then ignore this PR and we can move it to a bug report instead :D!