### PR TITLE
Add telemetry events to Controller.render_with_layouts/4

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -880,13 +880,25 @@ defmodule Phoenix.Controller do
     case root_layout(conn, format) do
       {layout_mod, layout_tpl} ->
         {layout_base, _} = split_template(layout_tpl)
-        inner = Phoenix.Template.render(view, template, format, render_assigns)
+        inner = template_render(view, template, format, render_assigns)
         root_assigns = render_assigns |> Map.put(:inner_content, inner) |> Map.delete(:layout)
-        Phoenix.Template.render_to_iodata(layout_mod, layout_base, format, root_assigns)
+        template_render_to_iodata(layout_mod, layout_base, format, root_assigns)
 
       false ->
-        Phoenix.Template.render_to_iodata(view, template, format, render_assigns)
+        template_render_to_iodata(view, template, format, render_assigns)
     end
+  end
+
+  defp template_render(view, template, format, assigns) do
+    :telemetry.span([:phoenix_template, :render], %{view: view, template: template, format: format}, fn() ->
+      {Phoenix.Template.render(view, template, format, assigns), %{}}
+    end)
+  end
+
+  defp template_render_to_iodata(view, template, format, assigns) do
+    :telemetry.span([:phoenix_template, :render], %{view: view, template: template, format: format}, fn() ->
+      {Phoenix.Template.render_to_iodata(view, template, format, assigns), %{}}
+    end)
   end
 
   defp prepare_assigns(conn, assigns, template, format) do

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -890,14 +890,18 @@ defmodule Phoenix.Controller do
   end
 
   defp template_render(view, template, format, assigns) do
-    :telemetry.span([:phoenix_template, :render], %{view: view, template: template, format: format}, fn() ->
-      {Phoenix.Template.render(view, template, format, assigns), %{}}
+    metadata = %{view: view, template: template, format: format}
+
+    :telemetry.span([:phoenix, :controller, :render], metadata, fn ->
+      {Phoenix.Template.render(view, template, format, assigns), metadata}
     end)
   end
 
   defp template_render_to_iodata(view, template, format, assigns) do
-    :telemetry.span([:phoenix_template, :render], %{view: view, template: template, format: format}, fn() ->
-      {Phoenix.Template.render_to_iodata(view, template, format, assigns), %{}}
+    metadata = %{view: view, template: template, format: format}
+
+    :telemetry.span([:phoenix, :controller, :render], metadata, fn ->
+      {Phoenix.Template.render_to_iodata(view, template, format, assigns), metadata}
     end)
   end
 

--- a/test/phoenix/controller/render_test.exs
+++ b/test/phoenix/controller/render_test.exs
@@ -162,4 +162,67 @@ defmodule Phoenix.Controller.RenderTest do
       render(conn() |> put_view(nil), "index.html")
     end
   end
+
+  describe "telemetry" do
+    @render_start_event [:phoenix, :controller, :render, :start]
+    @render_stop_event [:phoenix, :controller, :render, :stop]
+    @render_exception_event [:phoenix, :controller, :render, :exception]
+
+    @render_events [
+      @render_start_event,
+      @render_stop_event,
+      @render_exception_event
+    ]
+
+    setup context do
+      test_pid = self()
+      test_name = context.test
+
+      :telemetry.attach_many(
+        test_name,
+        @render_events,
+        fn event, measures, metadata, config ->
+          send(test_pid, {:telemetry_event, event, {measures, metadata, config}})
+        end,
+        nil
+      )
+    end
+
+    test "phoenix.controller.render.start and .stop are emitted on success" do
+      render(conn(), "index.html", title: "Hello")
+
+      assert_received {:telemetry_event, [:phoenix, :controller, :render, :start],
+                       {_, %{format: "html", template: "index", view: MyApp.UserView}, _}}
+
+      assert_received {:telemetry_event, [:phoenix, :controller, :render, :stop],
+                       {_, %{format: "html", template: "index", view: MyApp.UserView}, _}}
+
+      refute_received {:telemetry_event, [:phoenix, :controller, :render, :exception], _}
+    end
+
+    test "phoenix.controller.render.exception is emitted on failure" do
+      :ok =
+        try do
+          render(conn(), "index.html")
+        rescue
+          ArgumentError ->
+            :ok
+        end
+
+      assert_received {:telemetry_event, [:phoenix, :controller, :render, :start],
+                       {_, %{format: "html", template: "index", view: MyApp.UserView}, _}}
+
+      refute_received {:telemetry_event, [:phoenix, :controller, :render, :stop], _}
+
+      assert_received {:telemetry_event, [:phoenix, :controller, :render, :exception],
+                       {_,
+                        %{
+                          format: "html",
+                          template: "index",
+                          view: MyApp.UserView,
+                          kind: error,
+                          reason: %ArgumentError{}
+                        }, _}}
+    end
+  end
 end

--- a/test/phoenix/controller/render_test.exs
+++ b/test/phoenix/controller/render_test.exs
@@ -220,7 +220,7 @@ defmodule Phoenix.Controller.RenderTest do
                           format: "html",
                           template: "index",
                           view: MyApp.UserView,
-                          kind: error,
+                          kind: :error,
                           reason: %ArgumentError{}
                         }, _}}
     end


### PR DESCRIPTION
https://github.com/phoenixframework/phoenix_template/pull/4, but moved to the controller, by @josevalim’s request.

> In the current version of [AppSignal’s Phoenix integration](https://github.com/appsignal/appsignal-elixir-phoenix), we use [an extension called `Appsignal.Phoenix.View`](https://github.com/appsignal/appsignal-elixir-phoenix/blob/main/lib/appsignal_phoenix/view.ex) wich is [`use`d in Phoenix applications’ web module files](https://docs.appsignal.com/elixir/integrations/phoenix.html#template-rendering). Since Phoenix 1.7 uses phoenix_template directly, there’s no way for us to hook in anymore.
> 
> With an eye on the future, I’d like to propose adding :telemetry events to ~phoenix_template’s render~ the `Controller.render_with_layouts/4` function. That way, we can restore our functionality in AppSignal, and other APMs, as well as OpenTelemetry can subscribe to render events instead of solutions like extending Phoenix.View.
> 
> I’m interested in hearing what you think of this proof of concept. I’ve added the metadata we’ll need (the view module, template name and format), but I’m of course open to adding more.