### PR TITLE
Proposal: alias Phoenix.HTML in CoreComponets to avoid Credo warnings.

### DIFF
--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -11,6 +11,8 @@ defmodule <%= @web_namespace %>.CoreComponents do
   """
   use Phoenix.Component
 
+  alias Phoenix.HTML
+  alias Phoenix.HTML.Form
   alias Phoenix.LiveView.JS<%= if @gettext do %>
   import <%= @web_namespace %>.Gettext<% end %>
 
@@ -276,11 +278,11 @@ defmodule <%= @web_namespace %>.CoreComponents do
     assigns
     |> assign(field: nil)
     |> assign_new(:name, fn ->
-      name = Phoenix.HTML.Form.input_name(f, field)
+      name = Form.input_name(f, field)
       if assigns.multiple, do: name <> "[]", else: name
     end)
-    |> assign_new(:id, fn -> Phoenix.HTML.Form.input_id(f, field) end)
-    |> assign_new(:value, fn -> Phoenix.HTML.Form.input_value(f, field) end)
+    |> assign_new(:id, fn -> Form.input_id(f, field) end)
+    |> assign_new(:value, fn -> Form.input_value(f, field) end)
     |> assign_new(:errors, fn -> translate_errors(f.errors || [], field) end)
     |> input()
   end
@@ -317,7 +319,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
         {@rest}
       >
         <option :if={@prompt} value=""><%%= @prompt %></option>
-        <%%= Phoenix.HTML.Form.options_for_select(@options, @value) %>
+        <%%= Form.options_for_select(@options, @value) %>
       </select>
       <.error :for={msg <- @errors}><%%= msg %></.error>
     </div>
@@ -643,6 +645,6 @@ defmodule <%= @web_namespace %>.CoreComponents do
   end
 
   defp input_equals?(val1, val2) do
-    Phoenix.HTML.html_escape(val1) == Phoenix.HTML.html_escape(val2)
+    HTML.html_escape(val1) == HTML.html_escape(val2)
   end
 end


### PR DESCRIPTION
That would improve the experience as Credo is widespread used :)