### PR TITLE
Fix socket opts.params documentation

### DIFF
--- a/assets/js/phoenix/socket.js
+++ b/assets/js/phoenix/socket.js
@@ -78,7 +78,7 @@ import Timer from "./timer"
  *
  * Defaults to 20s (double the server long poll timer).
  *
- * @param {{Object|function)} [opts.params] - The optional params to pass when connecting
+ * @param {(Object|function)} [opts.params] - The optional params to pass when connecting
  * @param {string} [opts.binaryType] - The binary type to use for binary WebSocket frames.
  *
  * Defaults to "arraybuffer"


### PR DESCRIPTION
Due to a typo this parameter is not showing up in the online documentation.

Before
<img width="824" alt="Screen Shot 2021-12-17 at 1 44 16 PM" src="https://user-images.githubusercontent.com/8899069/146599656-e921f640-b2a0-49ac-b5f9-d746a12f3f9a.png">

After
<img width="901" alt="Screen Shot 2021-12-17 at 1 45 32 PM" src="https://user-images.githubusercontent.com/8899069/146599658-b0482eb0-3858-48aa-8dea-13371fe9b664.png">
