### PR TITLE
mix phx.digest to return non zero error code on failure

### DIFF
--- a/lib/mix/tasks/phx.digest.ex
+++ b/lib/mix/tasks/phx.digest.ex
@@ -65,6 +65,7 @@ defmodule Mix.Tasks.Phx.Digest do
         Mix.shell().info [:green, "Check your digested files at #{inspect output_path}"]
       {:error, :invalid_path} ->
         Mix.shell().error "The input path #{inspect input_path} does not exist"
+        exit({:shutdown, 1})
     end
   end
 end

--- a/test/mix/tasks/phx.digest_test.exs
+++ b/test/mix/tasks/phx.digest_test.exs
@@ -5,8 +5,9 @@ defmodule Mix.Tasks.Phx.DigestTest do
   import MixHelper
 
   test "fails when the given paths are invalid" do
-    Mix.Tasks.Phx.Digest.run(["invalid_path", "--no-deps-check"])
+    exit_code = catch_exit(Mix.Tasks.Phx.Digest.run(["invalid_path", "--no-deps-check"]))
     assert_received {:mix_shell, :error, ["The input path \"invalid_path\" does not exist"]}
+    assert exit_code == {:shutdown, 1}
   end
 
   @output_path "mix_phoenix_digest"


### PR DESCRIPTION
Currently `mix phx.digest` exits with 0 on error which makes it harder to detect that something went wrong in CI/CD. This PR adds exit with 1 in such case.