### PR TITLE
Bugfix: Render inner block instead of @message

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -383,7 +383,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     ~H"""
     <p class="phx-no-feedback:hidden mt-3 flex gap-3 text-sm leading-6 text-rose-600">
       <Heroicons.exclamation_circle mini class="mt-0.5 h-5 w-5 flex-none fill-rose-500" />
-      <%%= @message %>
+      <%%= render_slot(@inner_block) %>
     </p>
     """
   end


### PR DESCRIPTION
This seems like a bug and was broken when I ran the `mix phx.gen.live ..` and then `mix test`