### PR TITLE
Fixes typo in contexts documentation

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -483,7 +483,7 @@ With our schema associations set up, we can implement the selection of categorie
 
 First, we added `Repo.preload` to preload our categories when we fetch a product. This will allow us to reference `product.categories` in our controllers, templates, and anywhere else we want to make use of category information. Next, we modified our `create_product` and `update_product` functions to call into our existing `change_product` function to produce a changeset. Within `change_product` we added a lookup to find all categories if the `"category_ids"` attribute is present. Then we preloaded categories and called `Ecto.Changeset.put_assoc` to place the fetched categories into the changeset. Finally, we implemented the `list_categories_by_id/1` function to query the categories matching the category IDs, or return an empty list if no `"category_ids"` attribute is present. Now our `create_product` and `update_product` functions receive a changeset with the category associations all ready to go once we attempt an insert or update against our repo.
 
-Next, let's expose our new feature to the web by adding the category input to our product form. To keep our form template tidy, let's write a new function to wrap up the details of rendering a category select input for our product. Open up your `ProductView` in lib/hello_web/views/product_view.ex`: and key this in:
+Next, let's expose our new feature to the web by adding the category input to our product form. To keep our form template tidy, let's write a new function to wrap up the details of rendering a category select input for our product. Open up your `ProductView` in `lib/hello_web/views/product_view.ex`: and key this in:
 
 ```elixir
 defmodule HelloWeb.ProductView do


### PR DESCRIPTION
Missing back-tick causes incorrect formatting.

<img width="851" alt="Screenshot 2021-08-27 at 11 40 34" src="https://user-images.githubusercontent.com/545430/131145245-87bb63e7-bd76-4019-b382-89b63abe9a01.png">
