### PR TITLE
Fix broken live_reload in v1.7.0-rc.0

### DIFF
--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -48,8 +48,7 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
     patterns: [
       ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
       ~r"priv/gettext/.*(po)$",<% end %>
-      ~r"lib/<%= @lib_web_name %>/(live|views)/.*(ex)$",
-      ~r"lib/<%= @lib_web_name %>/templates/.*(eex)$"
+      ~r"lib/<%= @lib_web_name %>/(controllers|live|components)/.*(ex|heex)$"
     ]
   ]<% end %>
 

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -46,8 +46,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
     patterns: [
       ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
       ~r"priv/gettext/.*(po)$",<% end %>
-      ~r"lib/<%= @web_app_name %>/(live|views)/.*(ex)$",
-      ~r"lib/<%= @web_app_name %>/templates/.*(eex)$"
+      ~r"lib/<%= @web_app_name %>/(controllers|live|components)/.*(ex|heex)$"
     ]
   ]<% end %>
 


### PR DESCRIPTION
Following directories change in 1.7:
+ `views/` and `templates/` are replaced by `controllers/`.
+ `components/` is added.

This PR makes live_reload work with new file structure.