### PR TITLE
fix: remove role=main in documentation

### DIFF
--- a/guides/channels/presence.md
+++ b/guides/channels/presence.md
@@ -103,7 +103,7 @@ function renderOnlineUsers(presence) {
     response += `<br>${id} (count: ${count})</br>`
   })
 
-  document.querySelector("main[role=main]").innerHTML = response
+  document.querySelector("main").innerHTML = response
 }
 
 socket.connect()


### PR DESCRIPTION
Related to issue #4347 and pull request 4407 (https://github.com/phoenixframework/phoenix/pull/4407) where role="main" was removed from the standard templates.

I was just going through the docs/tutorials and ran into this. This PR will make sure the JavaScript works again. It's a tiny change, but as I proposed the earlier removal of role main so I felt obligated to also update this.

(creating it as a draft for now, maybe I find some other things that I can improve on)