### PR TITLE
Add `--repo` option to schema generator

### DIFF
--- a/priv/templates/phx.gen.context/context.ex
+++ b/priv/templates/phx.gen.context/context.ex
@@ -4,5 +4,5 @@ defmodule <%= inspect context.module %> do
   """
 
   import Ecto.Query, warn: false
-  alias <%= inspect schema.repo %>
+  alias <%= inspect schema.repo %><%= if schema.opts[:repo], do: ", as: Repo" %>
 end

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -273,6 +273,17 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
     end
   end
 
+  test "generates schema and migration with repo", config do
+    in_tmp_project config.test, fn ->
+      Gen.Schema.run(~w(Blog.Post posts --repo MyApp.SecondaryRepo))
+
+      assert [migration] = Path.wildcard("priv/secondary_repo/migrations/*_create_posts.exs")
+      assert_file migration, fn file ->
+        assert file =~ "MyApp.SecondaryRepo.Migrations.CreatePosts"
+      end
+    end
+  end
+
   test "skips migration with --no-migration option", config do
     in_tmp_project config.test, fn ->
       Gen.Schema.run(~w(Blog.Post posts --no-migration))


### PR DESCRIPTION
I added a `--repo` option to the schema generator so apps that have multiple repos can have the ability to select what repo the schema/migration should use.

I noticed `ecto.gen.migration` supports this flag and assumed it would work in phoenix as well. It did not, so here it is :-)

This works on the schema generator and other "parent" generators that call it (eg: `phx.gen.context`)

### NOTE to reviewer

Ideally, I wanted to support a custom `priv` config that may be set on the repo to determine the `migration_path`, however I noticed that will require me ensuring the repo module is compiled first. I wanted to get some advice on that before doing anything.
