### PR TITLE
Context Guide: Add "Category" alias in catalog.ex

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -449,6 +449,8 @@ With our schema associations set up, we can implement the selection of categorie
 
 
 ```diff
++ alias Hello.Catalog.Category
+
 - def get_product!(id), do: Repo.get!(Product, id)
 + def get_product!(id) do
 +   Product |> Repo.get(id) |> Repo.preload(:categories)


### PR DESCRIPTION
I was following the [In-context relationships guide](https://hexdocs.pm/phoenix/contexts.html#in-context-relationships) and noticed a problem when testing things out.

Creating a new product or editing an existing one would run into an `UndefinedFunctionError` in my `catalog.ex`:

```
function Category.__schema__/1 is undefined (module Category is not available)
```

The error appears here:

```elixir
def list_categories_by_id(category_ids) do
  Repo.all(from c in Category, where: c.id in ^category_ids)
end
```

Adding an `alias Hello.Catalog.Category` in my `catalog.ex` context solves the problem.

I didn't find the `alias` call being mentioned in the Context guide. This PR adds that `alias` call to the documentation, hoping that it'll help improve the guide a small bit.