### PR TITLE
fix: Extra newline in textarea component causes new textareas to be non-empty.

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -339,7 +339,6 @@ defmodule <%= @web_namespace %>.CoreComponents do
         ]}
         {@rest}
       >
-
     <%%= @value %></textarea>
       <.error :for={msg <- @errors}><%%= msg %></.error>
     </div>


### PR DESCRIPTION
The `textarea` input template in `core_components.ex` has an additional newline character as a child of the `<textarea>` block. This causes the textarea to always be rendered with this additional character, even when a value is supplied (like with a changeset). Removing this line fixes the issue for new generated projects.