### PR TITLE
Remove archive phx_new during compilation

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -1,4 +1,10 @@
 defmodule Mix.Tasks.Phx.New do
+
+#Remove archive to avoid conflicts
+with list when is_list(list) <- :code.lib_dir(:phx_new) do
+  :code.del_path(:filename.join(list, 'ebin'))
+end
+
   @moduledoc """
   Creates a new Phoenix project.
 


### PR DESCRIPTION
This was an issue raised in #3906 and closed in 496627f. But the test file that fixed this was removed. This commit also fixes the compilation error for all environments. Jose mentioned it in the issue that the line should be moved to somewhere else. 

I don't know if this is the right place for the line. 