### PR TITLE
Fix slack link in homepage template

### DIFF
--- a/installer/templates/phx_web/controllers/page_html/home.html.heex
+++ b/installer/templates/phx_web/controllers/page_html/home.html.heex
@@ -162,7 +162,7 @@
           </div>
           <div>
             <a
-              href="https://elixir-slackin.herokuapp.com"
+              href="https://elixir-lang.slack.com"
               class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-zinc-900"
             >
               <svg


### PR DESCRIPTION
Looks like the heroku links stopped working. Happy to change this to another link if available or close the PR if the link comes back online.