### PR TITLE
Handle query mounting for empty lists

### DIFF
--- a/lib/phoenix/router/helpers.ex
+++ b/lib/phoenix/router/helpers.ex
@@ -219,9 +219,12 @@ defmodule Phoenix.Router.Helpers do
         defp segments(segments, query, reserved, trailing_slash?, _opts)
              when is_list(query) or is_map(query) do
           dict =
-            for {k, v} <- query,
-                (k = to_string(k)) not in reserved,
-                do: {k, v}
+            for {k, v} <- query, (k = to_string(k)) not in reserved do
+              {k, case v do
+                [] -> nil
+                _ -> v
+              end}
+            end
 
           case Conn.Query.encode(dict, &to_param/1) do
             "" -> maybe_append_slash(segments, trailing_slash?)

--- a/test/phoenix/router/helpers_test.exs
+++ b/test/phoenix/router/helpers_test.exs
@@ -121,6 +121,7 @@ defmodule Phoenix.Router.HelpersTest do
     assert Helpers.post_path(Endpoint, :show, 5, foo: true) == "/posts/5?foo=true"
     assert Helpers.post_path(Endpoint, :show, 5, foo: false) == "/posts/5?foo=false"
     assert Helpers.post_path(Endpoint, :show, 5, foo: nil) == "/posts/5?foo="
+    assert Helpers.post_path(Endpoint, :show, 5, foo: []) == "/posts/5?foo="
 
     assert Helpers.post_path(Endpoint, :show, 5, foo: ~w(bar baz)) ==
            "/posts/5?foo[]=bar&foo[]=baz"


### PR DESCRIPTION
This PR fixes issue #4997 by making the empty lists have the same behavior as `nil`.