### PR TITLE
docs: typo: replace `text` by `json`

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -263,7 +263,7 @@ defmodule HelloWeb.Router do
   use HelloWeb, :router
 
   pipeline :browser do
-    plug :accepts, ["html", "text"]
+    plug :accepts, ["html", "json"]
     plug :fetch_session
     plug :fetch_live_flash
     plug :put_root_layout, {HelloWeb.LayoutView, :root}
@@ -273,7 +273,7 @@ defmodule HelloWeb.Router do
 ...
 ```
 
-If we go to [`http://localhost:4000/?_format=text`](http://localhost:4000/?_format=text), we will see %{"message": "this is some JSON"}.
+If we go to [`http://localhost:4000/?_format=json`](http://localhost:4000/?_format=json), we will see %{"message": "this is some JSON"}.
 
 ### Sending responses directly
 


### PR DESCRIPTION
the docs explains adding `json` format and uses `PageJSON` module, but the code example adds the format `text` 
for `text` format to work, we need to add it in `HelloWeb` too
```
def controller do
    quote do
      use Phoenix.Controller,
        namespace: EmrWeb,
        formats: [:html, :json, :text],
        layouts: [html: HelloWeb.Layouts]
   # ....
  end
end
```
I've tried it and it works, but this part is not mentioned in the docs, so I kept with `json`