### PR TITLE
Make live_modal id dynamic

### DIFF
--- a/priv/templates/phx.gen.live/live_helpers.ex
+++ b/priv/templates/phx.gen.live/live_helpers.ex
@@ -17,7 +17,8 @@ defmodule <%= inspect context.web_module %>.LiveHelpers do
   """
   def live_modal(component, opts) do
     path = Keyword.fetch!(opts, :return_to)
-    modal_opts = [id: :modal, return_to: path, component: component, opts: opts]
+    id = Keyword.get(opts, :id, :modal)
+    modal_opts = [id: id, return_to: path, component: component, opts: opts]
     live_component(<%= inspect context.web_module %>.ModalComponent, modal_opts)
   end
 end


### PR DESCRIPTION
If you have more than one calls to the `live_modal` in a view, it will fail with `...elixir phoenix found duplicate ID :modal for component,...` that's because the `id` inside the function is hardcoded. 

This PR will introduce a chance to use the `id` from the declaration. Falling back to `:modal` in case it is not set.