### PR TITLE
guides: Replace html entity in Telemetry guide

### DIFF
--- a/guides/telemetry.md
+++ b/guides/telemetry.md
@@ -157,7 +157,7 @@ A full list of all Phoenix telemetry events can be found in `Phoenix.Logger`
 > specific name, providing a view of the system's behaviour
 > over time.
 >
-> &#x2015; `Telemetry.Metrics`
+> ― `Telemetry.Metrics`
 
 The Telemetry.Metrics package provides a common interface
 for defining metrics. It exposes a set of [five metric type functions](https://hexdocs.pm/telemetry_metrics/Telemetry.Metrics.html#module-metrics) that are responsible for structuring a given Telemetry event as a particular measurement.


### PR DESCRIPTION
I noticed the current [Telemetry docs](https://hexdocs.pm/phoenix/telemetry.html#metrics) have a quote that uses the HTML code `&#x2015;` as the quote bar. Unfortunately, this does not get translated into the actual character:

<img width="619" alt="Screen Shot 2021-10-05 at 7 59 06 PM" src="https://user-images.githubusercontent.com/691365/136119929-aac34b56-3ecc-4762-893c-964ddc183b48.png">

This PR replaces the HTML entity with the actual character:

<img width="580" alt="Screen Shot 2021-10-05 at 8 03 56 PM" src="https://user-images.githubusercontent.com/691365/136120204-09329217-60ac-4d66-95b0-6a7a4fdc6b2f.png">



