### PR TITLE
Extract ErrorHelpers from CoreComponent

### DIFF
--- a/guides/json_and_apis.md
+++ b/guides/json_and_apis.md
@@ -258,7 +258,7 @@ With this knowledge in hand, we can explore the `FallbackController` (`lib/hello
     conn
     |> put_status(:unprocessable_entity)
     |> put_view(json: HelloWeb.ChangesetJSON)
-    |> render("error.json", changeset: changeset)
+    |> render(:error, changeset: changeset)
   end
 ```
 
@@ -270,10 +270,10 @@ defmodule HelloWeb.ChangesetJSON do
   Traverses and translates changeset errors.
 
   See `Ecto.Changeset.traverse_errors/2` and
-  `HelloWeb.CoreCompponents.translate_error/1` for more details.
+  `HelloWeb.ErrorHelpers.translate_error/1` for more details.
   """
   def translate_errors(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, &HelloWeb.CoreComponents.translate_error/1)
+    Ecto.Changeset.traverse_errors(changeset, &HelloWeb.ErrorHelpers.translate_error/1)
   end
 
   @doc """

--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -13,6 +13,7 @@ defmodule Phx.New.Single do
      "phx_single/lib/app_name/application.ex": "lib/:app/application.ex",
      "phx_single/lib/app_name.ex": "lib/:app.ex",
      "phx_web/controllers/error_json.ex": "lib/:lib_web_name/controllers/error_json.ex",
+     "phx_web/controllers/error_helpers.ex": "lib/:lib_web_name/controllers/error_helpers.ex",
      "phx_web/endpoint.ex": "lib/:lib_web_name/endpoint.ex",
      "phx_web/router.ex": "lib/:lib_web_name/router.ex",
      "phx_web/telemetry.ex": "lib/:lib_web_name/telemetry.ex",

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -23,6 +23,7 @@ defmodule Phx.New.Web do
      "phx_web/router.ex": "lib/:web_app/router.ex",
      "phx_web/telemetry.ex": "lib/:web_app/telemetry.ex",
      "phx_web/controllers/error_json.ex": "lib/:web_app/controllers/error_json.ex",
+     "phx_web/controllers/error_helpers.ex": "lib/:web_app/controllers/error_helpers.ex",
      "#{@pre}/mix.exs": "mix.exs",
      "#{@pre}/README.md": "README.md",
      "#{@pre}/gitignore": ".gitignore",

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -13,6 +13,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   alias Phoenix.LiveView.JS<%= if @gettext do %>
   import <%= @web_namespace %>.Gettext<% end %>
+  import <%= @web_namespace %>.ErrorHelpers
 
   @doc """
   Renders a modal.
@@ -591,55 +592,6 @@ defmodule <%= @web_namespace %>.CoreComponents do
     |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
     |> JS.remove_class("overflow-hidden", to: "body")
     |> JS.pop_focus()
-  end
-
-  @doc """
-  Translates an error message using gettext.
-  """<%= if @gettext do %>
-  def translate_error({msg, opts}) do
-    # When using gettext, we typically pass the strings we want
-    # to translate as a static argument:
-    #
-    #     # Translate "is invalid" in the "errors" domain
-    #     dgettext("errors", "is invalid")
-    #
-    #     # Translate the number of files with plural rules
-    #     dngettext("errors", "1 file", "%{count} files", count)
-    #
-    # Because the error messages we show in our forms and APIs
-    # are defined inside Ecto, we need to translate them dynamically.
-    # This requires us to call the Gettext module passing our gettext
-    # backend as first argument.
-    #
-    # Note we use the "errors" domain, which means translations
-    # should be written to the errors.po file. The :count option is
-    # set by Ecto and indicates we should also apply plural rules.
-    if count = opts[:count] do
-      Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
-    else
-      Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
-    end
-  end<% else %>
-  def translate_error({msg, opts}) do
-    # You can make use of gettext to translate error messages by
-    # uncommenting and adjusting the following code:
-
-    # if count = opts[:count] do
-    #   Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
-    # else
-    #   Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
-    # end
-
-    Enum.reduce(opts, msg, fn {key, value}, acc ->
-      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-    end)
-  end<% end %>
-
-  @doc """
-  Translates the errors for a field from a keyword list of errors.
-  """
-  def translate_errors(errors, field) when is_list(errors) do
-    for {^field, {msg, opts}} <- errors, do: translate_error({msg, opts})
   end
 
   defp input_equals?(val1, val2) do

--- a/installer/templates/phx_web/controllers/error_helpers.ex
+++ b/installer/templates/phx_web/controllers/error_helpers.ex
@@ -1,0 +1,50 @@
+defmodule <%= @web_namespace %>.ErrorHelpers do
+  @doc """
+  Translates an error message using gettext.
+  """<%= if @gettext do %>
+  def translate_error({msg, opts}) do
+    # When using gettext, we typically pass the strings we want
+    # to translate as a static argument:
+    #
+    #     # Translate "is invalid" in the "errors" domain
+    #     dgettext("errors", "is invalid")
+    #
+    #     # Translate the number of files with plural rules
+    #     dngettext("errors", "1 file", "%{count} files", count)
+    #
+    # Because the error messages we show in our forms and APIs
+    # are defined inside Ecto, we need to translate them dynamically.
+    # This requires us to call the Gettext module passing our gettext
+    # backend as first argument.
+    #
+    # Note we use the "errors" domain, which means translations
+    # should be written to the errors.po file. The :count option is
+    # set by Ecto and indicates we should also apply plural rules.
+    if count = opts[:count] do
+      Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
+    else
+      Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
+    end
+  end<% else %>
+  def translate_error({msg, opts}) do
+    # You can make use of gettext to translate error messages by
+    # uncommenting and adjusting the following code:
+
+    # if count = opts[:count] do
+    #   Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
+    # else
+    #   Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
+    # end
+
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
+    end)
+  end<% end %>
+
+  @doc """
+  Translates the errors for a field from a keyword list of errors.
+  """
+  def translate_errors(errors, field) when is_list(errors) do
+    for {^field, {msg, opts}} <- errors, do: translate_error({msg, opts})
+  end
+end

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -393,6 +393,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       refute_file("phx_blog/lib/phx_blog_web/controllers/error_html.ex")
       assert_file("phx_blog/lib/phx_blog_web/controllers/error_json.ex")
+      assert_file("phx_blog/lib/phx_blog_web/controllers/error_helpers.ex")
       assert_file("phx_blog/lib/phx_blog_web/router.ex", &refute(&1 =~ ~r"pipeline :browser"))
 
       # No Dashboard

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -401,6 +401,11 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file(web_path(@app, "lib/#{@app}_web/controllers/error_json.ex"), ~r".json")
 
+      assert_file(web_path(@app, "lib/#{@app}_web/controllers/error_helpers.ex"), fn file ->
+        assert file =~ "translate_errors"
+        assert file =~ "translate_error("
+      end)
+
       assert_file(
         web_path(@app, "lib/#{@app}_web/router.ex"),
         &refute(&1 =~ ~r"pipeline :browser")

--- a/priv/templates/phx.gen.json/changeset_json.ex
+++ b/priv/templates/phx.gen.json/changeset_json.ex
@@ -3,10 +3,10 @@ defmodule <%= inspect context.web_module %>.ChangesetJSON do
   Traverses and translates changeset errors.
 
   See `Ecto.Changeset.traverse_errors/2` and
-  `<%= inspect context.web_module %>.CoreCompponents.translate_error/1` for more details.
+  `<%= inspect context.web_module %>.ErrorHelpers.translate_error/1` for more details.
   """
   def translate_errors(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, &<%= inspect context.web_module %>.CoreComponents.translate_error/1)
+    Ecto.Changeset.traverse_errors(changeset, &<%= inspect context.web_module %>.ErrorHelpers.translate_error/1)
   end
 
   @doc """

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -13,6 +13,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   alias Phoenix.LiveView.JS<%= if @gettext do %>
   import <%= @web_namespace %>.Gettext<% end %>
+  import <%= @web_namespace %>.ErrorHelpers
 
   @doc """
   Renders a modal.
@@ -591,55 +592,6 @@ defmodule <%= @web_namespace %>.CoreComponents do
     |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
     |> JS.remove_class("overflow-hidden", to: "body")
     |> JS.pop_focus()
-  end
-
-  @doc """
-  Translates an error message using gettext.
-  """<%= if @gettext do %>
-  def translate_error({msg, opts}) do
-    # When using gettext, we typically pass the strings we want
-    # to translate as a static argument:
-    #
-    #     # Translate "is invalid" in the "errors" domain
-    #     dgettext("errors", "is invalid")
-    #
-    #     # Translate the number of files with plural rules
-    #     dngettext("errors", "1 file", "%{count} files", count)
-    #
-    # Because the error messages we show in our forms and APIs
-    # are defined inside Ecto, we need to translate them dynamically.
-    # This requires us to call the Gettext module passing our gettext
-    # backend as first argument.
-    #
-    # Note we use the "errors" domain, which means translations
-    # should be written to the errors.po file. The :count option is
-    # set by Ecto and indicates we should also apply plural rules.
-    if count = opts[:count] do
-      Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
-    else
-      Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
-    end
-  end<% else %>
-  def translate_error({msg, opts}) do
-    # You can make use of gettext to translate error messages by
-    # uncommenting and adjusting the following code:
-
-    # if count = opts[:count] do
-    #   Gettext.dngettext(<%= @web_namespace %>.Gettext, "errors", msg, msg, count, opts)
-    # else
-    #   Gettext.dgettext(<%= @web_namespace %>.Gettext, "errors", msg, opts)
-    # end
-
-    Enum.reduce(opts, msg, fn {key, value}, acc ->
-      String.replace(acc, "%{#{key}}", fn _ -> to_string(value) end)
-    end)
-  end<% end %>
-
-  @doc """
-  Translates the errors for a field from a keyword list of errors.
-  """
-  def translate_errors(errors, field) when is_list(errors) do
-    for {^field, {msg, opts}} <- errors, do: translate_error({msg, opts})
   end
 
   defp input_equals?(val1, val2) do

--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -109,6 +109,12 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
         assert file =~ ~s|~p"/api/posts|
       end)
 
+      assert_file("lib/phoenix_web/controllers/changeset_json.ex", fn file ->
+        assert file =~ "def translate_errors"
+        assert file =~ "def error"
+        assert file =~ "ErrorHelpers"
+      end)
+
       assert_receive {:mix_shell, :info,
                       [
                         """


### PR DESCRIPTION
Fix #5136 based on assumption that it breaks like the following screenshot:

![core_components](https://user-images.githubusercontent.com/2753398/205420808-a89576be-466b-47c3-8b02-a85a2164f02a.jpg)

So that `mix phx.gen.json` work with `mix phx.new --no-html` app because ErrorHelpers is always generated.

Note: The screenshot is `mix test` ran on [`mix phx.gen.json` on top of `mix phx.new --no-html` app] code.

---
Let me know if it breaks anything else or any convention I should follow. Thanks!