### PR TITLE
Fix syntax highlighting in a socket config

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -846,17 +846,21 @@ defmodule Phoenix.Endpoint do
 
       For example:
 
-          socket "/socket", AppWeb.UserSocket,
+      ```
+        socket "/socket", AppWeb.UserSocket,
             websocket: [
               connect_info: [:peer_data, :trace_context_headers, :x_headers, :uri, session: [store: :cookie]]
             ]
+      ```
 
       With arbitrary keywords:
 
-          socket "/socket", AppWeb.UserSocket,
+      ```
+        socket "/socket", AppWeb.UserSocket,
             websocket: [
               connect_info: [:uri, custom_value: "abcdef"]
             ]
+      ```
 
   ## Websocket configuration
 


### PR DESCRIPTION
Not sure why it is broken currently, but https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-common-configuration is pretty hard to read right now.
