### PR TITLE
Update heroku.md to remove broken hook command

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -105,7 +105,7 @@ erlang_version=24.0.3
 
 # Invoke assets.deploy defined in your mix.exs to deploy assets with esbuild
 # Note we nuke the esbuild executable from the image
-hook_post_compile="mix assets.deploy"
+hook_post_compile="eval mix assets.deploy && rm -f _build/esbuild"
 ```
 
 Finally, let's tell the build pack how to start our webserver. Create a file named `Procfile` at the root of your project:

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -105,7 +105,7 @@ erlang_version=24.0.3
 
 # Invoke assets.deploy defined in your mix.exs to deploy assets with esbuild
 # Note we nuke the esbuild executable from the image
-hook_post_compile="mix assets.deploy && rm -f _build/esbuild"
+hook_post_compile="mix assets.deploy"
 ```
 
 Finally, let's tell the build pack how to start our webserver. Create a file named `Procfile` at the root of your project:


### PR DESCRIPTION
The `esbuild` step as proposed in the Heroku guide is broken and produces the error:

```
The input path "&&" does not exist
```

As it seems to not be interpreting the string as a shell command. This in turn causes the boot error:

```
[error] Could not find static manifest at "/app/_build/prod/rel/<app>/lib/<app>-0.1.0/priv/static/cache_manifest.json". Run "mix phx.digest" after building your static files or remove the configuration from "config/prod.exs".
```

Simply dropping the cleanup step from build "solves" the problem, but maybe the cleanup needs to happen inside the generated mix task?