### PR TITLE
Move swoosh api_client config out of config.exs to ENV.exs

### DIFF
--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -26,10 +26,7 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
 #
 # For production it's recommended to configure a different adapter
 # at the `config/runtime.exs`.
-config :<%= @app_name %>, <%= @app_module %>.Mailer, adapter: Swoosh.Adapters.Local
-
-# Swoosh API client is needed for adapters other than SMTP.
-config :swoosh, :api_client, false<% end %><%= if @assets do %>
+config :<%= @app_name %>, <%= @app_module %>.Mailer, adapter: Swoosh.Adapters.Local<% end %><%= if @assets do %>
 
 # Configure esbuild (the version is required)
 config :esbuild,

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -62,4 +62,7 @@ config :logger, :console, format: "[$level] $message\n"
 config :phoenix, :stacktrace_depth, 20
 
 # Initialize plugs at runtime for faster development compilation
-config :phoenix, :plug_init_mode, :runtime
+config :phoenix, :plug_init_mode, :runtime<%= if @mailer do %>
+
+# Disable swoosh api client as it is only required for production adapters.
+config :swoosh, :api_client, false<% end %>

--- a/installer/templates/phx_single/config/test.exs
+++ b/installer/templates/phx_single/config/test.exs
@@ -9,7 +9,10 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
 
 # In test we don't send emails.
 config :<%= @app_name %>, <%= @app_module %>.Mailer,
-  adapter: Swoosh.Adapters.Test<% end %>
+  adapter: Swoosh.Adapters.Test
+
+# Disable swoosh api client as it is only required for production adapters.
+config :swoosh, :api_client, false<% end %>
 
 # Print only warnings and errors during test
 config :logger, level: :warn

--- a/installer/templates/phx_umbrella/apps/app_name/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/config/config.exs
@@ -10,7 +10,4 @@ config :<%= @app_name %><%= if @namespaced? do %>,
 #
 # For production it's recommended to configure a different adapter
 # at the `config/runtime.exs`.
-config :<%= @app_name %>, <%= @app_module %>.Mailer, adapter: Swoosh.Adapters.Local
-
-# Swoosh API client is needed for adapters other than SMTP.
-config :swoosh, :api_client, false<% end %>
+config :<%= @app_name %>, <%= @app_module %>.Mailer, adapter: Swoosh.Adapters.Local<% end %>

--- a/installer/templates/phx_umbrella/config/dev.exs
+++ b/installer/templates/phx_umbrella/config/dev.exs
@@ -4,7 +4,10 @@ import Config
 config :logger, :console, format: "[$level] $message\n"
 
 # Initialize plugs at runtime for faster development compilation
-config :phoenix, :plug_init_mode, :runtime
+config :phoenix, :plug_init_mode, :runtime<%= if @mailer do %>
+
+# Disable swoosh api client as it is only required for production adapters.
+config :swoosh, :api_client, false<% end %>
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/installer/templates/phx_umbrella/config/test.exs
+++ b/installer/templates/phx_umbrella/config/test.exs
@@ -5,7 +5,10 @@ config :logger, level: :warn<%= if @mailer do %>
 
 # In test we don't send emails.
 config :<%= @app_name %>, <%= @app_module %>.Mailer,
-  adapter: Swoosh.Adapters.Test<% end %>
+  adapter: Swoosh.Adapters.Test
+
+# Disable swoosh api client as it is only required for production adapters.
+config :swoosh, :api_client, false<% end %>
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -222,12 +222,16 @@ defmodule Mix.Tasks.Phx.NewTest do
       end
 
       assert_file "phx_blog/config/config.exs", fn file ->
-        assert file =~ "config :swoosh"
         assert file =~ "config :phx_blog, PhxBlog.Mailer, adapter: Swoosh.Adapters.Local"
       end
 
       assert_file "phx_blog/config/test.exs", fn file ->
+        assert file =~ "config :swoosh"
         assert file =~ "config :phx_blog, PhxBlog.Mailer, adapter: Swoosh.Adapters.Test"
+      end
+
+      assert_file "phx_blog/config/dev.exs", fn file ->
+        assert file =~ "config :swoosh"
       end
 
       # Install dependencies?
@@ -359,6 +363,15 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/config/config.exs", fn file ->
         refute file =~ "config :swoosh"
         refute file =~ "config :phx_blog, PhxBlog.Mailer, adapter: Swoosh.Adapters.Local"
+      end
+
+      assert_file "phx_blog/config/test.exs", fn file ->
+        refute file =~ "config :swoosh"
+        refute file =~ "config :phx_blog, PhxBlog.Mailer, adapter: Swoosh.Adapters.Test"
+      end
+
+      assert_file "phx_blog/config/dev.exs", fn file ->
+        refute file =~ "config :swoosh"
       end
     end
   end

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -278,12 +278,16 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       end
 
       assert_file root_path(@app, "config/config.exs"), fn file ->
-        assert file =~ "config :swoosh"
         assert file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.Local"
       end
 
       assert_file root_path(@app, "config/test.exs"), fn file ->
+        assert file =~ "config :swoosh"
         assert file =~ "config :phx_umb, PhxUmb.Mailer, adapter: Swoosh.Adapters.Test"
+      end
+
+      assert_file root_path(@app, "config/dev.exs"), fn file ->
+        assert file =~ "config :swoosh"
       end
 
       # Install dependencies?


### PR DESCRIPTION
Since the `:swoosh, :api_client` is set to false in `config.exs`, this
requires setting both the adapter and api_client in either `prod.exs` or
`runtime.exs` to ensure mails are sent in a production environment.
However, if this is not configured, the following error is raised:

```
** (UndefinedFunctionError) function false.post/4 is undefined
(module false is not available)
```

It is not entirely clear from the error how to track the value back to
this configuration setting.

The `:api_client` is not set in `dev.exs` and `test.exs` separately, as
these are the environments where this value is less likely to be
configured. Now in production, it will default to the swoosh default
(currently hackney). If the user does not have hackney installed in
mix.exs then the error message is more friendly, prompting them to add
`{:hackney, "~>..."}` to their `mix.exs` file.