### PR TITLE
small fixup in the channel guide

### DIFF
--- a/guides/channels/channels.md
+++ b/guides/channels/channels.md
@@ -412,7 +412,7 @@ Next we need to pass this token to JavaScript. We can do so inside a script tag 
 
 ```html
 <script>window.userToken = "<%= assigns[:user_token] %>";</script>
-<script src="<%= Routes.static_path(@conn, "/js/app.js") %>"></script>
+<script src={Routes.static_path(@conn, "/assets/app.js")}></script>
 ```
 
 **Step 3 - Pass the Token to the Socket Constructor and Verify**


### PR DESCRIPTION
Hi, i noticed the html as shown in the guide would not compile. So I changed the docu to use the {}-notation and also changed the path from js/app.js to assets/app.js