### PR TITLE
Fix compilation errors when generating a new Phoenix application with Live View authentication

### DIFF
--- a/installer/templates/phx_single/lib/app_name_web.ex
+++ b/installer/templates/phx_single/lib/app_name_web.ex
@@ -100,7 +100,6 @@ defmodule <%= @web_namespace %> do
     quote do<%= if @html do %>
       # Import basic HTML rendering capabilities (tags, forms, etc)
       use Phoenix.HTML
-      use Phoenix.Component
 
       # Import .heex helpers (<.link>, <.form>, etc) and alias JS module
       import Phoenix.LiveView.Helpers

--- a/installer/templates/phx_single/lib/app_name_web.ex
+++ b/installer/templates/phx_single/lib/app_name_web.ex
@@ -100,6 +100,7 @@ defmodule <%= @web_namespace %> do
     quote do<%= if @html do %>
       # Import basic HTML rendering capabilities (tags, forms, etc)
       use Phoenix.HTML
+      use Phoenix.Component
 
       # Import .heex helpers (<.link>, <.form>, etc) and alias JS module
       import Phoenix.LiveView.Helpers

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -3,7 +3,8 @@ defmodule <%= inspect auth_module %> do
 
   import Plug.Conn
   import Phoenix.Controller
-
+  
+  alias Phoenix.Component
   alias Phoenix.LiveView
   alias <%= inspect context.module %>
 
@@ -176,12 +177,12 @@ defmodule <%= inspect auth_module %> do
   defp mount_current_<%= schema.singular %>(session, socket) do
     case session do
       %{"<%= schema.singular %>_token" => <%= schema.singular %>_token} ->
-        LiveView.assign_new(socket, :current_<%= schema.singular %>, fn ->
+        Component.assign_new(socket, :current_<%= schema.singular %>, fn ->
           <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(<%= schema.singular %>_token)
         end)
 
       %{} ->
-        LiveView.assign_new(socket, :current_<%= schema.singular %>, fn -> nil end)
+        Component.assign_new(socket, :current_<%= schema.singular %>, fn -> nil end)
     end
   end
 


### PR DESCRIPTION
Generating a new Phoenix application fails to compile on `master` with the following errors:
```
warning: undefined function live_flash/2 (expected DemoWeb.LayoutView to define such a function or for it to be imported, but none are available)
  lib/demo_web/templates/layout/live.html.heex:8


== Compilation error in file lib/stub_web/views/layout_view.ex ==
** (CompileError) lib/demo_web/templates/layout/live.html.heex:4: undefined function live_flash/2 (expected DemoWeb.LayoutView to define such a function or for it to be imported, but none are available)
```

Additionally, adding authentication via `mix phx.gen.auth --live` fails to compile with the following errors:
```
warning: Phoenix.LiveView.assign_new/3 is undefined or private
Invalid call found at 2 locations:
  lib/demo_web/users_auth.ex:179: DemoWeb.UsersAuth.mount_current_users/2
  lib/demo_web/users_auth.ex:184: DemoWeb.UsersAuth.mount_current_users/2
```

This PR fixes these two bugs by fixing the aliases to use the new location of these functions 🙂 