### PR TITLE
Fix Dockerfile in guides/deployment/releases.md

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -217,7 +217,7 @@ RUN \
 # Everything from this line onwards will run in the context of the unprivileged user.
 USER "${USER}"
 
-COPY --from=build --chown="${USER}":"${USER}" /app/_build/"${MIX_ENV}"/rel/my_app ./
+COPY --from=build --chown="${USER}":"${USER}" /app/_build/"${MIX_ENV}"/rel/my_app/* ./
 
 ENTRYPOINT ["bin/my_app"]
 


### PR DESCRIPTION
The current `Dockerfile` example seems to be not working out of the box. 

This is due to the `COPY` command which copies `my_app/` release directory instead of its content, and when referenced in the `ENTRYPOINT`, it was expecting `bin/` folder.

To fix this I added `/*` to reference the directory content like in this PR

OR

We could reference the directory in `ENTRYPOINT`
```docker
ENTRYPOINT ["my_app/bin/my_app"]
```

But imho, I think the PR solution is cleaner