### PR TITLE
Add documentation line length suggestion to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,3 +225,4 @@ For formatting the guides:
   in the template.
 - We use backticks for filenames and directory paths.
 - We use backticks for module names, function names, and variable names.
+- Documentation line length should hard wrapped at around 100 characters if possible.


### PR DESCRIPTION
The formatter wont touch documentation blocks so they must be wrapped manually. I have previously been unsure about this and have noticed some wrap-edits before merges. 100ch seemed to be about what things were wrapped at?