### PR TITLE
Replace view with html for umbrella generators

### DIFF
--- a/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name.ex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name.ex
@@ -33,14 +33,10 @@ defmodule <%= @web_namespace %> do
     end
   end
 
-  def view do
-    quote do
-      use Phoenix.View,
-        root: "lib/<%= @lib_web_name %>/templates",
-        namespace: <%= @web_namespace %><%= if @html do %>
-
+  def html do
+    quote do<%= if @html do %>
       use Phoenix.Component
-<% end %>
+      <% end %>
       # Import convenience functions from controllers
       import Phoenix.Controller,
         only: [get_csrf_token: 0, view_module: 1, view_template: 1]

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -131,7 +131,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file(web_path(@app, "lib/#{@app}_web.ex"), fn file ->
         assert file =~ "defmodule PhxUmbWeb do"
-        assert file =~ ~r/use Phoenix.View,\s+root: "lib\/phx_umb_web\/templates"/
+        assert file =~ "use Phoenix.Component"
         assert file =~ "import Phoenix.HTML"
         assert file =~ "Phoenix.LiveView"
       end)


### PR DESCRIPTION
This seems to have been overlooked when replacing Phoenix.View in https://github.com/phoenixframework/phoenix/pull/4986