### PR TITLE
Implement Bandit HTTP server adapter

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -235,6 +235,37 @@ defmodule Phoenix.Endpoint do
       Defaults to `[]`, which will start a drainer process for each configured endpoint,
       but can be disabled by setting it to `false`.
 
+  Phoenix also provides the `Phoenix.Endpoint.BanditAdapter` adapter which works with the
+  [Bandit](https://hexdocs.pm/bandit) web server. It can be configured via the following top-level
+  options:
+
+    * `:http`: the configuration for the HTTP server. Accepts the following options:
+      * `port`: The port to run on. Defaults to 4000
+      * `ip`: The address to bind to. Can be specified as `{127, 0, 0, 1}`, or using `{:local,
+        path}` to bind to a Unix domain socket. Defaults to {127, 0, 0, 1}.
+      * `transport_options`: Any valid value from `ThousandIsland.Transports.TCP`
+    
+      Defaults to `false`, which will cause Bandit to not start an HTTP server.
+
+    * `:https`: the configuration for the HTTPS server. Accepts the following options:
+      * `port`: The port to run on. Defaults to 4040
+      * `ip`: The address to bind to. Can be specified as `{127, 0, 0, 1}`, or using `{:local,
+        path}` to bind to a Unix domain socket. Defaults to {127, 0, 0, 1}.
+      * `transport_options`: Any valid value from `ThousandIsland.Transports.SSL`
+    
+      Defaults to `false`, which will cause Bandit to not start an HTTPS server.
+
+  To use the bandit adapter, add the following to your endpoint configuration in
+  `config/config.exs`:
+
+  ```
+  config :your_app, YourAppWeb.Endpoint,
+    adapter: Phoenix.Endpoint.BanditAdapter
+  ```
+
+  Note that the Bandit adapter does not currently support WebSocket connections; it is
+  only suitable for use with HTTP(S)-only Phoenix instances.
+
   ## Endpoint API
 
   In the previous section, we have used the `c:config/2` function that is

--- a/lib/phoenix/endpoint/bandit_adapter.ex
+++ b/lib/phoenix/endpoint/bandit_adapter.ex
@@ -1,0 +1,58 @@
+defmodule Phoenix.Endpoint.BanditAdapter do
+  @moduledoc """
+  A Bandit adapter for Phoenix.
+
+  Note that this adapter does not currently support WebSocket connections; it is
+  only suitable for use with HTTP(S)-only Phoenix instances.
+
+  To use this adapter, your project will need to include Bandit as a dependency; see
+  https://hex.pm/bandit for details on the currently supported version of Bandit to include.
+
+  ## Endpoint configuration
+
+  This adapter uses the following endpoint configuration:
+
+    * `:http`: the configuration for the HTTP server. Accepts the following options:
+      * `port`: The port to run on. Defaults to 4000
+      * `ip`: The address to bind to. Can be specified as `{127, 0, 0, 1}`, or using `{:local,
+        path}` to bind to a Unix domain socket. Defaults to {127, 0, 0, 1}.
+      * `transport_options`: Any valid value from `ThousandIsland.Transports.TCP`
+    
+      Defaults to `false`, which will cause Bandit to not start an HTTP server.
+
+    * `:https`: the configuration for the HTTPS server. Accepts the following options:
+      * `port`: The port to run on. Defaults to 4040
+      * `ip`: The address to bind to. Can be specified as `{127, 0, 0, 1}`, or using `{:local,
+        path}` to bind to a Unix domain socket. Defaults to {127, 0, 0, 1}.
+      * `transport_options`: Any valid value from `ThousandIsland.Transports.SSL`
+    
+      Defaults to `false`, which will cause Bandit to not start an HTTPS server.
+  """
+
+  require Logger
+
+  @doc false
+  def child_specs(endpoint, config) do
+    for {scheme, port} <- [http: 4000, https: 4040], opts = config[scheme] do
+      port = :proplists.get_value(:port, opts, port)
+
+      unless port do
+        Logger.error(":port for #{scheme} config is nil, cannot start server")
+        raise "aborting due to nil port"
+      end
+
+      ip = :proplists.get_value(:ip, opts, {127, 0, 0, 1})
+      transport_options = :proplists.get_value(:transport_options, opts, [])
+      opts = [port: port_to_integer(port), transport_options: [ip: ip] ++ transport_options]
+
+      [plug: endpoint, scheme: scheme, options: opts]
+      |> Bandit.child_spec()
+      |> Supervisor.child_spec(id: {endpoint, scheme})
+    end
+  end
+
+  # TODO: Deprecate {:system, env_var} once we require Elixir v1.9+
+  defp port_to_integer({:system, env_var}), do: port_to_integer(System.get_env(env_var))
+  defp port_to_integer(port) when is_binary(port), do: String.to_integer(port)
+  defp port_to_integer(port) when is_integer(port), do: port
+end

--- a/mix.exs
+++ b/mix.exs
@@ -78,6 +78,7 @@ defmodule Phoenix.MixProject do
       # Optional deps
       {:plug_cowboy, "~> 2.2", optional: true},
       {:jason, "~> 1.0", optional: true},
+      {:bandit, ">= 0.4.9", optional: true},
 
       # Docs dependencies (some for cross references)
       {:ex_doc, "~> 0.24", only: :docs},
@@ -193,7 +194,8 @@ defmodule Phoenix.MixProject do
       ],
       "Adapters and Plugs": [
         Phoenix.CodeReloader,
-        Phoenix.Endpoint.Cowboy2Adapter
+        Phoenix.Endpoint.Cowboy2Adapter,
+        Phoenix.Endpoint.BanditAdapter
       ],
       "Socket and Transport": [
         Phoenix.Socket,

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "bandit": {:hex, :bandit, "0.4.10", "307c45c52bd618876f620d71decb23157a478aad1bb520227fb2483fc4525afe", [:mix], [{:hpax, "~> 0.1.1", [hex: :hpax, repo: "hexpm", optional: false]}, {:plug, "~> 1.12", [hex: :plug, repo: "hexpm", optional: false]}, {:thousand_island, "~> 0.5.7", [hex: :thousand_island, repo: "hexpm", optional: false]}], "hexpm", "98b5462d90627e0752b2964080728beab7c001ed0c4a70124ba547045bcbf6ab"},
   "castore": {:hex, :castore, "0.1.16", "2675f717adc700475345c5512c381ef9273eb5df26bdd3f8c13e2636cf4cc175", [:mix], [], "hexpm", "28ed2c43d83b5c25d35c51bc0abf229ac51359c170cba76171a462ced2e4b651"},
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},
   "cowboy": {:hex, :cowboy, "2.9.0", "865dd8b6607e14cf03282e10e934023a1bd8be6f6bacf921a7e2a96d800cd452", [:make, :rebar3], [{:cowlib, "2.11.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "2c729f934b4e1aa149aff882f57c6372c15399a20d54f65c8d67bef583021bde"},
@@ -33,4 +34,5 @@
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
   "telemetry_poller": {:hex, :telemetry_poller, "1.0.0", "db91bb424e07f2bb6e73926fcafbfcbcb295f0193e0a00e825e589a0a47e8453", [:rebar3], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "b3a24eafd66c3f42da30fc3ca7dda1e9d546c12250a2d60d7b81d264fbec4f6e"},
+  "thousand_island": {:hex, :thousand_island, "0.5.7", "5066fb800287a9eb2699365746f51853ddc5ed0d4d39ea4c8b906f40b14a2499", [:mix], [{:telemetry, "~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "5d79e910a9d295e75ee4022df3a68173588dcc9a7e4dfcce4876325c8a9f51a7"},
 }


### PR DESCRIPTION
Provides support for using Phoenix with the Plug-native HTTP server [Bandit](https://github.com/mtrudel/bandit). This adapter currently only supports HTTP(S) connections; WebSocket support is a work-in-progress which will be significantly facilitated by the work herein. 

Additionally, test coverage is unchanged here (though tests are, of course, green). I was unable to find any substantive tests which vary according to the underlying web server; happy to take guidance on this.