### PR TITLE
Add HTMLFormatter in formatter.exs templates

### DIFF
--- a/installer/templates/phx_single/formatter.exs
+++ b/installer/templates/phx_single/formatter.exs
@@ -1,6 +1,6 @@
 [
   import_deps: [<%= if @ecto do %>:ecto, <% end %>:phoenix],<%= if @ecto do %>
-  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  subdirectories: ["priv/*/migrations"]<% else %>
-  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]<% end %>
+  subdirectories: ["priv/*/migrations"],<% end %><%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
+  plugins: [Phoenix.LiveView.HTMLFormatter],<% end %>
+  inputs: [<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>"*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}"<% else %>"*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"<% end %><%= if @ecto do %>, "priv/*/seeds.exs"<% end %>]
 ]

--- a/installer/templates/phx_umbrella/apps/app_name/formatter.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/formatter.exs
@@ -1,6 +1,6 @@
 [<%= if @ecto do %>
   import_deps: [:ecto],
-  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  subdirectories: ["priv/*/migrations"]<% else %>
-  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]<% end %>
+  subdirectories: ["priv/*/migrations"],<% end %><%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
+  plugins: [Phoenix.LiveView.HTMLFormatter],<% end %>
+  inputs: [<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>"*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}"<% else %>"*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"<% end %><%= if @ecto do %>, "priv/*/seeds.exs"<% end %>]
 ]

--- a/installer/templates/phx_umbrella/apps/app_name_web/formatter.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/formatter.exs
@@ -1,4 +1,5 @@
 [
-  import_deps: [:phoenix],
-  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]
+  import_deps: [:phoenix],<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
+  plugins: [Phoenix.LiveView.HTMLFormatter],<% end %>
+  inputs: [<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>"*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}"<% else %>"*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"<% end %>]
 ]

--- a/installer/templates/phx_umbrella/mix.exs
+++ b/installer/templates/phx_umbrella/mix.exs
@@ -24,7 +24,6 @@ defmodule <%= @root_app_module %>.MixProject do
   # Dependencies listed here are available only for this project
   # and cannot be accessed from applications inside the apps/ folder.
   defp deps do<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
