### PR TITLE
Document `env` option on watchers

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -175,7 +175,7 @@ defmodule Phoenix.Endpoint do
       The `:cd` and `:env` options can be given at the end of the list to customize
       the watcher:
 
-          [node: [..., cd: "assets"]]
+          [node: [..., cd: "assets", env: [{"TAILWIND_MODE", "watch"}]]]
 
       A watcher can also be a module-function-args tuple that will be invoked accordingly:
 


### PR DESCRIPTION
Hi,

Similar to #2729, in the documentation of `Phoenix.Endpoint`, I have added more details to the example for `:watchers` when the `:env` option is given.

I did not know I needed to give a list of tuples to `:env`.