### PR TITLE
LongPoll callbacks: only use CloseEvent if exists

### DIFF
--- a/assets/js/phoenix/longpoll.js
+++ b/assets/js/phoenix/longpoll.js
@@ -113,11 +113,16 @@ export default class LongPoll {
 
   close(code, reason, wasClean){
     this.readyState = SOCKET_STATES.closed
-    this.onclose(
-      new CloseEvent(
-        'close',
-        Object.assign({ code: 1000, reason: undefined, wasClean: true }, { code, reason, wasClean }),
-      ),
-    )
+
+    const closeArgs = Object.assign(
+      {code: 1000, reason: undefined, wasClean: true},
+      {code, reason, wasClean}
+    );
+
+    if("CloseEvent" in window && !!CloseEvent){
+      this.onclose(new CloseEvent("close", closeArgs))
+    } else {
+      this.onclose(closeArgs)
+    }
   }
 }


### PR DESCRIPTION
It came to my attention that the `CloseEvent` constructor is not defined in some environments, such as the tests.
This PR fixes this by only using the `CloseEvent` constructor if it is defined. Sorry about that!