### PR TITLE
Add Further Phoenix Logger Telemetry Data to Generated Projects

### DIFF
--- a/installer/templates/phx_web/telemetry.ex
+++ b/installer/templates/phx_web/telemetry.ex
@@ -22,11 +22,35 @@ defmodule <%= @web_namespace %>.Telemetry do
   def metrics do
     [
       # Phoenix Metrics
+      summary("phoenix.endpoint.start.system_time",
+        unit: {:native, :millisecond}
+      ),
       summary("phoenix.endpoint.stop.duration",
+        unit: {:native, :millisecond}
+      ),
+      summary("phoenix.router_dispatch.start.system_time",
+        tags: [:route],
+        unit: {:native, :millisecond}
+      ),
+      summary("phoenix.router_dispatch.exception.duration",
+        tags: [:route],
         unit: {:native, :millisecond}
       ),
       summary("phoenix.router_dispatch.stop.duration",
         tags: [:route],
+        unit: {:native, :millisecond}
+      ),
+      summary("phoenix.error_rendered.duration",
+        unit: {:native, :millisecond}
+      ),
+      summary("phoenix.socket_connected.duration",
+        unit: {:native, :millisecond}
+      ),
+      summary("phoenix.channel_join.duration",
+        unit: {:native, :millisecond}
+      ),
+      summary("phoenix.channel_handled_in.duration",
+        tags: [:event],
         unit: {:native, :millisecond}
       ),<%= if @ecto do %>
 


### PR DESCRIPTION
# Overview

This pr addresses #4336 .

@chrismccord I took a stab at this issue, and added the remaining [`Phoenix.Logger`](https://hexdocs.pm/phoenix/Phoenix.Logger.html#module-instrumentation) metrics to the telemetry module in the installer template project. If this is not what you were intending let me know and I will close/change this pr!