### PR TITLE
Add "for" to input global includes

### DIFF
--- a/installer/templates/phx_web/components.ex
+++ b/installer/templates/phx_web/components.ex
@@ -250,7 +250,7 @@ defmodule <%= @web_namespace %>.Components do
   attr :value, :any
   attr :field, :any, doc: "a %Phoenix.HTML.Form{}/field name tuple, for example: {f, :email}"
   attr :errors, :list
-  attr :rest, :global, include: ~w(autocomplete checked disabled form max maxlength min minlength
+  attr :rest, :global, include: ~w(autocomplete checked disabled for form max maxlength min minlength
                                    multiple pattern placeholder readonly required size step)
   slot :inner_block
   slot :option, doc: "the slot for select input options" do

--- a/priv/templates/phx.gen.live/components.ex
+++ b/priv/templates/phx.gen.live/components.ex
@@ -250,7 +250,7 @@ defmodule <%= @web_namespace %>.Components do
   attr :value, :any
   attr :field, :any, doc: "a %Phoenix.HTML.Form{}/field name tuple, for example: {f, :email}"
   attr :errors, :list
-  attr :rest, :global, include: ~w(autocomplete checked disabled form max maxlength min minlength
+  attr :rest, :global, include: ~w(autocomplete checked disabled for form max maxlength min minlength
                                    multiple pattern placeholder readonly required size step)
   slot :inner_block
   slot :option, doc: "the slot for select input options" do


### PR DESCRIPTION
The `phx.gen.auth` generator currently generates a "for" attribute for the `input` component:

```
<.input
        field={{f, :current_password}}
        name="current_password"
        type="password"
        label="Confirm new password"
        for="current_password_for_password"
        id="current_password_for_password"
        value={@current_password}
        required
      />
```

Adding `for` to the list of global includes silences the warning about the "for" attribute being undefined.