### PR TITLE
Fixing spelling mistake in app.js

### DIFF
--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -1,5 +1,5 @@
 // We import the CSS which is extracted to its own file by esbuild.
-// Remove this line if you add a your own CSS build pipeline (e.g postcss).
+// Remove this line if you add your own CSS build pipeline (e.g postcss).
 import "../css/app.css"
 
 // If you want to use Phoenix channels, run `mix help phx.gen.channel`


### PR DESCRIPTION
We recently added a Phoenix installation guide to the Tailwind CSS website ([see here](https://tailwindcss.com/docs/guides/phoenix)), and someone pointed out that this comment has a spelling mistake. We've corrected it in our guide, but figured I'd share the fix upstream too 👍