### PR TITLE
phx.gen.auth: please credo

### DIFF
--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -1,4 +1,4 @@
-  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Token, <%= inspect schema.alias %>Notifier}
+  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Notifier, <%= inspect schema.alias %>Token}
 
   ## Database getters
 


### PR DESCRIPTION
`mix credo` returns some warnings for me on freshly baked code:

```
The alias `MyApp.Accounts.UserToken` is not alphabetically ordered among its group.
```

Should I also fix `modules should have a @moduledoc tag.`? for:

```
APPWeb.USERAuth
APP.ACCOUNTS.USERToken
APP.ACCOUNTS.USER
APP.ACCOUNTS.USERNotifier
```

(variables in uppercase)