### PR TITLE
Add empty value to select input prompt option

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -307,7 +307,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
         multiple={@multiple}
         {@rest}
       >
-        <option :if={@prompt}><%%= @prompt %></option>
+        <option :if={@prompt} value=""><%%= @prompt %></option>
         <%%= Phoenix.HTML.Form.options_for_select(@options, @value) %>
       </select>
       <.error :for={msg <- @errors}><%%= msg %></.error>

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -307,7 +307,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
         multiple={@multiple}
         {@rest}
       >
-        <option :if={@prompt}><%%= @prompt %></option>
+        <option :if={@prompt} value=""><%%= @prompt %></option>
         <%%= Phoenix.HTML.Form.options_for_select(@options, @value) %>
       </select>
       <.error :for={msg <- @errors}><%%= msg %></.error>


### PR DESCRIPTION
Without this the input sends the prompt text which is not desirable.
The current behaviour won't trigger an empty validation.