### PR TITLE
update controllers.md (safari no content type)

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -264,7 +264,7 @@ end
 
 Reloading [http://localhost:4000](http://localhost:4000) should show us a completely blank page. The network tab of our browser's developer tools should show a response status of "201" (Created). Some browsers (Safari) will download the response, as the content type is not set.
 
-So we would like to be specific about the content type, and we can use [`put_resp_content_type/2`] in conjunction with [`send_resp/3`].
+To be specific about the content type, we can use [`put_resp_content_type/2`] in conjunction with [`send_resp/3`].
 
 
 ```elixir

--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -262,9 +262,10 @@ def index(conn, _params) do
 end
 ```
 
-Reloading [http://localhost:4000](http://localhost:4000) should show us a completely blank page. The network tab of our browser's developer tools should show a response status of "201" (Created).
+Reloading [http://localhost:4000](http://localhost:4000) should show us a completely blank page. The network tab of our browser's developer tools should show a response status of "201" (Created). Some browsers (Safari) will download the response, as the content type is not set.
 
-If we would like to be really specific about the content type, we can use [`put_resp_content_type/2`] in conjunction with [`send_resp/3`].
+So we would like to be specific about the content type, and we can use [`put_resp_content_type/2`] in conjunction with [`send_resp/3`].
+
 
 ```elixir
 def index(conn, _params) do


### PR DESCRIPTION
The docs are not precise, when using safari - as it will not render without a content_type..

More than open for better wording.

fixes https://github.com/phoenixframework/phoenix/issues/4597