### PR TITLE
Set @moduledoc to false in generated modules

### DIFF
--- a/installer/templates/phx_mailer/lib/app_name/mailer.ex
+++ b/installer/templates/phx_mailer/lib/app_name/mailer.ex
@@ -1,3 +1,5 @@
 defmodule <%= @app_module %>.Mailer do
+  @moduledoc false
+  
   use Swoosh.Mailer, otp_app: :<%= @app_name %>
 end

--- a/installer/templates/phx_web/telemetry.ex
+++ b/installer/templates/phx_web/telemetry.ex
@@ -1,4 +1,6 @@
 defmodule <%= @web_namespace %>.Telemetry do
+  @moduledoc false
+  
   use Supervisor
   import Telemetry.Metrics
 


### PR DESCRIPTION
Credo warns about these module not having moduledoc