### PR TITLE
Fix: Don't alias Phoenix.LiveView.JS twice

### DIFF
--- a/installer/templates/phx_single/lib/app_name_web.ex
+++ b/installer/templates/phx_single/lib/app_name_web.ex
@@ -97,22 +97,23 @@ defmodule <%= @web_namespace %> do
   end
 
   defp view_helpers do
-    quote do<%= if @html do %>
-      use Phoenix.Component
+    quote do
+      <%= if @html do %>
+        use Phoenix.Component
 
-      import Phoenix.HTML
-      import Phoenix.HTML.Form
-      import <%= @web_namespace %>.Components
+        import Phoenix.HTML
+        import Phoenix.HTML.Form
+        import <%= @web_namespace %>.Components
 
-      # Import and alias LiveView and .heex helpers (live_render, <.link>, <.form>, etc)
-      import Phoenix.LiveView.Helpers
-      alias Phoenix.LiveView.JS
-<% end %>
+        # Import and alias LiveView and .heex helpers (live_render, <.link>, <.form>, etc)
+        import Phoenix.LiveView.Helpers
+        alias Phoenix.LiveView.JS
+      <% end %>
       # Import basic rendering functionality (render, render_layout, etc)
       import Phoenix.View
       <%= if @gettext do %>
-      import <%= @web_namespace %>.Gettext<% end %><%= if @html do %>
-      alias Phoenix.LiveView.JS<% end %>
+        import <%= @web_namespace %>.Gettext
+      <% end %>
       unquote(verified_routes())
     end
   end


### PR DESCRIPTION
Removes the duplicated alias and adds some basic indentation

Fixes #4961