### PR TITLE
Remove unnecessary \ from phx.gen.auth info

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -853,7 +853,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
           Mix.shell().info("""
           An authentication system can be created in two different ways:
           - Using Phoenix.LiveView (default)
-          - Using Phoenix.Controller only\
+          - Using Phoenix.Controller only
           """)
 
           if Mix.shell().yes?("Do you want to create a LiveView based authentication system?") do


### PR DESCRIPTION
While swapping from
`- Using Phoenix.View` to `- Using Phoenix.Controller only` an erroneous `\` was added.