### PR TITLE
Fix typo in `maybe_print_mailer_installation_instructions/1` docs

### DIFF
--- a/lib/mix/tasks/phx.gen.notifier.ex
+++ b/lib/mix/tasks/phx.gen.notifier.ex
@@ -180,7 +180,7 @@ defmodule Mix.Tasks.Phx.Gen.Notifier do
   @doc """
   Print mailer instructions if mailer is not defined.
 
-  This is useful for applications there were created without the
+  This is useful for applications that were created without the
   mailer.
   """
   @spec maybe_print_mailer_installation_instructions(%Context{}) :: %Context{}


### PR DESCRIPTION
Looking at [maybe_print_mailer_installation_instructions/1](https://hexdocs.pm/phoenix/Mix.Tasks.Phx.Gen.Notifier.html#maybe_print_mailer_installation_instructions/1), there was a small typo found.