### PR TITLE
Update select tag generator with new components syntax

### DIFF
--- a/installer/templates/phx_web/components.ex
+++ b/installer/templates/phx_web/components.ex
@@ -250,7 +250,9 @@ defmodule <%= @web_namespace %>.Components do
   attr :rest, :global, doc: "the arbitrary HTML attributes for the input tag"
 
   slot :inner_block
-  slot :option, doc: "the slot for select input options"
+  slot :option, doc: "the slot for select input options" do
+    attr :value, :any
+  end
 
   def input(%{field: {f, field}} = assigns) do
     assigns

--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -195,9 +195,9 @@ defmodule Mix.Tasks.Phx.Gen.Html do
         ~s"""
         <.input field={{f, #{inspect(key)}}} type="select" label="#{label(key)}">
           <:option>Choose a value</:option>
-          <%= for value <- Ecto.Enum.values(#{inspect(schema.module)}, #{inspect(key)}) do %>
-            <:option value={value}><%= value %></:option>
-          <% end %>
+          <:option :for={value <- Ecto.Enum.values(#{inspect(schema.module)}, #{inspect(key)})} value={value}>
+            <%= value %>
+          </:option>
         </.input>
         """
       {key, _}  ->

--- a/priv/templates/phx.gen.live/components.ex
+++ b/priv/templates/phx.gen.live/components.ex
@@ -250,7 +250,9 @@ defmodule <%= @web_namespace %>.Components do
   attr :rest, :global, doc: "the arbitrary HTML attributes for the input tag"
 
   slot :inner_block
-  slot :option, doc: "the slot for select input options"
+  slot :option, doc: "the slot for select input options" do
+    attr :value, :any
+  end
 
   def input(%{field: {f, field}} = assigns) do
     assigns


### PR DESCRIPTION
This fixes two issues when generating HTML for a schema with a select tag.

The first is the slot within a `for` comprehension.

The other is the missing attribute `value` for the `:option` slot:
```
warning: undefined attribute "value" in slot "option" for component PhxBlogWeb.Components.input/1
  lib/phx_blog_web/templates/post/edit.html.heex:17: (file)
```