### PR TITLE
Allowing the use of nested resources with name: nil

### DIFF
--- a/lib/phoenix/router/resource.ex
+++ b/lib/phoenix/router/resource.ex
@@ -32,7 +32,7 @@ defmodule Phoenix.Router.Resource do
     alias   = Keyword.get(options, :alias)
     param   = Keyword.get(options, :param, @default_param_key)
     name    = Keyword.get(options, :name, Phoenix.Naming.resource_name(controller, "Controller"))
-    as      = Keyword.get(options, :as, name)
+    as      = Keyword.get(options, :as, (if is_nil(name), do: Phoenix.Naming.resource_name(controller, "Controller"), else: name))
     private = Keyword.get(options, :private, %{})
     assigns = Keyword.get(options, :assigns, %{})
 
@@ -41,7 +41,7 @@ defmodule Phoenix.Router.Resource do
 
     route       = [as: as, private: private, assigns: assigns]
     collection  = [path: path, as: as, private: private, assigns: assigns]
-    member_path = if singleton, do: path, else: Path.join(path, ":#{name}_#{param}")
+    member_path = if singleton, do: path, else: Path.join(path, (if is_nil(name), do: ":#{param}", else: ":#{name}_#{param}"))
     member      = [path: member_path, as: as, alias: alias, private: private, assigns: assigns]
 
     %Resource{path: path, actions: actions, param: param, route: route,

--- a/test/phoenix/router/resources_test.exs
+++ b/test/phoenix/router/resources_test.exs
@@ -31,6 +31,11 @@ defmodule Phoenix.Router.ResourcesTest do
     def special(conn, _params), do: text(conn, "special comments")
   end
 
+  defmodule ProductController do
+    use Phoenix.Controller
+    def index(conn, _params), do: text(conn, "index roles")
+  end
+
   defmodule Router do
     use Phoenix.Router
 
@@ -48,6 +53,10 @@ defmodule Phoenix.Router.ResourcesTest do
     resources "/admin", UserController, param: "slug", name: "admin", only: [:show], alias: Api do
       resources "/comments", CommentController, param: "key", name: "post", except: [:delete]
       resources "/files", FileController, only: [:show, :index, :new]
+    end
+
+    resources "/products", ProductController, param: "uuid", name: nil do
+      resources "/comments", Api.CommentController
     end
   end
 
@@ -145,6 +154,14 @@ defmodule Phoenix.Router.ResourcesTest do
     assert conn.resp_body == "delete comments"
     assert conn.params["user_id"] == "1"
     assert conn.params["id"] == "123"
+  end
+
+  test "1-Level nested route works when name is nil" do
+    conn = call(Router, :get, "products/1/comments")
+    assert conn.status == 200
+    assert conn.resp_body == "index comments"
+    assert conn.params["uuid"] == "1"
+    assert Router.Helpers.product_comment_path(conn, :index, "foo") == "/products/foo/comments"
   end
 
   test "2-Level nested route with get matches" do


### PR DESCRIPTION
This PR allows for the resources _name_ option to be nil. I currently need to add a nested route with a custom ID name and don't see any other option of doing it.

Example:
```
    resources "/products", ProductController, param: "uuid" do
      resources "/comments", Api.CommentController
    end
```

This will generate routes like `products/:product_uuid/comments` and I need to have `:uuid` instead of `:product_uuid`.

So I've tried this:
```
    resources "/products", ProductController, param: "uuid", name: nil do
      resources "/comments", Api.CommentController
    end
```

and got the following warning

`warning: the underscored variable "_uuid" is used after being set. A leading underscore indicates that the value of the variable should be ignored. If this is intended please rename the variable to remove the underscore
  test/phoenix/router/resources_test.exs: Phoenix.Router.ResourcesTest.Router.Helpers.comment_path/3`

plus the route itself turned to be slightly wrong `products/:_uuid/comments` and also the name of the path didn't have the product word in it. This PR solves all the 3 problems.
