### PR TITLE
Fix `mix phx.server --open`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,6 @@ defmodule Phoenix.MixProject do
       mod: {Phoenix, []},
       extra_applications: [:logger, :eex, :crypto, :public_key],
       env: [
-        browser_open: false,
         logger: true,
         stacktrace_depth: nil,
         filter_parameters: ["password"],


### PR DESCRIPTION
Before this patch, the `browser_open` app env was `false` even though `--open` was used. Not sure why exactly this was broken, but fwiw I found this commit: https://github.com/phoenixframework/phoenix/commit/1422abdbec937a95a934a1a9a82bb9797a9efafb

cc @josevalim
