### PR TITLE
Fix link to phoenix javascript files

### DIFF
--- a/guides/real_time/channels.md
+++ b/guides/real_time/channels.md
@@ -168,7 +168,7 @@ The following libraries exist today, and new ones are always welcome.
 
 #### Official
 
-Phoenix ships with a JavaScript client that is available when generating a new Phoenix project. The documentation for the JavaScript module is available at [https://hexdocs.pm/phoenix/js/](https://hexdocs.pm/phoenix/js/); the code is in [phoenix.js](https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix.js).
+Phoenix ships with a JavaScript client that is available when generating a new Phoenix project. The documentation for the JavaScript module is available at [https://hexdocs.pm/phoenix/js/](https://hexdocs.pm/phoenix/js/); the code is in [multiple js files](https://github.com/phoenixframework/phoenix/blob/master/assets/js/phoenix/).
 
 #### 3rd Party
 


### PR DESCRIPTION
phoenix.js is no longer in a single js file, it is now a directory of files. Alternatively we could link to the index.js as the entry point but I think linking to the entire directory is easier to navigate from.