### PR TITLE
Unify `gen.auth` and `phx.new` menu styles

### DIFF
--- a/lib/mix/tasks/phx.gen.auth/injector.ex
+++ b/lib/mix/tasks/phx.gen.auth/injector.ex
@@ -149,6 +149,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.Injector do
   """
   def app_layout_menu_help_text(file_path, %Schema{} = schema) do
     {_dup_check, code} = app_layout_menu_code_to_inject(schema)
+
     """
     Add the following #{schema.singular} menu items to your #{Path.relative_to_cwd(file_path)} layout file:
 
@@ -172,17 +173,38 @@ defmodule Mix.Tasks.Phx.Gen.Auth.Injector do
           <%= @current_#{schema.singular}.email %>
         </li>
         <li>
-          <.link href={~p"#{schema.route_prefix}/settings"} class="#{link_tailwind_classes}">Settings</.link>
+          <.link
+            href={~p"#{schema.route_prefix}/settings"}
+            class="#{link_tailwind_classes}"
+          >
+            Settings
+          </.link>
         </li>
         <li>
-          <.link href={~p"#{schema.route_prefix}/log_out"} method="delete" class="#{link_tailwind_classes}">Log out</.link>
+          <.link
+            href={~p"#{schema.route_prefix}/log_out"}
+            method="delete"
+            class="#{link_tailwind_classes}"
+          >
+            Log out
+          </.link>
         </li>
       <% else %>
         <li>
-          <.link href={~p"#{schema.route_prefix}/register"} class="#{link_tailwind_classes}">Register</.link>
+          <.link
+            href={~p"#{schema.route_prefix}/register"}
+            class="#{link_tailwind_classes}"
+          >
+            Register
+          </.link>
         </li>
         <li>
-          <.link href={~p"#{schema.route_prefix}/log_in"} class="#{link_tailwind_classes}">Log in</.link>
+          <.link
+            href={~p"#{schema.route_prefix}/log_in"}
+            class="#{link_tailwind_classes}"
+          >
+            Log in
+          </.link>
         </li>
       <% end %>
     </ul>\

--- a/lib/mix/tasks/phx.gen.auth/injector.ex
+++ b/lib/mix/tasks/phx.gen.auth/injector.ex
@@ -166,7 +166,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.Injector do
     link_tailwind_classes = "#{base_tailwind_classes} font-semibold hover:text-zinc-700"
 
     template = """
-    <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8">
+    <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
       <%= if @current_#{schema.singular} do %>
         <li class="#{base_tailwind_classes}">
           <%= @current_#{schema.singular}.email %>

--- a/lib/mix/tasks/phx.gen.auth/injector.ex
+++ b/lib/mix/tasks/phx.gen.auth/injector.ex
@@ -163,7 +163,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.Injector do
   def app_layout_menu_code_to_inject(%Schema{} = schema, padding \\ 4, newline \\ "\n") do
     already_injected_str = "#{schema.route_prefix}/log_in"
 
-    base_tailwind_classes = "text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700"
+    base_tailwind_classes = "text-[0.8125rem] leading-6 text-zinc-900"
     link_tailwind_classes = "#{base_tailwind_classes} font-semibold hover:text-zinc-700"
 
     template = """

--- a/lib/mix/tasks/phx.gen.auth/injector.ex
+++ b/lib/mix/tasks/phx.gen.auth/injector.ex
@@ -175,7 +175,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.Injector do
           <.link href={~p"#{schema.route_prefix}/settings"} class="#{link_tailwind_classes}">Settings</.link>
         </li>
         <li>
-          <.link href={~p"#{schema.route_prefix}/log_out"} class="#{link_tailwind_classes}" method="delete">Log out</.link>
+          <.link href={~p"#{schema.route_prefix}/log_out"} method="delete" class="#{link_tailwind_classes}">Log out</.link>
         </li>
       <% else %>
         <li>

--- a/lib/mix/tasks/phx.gen.auth/injector.ex
+++ b/lib/mix/tasks/phx.gen.auth/injector.ex
@@ -162,24 +162,27 @@ defmodule Mix.Tasks.Phx.Gen.Auth.Injector do
   def app_layout_menu_code_to_inject(%Schema{} = schema, padding \\ 4, newline \\ "\n") do
     already_injected_str = "#{schema.route_prefix}/log_in"
 
