### PR TITLE
log_out redirects to the / route

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -81,7 +81,7 @@ defmodule <%= inspect auth_module %> do
     conn
     |> renew_session()
     |> delete_resp_cookie(@remember_me_cookie)
-    |> redirect(to: "/")
+    |> redirect(to: Router.page_path(conn, :index))
   end
 
   @doc """


### PR DESCRIPTION
on log_out, redirect to the / route (which includes a possible prefix path) rather than to the root of the domain. Closes #4441 . Thanks to @theMarinac for the fix.