### PR TITLE
Add typespecs to phoenix token functions

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -116,7 +116,7 @@ defmodule Phoenix.Token do
     * `:signed_at` - set the timestamp of the token in seconds.
       Defaults to `System.system_time(:second)`
     * `:max_age` - the default maximum age of the token. Defaults to
-      86400 seconds (1 day) and it may be overridden on `Plug.Crypto.verify/4`.
+      86400 seconds (1 day) and it may be overridden on `verify/4`.
 
   """
   @spec sign(context, binary, term, [shared_opt | signed_at_opt | max_age_opt]) :: binary

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -115,11 +115,9 @@ defmodule Phoenix.Token do
       when generating the encryption and signing keys. Defaults to `:sha256`
     * `:signed_at` - set the timestamp of the token in seconds.
       Defaults to `System.system_time(:second)`
-    * `:max_age` - the default maximum age of the token. Defaults to
-      86400 seconds (1 day) and it may be overridden on `verify/4`.
 
   """
-  @spec sign(context, binary, term, [shared_opt | signed_at_opt | max_age_opt]) :: binary
+  @spec sign(context, binary, term, [shared_opt | signed_at_opt]) :: binary
   def sign(context, salt, data, opts \\ []) when is_binary(salt) do
     context
     |> get_key_base()

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -92,8 +92,18 @@ defmodule Phoenix.Token do
 
   require Logger
 
+  @type context :: Plug.Conn.t() | Phoenix.Socket.t() | atom | binary
+
+  @type shared_opt ::
+          {:key_iterations, pos_integer}
+          | {:key_length, pos_integer}
+          | {:key_digest, :sha256 | :sha384 | :sha512}
+
+  @type max_age_opt :: {:max_age, pos_integer}
+  @type signed_at_opt :: {:signed_at, pos_integer}
+
   @doc """
-  Encodes  and signs data into a token you can send to clients.
+  Encodes and signs data into a token you can send to clients.
 
   ## Options
 
@@ -109,6 +119,7 @@ defmodule Phoenix.Token do
       86400 seconds (1 day) and it may be overridden on verify/4.
 
   """
+  @spec sign(context, binary, term, [shared_opt | signed_at_opt | max_age_opt]) :: binary
   def sign(context, salt, data, opts \\ []) when is_binary(salt) do
     context
     |> get_key_base()
@@ -130,6 +141,7 @@ defmodule Phoenix.Token do
       Defaults to `System.system_time(:second)`
 
   """
+  @spec encrypt(context, binary, term, [shared_opt | signed_at_opt]) :: binary
   def encrypt(context, secret, data, opts \\ []) when is_binary(secret) do
     context
     |> get_key_base()
@@ -179,17 +191,19 @@ defmodule Phoenix.Token do
 
   ## Options
 
-    * `:max_age` - verifies the token only if it has been generated
-      "max age" ago in seconds. A reasonable value is 1 day (86400
-      seconds)
     * `:key_iterations` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to 1000
     * `:key_length` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to 32
     * `:key_digest` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to `:sha256`
+    * `:max_age` - verifies the token only if it has been generated
+      "max age" ago in seconds. A reasonable value is 1 day (86400
+      seconds)
 
   """
+  @spec verify(context, binary, binary, [shared_opt | max_age_opt]) ::
+          {:ok, term} | {:error, :expired | :invalid | :missing}
   def verify(context, salt, token, opts \\ []) when is_binary(salt) do
     context
     |> get_key_base()
@@ -201,17 +215,17 @@ defmodule Phoenix.Token do
 
   ## Options
 
-    * `:max_age` - verifies the token only if it has been generated
-      "max age" ago in seconds. Defaults to the max age signed in the
-      token (86400)
     * `:key_iterations` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to 1000
     * `:key_length` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to 32
     * `:key_digest` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to `:sha256`
-
+    * `:max_age` - verifies the token only if it has been generated
+      "max age" ago in seconds. Defaults to the max age signed in the
+      token (86400)
   """
+  @spec decrypt(context, binary, binary, [shared_opt | max_age_opt]) :: term()
   def decrypt(context, secret, token, opts \\ []) when is_binary(secret) do
     context
     |> get_key_base()

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -116,7 +116,7 @@ defmodule Phoenix.Token do
     * `:signed_at` - set the timestamp of the token in seconds.
       Defaults to `System.system_time(:second)`
     * `:max_age` - the default maximum age of the token. Defaults to
-      86400 seconds (1 day) and it may be overridden on verify/4.
+      86400 seconds (1 day) and it may be overridden on `Plug.Crypto.verify/4`.
 
   """
   @spec sign(context, binary, term, [shared_opt | signed_at_opt | max_age_opt]) :: binary


### PR DESCRIPTION
Each `Phoenix.Token` function takes multiple arguments with ambiguous types. Furthermore, the functions delegate to `Plug.Crypto` which also lacks typespecs. This adds types and specs to make working with `Token` clearer, along with a minor adjustment to option documentation to keep the order consistent between functions.