### PR TITLE
Use ~H sigil in views fixture

### DIFF
--- a/test/fixtures/views.exs
+++ b/test/fixtures/views.exs
@@ -10,8 +10,8 @@ defmodule MyApp.LayoutView do
   use Phoenix.View, root: "test/fixtures/templates"
   import Phoenix.HTML
 
-  def render("root.html", assigns) do
-    ~E"""
+  def render("root.html", _assigns) do
+    ~H"""
     ROOTSTART[<%= @title %>]<%= @inner_content %>ROOTEND
     """
   end


### PR DESCRIPTION
Prevents deprecation warning:

  warning: Phoenix.HTML.sigil_E/2 is deprecated