### PR TITLE
Allow --repo option & --migration-dir for phx.gen.schema 

### DIFF
--- a/lib/mix/tasks/phx.gen.schema.ex
+++ b/lib/mix/tasks/phx.gen.schema.ex
@@ -86,6 +86,21 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   Generated migration can use `binary_id` for schema's primary key
   and its references with option `--binary-id`.
 
+  ## repo
+
+  Generated migration can use `repo` to set the migration repository
+  folder with option `--repo`.
+
+      $ mix phx.gen.schema Blog.Post posts --repo MyApp.Repo.Auth
+
+  ## migration_dir
+
+  Generated migrations can be added to a specific `migration-dir` which sets the
+  migration folder path
+
+      $ mix phx.gen.schema Blog.Post posts --migration-dir /path/to/directory
+
+
   ## prefix
 
   By default migrations and schemas are generated without a prefix.
@@ -131,7 +146,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   alias Mix.Phoenix.Schema
 
   @switches [migration: :boolean, binary_id: :boolean, table: :string,
-             web: :string, context_app: :string, prefix: :string]
+             web: :string, context_app: :string, prefix: :string, repo: :string, migration_dir: :string]
 
   @doc false
   def run(args) do
@@ -163,11 +178,21 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
     opts =
       parent_opts
       |> Keyword.merge(schema_opts)
+      |> Keyword.put(:migration_dir, schema_opts[:migration_dir])
       |> put_context_app(schema_opts[:context_app])
+      |> maybe_update_repo_module
 
     schema = Schema.new(schema_name, plural, attrs, opts)
 
     schema
+  end
+
+  defp maybe_update_repo_module(opts) do
+    if is_nil(opts[:repo]) do
+      opts
+    else
+      Keyword.update!(opts, :repo, &Module.concat([&1]))
+    end
   end
 
   defp put_context_app(opts, nil), do: opts
@@ -181,12 +206,15 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   end
 
   @doc false
-  def copy_new_files(%Schema{context_app: ctx_app} = schema, paths, binding) do
+  def copy_new_files(%Schema{context_app: ctx_app, repo: repo, opts: opts} = schema, paths, binding) do
     files = files_to_be_generated(schema)
     Mix.Phoenix.copy_from(paths, "priv/templates/phx.gen.schema", binding, files)
 
     if schema.migration? do
-      migration_path = Mix.Phoenix.context_app_path(ctx_app, "priv/repo/migrations/#{timestamp()}_create_#{schema.table}.exs")
+      repo_name = repo |> Module.split |> List.last |> Macro.underscore
+      migration_dir = opts[:migration_dir] || Mix.Phoenix.context_app_path(ctx_app, "priv/#{repo_name}/migrations/")
+      migration_path = Path.join(migration_dir, "#{timestamp()}_create_#{schema.table}.exs")
+
       Mix.Phoenix.copy_from paths, "priv/templates/phx.gen.schema", binding, [
         {:eex, "migration.exs", migration_path},
       ]

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -113,6 +113,40 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
     end
   end
 
+  test "allows a custom repo", config do
+    in_tmp_project config.test, fn ->
+      Gen.Schema.run(~w(Blog.Post blog_posts title:string --repo MyApp.CustomRepo))
+
+      assert [migration] = Path.wildcard("priv/custom_repo/migrations/*_create_blog_posts.exs")
+      assert_file migration, fn file ->
+        assert file =~ "defmodule MyApp.CustomRepo.Migrations.CreateBlogPosts do"
+      end
+    end
+  end
+
+  test "allows a custom migration dir", config do
+    in_tmp_project config.test, fn ->
+      Gen.Schema.run(~w(Blog.Post blog_posts title:string --migration-dir priv/custom_dir))
+
+      assert [migration] = Path.wildcard("priv/custom_dir/*_create_blog_posts.exs")
+      assert_file migration, fn file ->
+        assert file =~ "defmodule Phoenix.Repo.Migrations.CreateBlogPosts do"
+      end
+    end
+  end
+
+  test "custom migration_dir takes precedence over custom repo name", config do
+    in_tmp_project config.test, fn ->
+      Gen.Schema.run(~w(Blog.Post blog_posts title:string \
+        --repo MyApp.CustomRepo --migration-dir priv/custom_dir))
+
+      assert [migration] = Path.wildcard("priv/custom_dir/*_create_blog_posts.exs")
+      assert_file migration, fn file ->
+        assert file =~ "defmodule MyApp.CustomRepo.Migrations.CreateBlogPosts do"
+      end
+    end
+  end
+
   test "does not add maps to the required list", config do
     in_tmp_project config.test, fn ->
       Gen.Schema.run(~w(Blog.Post blog_posts title:string tags:map published_at:naive_datetime))


### PR DESCRIPTION
This allows us to provide a `--repo` flag to `mix phx.gen.schema`

It seems support is already built in for this with `Mix.Phoenix.Schema` so I simply added it to the `opts` in the format it seems is expected and made it utilise that `repo` for the migration path as well

Through options i've also added a `--migration_dir` which is passed in and used instead of the generated repo path

If this is wanted lemme know and I'll add tests to get it merged