### PR TITLE
Add .elixir_ls to .dockerignore

### DIFF
--- a/priv/templates/phx.gen.release/dockerignore.eex
+++ b/priv/templates/phx.gen.release/dockerignore.eex
@@ -24,6 +24,7 @@
 /doc/
 /test/
 /tmp/
+.elixir_ls
 
 # Mix artifacts
 /_build/


### PR DESCRIPTION
I noticed builds were hanging when the language server running in VS Code had files open when the docker context was being built. Adding `.elixir_ls` to the `.dockerignore` file fixed it up and reduced the build context by ~18mb.

Some more context: https://community.fly.io/t/elixir-phoenix-docker-builder-timeouts-after-10-minutes-with-an-eof-error/3632