### PR TITLE
Fix `LongPoll` callbacks in JS client

### DIFF
--- a/assets/js/phoenix/longpoll.js
+++ b/assets/js/phoenix/longpoll.js
@@ -85,16 +85,16 @@ export default class LongPoll {
           break
         case 410:
           this.readyState = SOCKET_STATES.open
-          this.onopen()
+          this.onopen({})
           this.poll()
           break
         case 403:
-          this.onerror()
+          this.onerror(status)
           this.close()
           break
         case 0:
         case 500:
-          this.onerror()
+          this.onerror(status)
           this.closeAndRetry()
           break
         default: throw new Error(`unhandled poll status ${status}`)
@@ -111,8 +111,8 @@ export default class LongPoll {
     })
   }
 
-  close(_code, _reason){
+  close(code, reason){
     this.readyState = SOCKET_STATES.closed
-    this.onclose()
+    this.onclose({code, reason})
   }
 }


### PR DESCRIPTION
Hi,

As a few of my clients access my Phoenix site from restricted networks like government departments, which block or intercept websocket connections, I have to fall back to `LongPoll` from time to time.

When this happens, I'm seeing a lot of errors along the lines of `Cannot read properties of undefined (reading 'code')`, `event is undefined` and so on. After some debugging, I traced the issue back to the `LongPoll` implementation calling the `onclose` and `onerror` callbacks without any arguments, causing those errors when Phoenix's `Socket` tries to access properties on callback events.

In this PR, i updated the `onclose`, `onopen` and `onerror` callbacks to always include an argument, even if it only is an empty object, to closer reflect the behavior of the `WebSocket` transport.

I already deployed my own version of the `LongPoll` implementation with those fixes to production, and this fixed all `LongPoll` issues, and channels as well as LiveView are working again.