### PR TITLE
Added the --no-gettext arg to the mix phx.new command. This is to get…

### DIFF
--- a/guides/introduction/up_and_running.md
+++ b/guides/introduction/up_and_running.md
@@ -7,7 +7,7 @@ Before we begin, please take a minute to read the [Installation Guide](installat
 We can run `mix phx.new` from any directory in order to bootstrap our Phoenix application. Phoenix will accept either an absolute or relative path for the directory of our new project. Assuming that the name of our application is `hello`, let's run the following command:
 
 ```console
-$ mix phx.new hello
+$ mix phx.new hello --no-gettext
 ```
 
 > A note about [Ecto](ecto.html): Ecto allows our Phoenix application to communicate with a data store, such as PostgreSQL, MySQL, and others. If our application will not require this component we can skip this dependency by passing the `--no-ecto` flag to `mix phx.new`.


### PR DESCRIPTION
… rid of the annoying gettext warnings when running mix phx.server.

Below is the warning I am trying to avoid. 

warning: the :gettext compiler is no longer required in your mix.exs.

Please find the following line in your mix.exs and remove the :gettext entry:

    compilers: [..., :gettext, ...] ++ Mix.compilers(),

  (gettext 0.20.0) lib/mix/tasks/compile.gettext.ex:5: Mix.Tasks.Compile.Gettext.run/1
  (mix 1.12.2) lib/mix/task.ex:394: anonymous fn/3 in Mix.Task.run_task/3
  (mix 1.12.2) lib/mix/tasks/compile.all.ex:92: Mix.Tasks.Compile.All.run_compiler/2
  (mix 1.12.2) lib/mix/tasks/compile.all.ex:72: Mix.Tasks.Compile.All.compile/4
  (mix 1.12.2) lib/mix/tasks/compile.all.ex:59: Mix.Tasks.Compile.All.with_logger_app/2
  (mix 1.12.2) lib/mix/tasks/compile.all.ex:36: Mix.Tasks.Compile.All.run/1