### PR TITLE
close code block in routing.md

### DIFF
--- a/guides/routing.md
+++ b/guides/routing.md
@@ -245,7 +245,7 @@ Verified routes also support the `Phoenix.Param` protocol, but we don't need to 
 ```elixir
 ~p"/users/#{user}/#{post}"
 "/users/42/posts/17"
-`
+```
 
 Notice how we didn't need to interpolate `user.id` or `post.id`? This is particularly nice if we decide later we want to make our URLs a little nicer and start using slugs instead. We don't need to change any of our `~p`'s!
 


### PR DESCRIPTION
I got the following waring when building the docs:
warning: ExDoc.Markdown.Earmark (error) guides/routing.md:617 Fenced Code Block opened with ``` not closed at end of input

This fixes it an the layout issue that came with the code block not being closed 
