### PR TITLE
Add HTMLFormatter to umbrella root

### DIFF
--- a/installer/templates/phx_umbrella/formatter.exs
+++ b/installer/templates/phx_umbrella/formatter.exs
@@ -1,4 +1,5 @@
-[
+[<%= if @html and Version.match?(System.version(), ">= 1.13.4") do %>
+  plugins: [Phoenix.LiveView.HTMLFormatter],<% end %>
   inputs: ["mix.exs", "config/*.exs"],
   subdirectories: ["apps/*"]
 ]

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -88,6 +88,12 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file root_path(@app, "config/runtime.exs"), ~r/ip: {0, 0, 0, 0, 0, 0, 0, 0}/
 
       if Version.match?(System.version(), ">= 1.13.4") do
+        assert_file root_path(@app, ".formatter.exs"), fn file ->
+          assert file =~ "plugins: [Phoenix.LiveView.HTMLFormatter]"
+          assert file =~ "inputs: [\"mix.exs\", \"config/*.exs\"]"
+          assert file =~ "subdirectories: [\"apps/*\"]"
+        end
+
         assert_file app_path(@app, ".formatter.exs"), fn file ->
           assert file =~ "import_deps: [:ecto]"
           assert file =~ "subdirectories: [\"priv/*/migrations\"]"
@@ -103,6 +109,12 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
           refute file =~ "subdirectories:"
         end
       else
+        assert_file root_path(@app, ".formatter.exs"), fn file ->
+          assert file =~ "inputs: [\"mix.exs\", \"config/*.exs\"]"
+          assert file =~ "subdirectories: [\"apps/*\"]"
+          refute file =~ "plugins:"
+        end
+
         assert_file app_path(@app, ".formatter.exs"), fn file ->
           assert file =~ "import_deps: [:ecto]"
           assert file =~ "subdirectories: [\"priv/*/migrations\"]"


### PR DESCRIPTION
Fix https://github.com/phoenixframework/phoenix/pull/4793#issuecomment-1102287862

Confirmed the behavior related on https://github.com/phoenixframework/phoenix_live_view/issues/1969 by generating a new umbrella app locally. I get the same exception if there is no `plugins: [Phoenix.LiveView.HTMLFormatter]` on umbrella root.