### PR TITLE
Add --no-runtime-config option to esbuild

### DIFF
--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -68,7 +68,7 @@ defmodule <%= @app_module %>.MixProject do
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %><%= if @assets do %>,
-      "assets.deploy": ["esbuild default --minify", "phx.digest"]<% end %>
+      "assets.deploy": ["esbuild --no-runtime-config default --minify", "phx.digest"]<% end %>
     ]
   end
 end


### PR DESCRIPTION
Running `assets.deploy` in a CI/CD pipeline fails because `esbuild` reads the `config/runtime.exs` file which raises because the CI environment doesn't have access to the environment variables. The flag `--no-runtime-config` was added in https://github.com/phoenixframework/esbuild/commit/9779f2bc445dc2ae8413e0345bd35050f6cb9872 which would mitigate this issue.