### PR TITLE
Support :mime 2.0.0

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1291,11 +1291,13 @@ defmodule Phoenix.Controller do
 
   defp parse_exts("*", "*"),      do: "*/*"
   defp parse_exts(type, "*"),     do: type
+  defp parse_exts("text", "plain"), do: ["text"]
   defp parse_exts(type, subtype), do: MIME.extensions(type <> "/" <> subtype)
 
   defp find_format("*/*", accepted),                   do: Enum.fetch!(accepted, 0)
   defp find_format(exts, accepted) when is_list(exts), do: Enum.find(exts, &(&1 in accepted))
   defp find_format(_type_range, []),                   do: nil
+  defp find_format("text", ["text"|_]), do: "text"
   defp find_format(type_range, [h|t]) do
     mime_type = MIME.type(h)
     case Plug.Conn.Utils.media_type(mime_type) do

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -321,6 +321,8 @@ defmodule Phoenix.ConnTest do
 
   defp response_content_type?(header, format) do
     case parse_content_type(header) do
+      {"text", "plain"} ->
+        format == :text
       {part, subpart} ->
         format = Atom.to_string(format)
         format in MIME.extensions(part <> "/" <> subpart) or


### PR DESCRIPTION
I noticed that when using :mime 2.0.0 with the latest version of Phoenix, `text_response/2` does not work as it did previously. I traced this back to a behavior change between :mime 1.6.0 and 2.0.0. Previously, `MIME.extensions("text/plain")` returned a list of several extensions, including "text". In 2.0.0, the only extension returned is "txt." We rely on "text" being one of the returned extensions in two places that I saw:

- in ConnTest, for determining which content-types should be considered :text format
- in Controller, for content negotiation (matching :text response type to "text/*" and "text/plain" in the accepts header)

The proposed solution adds special cases to handle "text/plain" and "text/*" for :mime 2.0.0 while maintaining backward compatibility with 1.3.0+. I thought this was reasonable since text/plain is a catchall for text content without a more specific mime type. We have some special cases around :html as well. This solution means most framework users won't have to change anything in their application code.

An alternative would be to start using :txt instead of :text as the response type atom that goes with the mime type "text/plain." That's a more consistent solution but requires many more changes to both Phoenix and applications that use it, so I put it aside.