### PR TITLE
Update `Phoenix.Socket` docs to clarify defaults

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -10,8 +10,9 @@ defmodule Phoenix.Socket do
   It is the responsibility of the socket to tie transports and channels
   together.
 
-  By default, Phoenix supports both websockets and longpoll when invoking
-  `Phoenix.Endpoint.socket/3` in your endpoint:
+  Phoenix supports `websocket` and `longpoll` options when invoking
+  `Phoenix.Endpoint.socket/3` in your endpoint. `websocket` is set by default
+  and `longpoll` can also be configured explicitly.
 
       socket "/socket", MyAppWeb.Socket, websocket: true, longpoll: false
 


### PR DESCRIPTION
`Phoenix.Endpoint.socket/3` sets `websocket` on by default and `longpoll` is off by default. Previous phrasing implied that both were on by default.

https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3

`:longpoll` - controls the longpoll configuration. Defaults to false

https://github.com/phoenixframework/phoenix/blob/v1.5.12/lib/phoenix/endpoint.ex#L649-L650