### PR TITLE
Remove comma on generated form.html.heex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Phoenix v1.6 requires Elixir v1.9+.
 ### Enhancements
   * [mix phx.gen.auth] Validate bcrypt passwords are no longer than 72 bytes
   * re-enable `phx.routes` task to support back to back invocations, such as for aliased mix route tasks
+  * [mix phx.gen.html] Remove comma after `for={@changeset}` on `form.html.heex`
 
 ## 1.6.0-rc.0 (2021-08-26)
 

--- a/priv/templates/phx.gen.html/form.html.heex
+++ b/priv/templates/phx.gen.html/form.html.heex
@@ -1,4 +1,4 @@
-<.form let={f} for={@changeset}, action={@action}>
+<.form let={f} for={@changeset} action={@action}>
   <%%= if @changeset.action do %>
     <div class="alert alert-danger">
       <p>Oops, something went wrong! Please check the errors below.</p>

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -132,6 +132,7 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
       end
 
       assert_file "lib/phoenix_web/templates/post/form.html.heex", fn file ->
+        assert file =~ ~s(<.form let={f} for={@changeset} action={@action}>)
         assert file =~ ~s(<%= text_input f, :title %>)
         assert file =~ ~s(<%= number_input f, :votes %>)
         assert file =~ ~s(<%= number_input f, :cost, step: "any" %>)


### PR DESCRIPTION
After converting the template from .eex to .heex on https://github.com/phoenixframework/phoenix/commit/12f4116e299b43bec9c74a379d8de55b0a13262c, a comma was left behind.

```diff
-<.form let={f} for={@changeset}, action={@action}>
+<.form let={f} for={@changeset} action={@action}>
```

Thanks for making it so easy to contribute in this project. Just doing `mix deps.get` and `mix test` was enough to start.