### PR TITLE
bugfix: allow creating enum with a single value

### DIFF
--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -32,12 +32,8 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
         Gen.Html.run(~w(Blog Post))
       end
 
-      assert_raise Mix.Error, ~r/Enum type requires at least two values/, fn ->
+      assert_raise Mix.Error, ~r/Enum type requires at least one value/, fn ->
         Gen.Html.run(~w(Blog Post posts status:enum))
-      end
-
-      assert_raise Mix.Error, ~r/Enum type requires at least two values/, fn ->
-        Gen.Html.run(~w(Blog Post posts status:enum:new))
       end
     end
   end
@@ -418,6 +414,16 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
 
         assert_file "test/phoenix/controllers/user_controller_test.exs", fn file ->
           assert file =~ "defmodule Phoenix.UserControllerTest"
+        end
+      end
+    end
+
+    test "allows enum type with at least one value", config do
+      in_tmp_project config.test, fn ->
+        Gen.Html.run(~w(Blog Post posts status:enum:new))
+
+        assert_file "lib/phoenix_web/templates/post/form.html.heex", fn file ->
+          assert file =~ ~s|<%= select f, :status, Ecto.Enum.values(Phoenix.Blog.Post, :status), prompt: "Choose a value" %>|
         end
       end
     end


### PR DESCRIPTION
While I don't see why someone would want to do this, the DB
engines (e.g., PostgreSQL, MySQL) allow setting an enum type with a single value and don't throw
errors.

Fixes: #4594
