### PR TITLE
[phx.gen.auth] Improve references to current module SchemaToken module

### DIFF
--- a/priv/templates/phx.gen.auth/schema_token.ex
+++ b/priv/templates/phx.gen.auth/schema_token.ex
@@ -1,6 +1,7 @@
 defmodule <%= inspect schema.module %>Token do
   use Ecto.Schema
   import Ecto.Query
+  alias <%= inspect schema.module %>Token
 
   @hash_algorithm :sha256
   @rand_size 32
@@ -44,7 +45,7 @@ defmodule <%= inspect schema.module %>Token do
   """
   def build_session_token(<%= schema.singular %>) do
     token = :crypto.strong_rand_bytes(@rand_size)
-    {token, %__MODULE__{token: token, context: "session", <%= schema.singular %>_id: <%= schema.singular %>.id}}
+    {token, %<%= inspect schema.alias %>Token{token: token, context: "session", <%= schema.singular %>_id: <%= schema.singular %>.id}}
   end
 
   @doc """
@@ -87,7 +88,7 @@ defmodule <%= inspect schema.module %>Token do
     hashed_token = :crypto.hash(@hash_algorithm, token)
 
     {Base.url_encode64(token, padding: false),
-     %__MODULE__{
+     %<%= inspect schema.alias %>Token{
        token: hashed_token,
        context: context,
        sent_to: sent_to,
@@ -164,17 +165,17 @@ defmodule <%= inspect schema.module %>Token do
   Returns the token struct for the given token value and context.
   """
   def token_and_context_query(token, context) do
-    from <%= inspect schema.module %>Token, where: [token: ^token, context: ^context]
+    from <%= inspect schema.alias %>Token, where: [token: ^token, context: ^context]
   end
 
   @doc """
   Gets all tokens for the given <%= schema.singular %> for the given contexts.
   """
   def <%= schema.singular %>_and_contexts_query(<%= schema.singular %>, :all) do
-    from t in __MODULE__, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id
+    from t in <%= inspect schema.alias %>Token, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id
   end
 
   def <%= schema.singular %>_and_contexts_query(<%= schema.singular %>, [_ | _] = contexts) do
-    from t in __MODULE__, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id and t.context in ^contexts
+    from t in <%= inspect schema.alias %>Token, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id and t.context in ^contexts
   end
 end

--- a/priv/templates/phx.gen.auth/schema_token.ex
+++ b/priv/templates/phx.gen.auth/schema_token.ex
@@ -44,7 +44,7 @@ defmodule <%= inspect schema.module %>Token do
   """
   def build_session_token(<%= schema.singular %>) do
     token = :crypto.strong_rand_bytes(@rand_size)
-    {token, %<%= inspect schema.module %>Token{token: token, context: "session", <%= schema.singular %>_id: <%= schema.singular %>.id}}
+    {token, %__MODULE__{token: token, context: "session", <%= schema.singular %>_id: <%= schema.singular %>.id}}
   end
 
   @doc """
@@ -87,7 +87,7 @@ defmodule <%= inspect schema.module %>Token do
     hashed_token = :crypto.hash(@hash_algorithm, token)
 
     {Base.url_encode64(token, padding: false),
-     %<%= inspect schema.module %>Token{
+     %__MODULE__{
        token: hashed_token,
        context: context,
        sent_to: sent_to,
@@ -171,10 +171,10 @@ defmodule <%= inspect schema.module %>Token do
   Gets all tokens for the given <%= schema.singular %> for the given contexts.
   """
   def <%= schema.singular %>_and_contexts_query(<%= schema.singular %>, :all) do
-    from t in <%= inspect schema.module %>Token, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id
+    from t in __MODULE__, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id
   end
 
   def <%= schema.singular %>_and_contexts_query(<%= schema.singular %>, [_ | _] = contexts) do
-    from t in <%= inspect schema.module %>Token, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id and t.context in ^contexts
+    from t in __MODULE__, where: t.<%= schema.singular %>_id == ^<%= schema.singular %>.id and t.context in ^contexts
   end
 end


### PR DESCRIPTION
Currently `mix phx.gen.auth` creates a token module where its references to the current module look like this

```elixir
defmodule MyApp.Accounts.UserToken do
 # ...
    {token, %MyApp.Accounts.UserToken{token: token, context: "session", user_id: user.id}}
  #...
end
```
This seems pretty verbose, especially with a longer application name.

## My current approach

This PR switches the references to the current module from using the fully qualified name to use `__MODULE__` instead. This keeps these lines shorter, makes renaming this module easier, and reduces the formatting errors in the generated code if the application name is too long.

```elixir
defmodule MyApp.Accounts.UserToken do
 # ...
    {token, %__MODULE__{token: token, context: "session", user_id: user.id}}
  #...
end
```

## Another approach

I didn't find any other generated code that built structs for the current module, so I'm not sure what the best practices are. Another approach could be:

```elixir
defmodule MyApp.Accounts.UserToken do
  alias MyApp.Accounts.UserToken
 # ...
    {token, %UserToken{token: token, context: "session", user_id: user.id}}
  #...
end
```
This approach does repeat the current module's name when building the struct, but then sometimes I wonder "is this another module named UserToken from elsewhere, or is it the module I'm currently in?" I historically haven't taken this approach because  `__MODULE__` approach doesn't leave room for confusion and also removes the possibility of naming collisions.

## Questions

Which pattern is preferred for building a struct within the module that defines it?