### PR TITLE
Fix "Deploy your application" link

### DIFF
--- a/installer/templates/phx_web/controllers/page_html/home.html.heex
+++ b/installer/templates/phx_web/controllers/page_html/home.html.heex
@@ -216,7 +216,7 @@
           </div>
           <div>
             <a
-              href="https://fly.io/docs/getting-started/elixir/"
+              href="https://fly.io/docs/elixir/getting-started/"
               class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-zinc-900"
             >
               <svg


### PR DESCRIPTION
The current link redirects to https://fly.io/docs/elixir/getting-started/iex-into-running-app/.