### PR TITLE
Normalise phx.gen.auth function declaration names

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -72,7 +72,7 @@ defmodule <%= inspect auth_module %> do
   """
   def log_out_<%= schema.singular %>(conn) do
     <%= schema.singular %>_token = get_session(conn, :<%= schema.singular %>_token)
-    <%= schema.singular %>_token && <%= inspect context.alias %>.delete_session_token(<%= schema.singular %>_token)
+    <%= schema.singular %>_token && <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token(<%= schema.singular %>_token)
 
     if live_socket_id = get_session(conn, :live_socket_id) do
       <%= inspect(endpoint_module) %>.broadcast(live_socket_id, "disconnect", %{})

--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -154,11 +154,11 @@
 
   ## Examples
 
-      iex> deliver_update_email_instructions(<%= schema.singular %>, current_email, &Routes.<%= schema.singular %>_update_email_url(conn, :edit, &1))
+      iex> deliver_<%= schema.singular %>_update_email_instructions(<%= schema.singular %>, current_email, &Routes.<%= schema.singular %>_update_email_url(conn, :edit, &1))
       {:ok, %{to: ..., body: ...}}
 
   """
-  def deliver_update_email_instructions(%<%= inspect schema.alias %>{} = <%= schema.singular %>, current_email, update_email_url_fun)
+  def deliver_<%= schema.singular %>_update_email_instructions(%<%= inspect schema.alias %>{} = <%= schema.singular %>, current_email, update_email_url_fun)
       when is_function(update_email_url_fun, 1) do
     {encoded_token, <%= schema.singular %>_token} = <%= inspect schema.alias %>Token.build_email_token(<%= schema.singular %>, "change:#{current_email}")
 
@@ -229,7 +229,7 @@
   @doc """
   Deletes the signed token with the given context.
   """
-  def delete_session_token(token) do
+  def delete_<%= schema.singular %>_session_token(token) do
     Repo.delete_all(<%= inspect schema.alias %>Token.token_and_context_query(token, "session"))
     :ok
   end

--- a/priv/templates/phx.gen.auth/settings_controller.ex
+++ b/priv/templates/phx.gen.auth/settings_controller.ex
@@ -16,7 +16,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
     case <%= inspect context.alias %>.apply_<%= schema.singular %>_email(<%= schema.singular %>, password, <%= schema.singular %>_params) do
       {:ok, applied_<%= schema.singular %>} ->
-        <%= inspect context.alias %>.deliver_update_email_instructions(
+        <%= inspect context.alias %>.deliver_<%= schema.singular %>_update_email_instructions(
           applied_<%= schema.singular %>,
           <%= schema.singular %>.email,
           &Routes.<%= schema.route_helper %>_settings_url(conn, :confirm_email, &1)

--- a/priv/templates/phx.gen.auth/settings_controller_test.exs
+++ b/priv/templates/phx.gen.auth/settings_controller_test.exs
@@ -95,7 +95,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
       token =
         extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_update_email_instructions(%{<%= schema.singular %> | email: email}, <%= schema.singular %>.email, url)
+          <%= inspect context.alias %>.deliver_<%= schema.singular %>_update_email_instructions(%{<%= schema.singular %> | email: email}, <%= schema.singular %>.email, url)
         end)
 
       %{token: token, email: email}

--- a/priv/templates/phx.gen.auth/test_cases.exs
+++ b/priv/templates/phx.gen.auth/test_cases.exs
@@ -169,7 +169,7 @@
     end
   end
 
-  describe "deliver_update_email_instructions/3" do
+  describe "deliver_<%= schema.singular %>_update_email_instructions/3" do
     setup do
       %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
     end
@@ -177,7 +177,7 @@
     test "sends token through notification", %{<%= schema.singular %>: <%= schema.singular %>} do
       token =
         extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_update_email_instructions(<%= schema.singular %>, "current@example.com", url)
+          <%= inspect context.alias %>.deliver_<%= schema.singular %>_update_email_instructions(<%= schema.singular %>, "current@example.com", url)
         end)
 
       {:ok, token} = Base.url_decode64(token, padding: false)
@@ -195,7 +195,7 @@
 
       token =
         extract_<%= schema.singular %>_token(fn url ->
-          <%= inspect context.alias %>.deliver_update_email_instructions(%{<%= schema.singular %> | email: email}, <%= schema.singular %>.email, url)
+          <%= inspect context.alias %>.deliver_<%= schema.singular %>_update_email_instructions(%{<%= schema.singular %> | email: email}, <%= schema.singular %>.email, url)
         end)
 
       %{<%= schema.singular %>: <%= schema.singular %>, token: token, email: email}
@@ -348,11 +348,11 @@
     end
   end
 
-  describe "delete_session_token/1" do
+  describe "delete_<%= schema.singular %>_session_token/1" do
     test "deletes the token" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
       token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
-      assert <%= inspect context.alias %>.delete_session_token(token) == :ok
+      assert <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token(token) == :ok
       refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token)
     end
   end
@@ -495,7 +495,7 @@
     end
   end
 
-  describe "inspect/2" do
+  describe "inspect/2 for the <%= inspect schema.alias %> module" do
     test "does not include password" do
       refute inspect(%<%= inspect schema.alias %>{password: "123456"}) =~ "password: \"123456\""
     end


### PR DESCRIPTION
Use `schema.singular` on the context function declaration names as most of then already use it.
This is useful when the `phx.gen.auth` is used multiple times, for example:
```
mix phx.gen.auth Accounts User users --web auth
mix phx.gen.auth Accounts Admin admins --web admin
```

In test file, I'm not sure what is the best description for the `inspect/2` function.