### PR TITLE
Add execute permission to server in a container

### DIFF
--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -37,7 +37,7 @@ ENV MIX_ENV="prod"
 
 # install mix dependencies
 COPY mix.exs mix.lock ./
-RUN mix deps.get --only $MIX_ENV
+RUN mix deps.get --only ${MIX_ENV}
 RUN mkdir config
 
 # copy compile-time config files before we compile dependencies

--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -88,7 +88,7 @@ ENV MIX_ENV="prod"
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/<%= otp_app %> ./
 
 # set exectute to server
-RUN chmod 755 /app/bin/server
+RUN chmod +x /app/bin/server
 
 USER nobody
 

--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -87,6 +87,9 @@ ENV MIX_ENV="prod"
 # Only copy the final release from the build stage
 COPY --from=builder --chown=nobody:root /app/_build/${MIX_ENV}/rel/<%= otp_app %> ./
 
+# set exectute to server
+RUN chmod 755 /app/bin/server
+
 USER nobody
 
 CMD ["/app/bin/server"]


### PR DESCRIPTION
Generate the image from Azure leave the /app/bin/server without execute flag.
Its needed to place this explicit to make it work correctly.