### PR TITLE
Update Socket.t private field to allow any map

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -255,7 +255,7 @@ defmodule Phoenix.Socket do
           id: String.t | nil,
           joined: boolean,
           ref: term,
-          private: %{},
+          private: map,
           pubsub_server: atom,
           serializer: atom,
           topic: String.t,


### PR DESCRIPTION
`%{}` means an empty map

This should silence some dialyzer warnings in phoenix related packages
that use this field legitimately, e.g. this warning that currently appears
in Phoenix.LiveView.Socket.id/1 should disappear:

```
The inferred type for the 1st argument is not a
supertype of the expected type for the id/1 callback
in the Phoenix.Socket behaviour.

Success type:

  atom()
  | %{
      :private => atom() | %{:connect_info => nil | maybe_improper_list() | map(), _ => _},
      _ => _
    }


Behaviour callback type:
%Phoenix.Socket{
  :assigns => map(),
  :channel => atom(),
  :channel_pid => pid(),
  :endpoint => atom(),
  :handler => atom(),
  :id => nil | binary(),
  :join_ref => _,
  :joined => boolean(),
  :private => %{},
  :pubsub_server => atom(),
  :ref => _,
  :serializer => atom(),
  :topic => binary(),
  :transport => atom(),
  :transport_pid => pid()
}
```