### PR TITLE
Fix inconsistency in controllers guide

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -263,7 +263,7 @@ defmodule HelloWeb.Router do
   use HelloWeb, :router
 
   pipeline :browser do
-    plug :accepts, ["html", "text"]
+    plug :accepts, ["html", "json"]
     plug :fetch_session
     plug :fetch_live_flash
     plug :put_root_layout, {HelloWeb.LayoutView, :root}
@@ -273,7 +273,7 @@ defmodule HelloWeb.Router do
 ...
 ```
 
-If we go to [`http://localhost:4000/?_format=text`](http://localhost:4000/?_format=text), we will see %{"message": "this is some JSON"}.
+If we go to [`http://localhost:4000/?_format=json`](http://localhost:4000/?_format=json), we will see `%{"message": "this is some JSON"}`.
 
 ### Sending responses directly
 


### PR DESCRIPTION
The `Overriding rendering formats` section of the controllers guide talks about accepting `json`, but the example code was using `text.

This updates the example code to also use `json`. It also wraps the output with backticks to make it more clear that it's a literal response.