### PR TITLE
Adjust error message

### DIFF
--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -425,7 +425,7 @@ defmodule Phoenix.Endpoint.Supervisor do
       else
         Logger.error "Could not find static manifest at #{inspect outer}. " <>
                      "Run \"mix phx.digest\" after building your static files " <>
-                     "or remove the configuration from \"config/prod.exs\"."
+                     "or remove the \"cache_static_manifest\" key from your config."
       end
     else
       %{}

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -425,7 +425,7 @@ defmodule Phoenix.Endpoint.Supervisor do
       else
         Logger.error "Could not find static manifest at #{inspect outer}. " <>
                      "Run \"mix phx.digest\" after building your static files " <>
-                     "or remove the \"cache_static_manifest\" key from your config."
+                     "or remove the \"cache_static_manifest\" configuration from your config files."
       end
     else
       %{}


### PR DESCRIPTION
Since Elixir has got the runtime config, it's not necessarily the case that the manifest will be configured in "config/prod.exs", it might be done in the "config/runtime.exs" using env variables for example. For that reason the wording in the error message becomes a bit confusing, I tried to change it as good as I can, sill might need to be more general.