### PR TITLE
Remove repeated alias

### DIFF
--- a/installer/templates/phx_single/lib/app_name_web.ex
+++ b/installer/templates/phx_single/lib/app_name_web.ex
@@ -109,8 +109,7 @@ defmodule <%= @web_namespace %> do
       import Phoenix.View
 
       import <%= @web_namespace %>.ErrorHelpers<%= if @gettext do %>
-      import <%= @web_namespace %>.Gettext<% end %><%= if @html do %>
-      alias Phoenix.LiveView.JS<% end %>
+      import <%= @web_namespace %>.Gettext<% end %>
       unquote(verified_routes())
     end
   end


### PR DESCRIPTION
When a project is generated, `alias Phoenix.LiveView.JS` is duplicated in the `view_helpers/0` function in `installer/templates/phx_single/lib/app_name_web.ex`

Both aliases are created inside a conditional that check `@html`.

This PR removes the second conditional / alias.