+    base_tailwind_classes = "text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700"
+    link_tailwind_classes = "#{base_tailwind_classes} font-semibold hover:text-zinc-700"
+
     template = """
     <ul>
       <%= if @current_#{schema.singular} do %>
-        <li>
+        <li class="#{base_tailwind_classes}">
           <%= @current_#{schema.singular}.email %>
         </li>
         <li>
-          <.link href={~p"#{schema.route_prefix}/settings"}>Settings</.link>
+          <.link href={~p"#{schema.route_prefix}/settings"} class="#{link_tailwind_classes}">Settings</.link>
         </li>
         <li>
-          <.link href={~p"#{schema.route_prefix}/log_out"} method="delete">Log out</.link>
+          <.link href={~p"#{schema.route_prefix}/log_out"} class="#{link_tailwind_classes}" method="delete">Log out</.link>
         </li>
       <% else %>
         <li>
-          <.link href={~p"#{schema.route_prefix}/register"}>Register</.link>
+          <.link href={~p"#{schema.route_prefix}/register"} class="#{link_tailwind_classes}">Register</.link>
         </li>
         <li>
-          <.link href={~p"#{schema.route_prefix}/log_in"}>Log in</.link>
+          <.link href={~p"#{schema.route_prefix}/log_in"} class="#{link_tailwind_classes}">Log in</.link>
         </li>
       <% end %>
     </ul>\

--- a/lib/mix/tasks/phx.gen.auth/injector.ex
+++ b/lib/mix/tasks/phx.gen.auth/injector.ex
@@ -166,7 +166,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.Injector do
     link_tailwind_classes = "#{base_tailwind_classes} font-semibold hover:text-zinc-700"
 
     template = """
-    <ul>
+    <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8">
       <%= if @current_#{schema.singular} do %>
         <li class="#{base_tailwind_classes}">
           <%= @current_#{schema.singular}.email %>

--- a/priv/templates/phx.gen.auth/forgot_password_live_test.exs
+++ b/priv/templates/phx.gen.auth/forgot_password_live_test.exs
@@ -12,8 +12,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       {:ok, _lv, html} = live(conn, ~p"<%= schema.route_prefix %>/reset_password")
 
       assert html =~ "Forgot your password?"
-      assert html =~ "Register</a>"
-      assert html =~ "Log in</a>"
+      assert html =~ "/users/register"
+      assert html =~ "/users/log_in"
     end
 
     test "redirects if already logged in", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/forgot_password_live_test.exs
+++ b/priv/templates/phx.gen.auth/forgot_password_live_test.exs
@@ -9,11 +9,11 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   describe "Forgot password page" do
     test "renders email page", %{conn: conn} do
-      {:ok, _lv, html} = live(conn, ~p"<%= schema.route_prefix %>/reset_password")
+      {:ok, lv, html} = live(conn, ~p"<%= schema.route_prefix %>/reset_password")
 
       assert html =~ "Forgot your password?"
-      assert html =~ "/users/register"
-      assert html =~ "/users/log_in"
+      assert has_element?(lv, ~s|a[href="#{~p"/users/register"}"]|, "Register")
+      assert has_element?(lv, ~s|a[href="#{~p"/users/log_in"}"]|, "Log in")
     end
 
     test "redirects if already logged in", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/registration_controller_test.exs
+++ b/priv/templates/phx.gen.auth/registration_controller_test.exs
@@ -8,8 +8,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"<%= schema.route_prefix %>/register")
       response = html_response(conn, 200)
       assert response =~ "Register"
-      assert response =~ "Log in</a>"
-      assert response =~ "Register</a>"
+      assert response =~ "/users/log_in"
+      assert response =~ "/users/register"
     end
 
     test "redirects if already logged in", %{conn: conn} do
@@ -36,8 +36,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
       assert response =~ email
-      assert response =~ "Settings</a>"
-      assert response =~ "Log out</a>"
+      assert response =~ "/users/settings"
+      assert response =~ "/users/log_out"
     end
 
     test "render errors for invalid data", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/registration_controller_test.exs
+++ b/priv/templates/phx.gen.auth/registration_controller_test.exs
@@ -8,7 +8,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"<%= schema.route_prefix %>/register")
       response = html_response(conn, 200)
       assert response =~ "Register"
-      assert response =~ "/users/log_in"
+      assert response =~ ~p"/users/log_in"
       assert response =~ "/users/register"
     end
 

--- a/priv/templates/phx.gen.auth/registration_controller_test.exs
+++ b/priv/templates/phx.gen.auth/registration_controller_test.exs
@@ -36,7 +36,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
       assert response =~ email
-      assert response =~ "/users/settings"
+      assert response =~ ~p"/users/settings"
       assert response =~ "/users/log_out"
     end
 

--- a/priv/templates/phx.gen.auth/registration_controller_test.exs
+++ b/priv/templates/phx.gen.auth/registration_controller_test.exs
@@ -37,7 +37,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       response = html_response(conn, 200)
       assert response =~ email
       assert response =~ ~p"/users/settings"
-      assert response =~ "/users/log_out"
+      assert response =~ ~p"/users/log_out"
     end
 
     test "render errors for invalid data", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/registration_controller_test.exs
