### PR TITLE
Add phx-no-format to templates/layout/*.heex

### DIFF
--- a/installer/templates/phx_web/templates/layout/app.html.heex
+++ b/installer/templates/phx_web/templates/layout/app.html.heex
@@ -1,5 +1,5 @@
 <main class="container">
-  <p class="alert alert-info" role="alert"><%%= get_flash(@conn, :info) %></p>
-  <p class="alert alert-danger" role="alert"><%%= get_flash(@conn, :error) %></p>
+  <p class="alert alert-info" role="alert" phx-no-format><%%= get_flash(@conn, :info) %></p>
+  <p class="alert alert-danger" role="alert" phx-no-format><%%= get_flash(@conn, :error) %></p>
   <%%= @inner_content %>
 </main>

--- a/installer/templates/phx_web/templates/layout/live.html.heex
+++ b/installer/templates/phx_web/templates/layout/live.html.heex
@@ -1,11 +1,13 @@
 <main class="container">
   <p class="alert alert-info" role="alert"
     phx-click="lv:clear-flash"
-    phx-value-key="info"><%%= live_flash(@flash, :info) %></p>
+    phx-value-key="info"
+    phx-no-format><%%= live_flash(@flash, :info) %></p>
 
   <p class="alert alert-danger" role="alert"
     phx-click="lv:clear-flash"
-    phx-value-key="error"><%%= live_flash(@flash, :error) %></p>
+    phx-value-key="error"
+    phx-no-format><%%= live_flash(@flash, :error) %></p>
 
   <%%= @inner_content %>
 </main>


### PR DESCRIPTION
I added the new heex formatter to my project and then ran ```mix format``` and then when I ran my project the alert boxes for the liveview flash messages where now displayed all the time but with no text this is because the formatter adds some whitespace and the css for the flash alerts has this:
```css
.alert:empty {
    display: none;
}
```
but the added whitespace from the formatter makes it so that it is no longer empty and so is always displayed. So I added phx-no-format to the alert tags so they won't get formatted incorrectly according to @leandrocp  as on this thread: https://github.com/phoenixframework/phoenix_live_view/issues/2001
