### PR TITLE
Add phoenix_html to docs dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -80,7 +80,7 @@ defmodule Phoenix.MixProject do
       {:telemetry_metrics, "~> 0.6", only: :docs},
 
       # Test dependencies
-      {:phoenix_html, "~> 3.0", only: :test},
+      {:phoenix_html, "~> 3.0", only: [:docs, :test]},
       {:phx_new, path: "./installer", only: :test},
       {:websocket_client, git: "https://github.com/jeremyong/websocket_client.git", only: :test},
 


### PR DESCRIPTION
This fixes docs warnings:

    warning: documentation references "Phoenix.HTML.Form.form_for/4" but it is undefined or private
      guides/contexts.md

    warning: documentation references "Phoenix.HTML.Form.hidden_inputs_for/1" but it is undefined or private
      guides/contexts.md

    warning: documentation references "Phoenix.HTML.Form.hidden_inputs_for/1" but it is undefined or private
      guides/contexts.md

cc @josevalim