### PR TITLE
Fix generated gen.auth confirm/token path

### DIFF
--- a/priv/templates/phx.gen.auth/confirmation_edit.html.heex
+++ b/priv/templates/phx.gen.auth/confirmation_edit.html.heex
@@ -1,6 +1,6 @@
 <.header>Confirm account</.header>
 
-<.simple_form :let={_f} for={:<%= schema.singular %>} action={~p"<%= schema.route_prefix %>/confirmation/#{@token}"}>
+<.simple_form :let={_f} for={:<%= schema.singular %>} action={~p"<%= schema.route_prefix %>/confirm/#{@token}"}>
   <:actions>
     <.button>Confirm my account</.button>
   </:actions>


### PR DESCRIPTION
To fix:

```
warning: no route path for PhxBlogWeb.Router matches "/users/confirmation/#{assigns.token}"
 lib/phx_blog_web/templates/user_confirmation/edit.html.heex:3: PhxBlogWeb.UserConfirmationView."edit.html"/1
```

Ref https://github.com/phoenixframework/phoenix/blob/64ab5740a4c69337590a3c859ed52ac0744741a4/priv/templates/phx.gen.auth/routes.ex#L41