### PR TITLE
Put the overview guides link top of moduledoc

### DIFF
--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -2,6 +2,8 @@ defmodule Phoenix do
   @moduledoc """
   This is the documentation for the Phoenix project.
 
+  To get started, see our [overview guides](overview.html).
+  
   By default, Phoenix applications depend on the following packages
   across these categories.
 
@@ -44,7 +46,6 @@ defmodule Phoenix do
     * [Telemetry Metrics](https://hexdocs.pm/telemetry_metrics) - common
       interface for defining metrics based on Telemetry events
 
-  To get started, see our [overview guides](overview.html).
   """
   use Application
 


### PR DESCRIPTION
I had people today that were discovering Phoenix and just thought that this was the main hub as it was linked as "Docs" from the phoenixframework.org website. I think that for a newcomer that end up there, having the guide link at the top probably would make more sense.