### PR TITLE
Use the new :if to conditionally display the modals on phx.gen.live

### DIFF
--- a/priv/templates/phx.gen.live/index.html.heex
+++ b/priv/templates/phx.gen.live/index.html.heex
@@ -22,15 +22,18 @@
   </:action>
 </.table>
 
-<%%= if @live_action in [:new, :edit] do %>
-  <.modal id="<%= schema.singular %>-modal" show on_cancel={JS.navigate(~p"<%= schema.route_prefix %>")}>
-    <.live_component
-      module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
-      id={@<%= schema.singular %>.id || :new}
-      title={@page_title}
-      action={@live_action}
-      <%= schema.singular %>={@<%= schema.singular %>}
-      navigate={~p"<%= schema.route_prefix %>"}
-    />
-  </.modal>
-<%% end %>
+<.modal
+  :if={@live_action in [:new, :edit]}
+  id="<%= schema.singular %>-modal"
+  show
+  on_cancel={JS.navigate(~p"<%= schema.route_prefix %>")}
+  >
+  <.live_component
+    module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
+    id={@<%= schema.singular %>.id || :new}
+    title={@page_title}
+    action={@live_action}
+    <%= schema.singular %>={@<%= schema.singular %>}
+    navigate={~p"<%= schema.route_prefix %>"}
+  />
+</.modal>

--- a/priv/templates/phx.gen.live/show.html.heex
+++ b/priv/templates/phx.gen.live/show.html.heex
@@ -14,16 +14,19 @@
 
 <.back navigate={~p"<%= schema.route_prefix %>"}>Back to <%= schema.plural %></.back>
 
-<%%= if @live_action in [:edit] do %>
-  <.modal id="<%= schema.singular %>-modal" show on_cancel={JS.patch(~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}")}>
-    <.live_component
-      module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
-      id={@<%= schema.singular %>.id}
-      title={@page_title}
-      action={@live_action}
-      <%= schema.singular %>={@<%= schema.singular %>}
-      navigate={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}"}
-    />
-  </.modal>
-<%% end %>
+<.modal
+  :if={@live_action == :edit}
+  id="<%= schema.singular %>-modal"
+  show
+  on_cancel={JS.patch(~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}")}
+  >
+  <.live_component
+    module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
+    id={@<%= schema.singular %>.id}
+    title={@page_title}
+    action={@live_action}
+    <%= schema.singular %>={@<%= schema.singular %>}
+    navigate={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}"}
+  />
+</.modal>
 


### PR DESCRIPTION
This replaces the wrapper `if` with the new inline `:if`.

The tests are failing on this PR but #5000 fixes it.
Same error @leandrocp  mentioned https://github.com/phoenixframework/phoenix/pull/4820#issuecomment-1265797206.