### PR TITLE
Remove gettext compiler

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -189,7 +189,7 @@ defmodule Phx.New.Generator do
       end
 
     compilers =
-      for {compiler, enabled?} <- [gettext: gettext, phoenix_live_view: html],
+      for {compiler, enabled?} <- [phoenix_live_view: html],
           enabled?,
           do: inspect(compiler)
 


### PR DESCRIPTION
The gettext compiler is no longer necessary since gettext 0.20.0, and
this now prints a warning for newly-generated Phoenix projects.

```console
warning: the :gettext compiler is no longer required in your mix.exs.

Please find the following line in your mix.exs and remove the :gettext entry:

    compilers: [..., :gettext, ...] ++ Mix.compilers(),

  (gettext 0.20.0) lib/mix/tasks/compile.gettext.ex:5: Mix.Tasks.Compile.Gettext.run/1
  (mix 1.13.4) lib/mix/task.ex:397: anonymous fn/3 in Mix.Task.run_task/3
  (mix 1.13.4) lib/mix/tasks/compile.all.ex:92: Mix.Tasks.Compile.All.run_compiler/2
  (mix 1.13.4) lib/mix/tasks/compile.all.ex:72: Mix.Tasks.Compile.All.compile/4
  (mix 1.13.4) lib/mix/tasks/compile.all.ex:59: Mix.Tasks.Compile.All.with_logger_app/2
  (mix 1.13.4) lib/mix/tasks/compile.all.ex:36: Mix.Tasks.Compile.All.run/1
```