### PR TITLE
Correct the swoosh api client configuration

### DIFF
--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -12,7 +12,7 @@ import Config
 config :<%= @web_app_name %>, <%= @endpoint_module %>, cache_static_manifest: "priv/static/cache_manifest.json"<% end %><%= if @mailer do %>
 
 # Configures Swoosh API Client
-config :swoosh, :api_client, <%= @app_module %>.Finch<% end %>
+config :swoosh, api_client: Swoosh.ApiClient.Finch, finch_name: <%= @app_module %>.Finch<% end %>
 
 # Do not print debug messages in production
 config :logger, level: :info


### PR DESCRIPTION
The current swoosh API client config code doesn't work on fly.io, and this fixes it.  After some experimentation, I finally figured out that this works.  Note that the name in for Finch in application.ex is <%= @app_module %>.Finch, and so the finch_name on the adapter needs to be set to this same value in prod.exs.

Another solution is to just call the Finch service "Swoosh.Finch" in application.ex, and then you do not have to give a name for the api client in prod.exs, but the changes I'm suggesting seem more in line with the current code. 

Thanks!

-- Greg
