### PR TITLE
Fix broken `check_origin: :conn`

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -593,8 +593,13 @@ defmodule Phoenix.Socket.Transport do
 
   defp origin_allowed?({module, function, arguments}, uri, _endpoint, _conn),
     do: apply(module, function, [uri | arguments])
-  defp origin_allowed?(:conn, uri, _endpoint, %Plug.Conn{} = conn),
-    do: uri.host == conn.host and uri.scheme == conn.scheme and uri.port == conn.port
+
+  defp origin_allowed?(:conn, uri, _endpoint, %Plug.Conn{} = conn) do
+    uri.host == conn.host and
+      uri.scheme == Atom.to_string(conn.scheme) and
+      uri.port == conn.port
+  end
+
   defp origin_allowed?(_check_origin, %{host: nil}, _endpoint, _conn),
     do: false
   defp origin_allowed?(true, uri, endpoint, _conn),

--- a/test/phoenix/socket/transport_test.exs
+++ b/test/phoenix/socket/transport_test.exs
@@ -133,8 +133,8 @@ defmodule Phoenix.Socket.TransportTest do
       refute check_origin("", check_origin: mfa).halted
     end
 
-    test "checks origin against :host" do
-      conn = %Plug.Conn{conn(:get, "/") | host: "example.com", scheme: "http", port: 80}
+    test "checks origin against :conn" do
+      conn = %Plug.Conn{conn(:get, "/") | host: "example.com", scheme: :http, port: 80}
       refute check_origin(conn, "http://example.com", check_origin: :conn).halted
 
       assert check_origin(conn, "https://example.com", check_origin: :conn).halted
@@ -143,7 +143,7 @@ defmodule Phoenix.Socket.TransportTest do
       assert check_origin(conn, "http://www.example.com", check_origin: :conn).halted
       assert check_origin(conn, "http://www.another.com", check_origin: :conn).halted
 
-      conn = %Plug.Conn{conn(:get, "/") | host: "example.com", scheme: "https", port: 443}
+      conn = %Plug.Conn{conn(:get, "/") | host: "example.com", scheme: :https, port: 443}
       refute check_origin(conn, "https://example.com", check_origin: :conn).halted
       assert check_origin(conn, "http://example.com", check_origin: :conn).halted
       assert check_origin(conn, "https://example.com:4000", check_origin: :conn).halted


### PR DESCRIPTION
In the internal implementation, the related function is at [here](https://github.com/phoenixframework/phoenix/blob/8d2b33ac9691bd624ede602088d213f89600d233/lib/phoenix/socket/transport.ex#L596):

```elixir
defp origin_allowed?(:conn, uri, _endpoint, %Plug.Conn{} = conn)
```

`uri` is a struct which is generated by `URI.parse/1`, the type of `scheme`
field is a string.

`conn` is a `%Plug.Conn{}`, the type of `scheme` field is an atom.

Because of that, this check will always failed in real case.

* * *

This commit fixes above issue, and fix related tests.