### PR TITLE
Fix content of warning messages in phx.gen.release

### DIFF
--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -45,6 +45,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
 
     app = Mix.Phoenix.otp_app()
     app_namespace = Mix.Phoenix.base()
+    web_namespace = app_namespace |> Mix.Phoenix.web_module() |> inspect()
 
     binding = [
       app_namespace: app_namespace,
@@ -124,7 +125,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
     Add the following to the top of your config/runtime.exs:
 
         if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
-          config :#{app}, #{app_namespace}.Endpoint, server: true
+          config :#{app}, #{web_namespace}.Endpoint, server: true
         end
     """)
 
@@ -135,7 +136,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
 
         host = System.get_env("PHX_HOST") || "example.com"
 
-        config :#{app}, #{app_namespace}.Endpoint,
+        config :#{app}, #{web_namespace}.Endpoint,
           ...,
           url: [host: host, port: 443]
     """)


### PR DESCRIPTION
The task generates a hint that is misleading since it uses the wrong namespace:
```
[warn] Conditional IPV6 support missing from runtime configuration.
                                                                                                                                                                                  Add the following to your config/runtime.exs:                                                                                                                                                                                                                                                                                                                           maybe_ipv6 = if System.get_env("ECTO_IPV6"), do: [:inet6], else: []
    config :hello, Hello.Repo,
      ...,
      socket_options: maybe_ipv6

[warn] Conditional server startup is missing from runtime configuration.

Add the following to the top of your config/runtime.exs:

    if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
      config :hello, Hello.Endpoint, server: true
    end
```

Note that it should be `HelloWeb.Endpoint`. Otherwise the `config` has no effect and the endpoint does not start.