### PR TITLE
Fixes m1 container segfault (Issue #4629)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,7 +18,7 @@ if Mix.env() == :dev do
   end
 
   config :esbuild,
-    version: "0.13.5",
+    version: "0.14.0",
     module: esbuild.(~w(--format=esm --sourcemap --outfile=../priv/static/phoenix.esm.js)),
     main: esbuild.(~w(--format=cjs --sourcemap --outfile=../priv/static/phoenix.cjs.js)),
     cdn:

--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -33,7 +33,7 @@ config :swoosh, :api_client, false<% end %><%= if @assets do %>
 
 # Configure esbuild (the version is required)
 config :esbuild,
-  version: "0.13.5",
+  version: "0.14.0",
   default: [
     args:
       ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
@@ -13,7 +13,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 
 # Configure esbuild (the version is required)
 config :esbuild,
-  version: "0.13.5",
+  version: "0.14.0",
   default: [
     args:
       ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),


### PR DESCRIPTION
The `esbuild` installer is by default using version `0.14.0`. However `phx.new` is generating an old version `0.13.5` for the :dev config. When there is a mismatch, esbuild downloads the version that is in the config.

Seemingly esbuild v 0.13.5 segfaults in container, but 0.14.0 does not. Changing the version number in the config fixed my problem.

I made the changes to the `phx.new` installer templates, as well as the `config.ex` in the tree, and am submitting them as this PR.

Thanks for the great work.
