### PR TITLE
Fix Brotli Compressor example

### DIFF
--- a/lib/phoenix/digester/compressor.ex
+++ b/lib/phoenix/digester/compressor.ex
@@ -20,7 +20,7 @@ defmodule Phoenix.Digester.Compressor do
 
         def compress_file(file_path, content) do
           valid_extension = Path.extname(file_path) in Application.fetch_env!(:phoenix, :gzippable_exts)
-          compressed_content = :brotli.encode(content)
+          {:ok, compressed_content} = :brotli.encode(content)
 
           if valid_extension && byte_size(compressed_content) < byte_size(content) do
             {:ok, compressed_content}


### PR DESCRIPTION
The `:brotli` library returns an :ok tuple

See https://hexdocs.pm/brotli/brotli.html#encode/1