### PR TITLE
Use build arguments for docker base image versions

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -179,8 +179,12 @@ If you call `mix phx.gen.release --docker` you'll see a new file with these cont
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.12.0-erlang-24.0.1-debian-bullseye-20210902-slim
 #
-ARG BUILDER_IMAGE="hexpm/elixir:1.12.0-erlang-24.0.1-debian-bullseye-20210902-slim"
-ARG RUNNER_IMAGE="debian:bullseye-20210902-slim"
+ARG ELIXIR_VERSION=1.12.0
+ARG OTP_VERSION=24.0.1
+ARG DEBIAN_VERSION=bullseye-20210902-slim
+
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 
 FROM ${BUILDER_IMAGE} as builder
 

--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -12,8 +12,12 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:<%= elixir_vsn %>-erlang-<%= otp_vsn %>-debian-bullseye-20210902-slim
 #
-ARG BUILDER_IMAGE="hexpm/elixir:<%= elixir_vsn %>-erlang-<%= otp_vsn %>-debian-bullseye-20210902-slim"
-ARG RUNNER_IMAGE="debian:bullseye-20210902-slim"
+ARG ELIXIR_VERSION=<%= elixir_vsn %>
+ARG OTP_VERSION=<%= otp_vsn %>
+ARG DEBIAN_VERSION=bullseye-20210902-slim
+
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 
 FROM ${BUILDER_IMAGE} as builder
 


### PR DESCRIPTION
This PR refactors the Dockerfile to use build arguments for the base images (with defaults). This allows for easier customisation in CI. For example in Ci we do something like:

```yaml
      - name: Docker build
        uses: docker/build-push-action@v2
        with:
          build-args: |
            ELIXIR_VERSION=${{ steps.asdf-versions.outputs.elixir }}
            ERLANG_VERSION=${{ steps.asdf-versions.outputs.erlang }}
```