### PR TITLE
Add status code to ConnTest redirected_params (#5021)

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -576,17 +576,19 @@ defmodule Phoenix.ConnTest do
   Returns the matched params from the URL the connection was redirected to.
 
   Uses the provided `%Plug.Conn{}`s router matched in the previous request.
-  Raises if the response's location header is not set.
+  Raises if the response's location header is not set or if the response does
+  not match the redirect status code (defaults to 302).
 
   ## Examples
 
       assert redirected_to(conn) =~ "/posts/123"
       assert %{id: "123"} = redirected_params(conn)
+      assert %{id: "123"} = redirected_params(conn, 303)
   """
-  @spec redirected_params(Conn.t) :: map
-  def redirected_params(%Plug.Conn{} = conn) do
+  @spec redirected_params(Conn.t, status :: non_neg_integer) :: map
+  def redirected_params(%Plug.Conn{} = conn, status \\ 302) do
     router = Phoenix.Controller.router_module(conn)
-    %URI{path: path, host: host} = conn |> redirected_to() |> URI.parse()
+    %URI{path: path, host: host} = conn |> redirected_to(status) |> URI.parse()
 
     case Phoenix.Router.route_info(router, "GET", path, host || conn.host) do
       :error ->

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -427,7 +427,7 @@ defmodule Phoenix.Test.ConnTest do
     end
   end
 
-  describe "redirected_params/1" do
+  describe "redirected_params/2" do
     test "with matching route" do
       conn =
         build_conn(:get, "/")
@@ -459,6 +459,18 @@ defmodule Phoenix.Test.ConnTest do
         |> send_resp(200, "ok")
         |> redirected_params()
       end
+    end
+
+    test "with custom status code" do
+      Enum.each(300..308, fn status ->
+        conn =
+          build_conn(:get, "/")
+          |> RedirRouter.call(RedirRouter.init([]))
+          |> put_resp_header("location", "/posts/123")
+          |> send_resp(status, "foo")
+
+        assert redirected_params(conn, status) == %{id: "123"}
+      end)
     end
   end
 


### PR DESCRIPTION
Add status code to `Phoenix.ConnTest.redirected_params/2` so that can also be used when status code needs to be different from `302`. Started on (#5021).
#hacktoberfest