### PR TITLE
docs: fix diff on ecto contexts walk through

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -450,6 +450,8 @@ With our schema associations set up, we can implement the selection of categorie
 
 
 ```diff
++ alias Hello.Catalog.Category
+
 - def get_product!(id), do: Repo.get!(Product, id)
 + def get_product!(id) do
 +   Product |> Repo.get(id) |> Repo.preload(:categories)


### PR DESCRIPTION
Following the guide, eventually I got to this point:

```
$ mix phx.server
Compiling 3 files (.ex)
warning: Category.__schema__/1 is undefined (module Category is not available or is yet to be defined)
  lib/hello/catalog.ex:114: Hello.Catalog.list_categories_by_id/1
```

The flow of creating a product with categories then also fails.

The alias fixed it.