### PR TITLE
Deprecate {:system, env_var} tuples for configuring endpoint urls

### DIFF
--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -99,10 +99,10 @@ defmodule Phoenix.Endpoint.EndpointTest do
         start_supervised!(SystemTupleEndpoint)
       end)
 
-    assert log =~ "[:url, :host]"
-    assert log =~ "[:url, :port]"
-    assert log =~ "[:static_url, :host]"
-    assert log =~ "[:static_url, :host]"
+    assert log =~ ~S|host: System.get_env("ENDPOINT_TEST_HOST")|
+    assert log =~ ~S|port: System.get_env("ENDPOINT_TEST_PORT")|
+    assert log =~ ~S|host: System.get_env("ENDPOINT_TEST_ASSET_HOST")|
+    assert log =~ ~S|port: System.get_env("ENDPOINT_TEST_ASSET_PORT")|
   end
 
   test "sets script name when using path" do

--- a/test/phoenix/socket/transport_test.exs
+++ b/test/phoenix/socket/transport_test.exs
@@ -1,5 +1,3 @@
-System.put_env("TRANSPORT_TEST_HOST", "host.com")
-
 defmodule Phoenix.Socket.TransportTest do
   use ExUnit.Case, async: true
   use RouterHelper
@@ -12,7 +10,7 @@ defmodule Phoenix.Socket.TransportTest do
 
   Application.put_env :phoenix, __MODULE__.Endpoint,
     force_ssl: [],
-    url: [host: {:system, "TRANSPORT_TEST_HOST"}],
+    url: [host: "host.com"],
     check_origin: ["//endpoint.com"],
     secret_key_base: @secret_key_base
 


### PR DESCRIPTION
I was reading through the endpoint supervisor code and saw the following TODO so I thought I'd try tackling it.
```
# TODO: Deprecate {:system, env_var} once we require Elixir v1.9+
```
This adds the following log message when an endpoint's `:url` or `:static_url` function has a deprecated `{:system, env_var}` tuple.

```
00:14:41.051 [warn] :url configuration containing values of {:system, env_var} tuples for Phoenix.Endpoint.EndpointTest.SystemTupleEndpoint is deprecated.

Configuration:

    config :phoenix, Phoenix.Endpoint.EndpointTest.SystemTupleEndpoint,
      [host: {:system, "ENDPOINT_TEST_HOST"}, port: {:system, "ENDPOINT_TEST_PORT"}]

Either move these config values into config/runtime.exs:

    config :phoenix, Phoenix.Endpoint.EndpointTest.SystemTupleEndpoint,
      host: System.get_env("ENDPOINT_TEST_HOST"),
      port: System.get_env("ENDPOINT_TEST_PORT")

Or read them during initialization inside of the Phoenix.Endpoint.EndpointTest.SystemTupleEndpoint.init/2 callback.

    def init(:supervisor, config) do
      config
      |> put_in([:url, :host], System.get_env("ENDPOINT_TEST_HOST"))
      |> put_in([:url, :port], System.get_env("ENDPOINT_TEST_PORT"))

      {:ok, config}
    end
```

Please let me know what you think!