### PR TITLE
Don't generate asset handling in Docker when directory doesn't exist

### DIFF
--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -51,7 +51,8 @@ defmodule Mix.Tasks.Phx.Gen.Release do
       app_namespace: app_namespace,
       otp_app: app,
       elixir_vsn: System.version(),
-      otp_vsn: otp_vsn()
+      otp_vsn: otp_vsn(),
+      assets_dir_exists?: File.dir?("assets")
     ]
 
     Mix.Phoenix.copy_from(paths(), "priv/templates/phx.gen.release", binding, [

--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -45,12 +45,12 @@ RUN mix deps.compile
 COPY priv priv
 
 COPY lib lib
-
+<%= if assets_dir_exists? do %>
 COPY assets assets
 
 # compile assets
 RUN mix assets.deploy
-
+<% end %>
 # Compile the release
 RUN mix compile
 

--- a/test/mix/tasks/phx.gen.release_test.exs
+++ b/test/mix/tasks/phx.gen.release_test.exs
@@ -114,4 +114,27 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
       assert_receive {:mix_shell, :info, ["\nYour application is ready to be deployed" <> _]}
     end)
   end
+
+  test "generates release and docker files with assets dir", config do
+    in_tmp_project(config.test, fn ->
+      File.mkdir_p!("assets")
+      Gen.Release.run(["--docker"])
+
+      assert_file("Dockerfile", fn file ->
+        assert file =~ ~S|COPY assets assets|
+        assert file =~ ~S|mix assets.deploy|
+      end)
+    end)
+  end
+
+  test "generates release and docker files without assets dir", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Release.run(["--docker"])
+
+      assert_file("Dockerfile", fn file ->
+        refute file =~ ~S|COPY assets assets|
+        refute file =~ ~S|mix assets.deploy|
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
Checks if the `assets` directory is present and adds asset handling to the Dockerfile if needed.
Not sure if this is the desired direction.

Ref: #4669