### PR TITLE
Fix LongPoll readyState check

### DIFF
--- a/assets/js/phoenix/ajax.js
+++ b/assets/js/phoenix/ajax.js
@@ -1,11 +1,9 @@
 import {
-  global
+  global,
+  XHR_STATES
 } from "./constants"
 
 export default class Ajax {
-  constructor(){
-    this.states = {complete: 4}
-  }
 
   static request(method, endPoint, accept, body, timeout, ontimeout, callback){
     if(global.XDomainRequest){
@@ -38,7 +36,7 @@ export default class Ajax {
     req.setRequestHeader("Content-Type", accept)
     req.onerror = () => { callback && callback(null) }
     req.onreadystatechange = () => {
-      if(req.readyState === this.states.complete && callback){
+      if(req.readyState === XHR_STATES.complete && callback){
         let response = this.parseJSON(req.responseText)
         callback(response)
       }

--- a/assets/js/phoenix/constants.js
+++ b/assets/js/phoenix/constants.js
@@ -30,3 +30,6 @@ export const TRANSPORTS = {
   longpoll: "longpoll",
   websocket: "websocket"
 }
+export const XHR_STATES = {
+  complete: 4
+}


### PR DESCRIPTION
The `Ajax` class is never instantiated, so `this.states` would fail with the following error:
<img width="501" alt="Screen Shot 2021-09-14 at 10 26 26 AM" src="https://user-images.githubusercontent.com/168677/133305428-10c78160-e879-4ad8-87f5-b99fd74c0d3e.png">

To fix, I simply moved the ready states into a constant and check from there :)
