### PR TITLE
Fix flaky phx.gen.release ecto_sql check

### DIFF
--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -203,5 +203,5 @@ defmodule Mix.Tasks.Phx.Gen.Release do
     end
   end
 
-  defp ecto_sql_installed?, do: Application.loaded_applications() |> List.keymember?(:ecto_sql, 0)
+  defp ecto_sql_installed?, do: Mix.Project.deps_apps() |> Enum.member?(:ecto_sql)
 end


### PR DESCRIPTION
Sometimes in a project where everything is already compiled, The `mix phx.gen.release` task cannot correctly detect if ecto_sql is already installed or not. This is because the ecto_sql is in fact not loaded yet.

To resolve this we can either try to load ecto_sql using `Application.load(:ecto_sql)` before fetching the loaded apps or simply
use the `Mix.Project.deps_apps` to see if `ecto_sql` is there.

This PR currently implemented the latter.