+++ b/priv/templates/phx.gen.auth/registration_controller_test.exs
@@ -9,7 +9,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       response = html_response(conn, 200)
       assert response =~ "Register"
       assert response =~ ~p"/users/log_in"
-      assert response =~ "/users/register"
+      assert response =~ ~p"/users/register"
     end
 
     test "redirects if already logged in", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/session_controller_test.exs
+++ b/priv/templates/phx.gen.auth/session_controller_test.exs
@@ -12,7 +12,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"<%= schema.route_prefix %>/log_in")
       response = html_response(conn, 200)
       assert response =~ "Log in"
-      assert response =~ "Register</a>"
+      assert response =~ "/users/register"
       assert response =~ "Forgot your password?"
     end
 
@@ -36,8 +36,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
       assert response =~ <%= schema.singular %>.email
-      assert response =~ "Settings</a>"
-      assert response =~ "Log out</a>"
+      assert response =~ "/users/settings"
+      assert response =~ "/users/log_out"
     end
 
     test "logs the <%= schema.singular %> in with remember me", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do

--- a/priv/templates/phx.gen.auth/session_controller_test.exs
+++ b/priv/templates/phx.gen.auth/session_controller_test.exs
@@ -36,8 +36,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
       assert response =~ <%= schema.singular %>.email
-      assert response =~ "/users/settings"
-      assert response =~ "/users/log_out"
+      assert response =~ ~p"/users/settings"
+      assert response =~ ~p"/users/log_out"
     end
 
     test "logs the <%= schema.singular %> in with remember me", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do

--- a/priv/templates/phx.gen.auth/session_controller_test.exs
+++ b/priv/templates/phx.gen.auth/session_controller_test.exs
@@ -12,7 +12,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"<%= schema.route_prefix %>/log_in")
       response = html_response(conn, 200)
       assert response =~ "Log in"
-      assert response =~ "/users/register"
+      assert response =~ ~p"/users/register"
       assert response =~ "Forgot your password?"
     end
 

--- a/test/mix/tasks/phx.gen.auth/injector_test.exs
+++ b/test/mix/tasks/phx.gen.auth/injector_test.exs
@@ -667,13 +667,13 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                          </ul>
                          <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
                            <%= if @current_user do %>
-                             <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">
+                             <li class="text-[0.8125rem] leading-6 text-zinc-900">
                                <%= @current_user.email %>
                              </li>
                              <li>
                                <.link
                                  href={~p"/users/settings"}
-                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                                >
                                  Settings
                                </.link>
@@ -682,7 +682,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                                <.link
                                  href={~p"/users/log_out"}
                                  method="delete"
-                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                                >
                                  Log out
                                </.link>
@@ -691,7 +691,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                              <li>
                                <.link
                                  href={~p"/users/register"}
-                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                                >
                                  Register
                                </.link>
@@ -699,7 +699,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                              <li>
                                <.link
                                  href={~p"/users/log_in"}
-                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                                >
                                  Log in
                                </.link>
@@ -761,13 +761,13 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                          </ul>\r
                          <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">\r
                            <%= if @current_user do %>\r
-                             <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">\r
+                             <li class="text-[0.8125rem] leading-6 text-zinc-900">\r
                                <%= @current_user.email %>\r
                              </li>\r
                              <li>\r
                                <.link\r
                                  href={~p"/users/settings"}\r
-                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"\r
                                >\r
                                  Settings\r
                                </.link>\r
@@ -776,7 +776,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                                <.link\r
                                  href={~p"/users/log_out"}\r
                                  method="delete"\r
-                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"\r
                                >\r
                                  Log out\r
                                </.link>\r
@@ -785,7 +785,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                              <li>\r
                                <.link\r
                                  href={~p"/users/register"}\r
-                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"\r
                                >\r
                                  Register\r
                                </.link>\r
@@ -793,7 +793,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                              <li>\r
                                <.link\r
                                  href={~p"/users/log_in"}\r
-                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"\r
                                >\r
                                  Log in\r
                                </.link>\r
@@ -839,13 +839,13 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                  <body>
                    <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
                      <%= if @current_user do %>
-                       <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">
+                       <li class="text-[0.8125rem] leading-6 text-zinc-900">
                          <%= @current_user.email %>
                        </li>
                        <li>
                          <.link
                            href={~p"/users/settings"}
-                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                           class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                          >
                            Settings
                          </.link>
@@ -854,7 +854,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                          <.link
                            href={~p"/users/log_out"}
                            method="delete"
-                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                           class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                          >
                            Log out
                          </.link>
@@ -863,7 +863,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                        <li>
                          <.link
                            href={~p"/users/register"}
-                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                           class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                          >
                            Register
                          </.link>
@@ -871,7 +871,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                        <li>
                          <.link
                            href={~p"/users/log_in"}
-                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                           class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                          >
                            Log in
                          </.link>
