### PR TITLE
Add password inputs to password reset edit form

### DIFF
--- a/priv/templates/phx.gen.auth/reset_password_controller_test.exs
+++ b/priv/templates/phx.gen.auth/reset_password_controller_test.exs
@@ -60,7 +60,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
     test "renders reset password", %{conn: conn, token: token} do
       conn = get(conn, ~p"<%= schema.route_prefix %>/reset_password/#{token}")
-      assert html_response(conn, 200) =~ "Send password reset instructions"
+      assert html_response(conn, 200) =~ "Reset password"
     end
 
     test "does not render reset password with invalid token", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/reset_password_edit.html.heex
+++ b/priv/templates/phx.gen.auth/reset_password_edit.html.heex
@@ -1,19 +1,21 @@
 <div class="mx-auto max-w-sm">
   <.header class="text-center">
-    Forgot your password?
-    <:subtitle>We'll send a password reset link to your inbox</:subtitle>
+    Password Reset
+    <:subtitle>Use the form below to reset your password</:subtitle>
   </.header>
 
-  <.simple_form :let={f} for={@changeset} action={~p"<%= schema.route_prefix %>/reset_password/#{@token}"}>
+  <.simple_form :let={f} for={@changeset} action={~p"<%= schema.route_prefix %>/reset_password/#{@token}"} method="put" >
     <.error :if={@changeset.action}>
       Oops, something went wrong! Please check the errors below.
     </.error>
 
-    <.input field={{f, :email}} type="email" placeholder="Email" required />
+    <.input field={{f, :password}} type="password" placeholder="Password" required />
+    <.input field={{f, :password_confirmation}} type="password" placeholder="Password Confirmation" required />
     <:actions>
-      <.button phx-disable-with="Sending..." class="w-full">
-        Send password reset instructions
+      <.button phx-disable-with="Resetting..." class="w-full">
+        Reset password
       </.button>
     </:actions>
   </.simple_form>
 </div>
+

--- a/priv/templates/phx.gen.auth/reset_password_edit.html.heex
+++ b/priv/templates/phx.gen.auth/reset_password_edit.html.heex
@@ -1,7 +1,6 @@
 <div class="mx-auto max-w-sm">
   <.header class="text-center">
-    Password Reset
-    <:subtitle>Use the form below to reset your password</:subtitle>
+    Reset Password
   </.header>
 
   <.simple_form :let={f} for={@changeset} action={~p"<%= schema.route_prefix %>/reset_password/#{@token}"}>
@@ -9,8 +8,8 @@
       Oops, something went wrong! Please check the errors below.
     </.error>
 
-    <.input field={{f, :password}} type="password" placeholder="Password" required />
-    <.input field={{f, :password_confirmation}} type="password" placeholder="Password Confirmation" required />
+    <.input field={{f, :password}} type="password" label="New Password" required />
+    <.input field={{f, :password_confirmation}} type="password" label="Confirm new password" required />
     <:actions>
       <.button phx-disable-with="Resetting..." class="w-full">
         Reset password

--- a/priv/templates/phx.gen.auth/reset_password_edit.html.heex
+++ b/priv/templates/phx.gen.auth/reset_password_edit.html.heex
@@ -4,7 +4,7 @@
     <:subtitle>Use the form below to reset your password</:subtitle>
   </.header>
 
-  <.simple_form :let={f} for={@changeset} action={~p"<%= schema.route_prefix %>/reset_password/#{@token}"} method="put" >
+  <.simple_form :let={f} for={@changeset} action={~p"<%= schema.route_prefix %>/reset_password/#{@token}"} method="put">
     <.error :if={@changeset.action}>
       Oops, something went wrong! Please check the errors below.
     </.error>

--- a/priv/templates/phx.gen.auth/reset_password_edit.html.heex
+++ b/priv/templates/phx.gen.auth/reset_password_edit.html.heex
@@ -4,7 +4,7 @@
     <:subtitle>Use the form below to reset your password</:subtitle>
   </.header>
 
-  <.simple_form :let={f} for={@changeset} action={~p"<%= schema.route_prefix %>/reset_password/#{@token}"} method="put">
+  <.simple_form :let={f} for={@changeset} action={~p"<%= schema.route_prefix %>/reset_password/#{@token}"}>
     <.error :if={@changeset.action}>
       Oops, something went wrong! Please check the errors below.
     </.error>

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -591,7 +591,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         "lib/my_app_web/controllers/warehouse/user_reset_password_html/edit.html.heex",
         fn file ->
           assert file =~
-                   ~S|<.simple_form :let={f} for={@changeset} action={~p"/warehouse/users/reset_password/#{@token}"} method="put">|
+                   ~S|<.simple_form :let={f} for={@changeset} action={~p"/warehouse/users/reset_password/#{@token}"}>|
         end
       )
 

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -591,7 +591,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         "lib/my_app_web/controllers/warehouse/user_reset_password_html/edit.html.heex",
         fn file ->
           assert file =~
-                   ~S|<.simple_form :let={f} for={@changeset} action={~p"/warehouse/users/reset_password/#{@token}"}>|
+                   ~S|<.simple_form :let={f} for={@changeset} action={~p"/warehouse/users/reset_password/#{@token}"} method="put">|
         end
       )
 


### PR DESCRIPTION
the reset_password edit form did not have password or password_confirmation inputs.