### PR TITLE
Port 1.6 changelog to master branch (1.6.7-1.6.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ See the [upgrade guide](https://gist.github.com/chrismccord/2ab350f154235ad4a4d0
 
 Phoenix v1.6 requires Elixir v1.9+.
 
+## 1.6.9 (2022-05-16)
+
+### Bug Fixes
+  * [phx.gen.release] Fix generated .dockerignore comment
+
+## 1.6.8 (2022-05-06)
+
+### Bug Fixes
+  * [phx.gen.release] Fix Ecto check failing to find ecto in certain cases
+
+## 1.6.7 (2022-04-14)
+
+### Enhancements
+  * [Endpoint] Add Endpoint init telemetry event
+  * [Endpoint] Prioritize user :http configuration for ranch  to fix inet_backend failing to be respected
+  * [Logger] Support log_module in router metadata
+  * [phx.gen.release] Don't handle assets in Docker when directory doesn't exist
+  * [phx.gen.release] Skip generating migration files when ecto_sql is not installed
+
+### JavaScript Client Enhancements
+  * Switch to .mjs files for ESM for better compatibility across build tools
+
+### JavaScript Client Bug Fixes
+  * Fix LongPoll callbacks in JS client causing errors on connection close
+
 ## 1.6.6 (2022-01-04)
 
 ### Bug Fixes


### PR DESCRIPTION
Usually one checks the changelog on the main/master branch and I didn't find the newest updates there.

But I found them on the 1.6 branch: https://github.com/phoenixframework/phoenix/blob/v1.6/CHANGELOG.md

Hence porting them here for others!

Thanks for all your great work!

![IMG_20180805_081939](https://user-images.githubusercontent.com/606517/169982815-d08f6699-2391-43ef-a3e2-6e7063fd0686.jpg)

