### PR TITLE
Prioritize user `:http` configuration for ranch

### DIFF
--- a/lib/phoenix/endpoint/cowboy2_adapter.ex
+++ b/lib/phoenix/endpoint/cowboy2_adapter.ex
@@ -61,6 +61,7 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
           raise "aborting due to nil port"
         end
 
+        # Ranch options are read from the top, so we keep the user opts first.
         opts = :proplists.delete(:port, opts) ++ [port: port_to_integer(port), otp_app: otp_app]
         child_spec(scheme, endpoint, opts)
       end

--- a/lib/phoenix/endpoint/cowboy2_adapter.ex
+++ b/lib/phoenix/endpoint/cowboy2_adapter.ex
@@ -61,7 +61,7 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
           raise "aborting due to nil port"
         end
 
-        opts = [port: port_to_integer(port), otp_app: otp_app] ++ :proplists.delete(:port, opts)
+        opts = :proplists.delete(:port, opts) ++ [port: port_to_integer(port), otp_app: otp_app]
         child_spec(scheme, endpoint, opts)
       end
 


### PR DESCRIPTION
This puts an application's `:http` configuration for their Endpoint
first in the list to be sent into the ranch supervisor. When running on
a newer commit of ranch, this allows an application to specific
`:inet_backend` for the TCP sockets spawned by ranch.

Without this change, the application configuration is always _after_
port and IP. Since `:inet_backend` is only valid when specified as the
first argument to `:gen_tcp.listen/2`, this results in a `:badarg`
error.