### PR TITLE
Add # back for .dockerignore comment

### DIFF
--- a/priv/templates/phx.gen.release/dockerignore.eex
+++ b/priv/templates/phx.gen.release/dockerignore.eex
@@ -18,7 +18,7 @@
 
 # Ignore git, but keep git HEAD and refs to access current commit hash if needed:
 #
-$ cat .git/HEAD | awk '{print ".git/"$2}' | xargs cat
+# $ cat .git/HEAD | awk '{print ".git/"$2}' | xargs cat
 # d0b8727759e1e0e7aa3d41707d12376e373d5ecc
 .git
 !.git/HEAD


### PR DESCRIPTION
Perhaps I am mistaken, but it seems like the `$ cat ...` line is not intended.