### PR TITLE
Set `live_socket_id` when restoring session from cookie

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -94,13 +94,13 @@ defmodule <%= inspect auth_module %> do
   end
 
   defp ensure_<%= schema.singular %>_token(conn) do
-    if <%= schema.singular %>_token = get_session(conn, :<%= schema.singular %>_token) do
-      {<%= schema.singular %>_token, conn}
+    if token = get_session(conn, :<%= schema.singular %>_token) do
+      {token, conn}
     else
       conn = fetch_cookies(conn, signed: [@remember_me_cookie])
 
-      if <%= schema.singular %>_token = conn.cookies[@remember_me_cookie] do
-        {<%= schema.singular %>_token, put_token_in_session(conn, token)}
+      if token = conn.cookies[@remember_me_cookie] do
+        {token, put_token_in_session(conn, token)}
       else
         {nil, conn}
       end

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -101,7 +101,10 @@ defmodule <%= inspect auth_module %> do
       conn = fetch_cookies(conn, signed: [@remember_me_cookie])
 
       if <%= schema.singular %>_token = conn.cookies[@remember_me_cookie] do
-        {<%= schema.singular %>_token, put_session(conn, :<%= schema.singular %>_token, <%= schema.singular %>_token)}
+        {<%= schema.singular %>_token,
+         conn
+         |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token)
+         |> put_session(:live_socket_id, "<%= schema.plural %>_sessions:#{Base.url_encode64(<%= schema.singular %>_token)}")}
       else
         {nil, conn}
       end

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -30,8 +30,7 @@ defmodule <%= inspect auth_module %> do
 
     conn
     |> renew_session()
-    |> put_session(:<%= schema.singular %>_token, token)
-    |> put_session(:live_socket_id, "<%= schema.plural %>_sessions:#{Base.url_encode64(token)}")
+    |> put_token_in_session(token)
     |> maybe_write_remember_me_cookie(token, params)
     |> redirect(to: <%= schema.singular %>_return_to || signed_in_path(conn))
   end
@@ -101,10 +100,7 @@ defmodule <%= inspect auth_module %> do
       conn = fetch_cookies(conn, signed: [@remember_me_cookie])
 
       if <%= schema.singular %>_token = conn.cookies[@remember_me_cookie] do
-        {<%= schema.singular %>_token,
-         conn
-         |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token)
-         |> put_session(:live_socket_id, "<%= schema.plural %>_sessions:#{Base.url_encode64(<%= schema.singular %>_token)}")}
+        {<%= schema.singular %>_token, put_token_in_session(conn, token)}
       else
         {nil, conn}
       end
@@ -140,6 +136,12 @@ defmodule <%= inspect auth_module %> do
       |> redirect(to: Routes.<%= schema.route_helper %>_session_path(conn, :new))
       |> halt()
     end
+  end
+
+  defp put_token_in_session(conn, token) do
+    conn
+    |> put_session(:<%= schema.singular %>_token, token)
+    |> put_session(:live_socket_id, "<%= schema.plural %>_sessions:#{Base.url_encode64(token)}")
   end
 
   defp maybe_store_return_to(%{method: "GET"} = conn) do

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -102,6 +102,7 @@ defmodule <%= inspect auth_module %>Test do
         |> <%= inspect schema.alias %>Auth.fetch_current_<%= schema.singular %>([])
 
       assert get_session(conn, :<%= schema.singular %>_token) == <%= schema.singular %>_token
+      assert get_session(conn, :live_socket_id) == "<%= schema.plural %>_sessions:#{Base.url_encode64(<%= schema.singular %>_token)}"
       assert conn.assigns.current_<%= schema.singular %>.id == <%= schema.singular %>.id
     end
 

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -101,9 +101,11 @@ defmodule <%= inspect auth_module %>Test do
         |> put_req_cookie(@remember_me_cookie, signed_token)
         |> <%= inspect schema.alias %>Auth.fetch_current_<%= schema.singular %>([])
 
-      assert get_session(conn, :<%= schema.singular %>_token) == <%= schema.singular %>_token
-      assert get_session(conn, :live_socket_id) == "<%= schema.plural %>_sessions:#{Base.url_encode64(<%= schema.singular %>_token)}"
       assert conn.assigns.current_<%= schema.singular %>.id == <%= schema.singular %>.id
+      assert get_session(conn, :<%= schema.singular %>_token) == <%= schema.singular %>_token
+
+      assert get_session(conn, :live_socket_id) ==
+               "<%= schema.plural %>_sessions:#{Base.url_encode64(<%= schema.singular %>_token)}"
     end
 
     test "does not authenticate if data is missing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do


### PR DESCRIPTION
When restoring user sessions from the "remember me"-cookie, the `live_socket_id` value is not set, so the `log_out_*`-function does not disconnect sockets for users that are on a "restored" session.

This PR sets a `live_socket_id` on the session when creating a new session from the "remember me"-cookie and adds an assert in the test suite for this behaviour. 