### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Maintain dependencies for Phoenix itself
+  - package-ecosystem: "mix"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for Phoenix integration tests
+  - package-ecosystem: "mix"
+    directory: "/integration_test"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for Yarn
+  - package-ecosystem: "npm"
+    directory: "/assets"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This configures dependabot so it should be easier to keep our dependencies up to date. There are 4 checks configured in this PR.

1. Updates to the main mix.lock file
2. Updates to the integration_test mix.lock file
3. Updates for our github actions in `.github/workflows/ci.yml`
4. Updates for our `package.json` in `/assets` (this already seems to be happening

Out of curiosity, do we have a strategy for updating our current mix.lock files? If it's better to keep them at the minimum supported versions to maintain backward compatibility, maybe we don't need this. But if we want to keep everything up to date, this should help.