### PR TITLE
guard prepend_path/1 on :consolidate_protocols in code reloader

### DIFF
--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -174,7 +174,11 @@ defmodule Phoenix.CodeReloader.Server do
 
     purge = mix_compile_deps(Mix.Dep.cached(), apps_to_reload, compilers, purge)
     mix_compile_project(config[:app], apps_to_reload, compilers, purge)
-    Code.prepend_path(path)
+
+    if config[:consolidate_protocols] do
+      Code.prepend_path(path)
+    end
+
     :ok
   end
 


### PR DESCRIPTION
:wave: hello!

I was playing around with protocol consolidation and I noticed some odd behavior that happens when

- the code reloader is turned on
- protocols have been consolidated (`mix compile.protocols`, or you had `consolidate_protocols: true` in the mix.exs at some point)
    - so there are `.beam`s in `_build/<env>/lib/<my_app>/consolidated/`
- protocol consolidation is turned off in the `mix.exs`
- start up `iex -S mix phx.server`
    - trigger a code-reload
    - derive a protocol at runtime (paste in a new struct with `Jason.Encoder` to IEx for example)

It looks like the `purge` step and the run of the `compile.protocols` respect the `:consolidate_protocols` Mix.Project configuration but this `Code.prepend_path/1` called on the consolidation path does not, so triggering the code reloader will add the `_build/<env>/lib/<my_app>/consolidated/` directory to your code paths where `.beam`s left over from the last consolidation will be loaded.

This PR gates that `Code.prepend_path/1` call on the Mix.Project's `:consolidate_protocols` option, so even if you have compiled your protocols before they won't load into the code path when a code-reload occurs.

It's a bit obscure of a bug and hard to explain (I thought I was going crazy trying to reproduce it :sweat_smile:) so if needed I can definitely spin up an example repo with some steps to reproduce

versions:

- elixir 1.12.2
- otp 24.0
- phoenix master (165fe6425123ed2c707ac3c6aec8db72e3f268bd)