### PR TITLE
chore(gen.context): add unit test including enums

### DIFF
--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -357,4 +357,23 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       assert Path.wildcard("priv/repo/migrations/*_create_posts.exs") == []
     end
   end
+
+  test "generates context with enum", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Context.run(
+        ~w(Accounts User users email:text:unique password:text:redact status:enum:verified:unverified:disabled)
+      )
+
+      assert_file("lib/phoenix/accounts/user.ex", fn file ->
+        assert file =~ "field :status, Ecto.Enum, values: [:verified, :unverified, :disabled]"
+      end)
+
+      assert [path] = Path.wildcard("priv/repo/migrations/*_create_users.exs")
+
+      assert_file(path, fn file ->
+        assert file =~ "create table(:users)"
+        assert file =~ "add :status, :string"
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
As commented [here](https://github.com/phoenixframework/phoenix/issues/4683#issuecomment-1059713876). The issue #4683 should be already fixed, but I didn't see any unit test to generate a context that includes enums like:

```
mix phx.gen.context Accounts User users email:text:unique password:text:redact status:enum:verified:unverified:disable
```

So, the idea behind this unit test is to avoid regressions in the future.