### PR TITLE
Fixes flaky test case - test/mix/tasks/phx.gen.json_test.exs:166

### DIFF
--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -340,7 +340,7 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
       end
       """)
 
-      Code.compile_file("lib/phoenix_web/components/core_components.ex")
+      [{module, _}] = Code.compile_file("lib/phoenix_web/components/core_components.ex")
 
       Gen.Json.run(~w(Blog Post posts title:string --web Blog))
 
@@ -348,6 +348,10 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
         assert file =~
                  "Ecto.Changeset.traverse_errors(changeset, &PhoenixWeb.CoreComponents.translate_error/1)"
       end)
+
+      # Clean up test case specific compile artifact so it doesn't leak to other test cases
+      :code.purge(module)
+      :code.delete(module)
     end)
   end
 end


### PR DESCRIPTION
Hi!

Test cases in `phx.gen.json_test.exs` are isolated given gen tasks are run in different `tmp` subdirectories, however it seems this particular recently-added test case having a run time compilation of a `PhoenixWeb.CoreComponents` module is leaking to other test case given the module is not purged/deleted.

In particular it seems to affect the test case titled `"with json --web namespace generates namespaced web modules and directories"` in the same test file.

So the intermittence in the failure depends on the random order of the test case run.

Failure can be reproduced consistently with some seeds. E.g.

```
$ mix test test/mix/tasks/phx.gen.json_test.exs --seed 911231
```

Also, this is the failure that is making `master` last commit and a few pull requests fail: https://github.com/phoenixframework/phoenix/actions/runs/3696703936/jobs/6260760004.