### PR TITLE
Remove blank favicon.ico

### DIFF
--- a/installer/templates/phx_single/lib/app_name_web.ex
+++ b/installer/templates/phx_single/lib/app_name_web.ex
@@ -17,7 +17,7 @@ defmodule <%= @web_namespace %> do
   and import those modules here.
   """
 
-  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+  def static_paths, do: ~w(assets fonts images robots.txt)
 
   def controller do
     quote do

--- a/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name.ex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name.ex
@@ -17,7 +17,7 @@ defmodule <%= @web_namespace %> do
   and import those modules here.
   """
 
-  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+  def static_paths, do: ~w(assets fonts images robots.txt)
 
   def controller do
     quote do

--- a/installer/templates/phx_web/templates/layout/root.html.heex
+++ b/installer/templates/phx_web/templates/layout/root.html.heex
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="csrf-token" content={get_csrf_token()}>
     <.live_title suffix=" · Phoenix Framework"><%%= assigns[:page_title] || "<%= @app_module %>" %></.live_title>
+    <link rel="icon" href="data:,">
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"}/>
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}></script>
   </head>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Phx.NewTest do
   end
 
   test "assets are in sync with priv" do
-    for file <- ~w(favicon.ico phoenix.png) do
+    for file <- ~w(phoenix.png) do
       assert File.read!("../priv/static/#{file}") ==
         File.read!("templates/phx_static/#{file}")
     end
@@ -272,7 +272,6 @@ defmodule Mix.Tasks.Phx.NewTest do
       # No assets & No HTML
       refute_file "phx_blog/priv/static/assets/app.css"
       refute_file "phx_blog/priv/static/assets/phoenix.css"
-      refute_file "phx_blog/priv/static/favicon.ico"
       refute_file "phx_blog/priv/static/images/phoenix.png"
       refute_file "phx_blog/priv/static/assets/app.js"
 
@@ -458,7 +457,6 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file "phx_blog/priv/static/assets/app.css"
       assert_file "phx_blog/priv/static/assets/phoenix.css"
       assert_file "phx_blog/priv/static/assets/app.js"
-      assert_file "phx_blog/priv/static/favicon.ico"
       assert_file "phx_blog/priv/static/images/phoenix.png"
 
       assert_file "phx_blog/config/config.exs", fn file ->

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -185,7 +185,6 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file web_path(@app, "assets/css/app.css")
       assert_file web_path(@app, "assets/css/phoenix.css")
 
-      assert_file web_path(@app, "priv/static/favicon.ico")
       assert_file web_path(@app, "priv/static/images/phoenix.png")
 
       refute File.exists?(web_path(@app, "priv/static/assets/app.css"))
@@ -325,7 +324,6 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       refute_file web_path(@app, "priv/static/assets/app.js")
       refute_file web_path(@app, "priv/static/assets/app.css")
       refute_file web_path(@app, "priv/static/assets/phoenix.css")
-      refute_file web_path(@app, "priv/static/favicon.ico")
       refute_file web_path(@app, "priv/static/images/phoenix.png")
 
       # No Ecto
@@ -481,7 +479,6 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file web_path(@app, "priv/static/assets/app.js")
       assert_file web_path(@app, "priv/static/assets/app.css")
       assert_file web_path(@app, "priv/static/assets/phoenix.css")
-      assert_file web_path(@app, "priv/static/favicon.ico")
       assert_file web_path(@app, "priv/static/images/phoenix.png")
     end
   end
@@ -745,7 +742,6 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
         # assets
         assert_file "another/.gitignore", ~r/\n$/
-        assert_file "another/priv/static/favicon.ico"
         assert_file "another/priv/static/images/phoenix.png"
         assert_file "another/assets/css/app.css"
         assert_file "another/assets/css/phoenix.css"


### PR DESCRIPTION
We all agree, favicon is something app specific. But...

The blank favicon.ico was added to avoid Browsers requesting non existing favicon.ico file. Mainly to avoid error logs.
But the blank favicon.ico is still downloaded (without any benefit). And it makes the favicon space in Browser tabs blank.
The blank space doesn't look good and even during dev time it makes the tab harder to distinguish within the browser tab bar.

This variant doesn't download any favicon and uses a Browser default.

Before:
![grafik](https://user-images.githubusercontent.com/6823352/201353738-82974ef8-a2d5-4994-98bd-ac2563e7f61d.png)
![grafik](https://user-images.githubusercontent.com/6823352/201354040-e6a82d61-abe9-4087-9324-5bc520eb5491.png)


After:
![grafik](https://user-images.githubusercontent.com/6823352/201353888-53141cf7-8452-4467-956d-e0489262ddaf.png)
![grafik](https://user-images.githubusercontent.com/6823352/201354251-bec76dd8-a101-41ab-8a53-fb80253efb6a.png)
