### PR TITLE
guides: update Plug page

### DIFF
--- a/guides/plug.md
+++ b/guides/plug.md
@@ -144,21 +144,21 @@ defmodule HelloWeb.Endpoint do
 
 The default endpoint plugs do quite a lot of work. Here they are in order:
 
-- [Plug.Static](https://hexdocs.pm/plug/Plug.Static.html) - serves static assets. Since this plug comes before the logger, serving of static assets is not logged
+- `Plug.Static` - serves static assets. Since this plug comes before the logger, serving of static assets is not logged
 
-- [Phoenix.CodeReloader](https://hexdocs.pm/phoenix/Phoenix.CodeReloader.html) - a plug that enables code reloading for all entries in the web directory. It is configured directly in the Phoenix application
+- `Phoenix.LiveDashboard.RequestLogger` - sets up the _Request Logger_ for Phoenix LiveDashboard, this will allow you to have the option to either pass a query parameter to stream requests logs or to enable/disable a cookie that streams requests logs from your dashboard.
 
-- [Plug.RequestId](https://hexdocs.pm/plug/Plug.RequestId.html) - generates a unique request ID for each request.
+- `Plug.RequestId` - generates a unique request ID for each request.
 
-- [Plug.Telemetry](https://hexdocs.pm/plug/Plug.Telemetry.html) - adds instrumentation points so Phoenix can log the request path, status code and request time by default.
+- `Plug.Telemetry` - adds instrumentation points so Phoenix can log the request path, status code and request time by default.
 
-- [Plug.Parsers](https://hexdocs.pm/plug/Plug.Parsers.html) - parses the request body when a known parser is available. By default parsers parse URL-encoded, multipart and JSON (with `jason`). The request body is left untouched when the request content-type cannot be parsed
+- `Plug.Parsers` - parses the request body when a known parser is available. By default, `Plug.Parsers`, parse URL-encoded, multipart and JSON (with `Jason`). The request body is left untouched when the request content-type cannot be parsed
 
-- [Plug.MethodOverride](https://hexdocs.pm/plug/Plug.MethodOverride.html) - converts the request method to PUT, PATCH or DELETE for POST requests with a valid `_method` parameter
+- `Plug.MethodOverride` - converts the request method to PUT, PATCH or DELETE for POST requests with a valid `_method` parameter
 
-- [Plug.Head](https://hexdocs.pm/plug/Plug.Head.html) - converts HEAD requests to GET requests and strips the response body
+- `Plug.Head` - converts HEAD requests to GET requests and strips the response body
 
-- [Plug.Session](https://hexdocs.pm/plug/Plug.Session.html) - a plug that sets up session management. Note that `fetch_session/2` must still be explicitly called before using the session as this plug just sets up how the session is fetched
+- `Plug.Session` - a plug that sets up session management. Note that `fetch_session/2` must still be explicitly called before using the session as this plug just sets up how the session is fetched
 
 In the middle of the endpoint, there is also a conditional block:
 
@@ -187,7 +187,8 @@ defmodule HelloWeb.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
-    plug :fetch_flash
+    plug :fetch_live_flash
+    plug :put_root_layout, {HelloWeb.LayoutView, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug HelloWeb.Plugs.Locale, "en"
@@ -300,8 +301,9 @@ To make this all work, we converted the nested blocks of code and used `halt(con
 
 At the end of the day, by replacing the nested blocks of code with a flattened series of plug transformations, we are able to achieve the same functionality in a much more composable, clear, and reusable way.
 
-To learn more about plugs, see the documentation for the [Plug project](https://hexdocs.pm/plug), which provides many built-in plugs and functionalities.
+To learn more about plugs, see the documentation for the [Plug project](`Plug`), which provides many built-in plugs and functionalities.
 
 
 [`init/1`]: `c:Plug.init/1`
 [`call/2`]: `c:Plug.call/2`
+[`assign/3`]: `Plug.Conn.assign/3`


### PR DESCRIPTION
This PR includes:

* updates the default endpoint plugs based on the output of `mix phx.new hello` (v1.6.0), the main addition is the description of `Phoenix.LiveDashboard.RequestLogger`
* I also replaced some links like `[Module](https://hexdocs.pm/project/module.html` and took advantage of the links that ExDoc creates when it founds modules enclosed by backticks :)
* Now the pipeline `:browser` reflects the output from `mix phx.new hello`
* Finally, fixed a missed link to `Plug.Conn.assign/3`, you can find the link at the bottom of the text as references.
