### PR TITLE
Docs: fix typo & grammar mistakes

### DIFF
--- a/guides/directory_structure.md
+++ b/guides/directory_structure.md
@@ -125,7 +125,7 @@ Finally, there is a `lib/hello_web/gettext.ex` file which provides international
 
 ## The assets directory
 
-The `assets` directory contains source files related to front-end assets, such as JavaScript and CSS. Since Phoenix v1.6, we use the [`esbuild`](https://github.com/evanw/esbuild/) to compile assets, which is managed by [`esbuild`](https://github.com/phoenixframework/esbuild) Elixir package. The integration with `esbuild` is baked into your app. The relevant config can be found in your `config/config.exs` file.
+The `assets` directory contains source files related to front-end assets, such as JavaScript and CSS. Since Phoenix v1.6, we use [`esbuild`](https://github.com/evanw/esbuild/) to compile assets, which is managed by the [`esbuild`](https://github.com/phoenixframework/esbuild) Elixir package. The integration with `esbuild` is baked into your app. The relevant config can be found in your `config/config.exs` file.
 
 Your other static assets are placed in the `priv/static` folder, where `priv/static/assets` is kept for generated assets. Everything in `priv/static` is served by the `Plug.Static` plug configured in `lib/hello_web/endpoint.ex`.  When running in dev mode (`MIX_ENV=dev`), Phoenix watches for any changes you make in the `assets` directory, and then takes care of updating your front end application in your browser as you work.
 

--- a/guides/plug.md
+++ b/guides/plug.md
@@ -144,7 +144,7 @@ defmodule HelloWeb.Endpoint do
 
 The default endpoint plugs do quite a lot of work. Here they are in order:
 
-- `Plug.Static` - serves static assets. Since this plug comes before the logger, serving of static assets is not logged
+- `Plug.Static` - serves static assets. Since this plug comes before the logger, requests for static assets are not logged.
 
 - `Phoenix.LiveDashboard.RequestLogger` - sets up the _Request Logger_ for Phoenix LiveDashboard, this will allow you to have the option to either pass a query parameter to stream requests logs or to enable/disable a cookie that streams requests logs from your dashboard.
 
@@ -152,13 +152,13 @@ The default endpoint plugs do quite a lot of work. Here they are in order:
 
 - `Plug.Telemetry` - adds instrumentation points so Phoenix can log the request path, status code and request time by default.
 
-- `Plug.Parsers` - parses the request body when a known parser is available. By default, `Plug.Parsers`, parse URL-encoded, multipart and JSON (with `Jason`). The request body is left untouched when the request content-type cannot be parsed
+- `Plug.Parsers` - parses the request body when a known parser is available. By default, this plug can handle URL-encoded, multipart and JSON content (with `Jason`). The request body is left untouched if the request content-type cannot be parsed.
 
-- `Plug.MethodOverride` - converts the request method to PUT, PATCH or DELETE for POST requests with a valid `_method` parameter
+- `Plug.MethodOverride` - converts the request method to PUT, PATCH or DELETE for POST requests with a valid `_method` parameter.
 
-- `Plug.Head` - converts HEAD requests to GET requests and strips the response body
+- `Plug.Head` - converts HEAD requests to GET requests and strips the response body.
 
-- `Plug.Session` - a plug that sets up session management. Note that `fetch_session/2` must still be explicitly called before using the session as this plug just sets up how the session is fetched
+- `Plug.Session` - a plug that sets up session management. Note that `fetch_session/2` must still be explicitly called before using the session as this plug just sets up how the session is fetched.
 
 In the middle of the endpoint, there is also a conditional block:
 

--- a/guides/plug.md
+++ b/guides/plug.md
@@ -65,7 +65,7 @@ Host: "localhost"
 Headers: [...]
 ```
 
-Our plug simply prints information from the connection. Although our initial plug is very simple, you can virtually do anything you want inside of it. To learn about all fields available in the connection and all of the functionality associated to it, see the [documentation for `Plug.Conn`](https://hexdocs.pm/plug/Plug.Conn.html).
+Our plug simply prints information from the connection. Although our initial plug is very simple, you can do virtually anything you want inside of it. To learn about all fields available in the connection and all of the functionality associated to it, see the [documentation for `Plug.Conn`](https://hexdocs.pm/plug/Plug.Conn.html).
 
 Now let's look at the other plug variant, the module plugs.
 

--- a/installer/templates/phx_single/config/runtime.exs
+++ b/installer/templates/phx_single/config/runtime.exs
@@ -7,7 +7,7 @@ import Config
 # any compile-time configuration in here, as it won't be applied.
 # The block below contains prod specific runtime configuration.
 
-# Start the phoenix server if environment is set and running in a  release
+# Start the phoenix server if environment is set and running in a release
 if System.get_env("PHX_SERVER") && System.get_env("RELEASE_NAME") do
   config :<%= @app_name %>, <%= @endpoint_module %>, server: true
 end


### PR DESCRIPTION
This PR fixes a typo and improves the grammar in a few places in the docs.