### PR TITLE
Properly generate swoosh configuration for finch adapter

### DIFF
--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -12,7 +12,7 @@ import Config
 config :<%= @web_app_name %>, <%= @endpoint_module %>, cache_static_manifest: "priv/static/cache_manifest.json"<% end %><%= if @mailer do %>
 
 # Configures Swoosh API Client
-config :swoosh, :api_client, <%= @app_name %>.Finch<% end %>
+config :swoosh, :api_client, <%= @app_module %>.Finch<% end %>
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/installer/templates/phx_umbrella/config/prod.exs
+++ b/installer/templates/phx_umbrella/config/prod.exs
@@ -2,7 +2,7 @@ import Config
 
 <%= if @mailer do %>
 # Configures Swoosh API Client
-config :swoosh, :api_client, <%= @app_name %>.Finch<% end %>
+config :swoosh, :api_client, <%= @app_module %>.Finch<% end %>
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -155,7 +155,6 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file("phx_blog/assets/css/app.css")
 
-
       refute File.exists?("phx_blog/priv/static/assets/app.css")
       refute File.exists?("phx_blog/priv/static/assets/app.js")
       assert File.exists?("phx_blog/assets/vendor")
@@ -278,7 +277,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       end)
 
       assert_file("phx_blog/config/prod.exs", fn file ->
-        assert file =~ "config :swoosh, :api_client, #{@app_name}.Finch"
+        assert file =~ "config :swoosh, :api_client, PhxBlog.Finch"
       end)
 
       # Install dependencies?
@@ -415,7 +414,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       end)
 
       assert_file("phx_blog/lib/phx_blog/application.ex", fn file ->
-        refute file =~ "{Finch, name: #{@app_name}.Finch"
+        refute file =~ "{Finch, name: PhxBlog.Finch"
       end)
 
       refute File.exists?("phx_blog/lib/phx_blog/mailer.ex")

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -180,7 +180,6 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file(web_path(@app, ".gitignore"), ~r/\n$/)
       assert_file(web_path(@app, "assets/css/app.css"))
 
-
       assert_file(web_path(@app, "priv/static/favicon.ico"))
       assert_file(web_path(@app, "priv/static/images/phoenix.png"))
 
@@ -298,7 +297,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       end)
 
       assert_file(root_path(@app, "config/prod.exs"), fn file ->
-        assert file =~ "config :swoosh, :api_client, #{@app}.Finch"
+        assert file =~ "config :swoosh, :api_client, PhxUmb.Finch"
       end)
 
       # Install dependencies?
@@ -413,7 +412,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       end)
 
       assert_file(app_path(@app, "lib/#{@app}/application.ex"), fn file ->
-        refute file =~ "{Finch, name: #{@app}.Finch}"
+        refute file =~ "{Finch, name: PhxUmb.Finch}"
       end)
 
       refute File.exists?(app_path(@app, "lib/#{@app}/mailer.ex"))


### PR DESCRIPTION
The generators should generate `MyApp.Finch`, not `my_app.Finch`