### PR TITLE
Restore opening sentence in How-To Custom Error Pages

### DIFF
--- a/guides/howto/custom_error_pages.md
+++ b/guides/howto/custom_error_pages.md
@@ -1,6 +1,6 @@
 # Custom Error Pages
 
-Phoenix has a view called `ErrorView` which lives in `lib/hello_web/views/error_view.ex`. The purpose of `ErrorView` is to handle errors in s.)
+Phoenix has a view called `ErrorView` which lives in `lib/hello_web/views/error_view.ex`. The purpose of `ErrorView` is to handle errors in a general way, from one centralized location.
 
 ## The ErrorView
 


### PR DESCRIPTION
It seems that the opening sentence in the guide [How-To Custom Error Pages](https://hexdocs.pm/phoenix/1.6.0-rc.0/custom_error_pages.html) got accidentally cut off in PR #4226.

This PR aims to restore the full sentence, while keeping the intended edits from PR #4226.

Have a nice day!