### PR TITLE
docs(contexts): clearer diff in order_controller.ex

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -1204,7 +1204,8 @@ To complete an order, our cart page can issue a POST to the `OrderController.cre
 
 ```elixir
   def create(conn, _) do
-    case Orders.complete_order(conn.assigns.cart) do
+-   case Orders.create_order(conn.assigns.cart) do
++   case Orders.complete_order(conn.assigns.cart) do
       {:ok, order} ->
         conn
         |> put_flash(:info, "Order created successfully.")


### PR DESCRIPTION
When working through the guide, it wasn't clear we're changing Orders.create_order to Orders.complete_order in this step