### PR TITLE
add `:force_watchers` option to `Phoenix.Endpoint`

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -158,9 +158,10 @@ defmodule Phoenix.Endpoint do
     * `:watchers` - a set of watchers to run alongside your server. It
       expects a list of tuples containing the executable and its arguments.
       Watchers are guaranteed to run in the application directory, but only
-      when the server is enabled. For example, the watcher below will run
-      the "watch" mode of the webpack build tool when the server starts.
-      You can configure it to whatever build tool or command you want:
+      when the server is enabled (unless `:force_watchers` configuration is
+      set to `true`). For example, the watcher below will run the "watch" mode
+      of the webpack build tool when the server starts. You can configure it
+      to whatever build tool or command you want:
 
           [
             node: [
@@ -180,6 +181,9 @@ defmodule Phoenix.Endpoint do
       A watcher can also be a module-function-args tuple that will be invoked accordingly:
 
           [another: {Mod, :fun, [arg1, arg2]}]
+
+    * `:force_watchers` - when `true`, forces your watchers to start alongside your
+      server even when the `:server` option is set to `false`.
 
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -182,8 +182,8 @@ defmodule Phoenix.Endpoint do
 
           [another: {Mod, :fun, [arg1, arg2]}]
 
-    * `:force_watchers` - when `true`, forces your watchers to start alongside your
-      server even when the `:server` option is set to `false`.
+    * `:force_watchers` - when `true`, forces your watchers to start
+      even when the `:server` option is set to `false`.
 
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -99,14 +99,12 @@ defmodule Phoenix.Endpoint.Supervisor do
       Phoenix.CodeReloader.Server.check_symlinks()
     end
 
-    force_watchers? = force_watchers?(conf)
-
     children =
       config_children(mod, secret_conf, default_conf) ++
       pubsub_children(mod, conf) ++
       socket_children(mod) ++
       server_children(mod, conf, server?) ++
-      watcher_children(mod, conf, server?, force_watchers?)
+      watcher_children(mod, conf, server?)
 
     Supervisor.init(children, strategy: :one_for_one)
   end
@@ -157,16 +155,12 @@ defmodule Phoenix.Endpoint.Supervisor do
     end
   end
 
-  defp watcher_children(_mod, conf, server?, force_watchers?) do
-    if server? or force_watchers? do
+  defp watcher_children(_mod, conf, server?) do
+    if server? || conf[:force_watchers] do
       Enum.map(conf[:watchers], &{Phoenix.Endpoint.Watcher, &1})
     else
       []
     end
-  end
-
-  defp force_watchers?(conf) when is_list(conf) do
-    Keyword.get(conf, :force_watchers, false)
   end
 
   @doc """


### PR DESCRIPTION
This PR adds support for running watchers such as `esbuild` on an endpoint even when `:server` configuration is set to `false`. 

This is especially useful when running multiple Phoenix projects under an umbrella application in an environment where you only have access to a single port. In such an environment, you will likely resort to a proxy such as [master_proxy](https://github.com/jesseshieh/master_proxy) and set all the your Endpoint configurations to `server: false`.

See https://github.com/phoenixframework/esbuild/issues/34 for a more detailed explanation of the problem.