### PR TITLE
Fix dead reference to old Views guide

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -159,7 +159,7 @@ Or you can pass the assigns directly to `render` instead:
 
 Generally speaking, once all assigns are configured, we invoke the view layer. The view layer then renders `show.html` alongside the layout and a response is sent back to the browser.
 
-[Views, Components, and templates](views.html) have their own guide, so we won't spend much time on them here. What we will look at is how to assign a different layout, or none at all, from inside a controller action.
+[Components and templates](components.html) have their own guide, so we won't spend much time on them here. What we will look at is how to assign a different layout, or none at all, from inside a controller action.
 
 ### Assigning layouts
 


### PR DESCRIPTION
The Controllers guide was still referencing the Views guide, which no longer exists.

It appears to have been renamed to `components.md` (and significantly updated) in cd049a3325313280530315af9014fcc359d940f4, so this updates the reference accordingly.