### PR TITLE
Fix specs for put_layout, put_new_layout and put_root_layout

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -541,7 +541,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_layout(Plug.Conn.t(), [{format :: atom, layout}] | false) :: Plug.Conn.t()
+  @spec put_layout(Plug.Conn.t(), [{format :: atom, layout}] | layout) :: Plug.Conn.t()
   def put_layout(%Plug.Conn{state: state} = conn, layout) do
     if state in @unsent do
       put_private_layout(conn, :phoenix_layout, :replace, layout)
@@ -601,7 +601,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_new_layout(Plug.Conn.t(), [{format :: atom, layout}] | false) :: Plug.Conn.t()
+  @spec put_new_layout(Plug.Conn.t(), [{format :: atom, layout}] | layout) :: Plug.Conn.t()
   def put_new_layout(%Plug.Conn{state: state} = conn, layout)
       when (is_tuple(layout) and tuple_size(layout) == 2) or is_list(layout) or layout == false do
     unless state in @unsent, do: raise(AlreadySentError)
@@ -640,7 +640,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_root_layout(Plug.Conn.t(), [{format :: atom, layout}] | false) ::
+  @spec put_root_layout(Plug.Conn.t(), [{format :: atom, layout}] | layout) ::
           Plug.Conn.t()
   def put_root_layout(%Plug.Conn{state: state} = conn, layout) do
     if state in @unsent do


### PR DESCRIPTION
They're missing the original `{module(), atom()}` type for the `layout` arg for cases where the `:layouts` option is not supplied to `use Phoenix.Controller`, like in a Phoenix 1.6 app.

This PR fixes the following Dialyzer error:

```
lib/foo_web/controllers/bar_controller.ex:1:call
The function call will not succeed.

Phoenix.Controller.put_new_layout(
  _ :: %Plug.Conn{...},
  {FooWeb.LayoutView, :app}
)

breaks the contract
(Plug.Conn.t(), [{format :: atom(), layout()}] | false) :: Plug.Conn.t()
```