### PR TITLE
Fix JSON response @spec

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -400,6 +400,8 @@ defmodule Phoenix.ConnTest do
     body
   end
 
+  @type json_value :: integer | float | boolean | nil
+  @type json_response :: map | list | json_value
   @doc """
   Asserts the given status code, that we have a json response and
   returns the decoded JSON response if one was set or sent.
@@ -410,7 +412,7 @@ defmodule Phoenix.ConnTest do
       assert "can't be blank" in body["errors"]
 
   """
-  @spec json_response(Conn.t, status :: integer | atom) :: map | list | no_return
+  @spec json_response(Conn.t, status :: integer | atom) :: json_response | no_return
   def json_response(conn, status) do
     body = response(conn, status)
     _    = response_content_type(conn, :json)

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -410,7 +410,7 @@ defmodule Phoenix.ConnTest do
       assert "can't be blank" in body["errors"]
 
   """
-  @spec json_response(Conn.t, status :: integer | atom) :: map | no_return
+  @spec json_response(Conn.t, status :: integer | atom) :: map | list | no_return
   def json_response(conn, status) do
     body = response(conn, status)
     _    = response_content_type(conn, :json)

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -400,8 +400,6 @@ defmodule Phoenix.ConnTest do
     body
   end
 
-  @type json_value :: integer | float | boolean | nil
-  @type json_response :: map | list | json_value
   @doc """
   Asserts the given status code, that we have a json response and
   returns the decoded JSON response if one was set or sent.
@@ -412,7 +410,7 @@ defmodule Phoenix.ConnTest do
       assert "can't be blank" in body["errors"]
 
   """
-  @spec json_response(Conn.t, status :: integer | atom) :: json_response | no_return
+  @spec json_response(Conn.t, status :: integer | atom) :: term | no_return
   def json_response(conn, status) do
     body = response(conn, status)
     _    = response_content_type(conn, :json)


### PR DESCRIPTION
Hi!

I have an API that returns lists of things in the API without any wrapping. After parsing becomes a list:
`[object1, object2, object]`
and it breaks dialyzer because `json_response` specifies that parsed response might be only a map.

I've searched the project for lines that begin with `@spec`, have `json` in the name and `map` in the return value and it looks like it is the only place where `phoenix` assumes the shape of json.