### PR TITLE
Build CommonJS module along with ESM and IIFE

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -20,6 +20,7 @@ if Mix.env() == :dev do
   config :esbuild,
     version: "0.12.18",
     module: esbuild.(~w(--format=esm --sourcemap --outfile=../priv/static/phoenix.esm.js)),
+    main: esbuild.(~w(--format=cjs --sourcemap --outfile=../priv/static/phoenix.cjs.js)),
     cdn:
       esbuild.(
         ~w(--target=es2016 --format=iife --global-name=Phoenix --outfile=../priv/static/phoenix.js)

--- a/mix.exs
+++ b/mix.exs
@@ -198,7 +198,7 @@ defmodule Phoenix.MixProject do
   defp aliases do
     [
       docs: ["docs", &generate_js_docs/1],
-      "assets.build": ["esbuild module", "esbuild cdn", "esbuild cdn_min"],
+      "assets.build": ["esbuild module", "esbuild cdn", "esbuild cdn_min", "esbuild main"],
       "assets.watch": "esbuild module --watch"
     ]
   end

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The official JavaScript client for the Phoenix web framework.",
   "license": "MIT",
   "module": "./priv/static/phoenix.esm.js",
+  "main": "./priv/static/phoenix.cjs.js",
   "unpkg": "./priv/static/phoenix.min.js",
   "jsdelivr": "./priv/static/phoenix.min.js",
   "exports": {


### PR DESCRIPTION
I honestly don't know if this is the best approach but I am quite stuck with trying to upgrade to Phoenix 1.6 on a fairly large project that uses "Jest" for testing of their JavaScript code (elixirforum thread here: https://elixirforum.com/t/phoenix-1-6-0-npm-package-cannot-be-imported-in-jest/42670/4)

I tried various hacks and third party tools suggested on Jest thread but I wasted a whole day and fixing one thing breaks another, typical Node.js developer story. So, I decided to build CJS package of phoenix.js that Jest can understand like it used to up to 1.5.9.

Now I suspect there was a good reason for not including CJS file, but maybe it's just an omission - for the later case I provide this PR below. Note: in this project "phoenix" is the only package that doesn't provide CJS fallback, many other packages do ship with CJS and EMS and I tried to follow the pattern here.

esbuild can build CJS modules as well as ESM, and for the people using
build tools / or testing tools (such as Jest) that do not yet support
ESM modules, it is useful to have fallback when ESM is not availalbe.

This PR includes command to build CJS module along with currently
supported types, and adds entry "main" in package.json to point towards
that file.

This has been tested with Jest, which currently has very poor support
for ESM modules and allows for including "phoenix" in tests and also
stubbing it if needed.