### PR TITLE
Config url scheme to "https" to match port 443

### DIFF
--- a/installer/templates/phx_single/config/runtime.exs
+++ b/installer/templates/phx_single/config/runtime.exs
@@ -29,7 +29,7 @@ if config_env() == :prod do
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :<%= @app_name %>, <%= @endpoint_module %>,
-    url: [host: host, port: 443],
+    url: [host: host, port: 443, scheme: "https"],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -153,7 +153,7 @@ defmodule Mix.Tasks.Phx.NewTest do
         end
         """
         assert file =~ ~S[host = System.get_env("PHX_HOST") || "example.com"]
-        assert file =~ ~S|url: [host: host, port: 443],|
+        assert file =~ ~S|url: [host: host, port: 443, scheme: "https"],|
       end
       assert_file "phx_blog/config/test.exs", ~R/database: "phx_blog_test#\{System.get_env\("MIX_TEST_PARTITION"\)\}"/
       assert_file "phx_blog/lib/phx_blog/repo.ex", ~r"defmodule PhxBlog.Repo"


### PR DESCRIPTION
This fixes the following unexpected log upon start
```
Access EuronextWeb.Endpoint at http://example.com:443
```