### PR TITLE
Let watchers execute batch files on Windows

### DIFF
--- a/test/phoenix/endpoint/echo.bat
+++ b/test/phoenix/endpoint/echo.bat
@@ -1,0 +1,5 @@
+:: batch file used in Phoenix watcher test. serves 2 purposes:
+:: 1. polyfills the watcher test's use of `echo`, which isn't 
+::    an executable on windows but an internal command
+:: 2. verifies that the watcher code can launch batch files on windows.
+@echo %*

--- a/test/phoenix/endpoint/watcher_test.exs
+++ b/test/phoenix/endpoint/watcher_test.exs
@@ -4,12 +4,20 @@ defmodule Phoenix.Endpoint.WatcherTest do
   alias Phoenix.Endpoint.Watcher
   import ExUnit.CaptureIO
 
-  test "starts watching and writes to stdio with args" do
+  test "starts watching and writes to stdio with args (batch file when on windows)" do
     assert capture_io(fn ->
-      {:ok, pid} = Watcher.start_link({"echo", ["hello", cd: File.cwd!()]})
+      {:ok, pid} = Watcher.start_link({"echo", ["hello", cd: __DIR__]})
       ref = Process.monitor(pid)
       assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
-    end) == "hello\n"
+    end) =~ ~r/^hello\R$/
+  end
+
+  test "starts watching and writes to stdio with args (real executable)" do
+    assert capture_io(fn ->
+      {:ok, pid} = Watcher.start_link({"erl", ["-version"]})
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
+    end) =~ ~r/erlang.*version/i
   end
 
   test "starts watching and writes to stdio with fun" do


### PR DESCRIPTION
Turns out your ping helped Jose! As discussed in #4617, here's an attempt to let Phoenix watchers run batch files more easily.

I took care to not blanket pass any command to `cmd /c` on Windows, because that's a step in the direction of the same kind of hell that writing package.json scripts is, with people trying to write scripts that are both valid sh and valid cmd or something like that.

This should keep the old behavior in tact *unless*:
1. the user is on Windows
2. the executable specified is found in the system PATH (plus `opts[:cd]`) and ends with `.cmd` or `.bat`

I like to think that that can't cause breaking changes since any watcher that matches point 2 above would've failed previously (`System.cmd`'s `find_executable` call would find it, but subsequently fail to launch it) (come to think of it, that's a bit of a "bad error message" kind of bug in `System.cmd` isn't it?)

Note that this is my first proper Elixir ecosystem contribution and I'm not a very seasoned Elixir dev by any means. Any code commentary (or straights edits) will be warmly appreciated.