### PR TITLE
Return type of c:Endpoint.Cowboy2Handler.websocket_init/1

### DIFF
--- a/lib/phoenix/endpoint/cowboy2_handler.ex
+++ b/lib/phoenix/endpoint/cowboy2_handler.ex
@@ -137,8 +137,7 @@ defmodule Phoenix.Endpoint.Cowboy2Handler do
   ## Websocket callbacks
 
   def websocket_init([handler | state]) do
-    {:ok, state} = handler.init(state)
-    {:ok, [handler | state]}
+    handle_reply(handler, handler.init(state))
   end
 
   def websocket_handle({opcode, payload}, [handler | state]) when opcode in [:text, :binary] do

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -158,7 +158,10 @@ defmodule Phoenix.Socket.Transport do
   This must be executed from the process that will effectively
   operate the socket.
   """
-  @callback init(state) :: {:ok, state}
+  @callback init(state) ::
+              {:ok, state}
+              | {:push, {opcode :: atom, message :: term}, state}
+              | {:stop, reason :: term, state}
 
   @doc """
   Handles incoming socket messages.
@@ -200,7 +203,7 @@ defmodule Phoenix.Socket.Transport do
   """
   @callback handle_control({message :: term, opts :: keyword}, state) ::
               {:ok, state}
-              | {:reply, :ok | :error, {opcode :: atom, message :: term}, state}
+              | {:push, {opcode :: atom, message :: term}, state}
               | {:stop, reason :: term, state}
 
   @doc """

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -72,7 +72,7 @@ defmodule Phoenix.Socket.Transport do
         end
 
         def handle_in({text, _opts}, state) do
-          {:reply, :ok, {:text, text}, state}
+          {:push, {:text, text}, state}
         end
 
         def handle_info(_, state) do
@@ -170,7 +170,7 @@ defmodule Phoenix.Socket.Transport do
   return one of:
 
     * `{:ok, state}` - continues the socket with no reply
-    * `{:reply, status, reply, state}` - continues the socket with reply
+    * `{:push, reply, state}` - continues the socket with reply
     * `{:stop, reason, state}` - stops the socket
 
   The `reply` is a tuple contain an `opcode` atom and a message that can
@@ -180,7 +180,7 @@ defmodule Phoenix.Socket.Transport do
   """
   @callback handle_in({message :: term, opts :: keyword}, state) ::
               {:ok, state}
-              | {:reply, :ok | :error, {opcode :: atom, message :: term}, state}
+              | {:push, {opcode :: atom, message :: term}, state}
               | {:stop, reason :: term, state}
 
   @doc """
@@ -190,7 +190,7 @@ defmodule Phoenix.Socket.Transport do
   return one of:
 
     * `{:ok, state}` - continues the socket with no reply
-    * `{:reply, status, reply, state}` - continues the socket with reply
+    * `{:push, reply, state}` - continues the socket with reply
     * `{:stop, reason, state}` - stops the socket
 
   Control frames only supported when using websockets.

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -161,6 +161,7 @@ defmodule Phoenix.Socket.Transport do
   @callback init(state) ::
               {:ok, state}
               | {:push, {opcode :: atom, message :: term}, state}
+              | {:reply, :ok | :error, {opcode :: atom, message :: term}, state}
               | {:stop, reason :: term, state}
 
   @doc """
@@ -171,6 +172,7 @@ defmodule Phoenix.Socket.Transport do
 
     * `{:ok, state}` - continues the socket with no reply
     * `{:push, reply, state}` - continues the socket with reply
+    * `{:reply, status, reply, state}` - continues the socket with reply
     * `{:stop, reason, state}` - stops the socket
 
   The `reply` is a tuple contain an `opcode` atom and a message that can
@@ -181,6 +183,7 @@ defmodule Phoenix.Socket.Transport do
   @callback handle_in({message :: term, opts :: keyword}, state) ::
               {:ok, state}
               | {:push, {opcode :: atom, message :: term}, state}
+              | {:reply, :ok | :error, {opcode :: atom, message :: term}, state}
               | {:stop, reason :: term, state}
 
   @doc """
@@ -191,6 +194,7 @@ defmodule Phoenix.Socket.Transport do
 
     * `{:ok, state}` - continues the socket with no reply
     * `{:push, reply, state}` - continues the socket with reply
+    * `{:reply, status, reply, state}` - continues the socket with reply
     * `{:stop, reason, state}` - stops the socket
 
   Control frames only supported when using websockets.
@@ -204,6 +208,7 @@ defmodule Phoenix.Socket.Transport do
   @callback handle_control({message :: term, opts :: keyword}, state) ::
               {:ok, state}
               | {:push, {opcode :: atom, message :: term}, state}
+              | {:reply, :ok | :error, {opcode :: atom, message :: term}, state}
               | {:stop, reason :: term, state}
 
   @doc """
@@ -213,6 +218,7 @@ defmodule Phoenix.Socket.Transport do
 
     * `{:ok, state}` - continues the socket with no reply
     * `{:push, reply, state}` - continues the socket with reply
+    * `{:reply, status, reply, state}` - continues the socket with reply
     * `{:stop, reason, state}` - stops the socket
 
   The `reply` is a tuple contain an `opcode` atom and a message that can
@@ -223,6 +229,7 @@ defmodule Phoenix.Socket.Transport do
   @callback handle_info(message :: term, state) ::
               {:ok, state}
               | {:push, {opcode :: atom, message :: term}, state}
+              | {:reply, :ok | :error, {opcode :: atom, message :: term}, state}
               | {:stop, reason :: term, state}
 
   @doc """


### PR DESCRIPTION
[The documentation for `:cowboy_websocket`](https://ninenines.eu/docs/en/cowboy/2.4/manual/cowboy_websocket/) states that the `websocket_init/1` callback can return values specified in the `CallResult` type.

However, the current implementation of `Endpoint.Cowboy2Handler` **forces** the return from the handler/transport `Socket.Transport.init/1` callback to be `{:ok, state}` and cannot be other returns — like for example the simple `{:push, {:close, 4000, "Custom error"}, state}`.

Other callbacks like `websocket_handle/2` share the same `CallResult` result type, and use the private function `handle_reply/2` to translate the replies returned from the handler/transport. This PR changes the implementation of `websocket_init/2` to use that same private function and allow the aforementioned results to be returned.

---

With this change, we also want to modify the return type of `c:Socket.Transport.init/1` to account for the change in `websocket_init/1`. I have done so, and also modified the types of the rest of callbacks.

Though this last change sort of affects longpoll as well... because websocket and longpoll do not seem to share the same result types for the callbacks. **(?)**

---

**Background:** I need this because I am writing a custom websocket server and need to close the socket with custom codes in case of error on `init/1`. I.e. per example do `{:push, {:close, 4000, "Unknown user"}, state}`.