### PR TITLE
Use app name as from name for phx.gen.auth notifier

### DIFF
--- a/priv/templates/phx.gen.auth/notifier.ex
+++ b/priv/templates/phx.gen.auth/notifier.ex
@@ -8,7 +8,7 @@ defmodule <%= inspect context.module %>.<%= inspect schema.alias %>Notifier do
     email =
       new()
       |> to(recipient)
-      |> from({"MyApp", "contact@example.com"})
+      |> from({"<%= inspect context.base_module %>", "contact@example.com"})
       |> subject(subject)
       |> text_body(body)
 

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -93,6 +93,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         assert file =~ "defmodule MyApp.Accounts.UserNotifier do"
         assert file =~ "import Swoosh.Email"
         assert file =~ "Mailer.deliver(email)"
+        assert file =~ ~s|from({"MyApp", "contact@example.com"})|
         assert file =~ ~s|deliver(user.email, "Confirmation instructions",|
         assert file =~ ~s|deliver(user.email, "Reset password instructions",|
         assert file =~ ~s|deliver(user.email, "Update email instructions",|


### PR DESCRIPTION
After running `mix phx.gen.auth` and registering a user, I was surprised to see the confirmation email come from the literal "MyApp" instead of the actual name of my app. This updates the generators to set from name to the actual name of the app.

## Question
I noticed `mix phx.gen.notifier` uses the from name "Phoenix Team" and email "team@example.com". 

https://github.com/phoenixframework/phoenix/blob/90a6494ffc028f2d5aa84a8a3d8f5a022fbd97d3/priv/templates/phx.gen.notifier/notifier.ex#L8

Do we want to update the default from name and email in both of these generators to match?