-  defp deps do<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
     [
       # Required to run "mix format" on ~H/.heex files from the umbrella root 
       {:phoenix_live_view, ">= 0.0.0"} 

--- a/installer/templates/phx_umbrella/mix.exs
+++ b/installer/templates/phx_umbrella/mix.exs
@@ -24,8 +24,9 @@ defmodule <%= @root_app_module %>.MixProject do
   # Dependencies listed here are available only for this project
   # and cannot be accessed from applications inside the apps/ folder.
   defp deps do<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
-    {:phoenix_live_view, ">= 0.0.0"} # required by Phoenix.LiveView.HTMLFormatter
-<% else %>
+    [
+      {:phoenix_live_view, ">= 0.0.0"} # required by Phoenix.LiveView.HTMLFormatter
+    ]<% else %>
     []<% end %>
   end
 

--- a/installer/templates/phx_umbrella/mix.exs
+++ b/installer/templates/phx_umbrella/mix.exs
@@ -24,8 +24,10 @@ defmodule <%= @root_app_module %>.MixProject do
   # Dependencies listed here are available only for this project
   # and cannot be accessed from applications inside the apps/ folder.
   defp deps do<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
+  defp deps do<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
     [
-      {:phoenix_live_view, ">= 0.0.0"} # required by Phoenix.LiveView.HTMLFormatter
+      # Required to run "mix format" on ~H/.heex files from the umbrella root 
+      {:phoenix_live_view, ">= 0.0.0"} 
     ]<% else %>
     []<% end %>
   end

--- a/installer/templates/phx_umbrella/mix.exs
+++ b/installer/templates/phx_umbrella/mix.exs
@@ -23,8 +23,10 @@ defmodule <%= @root_app_module %>.MixProject do
   #
   # Dependencies listed here are available only for this project
   # and cannot be accessed from applications inside the apps/ folder.
-  defp deps do
-    []
+  defp deps do<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
+    {:phoenix_live_view, ">= 0.0.0"} # required by Phoenix.LiveView.HTMLFormatter
+<% else %>
+    []<% end %>
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/installer/templates/phx_umbrella/mix.exs
+++ b/installer/templates/phx_umbrella/mix.exs
@@ -25,7 +25,7 @@ defmodule <%= @root_app_module %>.MixProject do
   # and cannot be accessed from applications inside the apps/ folder.
   defp deps do<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
     [
-      # Required to run "mix format" on ~H/.heex files from the umbrella root 
+      # required to run "mix format" on ~H/.heex files from the umbrella root 
       {:phoenix_live_view, ">= 0.0.0"} 
     ]<% else %>
     []<% end %>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -32,10 +32,20 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/README.md"
 
-      assert_file "phx_blog/.formatter.exs", fn file ->
-        assert file =~ "import_deps: [:ecto, :phoenix]"
-        assert file =~ "inputs: [\"*.{ex,exs}\", \"priv/*/seeds.exs\", \"{config,lib,test}/**/*.{ex,exs}\"]"
-        assert file =~ "subdirectories: [\"priv/*/migrations\"]"
+      if Version.match?(System.version(), ">= 1.13.4") do
+        assert_file "phx_blog/.formatter.exs", fn file ->
+          assert file =~ "import_deps: [:ecto, :phoenix]"
+          assert file =~ "subdirectories: [\"priv/*/migrations\"]"
+          assert file =~ "plugins: [Phoenix.LiveView.HTMLFormatter]"
+          assert file =~ "inputs: [\"*.{heex,ex,exs}\", \"{config,lib,test}/**/*.{heex,ex,exs}\", \"priv/*/seeds.exs\"]"
+        end
+      else
+        assert_file "phx_blog/.formatter.exs", fn file ->
+          assert file =~ "import_deps: [:ecto, :phoenix]"
+          assert file =~ "subdirectories: [\"priv/*/migrations\"]"
+          assert file =~ "inputs: [\"*.{ex,exs}\", \"{config,lib,test}/**/*.{ex,exs}\", \"priv/*/seeds.exs\"]"
+          refute file =~ "plugins:"
+        end
       end
 
       assert_file "phx_blog/mix.exs", fn file ->

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -400,6 +400,13 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~ ~s|:phoenix_live_dashboard|
       end
 
+      assert_file "phx_blog/.formatter.exs", fn file ->
+        assert file =~ "import_deps: [:ecto, :phoenix]"
+        assert file =~ "subdirectories: [\"priv/*/migrations\"]"
+        assert file =~ "inputs: [\"*.{ex,exs}\", \"{config,lib,test}/**/*.{ex,exs}\", \"priv/*/seeds.exs\"]"
+        refute file =~ "plugins:"
+      end
+
       assert_file "phx_blog/lib/phx_blog_web/endpoint.ex", fn file ->
         assert file =~ ~s|defmodule PhxBlogWeb.Endpoint|
         assert file =~ ~s|socket "/live"|
@@ -436,6 +443,21 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file "phx_blog/config/config.exs", fn file ->
         refute file =~ "config :esbuild"
+      end
+    end
+  end
+
+  test "new with --no-ecto" do
+    in_tmp "new with no_ecto", fn ->
+      Mix.Tasks.Phx.New.run([@app_name, "--no-ecto"])
+
+      if Version.match?(System.version(), ">= 1.13.4") do
+        assert_file "phx_blog/.formatter.exs", fn file ->
+          assert file =~ "import_deps: [:phoenix]"
+          assert file =~ "plugins: [Phoenix.LiveView.HTMLFormatter]"
+          assert file =~ "inputs: [\"*.{heex,ex,exs}\", \"{config,lib,test}/**/*.{heex,ex,exs}\"]"
+          refute file =~ "subdirectories:"
+        end
       end
     end
   end

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -76,16 +76,36 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file root_path(@app, "config/runtime.exs"), ~r/ip: {0, 0, 0, 0, 0, 0, 0, 0}/
 
-      assert_file app_path(@app, ".formatter.exs"), fn file ->
-        assert file =~ "import_deps: [:ecto]"
-        assert file =~ "inputs: [\"*.{ex,exs}\", \"priv/*/seeds.exs\", \"{config,lib,test}/**/*.{ex,exs}\"]"
-        assert file =~ "subdirectories: [\"priv/*/migrations\"]"
-      end
+      if Version.match?(System.version(), ">= 1.13.4") do
+        assert_file app_path(@app, ".formatter.exs"), fn file ->
+          assert file =~ "import_deps: [:ecto]"
+          assert file =~ "subdirectories: [\"priv/*/migrations\"]"
+          assert file =~ "plugins: [Phoenix.LiveView.HTMLFormatter]"
+          assert file =~ "inputs: [\"*.{heex,ex,exs}\", \"{config,lib,test}/**/*.{heex,ex,exs}\", \"priv/*/seeds.exs\"]"
+        end
 
-      assert_file web_path(@app, ".formatter.exs"), fn file ->
-        assert file =~ "inputs: [\"*.{ex,exs}\", \"{config,lib,test}/**/*.{ex,exs}\"]"
-        refute file =~ "import_deps: [:ecto]"
-        refute file =~ "subdirectories:"
+        assert_file web_path(@app, ".formatter.exs"), fn file ->
+          assert file =~ "import_deps: [:phoenix]"
+          assert file =~ "plugins: [Phoenix.LiveView.HTMLFormatter]"
+          assert file =~ "inputs: [\"*.{heex,ex,exs}\", \"{config,lib,test}/**/*.{heex,ex,exs}\"]"
+          refute file =~ "import_deps: [:ecto]"
+          refute file =~ "subdirectories:"
+        end
+      else
+        assert_file app_path(@app, ".formatter.exs"), fn file ->
+          assert file =~ "import_deps: [:ecto]"
+          assert file =~ "subdirectories: [\"priv/*/migrations\"]"
+          assert file =~ "inputs: [\"*.{ex,exs}\", \"{config,lib,test}/**/*.{ex,exs}\", \"priv/*/seeds.exs\"]"
+          refute file =~ "plugins:"
+        end
+
+        assert_file web_path(@app, ".formatter.exs"), fn file ->
+          assert file =~ "import_deps: [:phoenix]"
+          assert file =~ "inputs: [\"*.{ex,exs}\", \"{config,lib,test}/**/*.{ex,exs}\"]"
+          refute file =~ "import_deps: [:ecto]"
+          refute file =~ "subdirectories:"
+          refute file =~ "plugins:"
+        end
       end
 
       assert_file app_path(@app, "lib/#{@app}/application.ex"), ~r/defmodule PhxUmb.Application do/

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -45,6 +45,17 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         assert file =~ "apps_path: \"apps\""
       end
 
+      # Phoenix.LiveView.HTMLFormatter
+      if Version.match?(System.version(), ">= 1.13.4") do
+        assert_file root_path(@app, "mix.exs"), fn file ->
+          assert file =~ "defp deps do\n    {:phoenix_live_view, \">= 0.0.0\"}"
+        end
+      else
+        assert_file root_path(@app, "mix.exs"), fn file ->
+          assert file =~ "defp deps do\n    []"
+        end
+      end
+
       assert_file app_path(@app, "mix.exs"), fn file ->
         assert file =~ "app: :phx_umb"
         assert file =~ ~S{build_path: "../../_build"}
@@ -414,6 +425,10 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
   test "new with --no-html" do
     in_tmp "new with no_html", fn ->
       Mix.Tasks.Phx.New.run([@app, "--umbrella", "--no-html"])
+
+      assert_file root_path(@app, "mix.exs"), fn file ->
+        assert file =~ "defp deps do\n    []"
+      end
 
       assert_file web_path(@app, "mix.exs"), fn file ->
         refute file =~ ~s|:phoenix_live_view|

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       # Phoenix.LiveView.HTMLFormatter
       if Version.match?(System.version(), ">= 1.13.4") do
         assert_file root_path(@app, "mix.exs"), fn file ->
-          assert file =~ "{:phoenix_live_view, \">= 0.0.0\"}"
+          assert file =~ ~r/defp deps do\n.*\[\n.*\n.*{:phoenix_live_view, \">= 0.0.0\"}/
         end
       else
         assert_file root_path(@app, "mix.exs"), fn file ->

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       # Phoenix.LiveView.HTMLFormatter
       if Version.match?(System.version(), ">= 1.13.4") do
         assert_file root_path(@app, "mix.exs"), fn file ->
-          assert file =~ ~r/defp deps do\n.*\[\n.*\n.*{:phoenix_live_view, \">= 0.0.0\"}/
+          assert file =~ "{:phoenix_live_view, \">= 0.0.0\"}"
         end
       else
         assert_file root_path(@app, "mix.exs"), fn file ->

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       # Phoenix.LiveView.HTMLFormatter
       if Version.match?(System.version(), ">= 1.13.4") do
         assert_file root_path(@app, "mix.exs"), fn file ->
-          assert file =~ "defp deps do\n    {:phoenix_live_view, \">= 0.0.0\"}"
+          assert file =~ "{:phoenix_live_view, \">= 0.0.0\"}"
         end
       else
         assert_file root_path(@app, "mix.exs"), fn file ->


### PR DESCRIPTION
That's an attempt to close #4749 

The config is added only if `@html` and Elixir >= 1.13.4 to meet formatter requirements.