### PR TITLE
Add .git to dockerignore

### DIFF
--- a/priv/templates/phx.gen.release/dockerignore.eex
+++ b/priv/templates/phx.gen.release/dockerignore.eex
@@ -14,10 +14,8 @@
 # More information on using .dockerignore is available here:
 # https://docs.docker.com/engine/reference/builder/#dockerignore-file
 
-.dockerignore
-# There are valid reasons to keep .git, namely so that you can get the
-# current commit hash
-#/.git/
+# Git repository
+/.git/
 
 # Common development/test artifacts
 /cover/


### PR DESCRIPTION
This PR adds `/.git/` to `.dockerignore` when running `mix phx.gen.release --docker`. The `.git` folder is not used in the `Dockerfile` we generate, so it seems unnecessary to have it included in the build context. Also, when running on a larger repo, the `.git` folder can become pretty big and it would be nice not to have to send it to the docker daemon.

This also removes `.dockerignore` from the list of excluded files because it's a small, single file and doesn't seem like it gives us much benefit to explicitly exclude it from the build context.