### PR TITLE
Replace "setup tags" with "setup context"

### DIFF
--- a/guides/testing/testing.md
+++ b/guides/testing/testing.md
@@ -106,8 +106,8 @@ defmodule HelloWeb.ConnCase do
     end
   end
 
-  setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Demo.Repo, shared: not tags[:async])
+  setup context do
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Demo.Repo, shared: not context[:async])
     on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
     %{conn: Phoenix.ConnTest.build_conn()}
   end

--- a/guides/testing/testing_channels.md
+++ b/guides/testing/testing_channels.md
@@ -64,7 +64,7 @@ defmodule HelloWeb.ChannelCase do
     end
   end
 
-  setup _tags do
+  setup _context do
     :ok
   end
 end

--- a/guides/testing/testing_contexts.md
+++ b/guides/testing/testing_contexts.md
@@ -105,8 +105,8 @@ defmodule Hello.DataCase do
     end
   end
 
-  setup tags do
-    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Demo.Repo, shared: not tags[:async])
+  setup context do
+    pid = Ecto.Adapters.SQL.Sandbox.start_owner!(Demo.Repo, shared: not context[:async])
     on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
     :ok
   end

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -305,7 +305,7 @@ defmodule Phx.New.Generator do
       ],
       test_setup_all: "Ecto.Adapters.SQL.Sandbox.mode(#{inspect(module)}.Repo, :manual)",
       test_setup: """
-          pid = Ecto.Adapters.SQL.Sandbox.start_owner!(#{inspect(module)}.Repo, shared: not tags[:async])
+          pid = Ecto.Adapters.SQL.Sandbox.start_owner!(#{inspect(module)}.Repo, shared: not context[:async])
           on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)\
       """,
       prod_variables: """
@@ -344,7 +344,7 @@ defmodule Phx.New.Generator do
       ],
       test_setup_all: "Ecto.Adapters.SQL.Sandbox.mode(#{inspect(module)}.Repo, :manual)",
       test_setup: """
-          pid = Ecto.Adapters.SQL.Sandbox.start_owner!(#{inspect(module)}.Repo, shared: not tags[:async])
+          pid = Ecto.Adapters.SQL.Sandbox.start_owner!(#{inspect(module)}.Repo, shared: not context[:async])
           on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)\
       """,
       prod_variables: """

--- a/installer/templates/phx_ecto/data_case.ex
+++ b/installer/templates/phx_ecto/data_case.ex
@@ -27,15 +27,15 @@ defmodule <%= @app_module %>.DataCase do
     end
   end
 
-  setup tags do
-    <%= @app_module %>.DataCase.setup_sandbox(tags)
+  setup context do
+    <%= @app_module %>.DataCase.setup_sandbox(context)
     :ok
   end
 
   @doc """
-  Sets up the sandbox based on the test tags.
+  Sets up the sandbox based on the test context.
   """
-  def setup_sandbox(tags) do
+  def setup_sandbox(context) do
 <%= @adapter_config[:test_setup] %>
   end
 

--- a/installer/templates/phx_test/support/conn_case.ex
+++ b/installer/templates/phx_test/support/conn_case.ex
@@ -31,12 +31,12 @@ defmodule <%= @web_namespace %>.ConnCase do
     end
   end<%= if @ecto do %>
 
-  setup tags do
-    <%= @app_module %>.DataCase.setup_sandbox(tags)
+  setup context do
+    <%= @app_module %>.DataCase.setup_sandbox(context)
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end<% else %>
 
-  setup _tags do
+  setup _context do
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end<% end %>
 end

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -624,7 +624,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file("custom_path/config/runtime.exs", [~r/url: database_url/])
       assert_file("custom_path/lib/custom_path/repo.ex", "Ecto.Adapters.Postgres")
 
-      assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(tags)")
+      assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(context)")
 
       assert_file(
         "custom_path/test/support/data_case.ex",
@@ -644,7 +644,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file("custom_path/config/runtime.exs", [~r/url: database_url/])
       assert_file("custom_path/lib/custom_path/repo.ex", "Ecto.Adapters.MyXQL")
 
-      assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(tags)")
+      assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(context)")
 
       assert_file(
         "custom_path/test/support/data_case.ex",
@@ -664,7 +664,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file("custom_path/config/runtime.exs", [~r/database: database_path/])
       assert_file("custom_path/lib/custom_path/repo.ex", "Ecto.Adapters.SQLite3")
 
-      assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(tags)")
+      assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(context)")
 
       assert_file(
         "custom_path/test/support/data_case.ex",
@@ -696,7 +696,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file("custom_path/config/runtime.exs", [~r/url: database_url/])
       assert_file("custom_path/lib/custom_path/repo.ex", "Ecto.Adapters.Tds")
 
-      assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(tags)")
+      assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(context)")
 
       assert_file(
         "custom_path/test/support/data_case.ex",

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -609,7 +609,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file(root_path(app, "config/runtime.exs"), [~r/url: database_url/])
 
-      assert_file(web_path(app, "test/support/conn_case.ex"), "DataCase.setup_sandbox(tags)")
+      assert_file(web_path(app, "test/support/conn_case.ex"), "DataCase.setup_sandbox(context)")
     end)
   end
 
@@ -626,7 +626,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file(root_path(app, "config/test.exs"), [~r/username: "root"/, ~r/password: ""/])
       assert_file(root_path(app, "config/runtime.exs"), [~r/url: database_url/])
 
-      assert_file(web_path(app, "test/support/conn_case.ex"), "DataCase.setup_sandbox(tags)")
+      assert_file(web_path(app, "test/support/conn_case.ex"), "DataCase.setup_sandbox(context)")
     end)
   end
 
@@ -643,7 +643,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file(root_path(app, "config/test.exs"), [~r/database: .*_test.db/])
       assert_file(root_path(app, "config/runtime.exs"), [~r/database: database_path/])
 
-      assert_file(web_path(app, "test/support/conn_case.ex"), "DataCase.setup_sandbox(tags)")
+      assert_file(web_path(app, "test/support/conn_case.ex"), "DataCase.setup_sandbox(context)")
 
       assert_file(root_path(app, ".gitignore"), "*.db")
       assert_file(root_path(app, ".gitignore"), "*.db-*")
@@ -671,7 +671,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file(root_path(app, "config/runtime.exs"), [~r/url: database_url/])
 
-      assert_file(web_path(app, "test/support/conn_case.ex"), "DataCase.setup_sandbox(tags)")
+      assert_file(web_path(app, "test/support/conn_case.ex"), "DataCase.setup_sandbox(context)")
     end)
   end
 

--- a/priv/templates/phx.gen.channel/channel_case.ex
+++ b/priv/templates/phx.gen.channel/channel_case.ex
@@ -28,12 +28,12 @@ defmodule <%= web_module %>.ChannelCase do
     end
   end<%= if Code.ensure_loaded?(Ecto.Adapters.SQL) do %>
 
-  setup tags do
-    <%= base %>.DataCase.setup_sandbox(tags)
+  setup context do
+    <%= base %>.DataCase.setup_sandbox(context)
     :ok
   end<% else %>
 
-  setup _tags do
+  setup _context do
     :ok
   end<% end %>
 end


### PR DESCRIPTION
As this is the current terminology used in Elixir. Tags is reserved for the `@tag` attribute.