### PR TITLE
Place hostname before database in config

### DIFF
--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -137,8 +137,8 @@ When `phx.new` generated our application, it included some basic repository conf
 config :hello, Hello.Repo,
   username: "postgres",
   password: "postgres",
-  database: "hello_dev",
   hostname: "localhost",
+  database: "hello_dev",
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 ...

--- a/guides/mix_tasks.md
+++ b/guides/mix_tasks.md
@@ -580,10 +580,10 @@ Notice that this task has updated `config/config.exs`. If we take a look, we'll 
 ```elixir
 . . .
 config :hello, OurCustom.Repo,
-  database: "hello_repo",
   username: "user",
   password: "pass",
-  hostname: "localhost"
+  hostname: "localhost",
+  database: "hello_repo",
 . . .
 ```
 

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -324,16 +324,16 @@ defmodule Phx.New.Generator do
       dev: [
         username: user,
         password: pass,
-        database: "#{app}_dev",
         hostname: "localhost",
+        database: "#{app}_dev",
         show_sensitive_data_on_connection_error: true,
         pool_size: 10
       ],
       test: [
         username: user,
         password: pass,
-        database: {:literal, ~s|"#{app}_test\#{System.get_env("MIX_TEST_PARTITION")}"|},
         hostname: "localhost",
+        database: {:literal, ~s|"#{app}_test\#{System.get_env("MIX_TEST_PARTITION")}"|},
         pool: Ecto.Adapters.SQL.Sandbox,
         pool_size: 10,
       ],


### PR DESCRIPTION
This follows the orders used in DATABASE_URL, which is
1. username
2. password
3. host
4. database