### PR TITLE
Improve table component example

### DIFF
--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -405,7 +405,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   ## Examples
 
-      <.table rows={@users}>
+      <.table id="users" rows={@users}>
         <:col :let={user} label="id"><%%= user.id %></:col>
         <:col :let={user} label="username"><%%= user.username %></:col>
       </.table>


### PR DESCRIPTION
The id attr is required, so we should include it in the example.