### PR TITLE
Auto format generated templates

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -81,7 +81,9 @@ defmodule Phx.New.Generator do
 
         :eex ->
           contents = mod.render(name, source, project.binding)
-          create_file(target, contents)
+          file = create_file(target, contents)
+          :ok = Mix.Tasks.Format.run([target])
+          file
       end
     end
   end

--- a/lib/mix/phoenix.ex
+++ b/lib/mix/phoenix.ex
@@ -36,16 +36,20 @@ defmodule Mix.Phoenix do
           if File.exists?(source), do: source
         end) || raise "could not find #{source_file_path} in any of the sources"
 
-      case format do
-        :text -> Mix.Generator.create_file(target, File.read!(source))
-        :eex  -> Mix.Generator.create_file(target, EEx.eval_file(source, binding))
-        :new_eex ->
-          if File.exists?(target) do
-            :ok
-          else
-            Mix.Generator.create_file(target, EEx.eval_file(source, binding))
-          end
-      end
+      file =
+        case format do
+          :text -> Mix.Generator.create_file(target, File.read!(source))
+          :eex  -> Mix.Generator.create_file(target, EEx.eval_file(source, binding))
+          :new_eex ->
+            if File.exists?(target) do
+              :ok
+            else
+              Mix.Generator.create_file(target, EEx.eval_file(source, binding))
+            end
+        end
+
+      :ok = Mix.Tasks.Format.run([target])
+      file
     end
   end
 


### PR DESCRIPTION
While working on https://github.com/phoenixframework/phoenix/pull/4820 I've realized that manually formatting templates with a default config won't work well because the user's project may have a different config for line length, generating a file that won't be formatted in that project context, forcing the user to run `mix format` to fix it anyways. Besides that a project may have custom plugins that is expected to modify those files.

So why not format on demand? The test shows how it could work. WDYT?