### PR TITLE
doc: Add dependency documentation for Swoosh

### DIFF
--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -12,6 +12,9 @@ defmodule Phoenix do
 
     * [ExUnit](https://hexdocs.pm/ex_unit) - Elixir's built-in test framework
 
+    * [Gettext](https://hexdocs.pm/gettext) - Internationalization and
+      localization through [`gettext`](https://www.gnu.org/software/gettext/)
+
     * [Phoenix](https://hexdocs.pm/phoenix) - the Phoenix web framework
       (these docs)
 
@@ -35,11 +38,10 @@ defmodule Phoenix do
     * [Plug](https://hexdocs.pm/plug) - a specification and conveniences
       for composable modules in between web applications
 
+    * [Swoosh](https://hexdocs.pm/swoosh) - email delivery for `phx.gen.auth`
+
     * [Telemetry Metrics](https://hexdocs.pm/telemetry_metrics) - common
       interface for defining metrics based on Telemetry events
-
-    * [Gettext](https://hexdocs.pm/gettext) - Internationalization and
-      localization through [`gettext`](https://www.gnu.org/software/gettext/)
 
   To get started, see our [overview guides](overview.html).
   """

--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -38,7 +38,8 @@ defmodule Phoenix do
     * [Plug](https://hexdocs.pm/plug) - a specification and conveniences
       for composable modules in between web applications
 
-    * [Swoosh](https://hexdocs.pm/swoosh) - email delivery for `phx.gen.auth`
+    * [Swoosh](https://hexdocs.pm/swoosh) - a library for composing,
+    delivering and testing emails, also used by `mix phx.gen.auth`
 
     * [Telemetry Metrics](https://hexdocs.pm/telemetry_metrics) - common
       interface for defining metrics based on Telemetry events


### PR DESCRIPTION
Considering that the name of the extension is not very indicative of its purpose and even if you do know what it is you may be wondering why it's included by default.

I had to do some light Github spelunking, but figured I'd save some time for the next person.

The list of dependencies generally seems to be out of date, this PR chips away at it :)