### PR TITLE
Fix formatting in Channels Guide example

### DIFF
--- a/guides/channels/channels.md
+++ b/guides/channels/channels.md
@@ -237,6 +237,7 @@ defmodule HelloWeb.RoomChannel do
   def join("room:lobby", _message, socket) do
     {:ok, socket}
   end
+
   def join("room:" <> _private_room_id, _params, _socket) do
     {:error, %{reason: "unauthorized"}}
   end
@@ -345,6 +346,7 @@ defmodule HelloWeb.RoomChannel do
   def join("room:lobby", _message, socket) do
     {:ok, socket}
   end
+
   def join("room:" <> _private_room_id, _params, _socket) do
     {:error, %{reason: "unauthorized"}}
   end


### PR DESCRIPTION
This PR fixes the formatting for the example in [Joining Channels](https://hexdocs.pm/phoenix/channels.html#joining-channels) and [Incoming Events](https://hexdocs.pm/phoenix/channels.html#incoming-events). 
It is missing a space between the two functions to be on par with `mix format` standards.

Fixes #4493 