### PR TITLE
Add more input types

### DIFF
--- a/installer/templates/phx_web/components.ex
+++ b/installer/templates/phx_web/components.ex
@@ -244,7 +244,8 @@ defmodule <%= @web_namespace %>.Components do
 
   attr :type, :string,
     default: "text",
-    values: ~w(text textarea number email date time datetime select)
+    values: ~w(button checkbox color date datetime-local email file hidden image month number
+               password radio range reset search submit tel text time url week)
 
   attr :value, :any
   attr :field, :any, doc: "a %Phoenix.HTML.Form{}/field name tuple, for example: {f, :email}"


### PR DESCRIPTION
Allowed types for `input` element were missing most of supported types which even generated warnings in templates generated with `phx.gen.html`.