### PR TITLE
Fixes warning in test case by explicitly asking for no cert path validation

### DIFF
--- a/test/mix/tasks/phx.gen.cert_test.exs
+++ b/test/mix/tasks/phx.gen.cert_test.exs
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Phx.CertTest do
 
       # We don't actually verify the server cert contents, we just check that
       # the client and server are able to complete the TLS handshake
-      assert {:ok, client} = :ssl.connect('localhost', port, [], @timeout)
+      assert {:ok, client} = :ssl.connect('localhost', port, [verify: :verify_none], @timeout)
       :ssl.close(client)
       :ssl.close(server)
     end)


### PR DESCRIPTION
Hi :wave: 

Just trying to fix a warning showing up in `mix test` runs with OPT24+.

### Before

```
(master) $ mix test test/mix/tasks/phx.gen.cert_test.exs

11:08:59.788 [warning] Description: 'Authenticity is not established by certificate path validation'
     Reason: 'Option {verify, verify_peer} and cacertfile/cacerts is missing'

...
Finished in 0.8 seconds (0.00s async, 0.8s sync)
3 tests, 0 failures
```

### After

```
(fix-test-warning-cert-path-validation) $ mix test test/mix/tasks/phx.gen.cert_test.exs
...
Finished in 0.7 seconds (0.00s async, 0.7s sync)
3 tests, 0 failures
```