### PR TITLE
use :error atom instead of "error.json"

### DIFF
--- a/priv/templates/phx.gen.json/fallback_controller.ex
+++ b/priv/templates/phx.gen.json/fallback_controller.ex
@@ -11,7 +11,7 @@ defmodule <%= inspect context.web_module %>.FallbackController do
     conn
     |> put_status(:unprocessable_entity)
     |> put_view(json: <%= inspect context.web_module %>.ChangesetJSON)
-    |> render("error.json", changeset: changeset)
+    |> render(:error, changeset: changeset)
   end
 
   <% end %># This clause is an example of how to handle resources that cannot be found.


### PR DESCRIPTION
# Summary

Generated fallback controller uses `render("error.json",...`, but my interpretation of v1.7.0+ is that the new convention is to use an atom instead.

i.e:

```
# pre 1.7.0 convention
|> render("error.json", changeset: changeset)

# new convention
|> render(:error, changeset: changeset)
```

# Test

1. Generate a new project using this branch.

Instructions on how to use `mix phx.new ...` with a local version [are in the README](https://github.com/phoenixframework/phoenix#generating-a-phoenix-project-from-unreleased-versions)

2. Generate a json resource. Example: `mix phx.gen.json Accounts User users name:string` [generator docs](https://hexdocs.pm/phoenix/1.7.0-rc.0/Mix.Tasks.Phx.Gen.Json.html)

3. In order to trigger an error, add an Echo Changeset constraint to schema. 

```
  def changeset(user, attrs) do
    user
    |> cast(attrs, [:name])
    |> validate_required([:name])
    |> validate_length(:name, min: 50)
  end
```

4. Run controller test (should have been automatically generated), and observe that changeset errors are still returned correctly:

```
 mix test test/my_app_web/controllers/user_controller_test.exs

...
 test/my_app_web/controllers/user_controller_test.exs:28
   ** (RuntimeError) expected response with status 201, got: 422, with body:
     "{\"errors\":{\"name\":[\"should be at least 50 character(s)\"]}}"

```





