### PR TITLE
Fix socket binary reply

### DIFF
--- a/lib/phoenix/socket/serializers/v2_json_serializer.ex
+++ b/lib/phoenix/socket/serializers/v2_json_serializer.ex
@@ -37,8 +37,10 @@ defmodule Phoenix.Socket.V2.JSONSerializer do
   @impl true
   def encode!(%Reply{payload: {:binary, data}} = reply) do
     status = to_string(reply.status)
-    join_ref_size = byte_size!(reply.join_ref, :join_ref, 255)
-    ref_size = byte_size!(reply.ref, :ref, 255)
+    join_ref = to_string(reply.join_ref)
+    ref = to_string(reply.ref)
+    join_ref_size = byte_size!(join_ref, :join_ref, 255)
+    ref_size = byte_size!(ref, :ref, 255)
     topic_size = byte_size!(reply.topic, :topic, 255)
     status_size = byte_size!(status, :status, 255)
 
@@ -48,8 +50,8 @@ defmodule Phoenix.Socket.V2.JSONSerializer do
       ref_size::size(8),
       topic_size::size(8),
       status_size::size(8),
-      reply.join_ref::binary-size(join_ref_size),
-      reply.ref::binary-size(ref_size),
+      join_ref::binary-size(join_ref_size),
+      ref::binary-size(ref_size),
       reply.topic::binary-size(topic_size),
       status::binary-size(status_size),
       data::binary


### PR DESCRIPTION
This applies the same conversion for socket.join_ref + reply.ref as one that's done within `encode!` for %Message{}, fixing the error below for when returning `{:noreply, {:ok, {:binary, bin}}, socket}` in `handle_in`.

```
[error] GenServer #PID<0.2890.0> terminating
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: not a bitstring

This typically happens when calling Kernel.byte_size/1 with an invalid argument or when performing binary construction or binary concatenation with <> and one of the arguments is not a binary
    :erlang.byte_size(2)
    (phoenix 1.7.0-dev) lib/phoenix/socket/serializers/v2_json_serializer.ex:145: Phoenix.Socket.V2.JSONSerializer.byte_size!/3
    (phoenix 1.7.0-dev) lib/phoenix/socket/serializers/v2_json_serializer.ex:42: Phoenix.Socket.V2.JSONSerializer.encode!/1
    (phoenix 1.7.0-dev) lib/phoenix/channel/server.ex:252: Phoenix.Channel.Server.reply/6
    (phoenix 1.7.0-dev) lib/phoenix/channel/server.ex:491: Phoenix.Channel.Server.handle_in/1
    (stdlib 3.17) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17) gen_server.erl:771: :gen_server.handle_msg/6
    (stdlib 3.17) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```