### PR TITLE
Fix typos

### DIFF
--- a/installer/templates/phx_web/components.ex
+++ b/installer/templates/phx_web/components.ex
@@ -128,7 +128,7 @@ defmodule <%= @web_namespace %>.Components do
   attr :title, :string, default: nil
   attr :rest, :global
   attr :kind, :atom, doc: "one of :info, :error used for styling and flash lookup"
-  attr :autoshow, :boolean, default: true, doc: "wether to auto show the flash on mount"
+  attr :autoshow, :boolean, default: true, doc: "whether to auto show the flash on mount"
   attr :close, :boolean, default: true, doc: "whether the flash can be closed"
 
   slot :inner_block, doc: "the optional inner block that renders the flash message"
@@ -175,7 +175,7 @@ defmodule <%= @web_namespace %>.Components do
   """
   attr :for, :any, default: nil, doc: "the datastructure for the form"
   attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
-  attr :rest, :global, doc: "the arbitraty HTML attributes to apply to the form tag"
+  attr :rest, :global, doc: "the arbitrary HTML attributes to apply to the form tag"
 
   slot :inner_block, required: true
   slot :actions, doc: "the slot for form actions, such as a submit button"
@@ -203,7 +203,7 @@ defmodule <%= @web_namespace %>.Components do
   """
   attr :type, :string, default: nil
   attr :class, :string, default: nil
-  attr :rest, :global, doc: "the arbitraty HTML attributes to apply to the button tag"
+  attr :rest, :global, doc: "the arbitrary HTML attributes to apply to the button tag"
 
   slot :inner_block, required: true
 

--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -278,7 +278,7 @@ defmodule Phoenix.Router.Helpers do
       |> Enum.map(fn {_, bindings} -> length(bindings) end)
       |> Enum.uniq()
 
-    # Each helper defines catch alls like this:
+    # Each helper defines catch all like this:
     #
     #     def helper_path(context, action, ...binding)
     #     def helper_path(context, action, ...binding, params)
@@ -299,7 +299,7 @@ defmodule Phoenix.Router.Helpers do
   end
 
   @doc """
-  Callback for generate router catch alls.
+  Callback for generate router catch all.
   """
   def raise_route_error(mod, fun, arity, action, routes, params) do
     cond do

--- a/test/phoenix/endpoint/supervisor_test.exs
+++ b/test/phoenix/endpoint/supervisor_test.exs
@@ -96,7 +96,7 @@ defmodule Phoenix.Endpoint.SupervisorTest do
              end)
     end
 
-    test "init/1 doesnt start watchers when `:server` config is false" do
+    test "init/1 doesn't start watchers when `:server` config is false" do
       Application.put_env(:phoenix, WatchersEndpoint, server: false, watchers: @watchers)
       {:ok, {_, children}} = Supervisor.init({:phoenix, WatchersEndpoint, []})
 

--- a/test/phoenix/router/pipeline_test.exs
+++ b/test/phoenix/router/pipeline_test.exs
@@ -160,7 +160,7 @@ defmodule Phoenix.Router.PipelineTest do
   end
 
   test "pipeline raises on conflict" do
-    assert_raise ArgumentError, ~r{there is an import from Kernel with the same nam}, fn ->
+    assert_raise ArgumentError, ~r{there is an import from Kernel with the same name}, fn ->
       defmodule ConflictingPipeline do
         use Phoenix.Router, otp_app: :phoenix
         pipeline :raise do


### PR DESCRIPTION
Found via `codespell -S priv,assets,deps -L inflight,statics,nwe,reenable,warmup,froms,noes,cant`