### PR TITLE
Update the routing guide to remove outdated examples

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -88,18 +88,17 @@ defmodule Phoenix.Router do
       GET /pages/hello/world
       %{"page" => ["hello", "world"]} = params
 
-  Globs can match segments partially too. The difference is the whole segment
-  is captured along with the trailing segments.
+  Globs cannot have prefixes nor suffixes, but can be mixed with variables:
 
-      get "/pages/he*page", PageController, :show
+      get "/pages/he:page/*rest", PageController, :show
 
   matches
 
-      GET /pages/hello/world
-      %{"page" => ["hello", "world"]} = params
+      GET /pages/hello
+      %{"page" => "llo", "rest" => []} = params
 
-      GET /pages/hey/world
-      %{"page" => ["hey", "world"]} = params
+      GET /pages/hey/there/world
+      %{"page" => "y", "rest" => ["there" "world"]} = params
 
   ## Helpers
 
@@ -182,16 +181,16 @@ defmodule Phoenix.Router do
   For example, the route above will match on the path `"/api/v1/pages/1"`
   and the named route will be `api_v1_page_path`, as expected from the
   values given to `scope/2` option.
-  
+
   Like all paths you can define dynamic segments that will be applied as
   parameters in the controller:
-  
+
       scope "/api/:version", MyAppWeb do
         get "/pages/:id", PageController, :show
       end
-      
-  For example, the route above will match on the path `"/api/v1/pages/1"` 
-  and in the controller the `params` argument will have a map with the 
+
+  For example, the route above will match on the path `"/api/v1/pages/1"`
+  and in the controller the `params` argument will have a map with the
   key `:version` with the value `"v1"`.
 
   Phoenix also provides a `resources/4` macro that allows developers


### PR DESCRIPTION
Closes #4715.

The examples use glob patterns with a prefix which raise a warning with Plug 1.13+.