### PR TITLE
Permit customising HTML error page

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -215,6 +215,25 @@ defmodule Phoenix.Endpoint do
 
     * `:log_access_url` - log the access url once the server boots
 
+    * `:debug_banner_hooks` - a list of functions provided as MFA (`{module,
+      function, args}`) tuples. These functions are invoked in case
+      `:debug_errors` is set to `true` and an error occurs, in which case they may
+      contribute additional markup to be included in the error page. Each function
+      receives the following arguments, with the passed `args` concatenated to the
+      end:
+
+          [conn, status, kind, reason, stack]
+
+      For example, the following `debug_banner_hooks` option:
+
+          config :your_app, YourAppWeb.Endpoint,
+            debug_errors: true,
+            debug_banner_hooks: [{YourAppWeb.Helpers, :show_friendly_message, ["Chris"]}]
+
+      Would invoke the function
+
+          YourAppWebHelpers.show_friendly_message(conn, status, kind, reason, stack, "Chris")
+
   ### Adapter configuration
 
   Phoenix allows you to choose which webserver adapter to use. The default


### PR DESCRIPTION
This PR introduces support for a new endpoint configuration setting, `:debug_banner_hooks`.

It can be used to specify functions (as MFA tuples) to be invoked when rendering the debug banner. The functions can contribute additional markup to permit customising the error page.

The motivation behind this is the desire to build the package https://github.com/frerich/phoenix_live_debug_console which (by taking advantage of https://github.com/frerich/underthehood) can be included in Phoenix projects to augment the error view with an interactive IEx terminal (based on LiveView), right in the error page.

I previously brought this idea up in https://elixirforum.com/t/embedding-interactive-iex-shell-in-debugging-page-shown-for-development-builds/49554 and the (little) feedback I got encouraged me to give this a shot. 😊 

I'd ❤️  to hear what you think!