@@ -919,13 +919,13 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                  <body>\r
                    <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">\r
                      <%= if @current_user do %>\r
-                       <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">\r
+                       <li class="text-[0.8125rem] leading-6 text-zinc-900">\r
                          <%= @current_user.email %>\r
                        </li>\r
                        <li>\r
                          <.link\r
                            href={~p"/users/settings"}\r
-                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                           class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"\r
                          >\r
                            Settings\r
                          </.link>\r
@@ -934,7 +934,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                          <.link\r
                            href={~p"/users/log_out"}\r
                            method="delete"\r
-                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                           class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"\r
                          >\r
                            Log out\r
                          </.link>\r
@@ -943,7 +943,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                        <li>\r
                          <.link\r
                            href={~p"/users/register"}\r
-                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                           class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"\r
                          >\r
                            Register\r
                          </.link>\r
@@ -951,7 +951,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                        <li>\r
                          <.link\r
                            href={~p"/users/log_in"}\r
-                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                           class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"\r
                          >\r
                            Log in\r
                          </.link>\r

--- a/test/mix/tasks/phx.gen.auth/injector_test.exs
+++ b/test/mix/tasks/phx.gen.auth/injector_test.exs
@@ -671,17 +671,38 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                                <%= @current_user.email %>
                              </li>
                              <li>
-                               <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>
+                               <.link
+                                 href={~p"/users/settings"}
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                               >
+                                 Settings
+                               </.link>
                              </li>
                              <li>
-                               <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>
+                               <.link
+                                 href={~p"/users/log_out"}
+                                 method="delete"
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                               >
+                                 Log out
+                               </.link>
                              </li>
                            <% else %>
                              <li>
-                               <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>
+                               <.link
+                                 href={~p"/users/register"}
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                               >
+                                 Register
+                               </.link>
                              </li>
                              <li>
-                               <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>
+                               <.link
+                                 href={~p"/users/log_in"}
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                               >
+                                 Log in
+                               </.link>
                              </li>
                            <% end %>
                          </ul>
@@ -744,17 +765,38 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                                <%= @current_user.email %>\r
                              </li>\r
                              <li>\r
-                               <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>\r
+                               <.link\r
+                                 href={~p"/users/settings"}\r
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                               >\r
+                                 Settings\r
+                               </.link>\r
                              </li>\r
                              <li>\r
-                               <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>\r
+                               <.link\r
+                                 href={~p"/users/log_out"}\r
+                                 method="delete"\r
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                               >\r
+                                 Log out\r
+                               </.link>\r
                              </li>\r
                            <% else %>\r
                              <li>\r
-                               <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>\r
+                               <.link\r
+                                 href={~p"/users/register"}\r
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                               >\r
+                                 Register\r
+                               </.link>\r
                              </li>\r
                              <li>\r
-                               <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>\r
+                               <.link\r
+                                 href={~p"/users/log_in"}\r
+                                 class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                               >\r
+                                 Log in\r
+                               </.link>\r
                              </li>\r
                            <% end %>\r
                          </ul>\r
@@ -801,17 +843,38 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                          <%= @current_user.email %>
                        </li>
                        <li>
-                         <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>
+                         <.link
+                           href={~p"/users/settings"}
+                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                         >
+                           Settings
+                         </.link>
                        </li>
                        <li>
-                         <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>
+                         <.link
+                           href={~p"/users/log_out"}
+                           method="delete"
+                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                         >
+                           Log out
+                         </.link>
                        </li>
                      <% else %>
                        <li>
-                         <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>
+                         <.link
+                           href={~p"/users/register"}
+                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                         >
+                           Register
+                         </.link>
                        </li>
                        <li>
-                         <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>
+                         <.link
+                           href={~p"/users/log_in"}
+                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                         >
+                           Log in
+                         </.link>
                        </li>
                      <% end %>
                    </ul>
@@ -860,17 +923,38 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                          <%= @current_user.email %>\r
                        </li>\r
                        <li>\r
-                         <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>\r
+                         <.link\r
+                           href={~p"/users/settings"}\r
+                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                         >\r
+                           Settings\r
+                         </.link>\r
                        </li>\r
                        <li>\r
-                         <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>\r
+                         <.link\r
+                           href={~p"/users/log_out"}\r
+                           method="delete"\r
+                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                         >\r
+                           Log out\r
+                         </.link>\r
                        </li>\r
                      <% else %>\r
                        <li>\r
-                         <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>\r
+                         <.link\r
+                           href={~p"/users/register"}\r
+                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                         >\r
+                           Register\r
+                         </.link>\r
                        </li>\r
                        <li>\r
-                         <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>\r
+                         <.link\r
+                           href={~p"/users/log_in"}\r
+                           class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"\r
+                         >\r
+                           Log in\r
+                         </.link>\r
                        </li>\r
                      <% end %>\r
                    </ul>\r

