### PR TITLE
Deprecate port_to_integer method in Cowboy2Adapter

### DIFF
--- a/lib/phoenix/endpoint/cowboy2_adapter.ex
+++ b/lib/phoenix/endpoint/cowboy2_adapter.ex
@@ -125,8 +125,7 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
     end
   end
 
-  # TODO: Deprecate {:system, env_var} once we require Elixir v1.9+
-  defp port_to_integer({:system, env_var}), do: port_to_integer(System.get_env(env_var))
+
   defp port_to_integer(port) when is_binary(port), do: String.to_integer(port)
   defp port_to_integer(port) when is_integer(port), do: port
 end


### PR DESCRIPTION
Might be confused but seems like we currently require elixir 1.9 as per the [mix.exs](https://github.com/phoenixframework/phoenix/blob/master/mix.exs) and should be able to deprecate the method