### PR TITLE
Remove no_return from typespecs

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1207,7 +1207,7 @@ defmodule Phoenix.Controller do
       plug :accepts, ["html", "json-api"]
 
   """
-  @spec accepts(Plug.Conn.t, [binary]) :: Plug.Conn.t | no_return()
+  @spec accepts(Plug.Conn.t, [binary]) :: Plug.Conn.t
   def accepts(conn, [_|_] = accepted) do
     case Map.fetch(conn.params, "_format") do
       {:ok, format} ->

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -359,7 +359,7 @@ defmodule Phoenix.Endpoint do
 
   Raises in case of failures.
   """
-  @callback broadcast!(topic, event, msg) :: :ok | no_return
+  @callback broadcast!(topic, event, msg) :: :ok
 
   @doc """
   Broadcasts a `msg` from the given `from` as `event` in the given `topic` to all nodes.
@@ -371,7 +371,7 @@ defmodule Phoenix.Endpoint do
 
   Raises in case of failures.
   """
-  @callback broadcast_from!(from :: pid, topic, event, msg) :: :ok | no_return
+  @callback broadcast_from!(from :: pid, topic, event, msg) :: :ok
 
   @doc """
   Broadcasts a `msg` as `event` in the given `topic` within the current node.

--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -303,7 +303,7 @@ defmodule Phoenix.ConnTest do
       assert response_content_type(conn, :html) =~ "charset=utf-8"
 
   """
-  @spec response_content_type(Conn.t, atom) :: String.t | no_return
+  @spec response_content_type(Conn.t, atom) :: String.t
   def response_content_type(conn, format) when is_atom(format) do
     case Conn.get_resp_header(conn, "content-type") do
       [] ->
@@ -349,7 +349,7 @@ defmodule Phoenix.ConnTest do
       assert response(conn, 200) =~ "hello world"
 
   """
-  @spec response(Conn.t, status :: integer | atom) :: binary | no_return
+  @spec response(Conn.t, status :: integer | atom) :: binary
   def response(%Conn{state: :unset}, _status) do
     raise """
     expected connection to have a response but no response was set/sent.
@@ -378,7 +378,7 @@ defmodule Phoenix.ConnTest do
 
       assert html_response(conn, 200) =~ "<html>"
   """
-  @spec html_response(Conn.t, status :: integer | atom) :: String.t | no_return
+  @spec html_response(Conn.t, status :: integer | atom) :: String.t
   def html_response(conn, status) do
     body = response(conn, status)
     _    = response_content_type(conn, :html)
@@ -393,7 +393,7 @@ defmodule Phoenix.ConnTest do
 
       assert text_response(conn, 200) =~ "hello"
   """
-  @spec text_response(Conn.t, status :: integer | atom) :: String.t | no_return
+  @spec text_response(Conn.t, status :: integer | atom) :: String.t
   def text_response(conn, status) do
     body = response(conn, status)
     _    = response_content_type(conn, :text)
@@ -410,7 +410,7 @@ defmodule Phoenix.ConnTest do
       assert "can't be blank" in body["errors"]
 
   """
-  @spec json_response(Conn.t, status :: integer | atom) :: term | no_return
+  @spec json_response(Conn.t, status :: integer | atom) :: term
   def json_response(conn, status) do
     body = response(conn, status)
     _    = response_content_type(conn, :json)


### PR DESCRIPTION
This is a follow-up to @wojtekmach comment here https://github.com/phoenixframework/phoenix/pull/4830#discussion_r883127877

Dialzyer always assumes function can fail, so `some_type | no_return` is the same as `some_type`.

It does not cause any issues but is redundant.

I understand that it can be also used for documentation purposes "that function can explicitly rise". If that is the case, feel free to close that PR and we can add a comment about it in the `CONTRIBUTING.md`