### PR TITLE
Remove Outdated instructions in README for generating phonenix.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ $ mix archive.build
 ```bash
 $ cd assets
 $ npm install
-$ npm run watch
 ```
 
 ## Important links


### PR DESCRIPTION
As outlined in [Issue #4573](https://github.com/phoenixframework/phoenix/issues/4573), `After the switch to ESbuild, there is no longer a "watch" task`

This PR commit removes the outdated line from the `README.md`

Before submitting, I reviewed the [CONTRIBUTING.md](https://github.com/phoenixframework/phoenix/blob/master/CONTRIBUTING.md) and ran `mix test`

Result:

```
Finished in 0.02 seconds (0.02s async, 0.00s sync)
3 tests, 0 failures

Randomized with seed 268228
```

Thank you all for the amazing work you do!