### PR TITLE
Set missing `lib_web_name` in `phx.new.web`

### DIFF
--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -58,6 +58,7 @@ defmodule Phx.New.Web do
              project_path: project_path,
              web_path: web_path,
              web_app: app,
+             lib_web_name: app,
              generators: [context_app: false],
              web_namespace: project.app_mod}
   end


### PR DESCRIPTION
When generating a new `web_app` via `mix phx.gen.web` the `lib_web_name` was missing, resulting in invalid paths e.g. for the `root` in `use Phoenix.View`