### PR TITLE
Leverage MIX_ENV on the runner image

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -248,8 +248,11 @@ ENV LC_ALL en_US.UTF-8
 WORKDIR "/app"
 RUN chown nobody /app
 
+# set runner ENV
+ENV MIX_ENV="prod"
+
 # Only copy the final release from the build stage
-COPY --from=builder --chown=nobody:root /app/_build/prod/rel/my_app ./
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/my_app ./
 
 USER nobody
 

--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -81,8 +81,11 @@ ENV LC_ALL en_US.UTF-8
 WORKDIR "/app"
 RUN chown nobody /app
 
+# set runner ENV
+ENV MIX_ENV="prod"
+
 # Only copy the final release from the build stage
-COPY --from=builder --chown=nobody:root /app/_build/prod/rel/<%= otp_app %> ./
+COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/<%= otp_app %> ./
 
 USER nobody
 

--- a/test/mix/tasks/phx.gen.release_test.exs
+++ b/test/mix/tasks/phx.gen.release_test.exs
@@ -74,8 +74,6 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
     end)
   end
 
-
-
   test "generates release and docker files", config do
     in_tmp_project(config.test, fn ->
       Gen.Release.run(["--docker", "--ecto"])
@@ -86,12 +84,7 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
       end)
 
       assert_file("Dockerfile", fn file ->
-        assert file =~ ~S|COPY --from=builder --chown=nobody:root /app/_build/prod/rel/phoenix ./|
-        assert file =~ ~S|CMD /app/bin/server|
-      end)
-
-      assert_file("Dockerfile", fn file ->
-        assert file =~ ~S|COPY --from=builder --chown=nobody:root /app/_build/prod/rel/phoenix ./|
+        assert file =~ ~S|COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/phoenix ./|
         assert file =~ ~S|CMD /app/bin/server|
       end)
 


### PR DESCRIPTION
The builder image reuses `MIX_ENV` to get deps and copy configs, but the runner image assumes the app was built on the "prod" env, which may not be case if one changes the `MIX_ENV` env value on the build image. This PR just make it a bit easier to spot that the env should be same on both build and runner images.