### PR TITLE
Fix phx.gen.auth templates for --no-live

### DIFF
--- a/priv/templates/phx.gen.auth/confirmation_html.ex
+++ b/priv/templates/phx.gen.auth/confirmation_html.ex
@@ -1,3 +1,5 @@
 defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ConfirmationHTML do
   use <%= inspect context.web_module %>, :html
+
+  embed_templates "<%= schema.singular %>_confirmation_html/*"
 end

--- a/priv/templates/phx.gen.auth/registration_html.ex
+++ b/priv/templates/phx.gen.auth/registration_html.ex
@@ -1,3 +1,5 @@
 defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>RegistrationHTML do
   use <%= inspect context.web_module %>, :html
+
+  embed_templates "<%= schema.singular %>_registration_html/*"
 end

--- a/priv/templates/phx.gen.auth/reset_password_html.ex
+++ b/priv/templates/phx.gen.auth/reset_password_html.ex
@@ -1,3 +1,5 @@
 defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>ResetPasswordHTML do
   use <%= inspect context.web_module %>, :html
+
+  embed_templates "<%= schema.singular %>_reset_password_html/*"
 end

--- a/priv/templates/phx.gen.auth/session_html.ex
+++ b/priv/templates/phx.gen.auth/session_html.ex
@@ -1,3 +1,5 @@
 defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>SessionHTML do
   use <%= inspect context.web_module %>, :html
+
+  embed_templates "<%= schema.singular %>_session_html/*"
 end

--- a/priv/templates/phx.gen.auth/settings_html.ex
+++ b/priv/templates/phx.gen.auth/settings_html.ex
@@ -1,3 +1,5 @@
 defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>SettingsHTML do
   use <%= inspect context.web_module %>, :html
+
+  embed_templates "<%= schema.singular %>_settings_html/*"
 end


### PR DESCRIPTION
When running `mix phx.gen.auth Accounts User users --no-live`, we get multiple errors like this. 

```
   +integration-test |        8) test PUT /users/reset_password/:token does not reset password on invalid data (PhxBlogWeb.UserResetPasswordControllerTest)
   +integration-test |           test/phx_blog_web/controllers/user_reset_password_controller_test.exs:103
   +integration-test |           ** (ArgumentError) no "edit" html template defined for PhxBlogWeb.UserResetPasswordHTML
   +integration-test |           code: put(conn, ~p"/users/reset_password/#{token}", %{
   +integration-test |           stacktrace:
   +integration-test |             (phoenix_template 1.0.0) lib/phoenix/template.ex:177: Phoenix.Template.render_with_fallback/4
   +integration-test |             (phoenix_template 1.0.0) lib/phoenix/template.ex:133: Phoenix.Template.render_within_layout/4
   +integration-test |             (phoenix 1.7.0-rc.0) lib/phoenix/controller.ex:883: Phoenix.Controller.render_with_layouts/4
   +integration-test |             (phoenix 1.7.0-rc.0) lib/phoenix/controller.ex:870: Phoenix.Controller.render_and_send/4
   +integration-test |             (phx_blog 0.1.0) lib/phx_blog_web/controllers/user_reset_password_controller.ex:1: PhxBlogWeb.UserResetPasswordController.action/2
   +integration-test |             (phx_blog 0.1.0) lib/phx_blog_web/controllers/user_reset_password_controller.ex:1: PhxBlogWeb.UserResetPasswordController.phoenix_controller_pipeline/2
   +integration-test |             (phoenix 1.7.0-rc.0) lib/phoenix/router.ex:425: Phoenix.Router.__call__/2
   +integration-test |             (phx_blog 0.1.0) lib/phx_blog_web/endpoint.ex:1: PhxBlogWeb.Endpoint.plug_builder_call/2
   +integration-test |             (phx_blog 0.1.0) lib/phx_blog_web/endpoint.ex:1: PhxBlogWeb.Endpoint.call/2
   +integration-test |             (phoenix 1.7.0-rc.0) lib/phoenix/test/conn_test.ex:225: Phoenix.ConnTest.dispatch/5
   +integration-test |             test/phx_blog_web/controllers/user_reset_password_controller_test.exs:105: (test)
```

It appears each of these new `HTML` modules were missing `embed_template/1` calls. This PR adds those calls and the tests now pass.