### PR TITLE
Fix translate_error/1 for phx.new and phx.gen.live generators with --no-gettext option

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -612,7 +612,9 @@ defmodule <%= @web_namespace %>.CoreComponents do
     #   Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
     # end
 
-    msg
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
   end<% end %>
 
   @doc """

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -612,7 +612,9 @@ defmodule <%= @web_namespace %>.CoreComponents do
     #   Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
     # end
 
-    msg
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
   end<% end %>
 
   @doc """


### PR DESCRIPTION
closes: #5064