### PR TITLE
Add ecto.seed alias to generator

### DIFF
--- a/installer/templates/phx_ecto/seeds.exs
+++ b/installer/templates/phx_ecto/seeds.exs
@@ -1,6 +1,6 @@
 # Script for populating the database. You can run it as:
 #
-#     mix run priv/repo/seeds.exs
+#     mix ecto.seed
 #
 # Inside the script, you can read and write to any of your
 # repositories directly:

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -65,7 +65,8 @@ defmodule <%= @app_module %>.MixProject do
   defp aliases do
     [
       setup: ["deps.get"<%= if @ecto do %>, "ecto.setup"<% end %>]<%= if @ecto do %>,
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.seed": ["run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "ecto.seed"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %><%= if @assets do %>,
       "assets.deploy": ["esbuild default --minify", "phx.digest"]<% end %>


### PR DESCRIPTION
I create an `ecto.seed` alias in every app that I use, I think it is very useful to make it available in the aliases because a lot of the time we want to add more seeding data without necessary running any migration.

It is also much easier and fast to type.