### PR TITLE
Add `cache_manifest.json` to `.gitignore` in `mix phx.new` task

### DIFF
--- a/installer/templates/phx_single/gitignore
+++ b/installer/templates/phx_single/gitignore
@@ -25,6 +25,9 @@ erl_crash.dump
 # Ignore assets that are produced by build tools.
 /priv/static/assets/
 
+# Ignore digested assets cache.
+/priv/static/cache_manifest.json
+
 # In case you use Node.js/npm, you want to ignore these.
 npm-debug.log
 /assets/node_modules/

--- a/installer/templates/phx_umbrella/apps/app_name_web/gitignore
+++ b/installer/templates/phx_umbrella/apps/app_name_web/gitignore
@@ -25,6 +25,9 @@ erl_crash.dump
 # Ignore assets that are produced by build tools.
 /priv/static/assets/
 
+# Ignore digested assets cache.
+/priv/static/cache_manifest.json
+
 # In case you use Node.js/npm, you want to ignore these.
 npm-debug.log
 /assets/node_modules/


### PR DESCRIPTION
I noticed that `priv/static/cache_manifest.json` wasn't ignored by default in the `phx.new` generator while the `priv/static/assets` directory was, and this bugged me as it seems that both work hand in hand and should probably be committed together (or ignored together).

I asked for advice about that in [this forum thread](https://elixirforum.com/t/should-i-commit-priv-static-cache-manifest-json/42194) and apparently, checking the cache manifest runs the risk of Phoenix trying to serve the wrong assets unless the digested assets are also checked in with it (which is not the case by default). Though, in most cases `mix phx.digest` is run prior to deployments which overwrites the checked manifest and that's why this usually doesn't cause real-world problems.

Since it seems there is no apparent benefit to commit `cache_manifest.json`, and it could even potentially cause issues, this PR suggests to ignore it by default, as we can see [most people](https://github.com/search?q=in%3Apath+priv%2Fstatic%2Fcache_manifest.json&type=code) rely on the default and don't go out of their way to ignore that file.

Please close this PR in case there's a good reason to commit `cache_manifest.json` by default (I'd love to know why)! Cheers! :orange_heart: 