### PR TITLE
Restore web namespace name when generating core components

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -595,9 +595,9 @@ defmodule <%= @web_namespace %>.CoreComponents do
     # should be written to the errors.po file. The :count option is
     # set by Ecto and indicates we should also apply plural rules.
     if count = opts[:count] do
-      Gettext.dngettext(DemoWeb.Gettext, "errors", msg, msg, count, opts)
+      Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
     else
-      Gettext.dgettext(DemoWeb.Gettext, "errors", msg, opts)
+      Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
     end
   end
 

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -595,9 +595,9 @@ defmodule <%= @web_namespace %>.CoreComponents do
     # should be written to the errors.po file. The :count option is
     # set by Ecto and indicates we should also apply plural rules.
     if count = opts[:count] do
-      Gettext.dngettext(DemoWeb.Gettext, "errors", msg, msg, count, opts)
+      Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
     else
-      Gettext.dgettext(DemoWeb.Gettext, "errors", msg, opts)
+      Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
     end
   end
 


### PR DESCRIPTION
The commit https://github.com/phoenixframework/phoenix/commit/9f0b9eca871c9816cd33090177f77b82d152afe6 replaced the web namespace with a fixed name so the generated core component module would have the wrong namespace defined.