### PR TITLE
Disable busy waiting for docker deployments

### DIFF
--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -75,7 +75,8 @@ defmodule Mix.Tasks.Phx.Gen.Release do
     if opts.docker do
       Mix.Phoenix.copy_from(paths(), "priv/templates/phx.gen.release", binding, [
         {:eex, "Dockerfile.eex", "Dockerfile"},
-        {:eex, "dockerignore.eex", ".dockerignore"}
+        {:eex, "dockerignore.eex", ".dockerignore"},
+        {:text, "rel/vm.args.eex", "rel/vm.args.eex"}
       ])
     end
 

--- a/priv/templates/phx.gen.release/rel/vm.args.eex
+++ b/priv/templates/phx.gen.release/rel/vm.args.eex
@@ -1,0 +1,16 @@
+## Customize flags given to the VM: https://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, and others)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10
+
+# Disable busy waiting https://stressgrid.com/blog/beam_cpu_usage/ https://en.wikipedia.org/wiki/Busy_waiting
++sbwt none
++sbwtdcpu none
++sbwtdio none


### PR DESCRIPTION
Containerized applications are designed to run in shared environments, so I suggest disabling busy waiting, not to interfere with other applications and to allow kernel to properly estimate the load (for autoscaling/...)