### PR TITLE
Add explanations for `@`, and `<%= %>` vs `<% %>` to the views guide.

### DIFF
--- a/guides/views.md
+++ b/guides/views.md
@@ -50,13 +50,15 @@ end
 
 When we reload our home page, we should see our new title. Since templates are compiled inside the view, we could invoke the view function simply as `title()`, otherwise we would have to type `HelloWeb.LayoutView.title()`.
 
-As you may recall, Elixir templates use `EEx`, which stands for Embedded Elixir. We use `<%= expression %>` to execute Elixir expressions and interpolate their results into the template. You can use pretty much any Elixir expression. For example, in order to have conditionals:
+As you may recall, Elixir templates use `EEx`, which stands for Embedded Elixir. We use `<%= expression %>` to execute Elixir expressions and interpolate their results into the template. This is frequently used to display assigns we have set by way of the `@` shortcut. It is prudent to note that `<%= @user_name %>` is equivalent to `<%= assigns[:user_name] %>` and in essence, we are simply displaying a field from a map.
+
+In addition to displaying assigns and functions, we can use pretty much any Elixir expression. For example, in order to have conditionals:
 
 ```html
 <%= if some_condition? do %>
-  <p>Some condition is true for user: <%= @user.name %></p>
+  <p>Some condition is true for user: <%= @user_name %></p>
 <% else %>
-  <p>Some condition is false for user: <%= @user.name %></p>
+  <p>Some condition is false for user: <%= @user_name %></p>
 <% end %>
 ```
 
@@ -76,6 +78,8 @@ or even loops:
 <% end %>
 </table>
 ```
+
+Did you notice the use of `<%= %>` versus `<% %>` in the above loop? All expressions that output something to the template **must** use the equals sign (`=`). If this is not included the code will still be executed but nothing will be inserted into the template.
 
 At the end of the day, our templates are always compiled into Elixir code. Let's learn more about this.
 


### PR DESCRIPTION
Only a small addition to the docs, but I hope that it will be of use to new users.

- added `@` explanation, explicitly mentioning that it is simply a shortcut to assigns
- added `<%= %>` and `<% %>` use case explanations

The views guide seemed like the most appropriate place to expand on these items.

Following a discussion in the phoenix slack channel, I noted that I wished these basic concepts had been explained in such terms sooner. @hauleth suggested that I could add it to the docs as my contribution to the project. This is my attempt to do so.

🦆 

