### PR TITLE
camel case -> snake case

### DIFF
--- a/lib/mix/tasks/phx.gen.cert.ex
+++ b/lib/mix/tasks/phx.gen.cert.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Phx.Gen.Cert do
   @doc false
   def certificate_and_key(key_size, name, hostnames) do
     private_key =
-      case generate_rsa_key(key_size, 65537) do
+      case generate_rsa_key(key_size, 65_537) do
         {:ok, key} ->
           key
 
@@ -215,20 +215,20 @@ defmodule Mix.Tasks.Phx.Gen.Cert do
   )
 
   # OID values
-  @rsaEncryption {1, 2, 840, 113_549, 1, 1, 1}
-  @sha256WithRSAEncryption {1, 2, 840, 113_549, 1, 1, 11}
+  @rsa_encryption {1, 2, 840, 113_549, 1, 1, 1}
+  @sha256_with_rsa_encryption {1, 2, 840, 113_549, 1, 1, 11}
 
-  @basicConstraints {2, 5, 29, 19}
-  @keyUsage {2, 5, 29, 15}
-  @extendedKeyUsage {2, 5, 29, 37}
-  @subjectKeyIdentifier {2, 5, 29, 14}
-  @subjectAlternativeName {2, 5, 29, 17}
+  @basic_constraints {2, 5, 29, 19}
+  @key_usage {2, 5, 29, 15}
+  @extended_key_usage {2, 5, 29, 37}
+  @subject_key_identifier {2, 5, 29, 14}
+  @subject_alternative_name {2, 5, 29, 17}
 
-  @organizationName {2, 5, 4, 10}
-  @commonName {2, 5, 4, 3}
+  @organization_name {2, 5, 4, 10}
+  @common_name {2, 5, 4, 3}
 
-  @serverAuth {1, 3, 6, 1, 5, 5, 7, 3, 1}
-  @clientAuth {1, 3, 6, 1, 5, 5, 7, 3, 2}
+  @server_auth {1, 3, 6, 1, 5, 5, 7, 3, 1}
+  @client_auth {1, 3, 6, 1, 5, 5, 7, 3, 2}
 
   defp new_cert(public_key, common_name, hostnames) do
     <<serial::unsigned-64>> = :crypto.strong_rand_bytes(8)
@@ -251,7 +251,7 @@ defmodule Mix.Tasks.Phx.Gen.Cert do
     otp_tbs_certificate(
       version: :v3,
       serialNumber: serial,
-      signature: signature_algorithm(algorithm: @sha256WithRSAEncryption, parameters: :NULL),
+      signature: signature_algorithm(algorithm: @sha256_with_rsa_encryption, parameters: :NULL),
       issuer: rdn(common_name),
       validity:
         validity(
@@ -261,7 +261,7 @@ defmodule Mix.Tasks.Phx.Gen.Cert do
       subject: rdn(common_name),
       subjectPublicKeyInfo:
         otp_subject_public_key_info(
-          algorithm: public_key_algorithm(algorithm: @rsaEncryption, parameters: :NULL),
+          algorithm: public_key_algorithm(algorithm: @rsa_encryption, parameters: :NULL),
           subjectPublicKey: public_key
         ),
       extensions: extensions(public_key, hostnames)
@@ -271,35 +271,35 @@ defmodule Mix.Tasks.Phx.Gen.Cert do
   defp rdn(common_name) do
     {:rdnSequence,
      [
-       [attr(type: @organizationName, value: {:utf8String, "Phoenix Framework"})],
-       [attr(type: @commonName, value: {:utf8String, common_name})]
+       [attr(type: @organization_name, value: {:utf8String, "Phoenix Framework"})],
+       [attr(type: @common_name, value: {:utf8String, common_name})]
      ]}
   end
 
   defp extensions(public_key, hostnames) do
     [
       extension(
-        extnID: @basicConstraints,
+        extnID: @basic_constraints,
         critical: true,
         extnValue: basic_constraints(cA: false)
       ),
       extension(
-        extnID: @keyUsage,
+        extnID: @key_usage,
         critical: true,
         extnValue: [:digitalSignature, :keyEncipherment]
       ),
       extension(
-        extnID: @extendedKeyUsage,
+        extnID: @extended_key_usage,
         critical: false,
-        extnValue: [@serverAuth, @clientAuth]
+        extnValue: [@server_auth, @client_auth]
       ),
       extension(
-        extnID: @subjectKeyIdentifier,
+        extnID: @subject_key_identifier,
         critical: false,
         extnValue: key_identifier(public_key)
       ),
       extension(
-        extnID: @subjectAlternativeName,
+        extnID: @subject_alternative_name,
         critical: false,
         extnValue: Enum.map(hostnames, &{:dNSName, String.to_charlist(&1)})
       )

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -79,7 +79,7 @@ defmodule Phoenix.DigesterTest do
       assert json["version"] == 1
       assert is_integer(json["digests"][key]["mtime"])
       assert json["digests"][key]["logical_path"] == "phoenix.png"
-      assert json["digests"][key]["size"] == 13900
+      assert json["digests"][key]["size"] == 13_900
       assert json["digests"][key]["digest"] =~ ~r"#{@hash_regex}"
 
       assert json["digests"][key]["sha512"] ==

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -199,7 +199,7 @@ defmodule Phoenix.Test.ConnTest do
     test "peer data is persisted" do
       peer_data = %{
         address: {127, 0, 0, 1},
-        port: 111317,
+        port: 111_317,
         ssl_cert: <<1, 2, 3, 4>>
       }
       conn =


### PR DESCRIPTION
made changes as recommended by credo  "Code Readability"                                                                                 

- Numbers larger than 9999 should be written with underscores
-  Module attribute names should be written in snake_case