### PR TITLE
Removes unused module attribute @phoenix_log_level

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -38,9 +38,6 @@ defmodule Phoenix.Controller do
       the layout view. By default it uses the base alias
       in your controller name
 
-    * `:log` - the level to log. When false, disables controller
-      logging
-
     * `:put_default_views` - controls whether the default view
       and layout should be set or not
 
@@ -168,7 +165,7 @@ defmodule Phoenix.Controller do
       # TODO v2: No longer automatically import dependencies
       import Plug.Conn
 
-      use Phoenix.Controller.Pipeline, opts
+      use Phoenix.Controller.Pipeline
 
       if Keyword.get(opts, :put_default_views, true) do
         plug :put_new_layout, {Phoenix.Controller.__layout__(__MODULE__, opts), :app}

--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -2,8 +2,8 @@ defmodule Phoenix.Controller.Pipeline do
   @moduledoc false
 
   @doc false
-  defmacro __using__(opts) do
-    quote bind_quoted: [opts: opts] do
+  defmacro __using__(_) do
+    quote do
       @behaviour Plug
 
       require Phoenix.Endpoint
@@ -11,7 +11,6 @@ defmodule Phoenix.Controller.Pipeline do
 
       Module.register_attribute(__MODULE__, :plugs, accumulate: true)
       @before_compile Phoenix.Controller.Pipeline
-      @phoenix_log_level Keyword.get(opts, :log, :debug)
       @phoenix_fallback :unregistered
 
       @doc false


### PR DESCRIPTION
Hi!

Apparently became unused after the deprecation of the instrument API: 19b0b01e2fc751901e06fcd74db1fc5b39672d26

---

Was looking at options to disable/change log level per route or controller and reading these lines of code made me think `use Phoenix.Controller, log: false` was still a valid option, when apparently no longer is. So hopefully cleaning this up avoids any future confusion for anyone :-)
Unless this is in fact used and I am missing something.

Thanks!