### PR TITLE
Mention milligram in the guides

### DIFF
--- a/guides/directory_structure.md
+++ b/guides/directory_structure.md
@@ -133,4 +133,4 @@ Note that when you first create your Phoenix app using `mix phx.new` it is possi
 
 If the default esbuild integration does not cover your needs, for example because you want to use another build tool, you can switch to a [custom assets build](asset_management.html#custom_builds).
 
-As for CSS, Phoenix ships with a handful of custom styles as well as the [Milligram CSS Framework](https://milligram.io/), providing a solid foundation for many projects. However, as styling needs grow more complex, [Tailwind CSS](https://tailwindcss.com/) is a viable option that is popular within the community. More detail on how to add Tailwind or any other CSS framework to a Phoenix project is available [here](asset_management.md#css).
+As for CSS, Phoenix ships with a handful of custom styles as well as the [Milligram CSS Framework](https://milligram.io/), providing a minimal setup for projects. You may move to any CSS framework of your choice. Additional references can be found in the [asset management](asset_management.md#css) guide.

--- a/guides/directory_structure.md
+++ b/guides/directory_structure.md
@@ -132,3 +132,5 @@ Your other static assets are placed in the `priv/static` folder, where `priv/sta
 **NB:** When you first create your Phoenix app using `mix phx.new` it is possible to specify options that will affect the presence and layout of the `assets` directory.  In fact, Phoenix apps can bring their own front end tools or not have a front-end at all (handy if you're writing an API for example).  For more information you can run `mix help phx.new` or see the documentation in [Mix tasks](mix_tasks.html).
 
 If the default esbuild integration does not cover your needs, for example because you want to use another build tool, you can switch to a [custom assets build](asset_management.html#custom_builds).
+
+As for CSS, Phoenix ships with a handful of custom styles as well as the [Milligram CSS Framework](https://milligram.io/), providing a solid foundation for many projects. However, as styling needs grow more complex, [Tailwind CSS](https://tailwindcss.com/) is a viable option that is popular within the community. More detail on how to add Tailwind or any other CSS framework to a Phoenix project is available [here](asset_management.md#css).

--- a/guides/directory_structure.md
+++ b/guides/directory_structure.md
@@ -129,7 +129,7 @@ The `assets` directory contains source files related to front-end assets, such a
 
 Your other static assets are placed in the `priv/static` folder, where `priv/static/assets` is kept for generated assets. Everything in `priv/static` is served by the `Plug.Static` plug configured in `lib/hello_web/endpoint.ex`.  When running in dev mode (`MIX_ENV=dev`), Phoenix watches for any changes you make in the `assets` directory, and then takes care of updating your front end application in your browser as you work.
 
-**NB:** When you first create your Phoenix app using `mix phx.new` it is possible to specify options that will affect the presence and layout of the `assets` directory.  In fact, Phoenix apps can bring their own front end tools or not have a front-end at all (handy if you're writing an API for example).  For more information you can run `mix help phx.new` or see the documentation in [Mix tasks](mix_tasks.html).
+Note that when you first create your Phoenix app using `mix phx.new` it is possible to specify options that will affect the presence and layout of the `assets` directory.  In fact, Phoenix apps can bring their own front end tools or not have a front-end at all (handy if you're writing an API for example).  For more information you can run `mix help phx.new` or see the documentation in [Mix tasks](mix_tasks.html).
 
 If the default esbuild integration does not cover your needs, for example because you want to use another build tool, you can switch to a [custom assets build](asset_management.html#custom_builds).
 


### PR DESCRIPTION
The fact that Phoenix ships with [Milligram](https://milligram.io/) by default is presently not mentioned anywhere in the guides:

https://github.com/phoenixframework/phoenix/search?q=milligram+path%3Aguides

This PR is meant to address this by giving Milligram a quick mention early-on in the official guides.