### PR TITLE
Fix docker stop timeout with phx.gen.release

### DIFF
--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -86,4 +86,4 @@ COPY --from=builder --chown=nobody:root /app/_build/prod/rel/<%= otp_app %> ./
 
 USER nobody
 
-CMD /app/bin/server
+CMD ["/app/bin/server"]


### PR DESCRIPTION
Use _exec form_ instead of _shell form_ [https://docs.docker.com/engine/reference/builder/](https://docs.docker.com/engine/reference/builder/) because the _shell form_ does not forward signals (used by `docker stop`).