### PR TITLE
feat: `phx_web` generate `endpoint.ex` with `CheckRepoStatus` plug `migration_lock: false` option

### DIFF
--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -29,7 +29,7 @@ defmodule <%= @endpoint_module %> do
     socket "/phoenix/live_reload/socket", Phoenix.LiveReloader.Socket
     plug Phoenix.LiveReloader<% end %>
     plug Phoenix.CodeReloader<%= if @ecto do %>
-    plug Phoenix.Ecto.CheckRepoStatus, otp_app: :<%= @web_app_name %><% end %>
+    plug Phoenix.Ecto.CheckRepoStatus, otp_app: :<%= @web_app_name %>, migration_lock: false<% end %>
   end<%= if @dashboard do %>
 
   plug Phoenix.LiveDashboard.RequestLogger,


### PR DESCRIPTION
# Goal
`phx_web` generator: generate `CheckRepoStatus` plug line with an option so that it runs without migration lock.

# Background
https://github.com/phoenixframework/phoenix_ecto/pull/160 makes it possible to pass a `migration_lock` option to `CheckRepoStatus` plug. This plug is a convenience that checks for pending migrations. By default it uses the migration lock strategy defined in the OTP app ecto repo configuration. When that is configured to `:pg_advisory_lock`, concurrent requests in `dev` environment may be delayed by 5s. See this [elixir forum topic](https://elixirforum.com/t/does-phoenix-ecto-checkrepostatus-callling-ecto-migrator-migrations-1-need-to-run-under-an-ecto-migration-lock/52170/11) for more information.

IMO just reading the pending migrations should be possible without any migration lock. Hence this PR adds the `migration_lock: false` config option to `CheckRepoStatus` plug.

# Dependencies
This PR depends on the changes in https://github.com/phoenixframework/phoenix_ecto/pull/160, so first `phoenix_ecto` has to be released.