### PR TITLE
CI - Bump Elixir to latest v1.13.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         include:
           - elixir: 1.12.1
             otp: 22.3.4.19
+            alpine: 3.13.3
           - elixir: 1.13.4
             otp: 24.3.3
             alpine: 3.15.3
@@ -44,7 +45,7 @@ jobs:
       - name: Download released earth
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.4.1/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Execute tests
-        run: earthly -P --build-arg ELIXIR=${{ matrix.elixir }} --build-arg OTP=${{ matrix.otp }} --build-arg ALPINE=${{ matrix.alpine }}  +integration-test
+        run: earthly -P --build-arg ELIXIR=${{ matrix.elixir }} --build-arg OTP=${{ matrix.otp }} --build-arg ALPINE=${{ matrix.alpine }} +integration-test
   npm_test:
     name: npm
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
             otp: 21.3.8.24
             run_installer_tests: 0
           - elixir: 1.13.4
-            otp: 24.0.2
+            otp: 24.3.3
+            alpine: 3.15.3
             run_installer_tests: 1
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +36,8 @@ jobs:
           - elixir: 1.12.1
             otp: 22.3.4.19
           - elixir: 1.13.4
-            otp: 24.0.2
+            otp: 24.3.3
+            alpine: 3.15.3
     steps:
       - uses: actions/checkout@v3
       - name: Download released earth

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         include:
           - elixir: 1.10.0
             otp: 21.3.8.24
+            alpine: 3.13.3
             run_installer_tests: 0
           - elixir: 1.13.4
             otp: 24.3.3
@@ -23,7 +24,7 @@ jobs:
       - name: Download released earth
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.5.16/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Execute tests
-        run: earthly --build-arg ELIXIR=${{ matrix.elixir }} --build-arg OTP=${{ matrix.otp }} --build-arg RUN_INSTALLER_TESTS=${{ matrix.run_installer_tests }} +test
+        run: earthly --build-arg ELIXIR=${{ matrix.elixir }} --build-arg OTP=${{ matrix.otp }} --build-arg ALPINE=${{ matrix.alpine }} --build-arg RUN_INSTALLER_TESTS=${{ matrix.run_installer_tests }} +test
   integration-test-elixir:
     runs-on: ubuntu-latest
     env:
@@ -43,7 +44,7 @@ jobs:
       - name: Download released earth
         run: "sudo /bin/sh -c 'wget https://github.com/earthly/earthly/releases/download/v0.4.1/earthly-linux-amd64 -O /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly'"
       - name: Execute tests
-        run: earthly -P --build-arg ELIXIR=${{ matrix.elixir }} --build-arg OTP=${{ matrix.otp }} +integration-test
+        run: earthly -P --build-arg ELIXIR=${{ matrix.elixir }} --build-arg OTP=${{ matrix.otp }} --build-arg ALPINE=${{ matrix.alpine }}  +integration-test
   npm_test:
     name: npm
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           - elixir: 1.10.0
             otp: 21.3.8.24
             run_installer_tests: 0
-          - elixir: 1.12.1
+          - elixir: 1.13.4
             otp: 24.0.2
             run_installer_tests: 1
     steps:
@@ -34,7 +34,7 @@ jobs:
         include:
           - elixir: 1.12.1
             otp: 22.3.4.19
-          - elixir: 1.12.1
+          - elixir: 1.13.4
             otp: 24.0.2
     steps:
       - uses: actions/checkout@v3

--- a/Earthfile
+++ b/Earthfile
@@ -96,7 +96,8 @@ npm:
 setup-base:
    ARG ELIXIR=1.12.1
    ARG OTP=24.0.2
-   FROM hexpm/elixir:$ELIXIR-erlang-$OTP-alpine-3.13.3
+   ARG ALPINE=3.13.3
+   FROM hexpm/elixir:$ELIXIR-erlang-$OTP-alpine-$ALPINE
    RUN apk add --no-progress --update git build-base
    ENV ELIXIR_ASSERT_TIMEOUT=10000
    WORKDIR /src


### PR DESCRIPTION
Just realized that CI won't test https://github.com/phoenixframework/phoenix/pull/4793 completely so It might be worth updating max Elixir version already.