### PR TITLE
Fix small typo in gen.auth docs

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
       $ mix phx.gen.auth Accounts User users --web Warehouse
 
-  Which would generate the controllers, views, templates and associated tests in nested in the `MyAppWeb.Warehouse` namespace:
+  Which would generate the controllers, views, templates and associated tests nested in the `MyAppWeb.Warehouse` namespace:
 
     * `lib/my_app_web/controllers/warehouse/user_auth.ex`
     * `lib/my_app_web/controllers/warehouse/user_confirmation_controller.ex`


### PR DESCRIPTION
Remove a redundant 'in' from the gen.auth docs.