### PR TITLE
Remove duplicate modulename in alias

### DIFF
--- a/priv/templates/phx.gen.notifier/notifier_test.exs
+++ b/priv/templates/phx.gen.notifier/notifier_test.exs
@@ -2,12 +2,12 @@ defmodule <%= inspect context.module %>Test do
   use ExUnit.Case, async: true
   import Swoosh.TestAssertions
 
-  alias <%= inspect context.module %>.<%= inflections[:alias] %>Notifier<%= for message <- notifier_messages do %>
+  alias <%= inspect context.module %><%= for message <- notifier_messages do %>
 
   test "deliver_<%= message %>/1" do
     user = %{name: "Alice", email: "alice@example.com"}
 
-    <%= inflections[:alias] %>Notifier.deliver_<%= message %>(user)
+    <%= inflections[:alias] %>.deliver_<%= message %>(user)
 
     assert_email_sent(
       subject: "Welcome to Phoenix, Alice!",


### PR DESCRIPTION
This generated a duplicate alias modulename like 

```elixir
  alias SuperSimple.Tasks.TaskNotifier.TaskNotifierNotifier
```

Error message in the tests with:

<img width="1204" alt="bild" src="https://user-images.githubusercontent.com/897748/131086252-966440b9-1bcc-42c4-a884-6e769fd81e33.png">