--- a/test/mix/tasks/phx.gen.auth/injector_test.exs
+++ b/test/mix/tasks/phx.gen.auth/injector_test.exs
@@ -665,23 +665,23 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                              <li><.link href={Routes.live_dashboard_path(@conn, :home)}>LiveDashboard</.link></li>
                            <% end %>
                          </ul>
-                         <ul>
+                         <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
                            <%= if @current_user do %>
-                             <li>
+                             <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">
                                <%= @current_user.email %>
                              </li>
                              <li>
-                               <.link href={~p"/users/settings"}>Settings</.link>
+                               <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>
                              </li>
                              <li>
-                               <.link href={~p"/users/log_out"} method="delete">Log out</.link>
+                               <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>
                              </li>
                            <% else %>
                              <li>
-                               <.link href={~p"/users/register"}>Register</.link>
+                               <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>
                              </li>
                              <li>
-                               <.link href={~p"/users/log_in"}>Log in</.link>
+                               <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>
                              </li>
                            <% end %>
                          </ul>
@@ -738,23 +738,23 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                              <li><.link href={Routes.live_dashboard_path(@conn, :home)}>LiveDashboard</.link></li>\r
                            <% end %>\r
                          </ul>\r
-                         <ul>\r
+                         <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">\r
                            <%= if @current_user do %>\r
-                             <li>\r
+                             <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">\r
                                <%= @current_user.email %>\r
                              </li>\r
                              <li>\r
-                               <.link href={~p"/users/settings"}>Settings</.link>\r
+                               <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>\r
                              </li>\r
                              <li>\r
-                               <.link href={~p"/users/log_out"} method="delete">Log out</.link>\r
+                               <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>\r
                              </li>\r
                            <% else %>\r
                              <li>\r
-                               <.link href={~p"/users/register"}>Register</.link>\r
+                               <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>\r
                              </li>\r
                              <li>\r
-                               <.link href={~p"/users/log_in"}>Log in</.link>\r
+                               <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>\r
                              </li>\r
                            <% end %>\r
                          </ul>\r
@@ -795,23 +795,23 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                    <title>Demo · Phoenix Framework</title>
                  </head>
                  <body>
-                   <ul>
+                   <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
                      <%= if @current_user do %>
-                       <li>
+                       <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">
                          <%= @current_user.email %>
                        </li>
                        <li>
-                         <.link href={~p"/users/settings"}>Settings</.link>
+                         <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>
                        </li>
                        <li>
-                         <.link href={~p"/users/log_out"} method="delete">Log out</.link>
+                         <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>
                        </li>
                      <% else %>
                        <li>
-                         <.link href={~p"/users/register"}>Register</.link>
+                         <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>
                        </li>
                        <li>
-                         <.link href={~p"/users/log_in"}>Log in</.link>
+                         <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>
                        </li>
                      <% end %>
                    </ul>
@@ -854,23 +854,23 @@ defmodule Mix.Tasks.Phx.Gen.Auth.InjectorTest do
                    <title>Demo · Phoenix Framework</title>\r
                  </head>\r
                  <body>\r
-                   <ul>\r
+                   <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">\r
                      <%= if @current_user do %>\r
-                       <li>\r
+                       <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">\r
                          <%= @current_user.email %>\r
                        </li>\r
                        <li>\r
-                         <.link href={~p"/users/settings"}>Settings</.link>\r
+                         <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>\r
                        </li>\r
                        <li>\r
-                         <.link href={~p"/users/log_out"} method="delete">Log out</.link>\r
+                         <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>\r
                        </li>\r
                      <% else %>\r
                        <li>\r
-                         <.link href={~p"/users/register"}>Register</.link>\r
+                         <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>\r
                        </li>\r
                        <li>\r
-                         <.link href={~p"/users/log_in"}>Log in</.link>\r
+                         <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>\r
                        </li>\r
                      <% end %>\r
                    </ul>\r

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -1358,13 +1358,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
             <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
               <%= if @current_user do %>
-                <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">
+                <li class="text-[0.8125rem] leading-6 text-zinc-900">
                   <%= @current_user.email %>
                 </li>
                 <li>
                   <.link
                     href={~p"/users/settings"}
-                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                   >
                     Settings
                   </.link>
@@ -1373,7 +1373,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                   <.link
                     href={~p"/users/log_out"}
                     method="delete"
-                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                   >
                     Log out
                   </.link>
@@ -1382,7 +1382,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                 <li>
                   <.link
                     href={~p"/users/register"}
-                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                   >
                     Register
                   </.link>
@@ -1390,7 +1390,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                 <li>
                   <.link
                     href={~p"/users/log_in"}
-                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                   >
                     Log in
                   </.link>
@@ -1423,13 +1423,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
             <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
               <%= if @current_user do %>
