### PR TITLE
Remove obsolete meta http-equiv tag

### DIFF
--- a/guides/howto/custom_error_pages.md
+++ b/guides/howto/custom_error_pages.md
@@ -68,8 +68,7 @@ Phoenix generates an `ErrorView` for us, but it doesn't give us a `lib/hello_web
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>Welcome to Phoenix!</title>
     <link rel="stylesheet" href="/css/app.css"/>
     <script defer type="text/javascript" src="/js/app.js"></script>

--- a/installer/templates/phx_web/templates/layout/root.html.heex
+++ b/installer/templates/phx_web/templates/layout/root.html.heex
@@ -2,8 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="csrf-token" content={get_csrf_token()}>
     <.live_title suffix=" · Phoenix Framework"><%%= assigns[:page_title] || "<%= @app_module %>" %></.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"}/>


### PR DESCRIPTION
And shorten meta viewport tag to common practice.

I think no new phx project wants to target Internet Explorer anymore.