### PR TITLE
Implement ConnTest.path_params/2

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -593,6 +593,30 @@ defmodule Phoenix.ConnTest do
   end
 
   @doc """
+  Returns the matched params of the URL for the `%Plug.Conn{}`'s router.
+
+  Useful for testing LiveViews when we have any redirected paths that we want
+  to get the params out of.
+
+  ## Examples
+
+      assert {:error, {:redirect, %{to: "/posts/123" = to}}} = live(conn, "/path")
+      assert %{id: "123"} = path_params(conn, to)
+  """
+  @spec path_params(Conn.t, String.t) :: map
+  def path_params(%Plug.Conn{} = conn, to) when is_binary(to) do
+    router = Phoenix.Controller.router_module(conn)
+
+    case Phoenix.Router.route_info(router, "GET", to, conn.host) do
+    %{path_params: path_params} ->
+      Enum.into(path_params, %{}, fn {key, val} -> {String.to_atom(key), val} end)
+
+    :error ->
+      raise Phoenix.Router.NoRouteError, conn: conn, router: router
+    end
+  end
+
+  @doc """
   Asserts an error was wrapped and sent with the given status.
 
   Useful for testing actions that you expect raise an error and have

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -462,6 +462,22 @@ defmodule Phoenix.Test.ConnTest do
     end
   end
 
+  describe "path_params/1" do
+    test "with matching route" do
+      conn = RedirRouter.call(build_conn(:get, "/"), RedirRouter.init([]))
+
+      assert path_params(conn, "/posts/123") == %{id: "123"}
+    end
+
+    test "raises Phoenix.Router.NoRouteError for unmatched location" do
+      conn = RedirRouter.call(build_conn(:get, "/"), RedirRouter.init([]))
+
+      assert_raise Phoenix.Router.NoRouteError, fn ->
+        path_params(conn, "/unmatched")
+      end
+    end
+  end
+
   test "bypass_through/3 bypasses route match and invokes pipeline" do
     conn = get(build_conn(), "/")
     assert conn.assigns[:catch_all]


### PR DESCRIPTION
Implements a `ConnTest.path_params/2` function in favor of `LiveViewTest.redirected_params/2` 

Related to: https://github.com/phoenixframework/phoenix_live_view/pull/1575