### PR TITLE
Clarify language in phx.gen.auth

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -660,7 +660,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
         mix phx.new my_app --umbrella
         mix phx.new my_app --database mysql
 
-    Apps generated with --no-ecto and --no-html are not supported.
+    Apps generated with --no-ecto or --no-html are not supported.
     """)
   end
 


### PR DESCRIPTION
One word change to clarify that the generator doesn't work with projects generated with **either** `--no-ecto` **or** `--no-html`.