### PR TITLE
Fix app name in phx.gen.release docs

### DIFF
--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -93,15 +93,15 @@ defmodule Mix.Tasks.Phx.Gen.Release do
         mix release
 
         # To start your system with the Phoenix server running
-        _build/dev/rel/live_beats/bin/server
+        _build/dev/rel/#{app}/bin/server
     #{if ecto?, do: ecto_instructions(app)}
     Once the release is running you can connect to it remotely:
 
-        _build/dev/rel/live_beats/bin/live_beats remote
+        _build/dev/rel/#{app}/bin/#{app} remote
 
     To list all commands:
 
-        _build/dev/rel/live_beats/bin/live_beats
+        _build/dev/rel/#{app}/bin/#{app}
     """)
 
     if ecto? do


### PR DESCRIPTION
There are some mentions of **live_beats** (https://twitter.com/chris_mccord/status/1462851686352015361) in `phx.gen.release` task docs. Perhaps Chris is trying out new ways to tease us 🤔

Anyway, this PR fixes it to use current app name.