### PR TITLE
Use Telemetry as first child to not miss init telemetry events

### DIFF
--- a/guides/directory_structure.md
+++ b/guides/directory_structure.md
@@ -49,10 +49,10 @@ The `lib/hello/application.ex` file defines an Elixir application named `Hello.A
 
 ```elixir
 children = [
-  # Start the Ecto repository
-  Hello.Repo,
   # Start the Telemetry supervisor
   HelloWeb.Telemetry,
+  # Start the Ecto repository
+  Hello.Repo,
   # Start the PubSub system
   {Phoenix.PubSub, name: Hello.PubSub},
   # Start the Endpoint (http/https)

--- a/installer/templates/phx_single/lib/app_name/application.ex
+++ b/installer/templates/phx_single/lib/app_name/application.ex
@@ -8,10 +8,10 @@ defmodule <%= @app_module %>.Application do
   @impl true
   def start(_type, _args) do
     children = [<%= if @ecto do %>
-      # Start the Ecto repository
-      <%= @app_module %>.Repo,<% end %>
       # Start the Telemetry supervisor
       <%= @web_namespace %>.Telemetry,
+      # Start the Ecto repository
+      <%= @app_module %>.Repo,<% end %>
       # Start the PubSub system
       {Phoenix.PubSub, name: <%= @app_module %>.PubSub},
       # Start the Endpoint (http/https)


### PR DESCRIPTION
The `Ecto.Repo` trigger some `:init` events that can be lost if the Telemetry start after the Repo.