### PR TITLE
Don't generate `priv/static/images/phoenix.png` in 1.7.0-rc.0

### DIFF
--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -83,7 +83,6 @@ defmodule Phx.New.Single do
   template(:static, [
     {:text, :web,
      "phx_static/robots.txt": "priv/static/robots.txt",
-     "phx_static/phoenix.png": "priv/static/images/phoenix.png",
      "phx_static/favicon.ico": "priv/static/favicon.ico"}
   ])
 

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -321,7 +321,6 @@ defmodule Mix.Tasks.Phx.NewTest do
       # No assets & No HTML
       refute_file("phx_blog/priv/static/assets/app.css")
       refute_file("phx_blog/priv/static/favicon.ico")
-      refute_file("phx_blog/priv/static/images/phoenix.png")
       refute_file("phx_blog/priv/static/assets/app.js")
 
       # No Ecto
@@ -520,7 +519,6 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file("phx_blog/priv/static/assets/app.css")
       assert_file("phx_blog/priv/static/assets/app.js")
       assert_file("phx_blog/priv/static/favicon.ico")
-      assert_file("phx_blog/priv/static/images/phoenix.png")
 
       assert_file("phx_blog/config/config.exs", fn file ->
         refute file =~ "config :esbuild"

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -185,7 +185,6 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file(web_path(@app, "assets/css/app.css"))
 
       assert_file(web_path(@app, "priv/static/favicon.ico"))
-      assert_file(web_path(@app, "priv/static/images/phoenix.png"))
 
       refute File.exists?(web_path(@app, "priv/static/assets/app.css"))
       refute File.exists?(web_path(@app, "priv/static/assets/app.js"))
@@ -346,7 +345,6 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       refute_file(web_path(@app, "priv/static/assets/app.js"))
       refute_file(web_path(@app, "priv/static/assets/app.css"))
       refute_file(web_path(@app, "priv/static/favicon.ico"))
-      refute_file(web_path(@app, "priv/static/images/phoenix.png"))
 
       # No Ecto
       config = ~r/config :phx_umb, PhxUmb.Repo,/
@@ -511,7 +509,6 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file(web_path(@app, "priv/static/assets/app.js"))
       assert_file(web_path(@app, "priv/static/assets/app.css"))
       assert_file(web_path(@app, "priv/static/favicon.ico"))
-      assert_file(web_path(@app, "priv/static/images/phoenix.png"))
     end)
   end
 
@@ -834,7 +831,6 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         # assets
         assert_file("another/.gitignore", ~r/\n$/)
         assert_file("another/priv/static/favicon.ico")
-        assert_file("another/priv/static/images/phoenix.png")
         assert_file("another/assets/css/app.css")
 
         refute File.exists?("another/priv/static/assets/app.css")


### PR DESCRIPTION
In 1.7, The template is using a logo which is an embedded SVG, this file is useless.

Maybe, we can ignore it when generating a project.