### PR TITLE
Fixing doc to make example work with Phoenix 1.6

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -490,7 +490,7 @@ defmodule HelloWeb.ProductView do
   use HelloWeb, :view
 
   def category_select(f, changeset) do
-    existing_ids = changeset |> Ecto.Changeset.get_field(:categories) |> Enum.map(& &1.id)
+    existing_ids = changeset |> Ecto.Changeset.get_change(:categories, []) |> Enum.map(& &1.data.id)
 
     category_opts =
       for cat <- Hello.Catalog.list_categories(),


### PR DESCRIPTION
Using Changeset.get_field to fetch existing category id's didn't work.

Switcing to Changeset.get_change seems to correct the problem.

See 
https://elixirforum.com/t/problem-retrieving-products-selected-status-in-1-6-0-rc0-contexts-guide/42217
for full explanation : But note that poster was expecting different 
behavior from those two functions.

Could he have found a bug ?