### PR TITLE
Add missing `id` attribute for modal subtitle

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -82,7 +82,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
                   <h1 id={"#{@id}-title"} class="text-lg font-semibold leading-8 text-zinc-800">
                     <%%= render_slot(@title) %>
                   </h1>
-                  <p :if={@subtitle != []} class="mt-2 text-sm leading-6 text-zinc-600">
+                  <p :if={@subtitle != []} id={"#{@id}-description"} class="mt-2 text-sm leading-6 text-zinc-600">
                     <%%= render_slot(@subtitle) %>
                   </p>
                 </header>


### PR DESCRIPTION
The `aria-describedby={"#{@id}-description"}` is present in the modal tag but the `id={"#{@id}-description"}` attribute is missing in the subtitle tag. This PR fixed this issue.
