### PR TITLE
Installer - generate CSRF meta with csrf_token_value

### DIFF
--- a/installer/templates/phx_web/templates/layout/root.html.heex
+++ b/installer/templates/phx_web/templates/layout/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <%%= csrf_meta_tag() %>
+    <meta name="csrf-token" content={csrf_token_value()}>
     <%%= live_title_tag assigns[:page_title] || "<%= @app_module %>", suffix: " · Phoenix Framework" %>
     <link phx-track-static rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")}/>
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -107,7 +107,10 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~ ~s|plug Phoenix.LiveDashboard.RequestLogger|
       end
 
-      assert_file "phx_blog/lib/phx_blog_web/templates/layout/root.html.heex"
+      assert_file "phx_blog/lib/phx_blog_web/templates/layout/root.html.heex", fn file ->
+        assert file =~ ~s|<meta name="csrf-token" content={csrf_token_value()}>|
+      end
+
       assert_file "phx_blog/lib/phx_blog_web/templates/layout/app.html.heex"
 
       assert_file "phx_blog/lib/phx_blog_web/templates/page/index.html.heex", fn file ->

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -169,7 +169,11 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
                   ~r/defmodule PhxUmbWeb.PageView/
 
       assert_file web_path(@app, "lib/#{@app}_web/router.ex"), "defmodule PhxUmbWeb.Router"
-      assert_file web_path(@app, "lib/#{@app}_web/templates/layout/root.html.heex")
+
+      assert_file web_path(@app, "lib/#{@app}_web/templates/layout/root.html.heex"), fn file ->
+        assert file =~ ~s|<meta name="csrf-token" content={csrf_token_value()}>|
+      end
+
       assert_file web_path(@app, "lib/#{@app}_web/templates/layout/app.html.heex")
       assert_file web_path(@app, "test/#{@app}_web/views/page_view_test.exs"),
                   "defmodule PhxUmbWeb.PageViewTest"


### PR DESCRIPTION
Second part of https://github.com/phoenixframework/phoenix_html/pull/377

Ref https://github.com/phoenixframework/phoenix_html/issues/372#issuecomment-1107419742 "change the generators to use csrf_token_value".