### PR TITLE
Mention fly's remote builder on deployment guide

### DIFF
--- a/guides/deployment/fly.md
+++ b/guides/deployment/fly.md
@@ -230,6 +230,19 @@ Our project is now ready to be deployed to Fly.io.
 $ fly deploy
 ```
 
+Note: On Mac M1 computers, docker runs cross platform builds using qemu which might not always work. If you get a segmentation fault error like the following:
+
+```
+ => [build  7/17] RUN mix deps.get --only
+ => => # qemu: uncaught target signal 11 (Segmentation fault) - core dumped
+```
+
+You can use fly's remote builder by adding the `--remote-only` flag:
+
+```console
+$ fly deploy --remote-only
+```
+
 You can always check on the status of a deploy
 
 ```console

--- a/guides/deployment/fly.md
+++ b/guides/deployment/fly.md
@@ -230,7 +230,7 @@ Our project is now ready to be deployed to Fly.io.
 $ fly deploy
 ```
 
-Note: On Mac M1 computers, docker runs cross platform builds using qemu which might not always work. If you get a segmentation fault error like the following:
+Note: On Apple Silicon (M1) computers, docker runs cross platform builds using qemu which might not always work. If you get a segmentation fault error like the following:
 
 ```
  => [build  7/17] RUN mix deps.get --only


### PR DESCRIPTION
I ran into some issues when trying to deploy phoenix 1.6-rc0 to fly from a Mac M1 (Apple Silicon)

The problem seems to be with building the docker image locally. On Apple Silicon computers, Docker uses qemu as an emulation layer to build Linux platform images which seems to cause issues.

I solved the problem by using fly's remote builder (just using `fly deploy --remote-only`) and thought it would be good to update the docs in case someone else runs into the same issue.