### PR TITLE
Set argon2 as default hashing algorithm for mix.gen.auth

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
   ## Password hashing
 
-  The password hashing mechanism defaults to `bcrypt` for
+  The password hashing mechanism defaults to `argon2` for
   Unix systems and `pbkdf2` for Windows systems. Both
   systems use the [Comeonin interface](https://hexdocs.pm/comeonin/).
 
@@ -200,7 +200,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
   defp default_hashing_library_option do
     case :os.type() do
-      {:unix, _} -> "bcrypt"
+      {:unix, _} -> "argon2"
       {:win32, _} -> "pbkdf2"
     end
   end

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -83,7 +83,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       )
 
       assert_file "config/test.exs", fn file ->
-        assert file =~ "config :bcrypt_elixir, :log_rounds, 1"
+        assert file =~ "config :argon2_elixir, t_cost: 1, m_cost: 8"
       end
 
       assert_file "lib/my_app/accounts.ex"
@@ -130,7 +130,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       end
 
       assert_file "mix.exs", fn file ->
-        assert file =~ ~s|{:bcrypt_elixir, "~> 2.0"},|
+        assert file =~ ~s|{:argon2_elixir, "~> 2.0"},|
       end
 
       assert_file "lib/my_app_web/router.ex", fn file ->
@@ -776,11 +776,11 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
         assert_received {:mix_shell, :info, ["""
 
-        Add your {:bcrypt_elixir, "~> 2.0"} dependency to mix.exs:
+        Add your {:argon2_elixir, "~> 2.0"} dependency to mix.exs:
 
             defp deps do
               [
-                {:bcrypt_elixir, "~> 2.0"},
+                {:argon2_elixir, "~> 2.0"},
                 ...
               ]
             end


### PR DESCRIPTION
Argon2 is now recommended as the go-to algorithm by OWASP, being classified as modern and secure hashing algorithm. The [OWASP Password Storage page](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html) states that the first choice should be Argon2, listing bcrypt as a second option when Argon2 is not available.

This Pull Request sets Argon2 as a default algorithm used in `mix.gen.auth` and updates the test suite accordingly.

I decided not to update the default option for Windows as I am unaware of the stability of the Argon2 library on that Operating System.

I tried to follow the contribution guidelines but seeing as this is my first PR to Phoenix I will be happy to change anything that is not as expected.