### PR TITLE
Add missing "textarea" value to the component type list

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -245,7 +245,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   attr :type, :string,
     default: "text",
     values: ~w(checkbox color date datetime-local email file hidden month number password
-               range radio search select tel text time url week)
+               range radio search select tel text textarea time url week)
 
   attr :value, :any
   attr :field, :any, doc: "a %Phoenix.HTML.Form{}/field name tuple, for example: {f, :email}"

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -245,7 +245,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   attr :type, :string,
     default: "text",
     values: ~w(checkbox color date datetime-local email file hidden month number password
-               range radio search select tel text time url week)
+               range radio search select tel text textarea time url week)
 
   attr :value, :any
   attr :field, :any, doc: "a %Phoenix.HTML.Form{}/field name tuple, for example: {f, :email}"


### PR DESCRIPTION
This fixes a compilation warning related to the value attribute:

```warning: attribute "type" in component MyAppWeb.CoreComponents.input/1 must be one of ["checkbox", "color", "date", "datetime-local", "email", "file", "hidden", "month", "number", "password", "range", "radio", "search", "select", "tel", "text", "time", "url", "week"], got: "textarea"```