### PR TITLE
Emit telemetry span events for channel join and handle_in

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -298,7 +298,7 @@ defmodule Phoenix.Channel.Server do
 
     start = System.monotonic_time()
     measurements = %{system_time: System.system_time()}
-    metadata = %{topic: topic, params: auth_payload, socket: socket}
+    metadata = %{params: auth_payload, socket: socket}
     :telemetry.execute([:phoenix, :channel, :join, :start], measurements, metadata)
 
     try do

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -592,4 +592,9 @@ defmodule Phoenix.Channel.Server do
       [channel, proc, msg]
     )
   end
+
+  defp get_socket({:reply, _reply, socket}), do: socket
+  defp get_socket({:noreply, socket}), do: socket
+  defp get_socket({:noreply, socket, _timeout_or_hibernate}), do: socket
+  defp get_socket({:stop, _reason, socket}), do: socket
 end


### PR DESCRIPTION
This PR adds telemetry span events for `Phoenix.Channel` `join/3` and `handle_in/3` callbacks. The new events help with instrumenting channels with distributed traces (e.g. via OpenTelemetry).

The following new events were added:

- `[:phoenix, :channel, :join, :start]`
- `[:phoenix, :channel, :join, :stop]`
- `[:phoenix, :channel, :join, :exception]`
- `[:phoenix, :channel, :handle_in, :start]`
- `[:phoenix, :channel, :handle_in, :stop]`
- `[:phoenix, :channel, :handle_in, :exception]`

I haven't added documentation for the events yet, as I want to understand if this is something that the Phoenix team would accept as a feature, and if yes, what metadata to include the events. 