### PR TITLE
Hide maybe_print_mailer_installation_instructions/1 from docs

### DIFF
--- a/lib/mix/tasks/phx.gen.notifier.ex
+++ b/lib/mix/tasks/phx.gen.notifier.ex
@@ -177,10 +177,6 @@ defmodule Mix.Tasks.Phx.Gen.Notifier do
     |> Mix.Phoenix.prompt_for_conflicts()
   end
 
-  # Print mailer instructions if mailer is not defined.
-  #
-  # This is useful for applications that were created without the
-  # mailer.
   @doc false
   @spec maybe_print_mailer_installation_instructions(%Context{}) :: %Context{}
   def maybe_print_mailer_installation_instructions(%Context{} = context) do

--- a/lib/mix/tasks/phx.gen.notifier.ex
+++ b/lib/mix/tasks/phx.gen.notifier.ex
@@ -177,12 +177,11 @@ defmodule Mix.Tasks.Phx.Gen.Notifier do
     |> Mix.Phoenix.prompt_for_conflicts()
   end
 
-  @doc """
-  Print mailer instructions if mailer is not defined.
-
-  This is useful for applications that were created without the
-  mailer.
-  """
+  # Print mailer instructions if mailer is not defined.
+  #
+  # This is useful for applications that were created without the
+  # mailer.
+  @doc false
   @spec maybe_print_mailer_installation_instructions(%Context{}) :: %Context{}
   def maybe_print_mailer_installation_instructions(%Context{} = context) do
     mailer_module = Module.concat([context.base_module, "Mailer"])


### PR DESCRIPTION
This removes the `maybe_print_mailer_installation_instructions/1` function from the `mix phx.gen.notifier` docs. It seems like this is an internal phoenix function and not an API contract we want to maintain, I'm thinking it should probably be marked with `@doc false`.

If this is intentionally in the API docs so other libraries can depend on it, we can close this PR.