### PR TITLE
Disable ability to scroll background while in modal

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -568,6 +568,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       transition: {"transition-all transform ease-out duration-300", "opacity-0", "opacity-100"}
     )
     |> show("##{id}-container")
+    |> JS.add_class("overflow-hidden", to: "body")
     |> JS.focus_first(to: "##{id}-content")
   end
 
@@ -579,6 +580,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     )
     |> hide("##{id}-container")
     |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
+    |> JS.remove_class("overflow-hidden", to: "body")
     |> JS.pop_focus()
   end
 

--- a/installer/templates/phx_web/components/layouts/root.html.heex
+++ b/installer/templates/phx_web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="[scrollbar-gutter:stable]">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -568,6 +568,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       transition: {"transition-all transform ease-out duration-300", "opacity-0", "opacity-100"}
     )
     |> show("##{id}-container")
+    |> JS.add_class("overflow-hidden", to: "body")
     |> JS.focus_first(to: "##{id}-content")
   end
 
@@ -579,6 +580,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     )
     |> hide("##{id}-container")
     |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
+    |> JS.remove_class("overflow-hidden", to: "body")
     |> JS.pop_focus()
   end
 


### PR DESCRIPTION
## Problem
Currently while the modal is open a user can still scroll the primary page in the background. 
This is usually unexpected and also leads to two scrollbars being rendered by Chrome.
![image](https://user-images.githubusercontent.com/454563/201444920-b86fdfd6-aa7f-49ba-a295-70f9f158cb2d.png)

## Solution
In order to prevent the user from scrolling the background, one common practice is to set the `body` element to `overflow: hidden` while the modal is open.  

One issue with this method is that it causes the sidebar to disappear, triggering a layout shift of the pages content.

Per [CanIUse](https://caniuse.com/mdn-css_properties_scrollbar-gutter), all browsers (aside from Safari which uses floating scrollbars which do not take up space) have implemented support for `scrollbar-gutter` so we can use `scrollbar-gutter: stable` to prevent the shift.

## Issues
`scrollbar-gutter` works perfectly well in all browsers tested, aside from a [known issue in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1318404#c4) which prevents the scrollbar for the modal from rendering. The temporary hidden gutter is drawn above any `fixed` position element, causing the modals scrollbar to be hidden.

The `scrollbar-gutter` portion could be removed, keeping the layout shift from the sidebar disappearing but resolving the background scrolling/double scrollbar issue.

## Alternatives
The HTML5 [Dialog Element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) allows modals to be shown with a `showModal` command. Per [CanIUse](https://caniuse.com/mdn-api_htmldialogelement_showmodal) this has support in all browsers aside from IE11. It performs proper focus trapping, backdrop colors, prevents scrolling of backgrounds etc.