### PR TITLE
Fix extra whitespace in textarea in core_components

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -329,9 +329,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
           "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400 phx-no-feedback:focus:ring-zinc-800/5"
         ]}
         {@rest}
-      >
-
-    <%%= @value %></textarea>
+      ><%%= @value %></textarea>
       <.error :for={msg <- @errors}><%%= msg %></.error>
     </div>
     """

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -329,9 +329,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
           "phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400 phx-no-feedback:focus:ring-zinc-800/5"
         ]}
         {@rest}
-      >
-
-    <%%= @value %></textarea>
+      ><%%= @value %></textarea>
       <.error :for={msg <- @errors}><%%= msg %></.error>
     </div>
     """


### PR DESCRIPTION
The _textarea_ input type in `core_components.ex` adds a new line before the field value which also causes that a blank to be saved when submitting the form.

This error occurs on Chrome and Safari.