### PR TITLE
Add a call to `humanize` for input form generation for consistency

### DIFF
--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -231,7 +231,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
     end)
   end
 
-  defp label(key), do: to_string(key)
+  defp label(key), do: Phoenix.Naming.humanize(to_string(key))
 
   @doc false
   def indent_inputs(inputs, column_padding) do

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -158,7 +158,7 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
         assert_file("lib/phoenix_web/controllers/post_html/#{filename}", fn file ->
           assert file =~ ~s(<.input field={{f, :title}} type="text")
           assert file =~ ~s(<.input field={{f, :votes}} type="number")
-          assert file =~ ~s(<.input field={{f, :cost}} type="number" label="cost" step="any")
+          assert file =~ ~s(<.input field={{f, :cost}} type="number" label="Cost" step="any")
           assert file =~ """
             <.input
               field={{f, :tags}}
@@ -171,7 +171,7 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
           assert file =~ ~s(<.input field={{f, :deleted_at}} type="datetime-local")
           assert file =~ ~s(<.input field={{f, :announcement_date}} type="date")
           assert file =~ ~s(<.input field={{f, :alarm}} type="time")
-          assert file =~ ~s(<.input field={{f, :secret}} type="text" label="secret" />)
+          assert file =~ ~s(<.input field={{f, :secret}} type="text" label="Secret" />)
           assert file =~ """
             <.input
               field={{f, :status}}

--- a/test/mix/tasks/phx.gen.live_test.exs
+++ b/test/mix/tasks/phx.gen.live_test.exs
@@ -102,7 +102,7 @@ defmodule Mix.Tasks.Phx.Gen.LiveTest do
         assert file =~ ~s(<.simple_form\n        :let={f}\n        for={@changeset}\n)
         assert file =~ ~s(<.input field={{f, :title}} type="text")
         assert file =~ ~s(<.input field={{f, :votes}} type="number")
-        assert file =~ ~s(<.input field={{f, :cost}} type="number" label="cost" step="any")
+        assert file =~ ~s(<.input field={{f, :cost}} type="number" label="Cost" step="any")
         assert file =~ """
                 <.input
                   field={{f, :tags}}
@@ -115,7 +115,7 @@ defmodule Mix.Tasks.Phx.Gen.LiveTest do
         assert file =~ ~s(<.input field={{f, :deleted_at}} type="datetime-local")
         assert file =~ ~s(<.input field={{f, :announcement_date}} type="date")
         assert file =~ ~s(<.input field={{f, :alarm}} type="time")
-        assert file =~ ~s(<.input field={{f, :secret}} type="text" label="secret" />)
+        assert file =~ ~s(<.input field={{f, :secret}} type="text" label="Secret" />)
         assert file =~ """
                 <.input
                   field={{f, :status}}


### PR DESCRIPTION
The template generation for tables in `phx.gen.html/index.html.heex` uses a call to `Phoenix.Naming.humanize` to generate its labels while the generator for input forms only calls `to_string`.

This modifies the `label` function to call humanize as well for consistency.

## Before:
![Listing Page](https://user-images.githubusercontent.com/454563/200998187-9de56487-3ca7-4d7d-9503-35c6ee74b490.png)
![generated form](https://user-images.githubusercontent.com/454563/200998193-a70033a5-bf5f-4e56-843e-f3036c52703f.png)

## After:
![image](https://user-images.githubusercontent.com/454563/200998341-9c5fa7e1-bfe7-4427-85bb-7c92d65f9c75.png)
