### PR TITLE
Add reference to Components guide

### DIFF
--- a/guides/request_lifecycle.md
+++ b/guides/request_lifecycle.md
@@ -135,7 +135,8 @@ defmodule HelloWeb.HelloHTML do
 end
 ```
 
-You can read more about function components and `~H` heex templates in the `Phoenix.Component` documentation.
+You can read more about function components and `~H` heex templates in the
+[Components and HEEx Templates guide](components.html).
 
 Now lets define a template in its own file. First delete our `def index(assigns)` function from above and replace it with an `embed_templates` declaration:
 


### PR DESCRIPTION
In the `A new view` section of the `Request life-cycle`, the reader was being taken directly to the `Phoenix.Component` API documentation.

However, there is now a separate guide for components and HEEx templates (which then links to the API docs).

This links the reader to the components guide instead of the API documentation.