-                <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">
+                <li class="text-[0.8125rem] leading-6 text-zinc-900">
                   <%= @current_user.email %>
                 </li>
                 <li>
                   <.link
                     href={~p"/users/settings"}
-                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                   >
                     Settings
                   </.link>
@@ -1438,7 +1438,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                   <.link
                     href={~p"/users/log_out"}
                     method="delete"
-                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                   >
                     Log out
                   </.link>
@@ -1447,7 +1447,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                 <li>
                   <.link
                     href={~p"/users/register"}
-                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                   >
                     Register
                   </.link>
@@ -1455,7 +1455,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                 <li>
                   <.link
                     href={~p"/users/log_in"}
-                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 font-semibold hover:text-zinc-700"
                   >
                     Log in
                   </.link>

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -192,16 +192,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~S|<.link href={~p"/users/settings"}>Settings</.link>|
+                 ~r|<.link href={~p"/users/settings"}.*>Settings</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/log_out"} method="delete">Log out</.link>|
+                 ~r|<.link href={~p"/users/log_out"} method="delete".*>Log out</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/register"}>Register</.link>|
+                 ~r|<.link href={~p"/users/register"}.*>Register</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/log_in"}>Log in</.link>|
+                 ~r|<.link href={~p"/users/log_in"}.*>Log in</.link>|
       end)
 
       assert_file("test/support/conn_case.ex", fn file ->
@@ -327,16 +327,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~S|<.link href={~p"/users/settings"}>Settings</.link>|
+                 ~r|<\.link href={~p"/users/settings"}.*>Settings</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/log_out"} method="delete">Log out</.link>|
+                 ~r|<\.link href={~p"/users/log_out"} method="delete".*>Log out</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/register"}>Register</.link>|
+                 ~r|<\.link href={~p"/users/register"}.*>Register</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/log_in"}>Log in</.link>|
+                 ~r|<\.link href={~p"/users/log_in"}.*>Log in</.link>|
       end)
 
       assert_file("test/support/conn_case.ex", fn file ->
@@ -366,16 +366,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~S|<.link href={~p"/users/settings"}>Settings</.link>|
+                 ~r|<.link href={~p"/users/settings"}.*>Settings</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/log_out"} method="delete">Log out</.link>|
+                 ~r|<.link href={~p"/users/log_out"} method="delete".*>Log out</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/register"}>Register</.link>|
+                 ~r|<.link href={~p"/users/register"}.*>Register</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/log_in"}>Log in</.link>|
+                 ~r|<.link href={~p"/users/log_in"}.*>Log in</.link>|
       end)
 
       assert_file("lib/my_app_web/router.ex", fn file ->
@@ -435,16 +435,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~S|<.link href={~p"/users/settings"}>Settings</.link>|
+                 ~r|<.link href={~p"/users/settings"}.*>Settings</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/log_out"} method="delete">Log out</.link>|
+                 ~r|<.link href={~p"/users/log_out"} method="delete".*>Log out</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/register"}>Register</.link>|
+                 ~r|<.link href={~p"/users/register"}.*>Register</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/users/log_in"}>Log in</.link>|
+                 ~r|<.link href={~p"/users/log_in"}.*>Log in</.link>|
       end)
 
       assert_file("lib/my_app_web/router.ex", fn file ->
@@ -528,10 +528,10 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                  ~S(<.simple_form :let={f} for={@conn.params["user"]} as={:user} action={~p"/warehouse/users/confirm"}>)
 
         assert file =~
-                 ~S|<.link href={~p"/warehouse/users/register"}>Register</.link>|
+                 ~r|<\.link href={~p"/warehouse/users/register"}.*>Register</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/warehouse/users/log_in"}>Log in</.link>|
+                 ~r|<\.link href={~p"/warehouse/users/log_in"}.*>Log in</.link>|
       end)
 
       assert_file(
@@ -550,16 +550,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~S|<.link href={~p"/warehouse/users/settings"}>Settings</.link>|
+                 ~r|<\.link href={~p"/warehouse/users/settings"}.*>Settings</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/warehouse/users/log_out"} method="delete">Log out</.link>|
+                 ~r|<\.link href={~p"/warehouse/users/log_out"} method="delete".*>Log out</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/warehouse/users/register"}>Register</.link>|
+                 ~r|<\.link href={~p"/warehouse/users/register"}.*>Register</.link>|
 
         assert file =~
-                 ~S|<.link href={~p"/warehouse/users/log_in"}>Log in</.link>|
+                 ~r|<\.link href={~p"/warehouse/users/log_in"}.*>Log in</.link>|
       end)
 
       assert_file(
@@ -1356,23 +1356,23 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         layout file, please add the following code to it where you'd
         like the user menu items to be rendered.
 
-            <ul>
+            <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
               <%= if @current_user do %>
-                <li>
+                <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">
                   <%= @current_user.email %>
                 </li>
                 <li>
-                  <.link href={~p"/users/settings"}>Settings</.link>
+                  <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>
                 </li>
                 <li>
-                  <.link href={~p"/users/log_out"} method="delete">Log out</.link>
+                  <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>
                 </li>
               <% else %>
                 <li>
-                  <.link href={~p"/users/register"}>Register</.link>
+                  <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>
                 </li>
                 <li>
-                  <.link href={~p"/users/log_in"}>Log in</.link>
+                  <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>
                 </li>
               <% end %>
             </ul>
@@ -1400,23 +1400,23 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
         Add the following user menu items to your lib/my_app_web/components/layouts/root.html.heex layout file:
 
-            <ul>
+            <ul class="flex items-center gap-4 px-4 sm:px-6 lg:px-8 justify-end">
               <%= if @current_user do %>
-                <li>
+                <li class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700">
                   <%= @current_user.email %>
                 </li>
                 <li>
-                  <.link href={~p"/users/settings"}>Settings</.link>
+                  <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>
                 </li>
                 <li>
-                  <.link href={~p"/users/log_out"} method="delete">Log out</.link>
+                  <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>
                 </li>
               <% else %>
                 <li>
-                  <.link href={~p"/users/register"}>Register</.link>
+                  <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>
                 </li>
                 <li>
-                  <.link href={~p"/users/log_in"}>Log in</.link>
+                  <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>
                 </li>
               <% end %>
             </ul>

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -192,16 +192,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~r|<.link href={~p"/users/settings"}.*>Settings</.link>|
+                 ~r|<.link.*href={~p"/users/settings"}.*>|s
 
         assert file =~
-                 ~r|<.link href={~p"/users/log_out"} method="delete".*>Log out</.link>|
+                 ~r|<.link.*href={~p"/users/log_out"}.*method="delete".*>|s
 
         assert file =~
-                 ~r|<.link href={~p"/users/register"}.*>Register</.link>|
+                 ~r|<.link.*href={~p"/users/register"}.*>|s
 
         assert file =~
-                 ~r|<.link href={~p"/users/log_in"}.*>Log in</.link>|
+                 ~r|<.link.*href={~p"/users/log_in"}.*>|s
       end)
 
       assert_file("test/support/conn_case.ex", fn file ->
@@ -327,16 +327,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~r|<\.link href={~p"/users/settings"}.*>Settings</.link>|
+                 ~r|<\.link.*href={~p"/users/settings"}.*>|s
 
         assert file =~
-                 ~r|<\.link href={~p"/users/log_out"} method="delete".*>Log out</.link>|
+                 ~r|<\.link.*href={~p"/users/log_out"}.*method="delete".*>|s
 
         assert file =~
-                 ~r|<\.link href={~p"/users/register"}.*>Register</.link>|
+                 ~r|<\.link.*href={~p"/users/register"}.*>|s
 
         assert file =~
-                 ~r|<\.link href={~p"/users/log_in"}.*>Log in</.link>|
+                 ~r|<\.link.*href={~p"/users/log_in"}.*>|s
       end)
 
       assert_file("test/support/conn_case.ex", fn file ->
@@ -366,16 +366,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~r|<.link href={~p"/users/settings"}.*>Settings</.link>|
+                 ~r|<.link.*href={~p"/users/settings"}.*>|s
 
         assert file =~
-                 ~r|<.link href={~p"/users/log_out"} method="delete".*>Log out</.link>|
+                 ~r|<.link.*href={~p"/users/log_out"}.*method="delete".*>|s
 
         assert file =~
-                 ~r|<.link href={~p"/users/register"}.*>Register</.link>|
+                 ~r|<.link.*href={~p"/users/register"}.*>|s
 
         assert file =~
-                 ~r|<.link href={~p"/users/log_in"}.*>Log in</.link>|
+                 ~r|<.link.*href={~p"/users/log_in"}.*>|s
       end)
 
       assert_file("lib/my_app_web/router.ex", fn file ->
@@ -435,16 +435,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~r|<.link href={~p"/users/settings"}.*>Settings</.link>|
+                 ~r|<.link.*href={~p"/users/settings"}.*>|s
 
         assert file =~
-                 ~r|<.link href={~p"/users/log_out"} method="delete".*>Log out</.link>|
+                 ~r|<.link.*href={~p"/users/log_out"}.*method="delete".*>|s
 
         assert file =~
-                 ~r|<.link href={~p"/users/register"}.*>Register</.link>|
+                 ~r|<.link.*href={~p"/users/register"}.*>|s
 
         assert file =~
-                 ~r|<.link href={~p"/users/log_in"}.*>Log in</.link>|
+                 ~r|<.link.*href={~p"/users/log_in"}.*>|s
       end)
 
       assert_file("lib/my_app_web/router.ex", fn file ->
@@ -528,10 +528,10 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                  ~S(<.simple_form :let={f} for={@conn.params["user"]} as={:user} action={~p"/warehouse/users/confirm"}>)
 
         assert file =~
-                 ~r|<\.link href={~p"/warehouse/users/register"}.*>Register</.link>|
+                 ~r|<\.link.*href={~p"/warehouse/users/register"}.*>|s
 
         assert file =~
-                 ~r|<\.link href={~p"/warehouse/users/log_in"}.*>Log in</.link>|
+                 ~r|<\.link.*href={~p"/warehouse/users/log_in"}.*>|s
       end)
 
       assert_file(
@@ -550,16 +550,16 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
       assert_file("lib/my_app_web/components/layouts/root.html.heex", fn file ->
         assert file =~
-                 ~r|<\.link href={~p"/warehouse/users/settings"}.*>Settings</.link>|
+                 ~r|<\.link.*href={~p"/warehouse/users/settings"}.*>|s
 
         assert file =~
-                 ~r|<\.link href={~p"/warehouse/users/log_out"} method="delete".*>Log out</.link>|
+                 ~r|<\.link.*href={~p"/warehouse/users/log_out"}.*method="delete".*>|s
 
         assert file =~
-                 ~r|<\.link href={~p"/warehouse/users/register"}.*>Register</.link>|
+                 ~r|<\.link.*href={~p"/warehouse/users/register"}.*>|s
 
         assert file =~
-                 ~r|<\.link href={~p"/warehouse/users/log_in"}.*>Log in</.link>|
+                 ~r|<\.link.*href={~p"/warehouse/users/log_in"}.*>|s
       end)
 
       assert_file(
@@ -1362,17 +1362,38 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                   <%= @current_user.email %>
                 </li>
                 <li>
-                  <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>
+                  <.link
+                    href={~p"/users/settings"}
+                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                  >
+                    Settings
+                  </.link>
                 </li>
                 <li>
-                  <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>
+                  <.link
+                    href={~p"/users/log_out"}
+                    method="delete"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                  >
+                    Log out
+                  </.link>
                 </li>
               <% else %>
                 <li>
-                  <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>
+                  <.link
+                    href={~p"/users/register"}
+                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                  >
+                    Register
+                  </.link>
                 </li>
                 <li>
-                  <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>
+                  <.link
+                    href={~p"/users/log_in"}
+                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                  >
+                    Log in
+                  </.link>
                 </li>
               <% end %>
             </ul>
@@ -1406,17 +1427,38 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                   <%= @current_user.email %>
                 </li>
                 <li>
-                  <.link href={~p"/users/settings"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Settings</.link>
+                  <.link
+                    href={~p"/users/settings"}
+                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                  >
+                    Settings
+                  </.link>
                 </li>
                 <li>
-                  <.link href={~p"/users/log_out"} method="delete" class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log out</.link>
+                  <.link
+                    href={~p"/users/log_out"}
+                    method="delete"
+                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                  >
+                    Log out
+                  </.link>
                 </li>
               <% else %>
                 <li>
-                  <.link href={~p"/users/register"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Register</.link>
+                  <.link
+                    href={~p"/users/register"}
+                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                  >
+                    Register
+                  </.link>
                 </li>
                 <li>
-                  <.link href={~p"/users/log_in"} class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700">Log in</.link>
+                  <.link
+                    href={~p"/users/log_in"}
+                    class="text-[0.8125rem] leading-6 text-zinc-900 hover:text-zinc-700 font-semibold hover:text-zinc-700"
+                  >
+                    Log in
+                  </.link>
                 </li>
               <% end %>
             </ul>


### PR DESCRIPTION
Hi all,
Pulled the 1.7rc, and noticed that the `gen.auth` templates aren't stylistically aligned with the awesome work that the tailwind devs applied to the rest of the `phx.new` templates. There are a handful of additional updates I would make, but I wanted to keep the PRs small, so this one just updates the auth-related link styles so that they're identical to the link styles from `phx.new`.

## Before
<img width="1512" alt="before_styling_updates" src="https://user-images.githubusercontent.com/4386645/200632837-9b36a020-0e8d-47d9-92a5-da789e3c38d5.png">

## After

<img width="1512" alt="after_styling_updates" src="https://user-images.githubusercontent.com/4386645/200633090-b54802b5-6f1f-447b-a956-23a7e78b3687.png">

## Possible Additional Update

I _think_ it would make sense to replace the `@phoenixframework`, `GitHub` and `Getting Started` links if a user has already taken the step to generate authentication, as that implies that the developer already has a level of fluency in the elixir/phoenix ecosystem. Then these registration links would sit in their place, inline with the phoenix logo, but that change feels like a bigger discussion and might be non-trivial given the existing structure of the generators and templates. 

