### PR TITLE
Fix redirected_params helper to forward status code

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -586,7 +586,7 @@ defmodule Phoenix.ConnTest do
   @spec redirected_params(Conn.t) :: map
   def redirected_params(%Plug.Conn{} = conn) do
     router = Phoenix.Controller.router_module(conn)
-    %URI{path: path, host: host} = conn |> redirected_to() |> URI.parse()
+    %URI{path: path, host: host} = conn |> redirected_to(conn.status) |> URI.parse()
 
     case Phoenix.Router.route_info(router, "GET", path, host || conn.host) do
       :error ->

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -460,6 +460,18 @@ defmodule Phoenix.Test.ConnTest do
         |> redirected_params()
       end
     end
+    
+    test "with custom status code" do
+      Enum.each(300..308, fn status ->
+        conn =
+          build_conn(:get, "/")
+          |> RedirRouter.call(RedirRouter.init([]))
+          |> put_resp_header("location", "/posts/123")
+          |> send_resp(status, "foo")
+
+        assert redirected_params(conn) == %{id: "123"}
+      end)
+    end
   end
 
   describe "path_params/1" do


### PR DESCRIPTION
This PR addresses and Closes #5021 highlighted issues.

### What was done
Now the helper function `redirected_params` to forward the status code received from the connection when calling the `redirected_to` helper which defaults to `302`, resulting in the error when a different value was received.

#hacktoberfest