### PR TITLE
fix path of core_components.ex in the live generator

### DIFF
--- a/lib/mix/tasks/phx.gen.live.ex
+++ b/lib/mix/tasks/phx.gen.live.ex
@@ -147,7 +147,7 @@ defmodule Mix.Tasks.Phx.Gen.Live do
       {:eex, "index.html.heex", Path.join(web_live, "index.html.heex")},
       {:eex, "show.html.heex", Path.join(web_live, "show.html.heex")},
       {:eex, "live_test.exs", Path.join(test_live, "#{schema.singular}_live_test.exs")},
-      {:new_eex, "core_components.ex", Path.join([web_prefix, "core_components.ex"])}
+      {:new_eex, "core_components.ex", Path.join([web_prefix, "components", "core_components.ex"])}
     ]
   end
 


### PR DESCRIPTION
Previously, this file would end up in:

`app_web/core_components.ex`

However the live generator would generate a file in `app_web/components/core_components.ex`. Running the live generator in a project created with `mix phx.new app --live` will result in 2 core_components.ex files after running the live generator.

This commit updates the path to match the application generator.

This closes #5028