### PR TITLE
Tweak Channel Generator Output

### DIFF
--- a/priv/templates/phx.gen.channel/channel.ex
+++ b/priv/templates/phx.gen.channel/channel.ex
@@ -21,7 +21,7 @@ defmodule <%= module %>Channel do
   # broadcast to everyone in the current topic (<%= singular %>:lobby).
   @impl true
   def handle_in("shout", payload, socket) do
-    broadcast socket, "shout", payload
+    broadcast(socket, "shout", payload)
     {:noreply, socket}
   end
 

--- a/priv/templates/phx.gen.channel/channel_test.exs
+++ b/priv/templates/phx.gen.channel/channel_test.exs
@@ -11,17 +11,17 @@ defmodule <%= module %>ChannelTest do
   end
 
   test "ping replies with status ok", %{socket: socket} do
-    ref = push socket, "ping", %{"hello" => "there"}
+    ref = push(socket, "ping", %{"hello" => "there"})
     assert_reply ref, :ok, %{"hello" => "there"}
   end
 
   test "shout broadcasts to <%= singular %>:lobby", %{socket: socket} do
-    push socket, "shout", %{"hello" => "all"}
+    push(socket, "shout", %{"hello" => "all"})
     assert_broadcast "shout", %{"hello" => "all"}
   end
 
   test "broadcasts are pushed to the client", %{socket: socket} do
-    broadcast_from! socket, "broadcast", %{"some" => "data"}
+    broadcast_from!(socket, "broadcast", %{"some" => "data"})
     assert_push "broadcast", %{"some" => "data"}
   end
 end

--- a/test/mix/tasks/phx.gen.channel_test.exs
+++ b/test/mix/tasks/phx.gen.channel_test.exs
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Phx.Gen.ChannelTest do
         assert file =~ ~S|def handle_in("ping", payload, socket) do|
         assert file =~ ~S|{:reply, {:ok, payload}, socket}|
         assert file =~ ~S|def handle_in("shout", payload, socket) do|
-        assert file =~ ~S|broadcast socket, "shout", payload|
+        assert file =~ ~S|broadcast(socket, "shout", payload)|
         assert file =~ ~S|{:noreply, socket}|
       end)
 
@@ -38,15 +38,15 @@ defmodule Mix.Tasks.Phx.Gen.ChannelTest do
         assert file =~ ~S|> subscribe_and_join(PhoenixWeb.RoomChannel|
 
         assert file =~ ~S|test "ping replies with status ok"|
-        assert file =~ ~S|ref = push socket, "ping", %{"hello" => "there"}|
+        assert file =~ ~S|ref = push(socket, "ping", %{"hello" => "there"})|
         assert file =~ ~S|assert_reply ref, :ok, %{"hello" => "there"}|
 
         assert file =~ ~S|test "shout broadcasts to room:lobby"|
-        assert file =~ ~S|push socket, "shout", %{"hello" => "all"}|
+        assert file =~ ~S|push(socket, "shout", %{"hello" => "all"})|
         assert file =~ ~S|assert_broadcast "shout", %{"hello" => "all"}|
 
         assert file =~ ~S|test "broadcasts are pushed to the client"|
-        assert file =~ ~S|broadcast_from! socket, "broadcast", %{"some" => "data"}|
+        assert file =~ ~S|broadcast_from!(socket, "broadcast", %{"some" => "data"})|
         assert file =~ ~S|assert_push "broadcast", %{"some" => "data"}|
       end)
     end)


### PR DESCRIPTION
I added some parentheses, so the generated code passes `mix format --check-formatted`.