### PR TITLE
Get rid of top-level `this` in constants.js

### DIFF
--- a/assets/js/phoenix/constants.js
+++ b/assets/js/phoenix/constants.js
@@ -1,6 +1,6 @@
 export const globalSelf = typeof self !== "undefined" ? self : null
 export const phxWindow = typeof window !== "undefined" ? window : null
-export const global = globalSelf || phxWindow || this
+export const global = globalSelf || phxWindow || global
 export const DEFAULT_VSN = "2.0.0"
 export const SOCKET_STATES = {connecting: 0, open: 1, closing: 2, closed: 3}
 export const DEFAULT_TIMEOUT = 10000


### PR DESCRIPTION
This is a quick drive-by I'm making while I was building the javascript in #4670 

Building our javascript gives the following warning:

```
 > js/phoenix/constants.js:3:49: warning: Top-level "this" will be replaced with undefined since this file is an ECMAScript module
     3 │ export const global = globalSelf || phxWindow || this
```

Based on [globalThis - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis#search_for_the_global_across_environments) I this the intention here is to use `global` if `window` and `self` both fall through.