### PR TITLE
Fix live_reload config tests

### DIFF
--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -149,8 +149,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file("phx_blog/config/dev.exs", fn file ->
         assert file =~ "esbuild: {Esbuild,"
-        assert file =~ "lib/phx_blog_web/(live|views)/.*(ex)"
-        assert file =~ "lib/phx_blog_web/templates/.*(eex)"
+        assert file =~ "lib/phx_blog_web/(controllers|live|components)/.*(ex|heex)"
       end)
 
       assert_file("phx_blog/assets/css/app.css")

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -71,8 +71,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file(root_path(@app, "config/dev.exs"), fn file ->
         assert file =~ ~r[esbuild: {Esbuild]
-        assert file =~ "lib/#{@app}_web/(live|views)/.*(ex)"
-        assert file =~ "lib/#{@app}_web/templates/.*(eex)"
+        assert file =~ "lib/#{@app}_web/(controllers|live|components)/.*(ex|heex)"
         assert file =~ "config :#{@app}_web, dev_routes: true"
       end)
 


### PR DESCRIPTION
This fixes the following test failures we've been seeing on master

```
   1) test new with umbrella and defaults (Mix.Tasks.Phx.New.UmbrellaTest)
Error:      test/phx_new_umbrella_test.exs:32
     Assertion with =~ failed
     code:  assert file =~ "lib/#{@app}_web/(live|views)/.*(ex)"

  2) test new with defaults (Mix.Tasks.Phx.NewTest)
Error:      test/phx_new_test.exs:34
     Assertion with =~ failed
     code:  assert file =~ "lib/phx_blog_web/(live|views)/.*(ex)"
```

It appears this was changed in #5082 and we forgot to update the tests.