### PR TITLE
Fixes missing :references generation to phx.gen.embedded

### DIFF
--- a/priv/templates/phx.gen.embedded/embedded_schema.ex
+++ b/priv/templates/phx.gen.embedded/embedded_schema.ex
@@ -3,8 +3,8 @@ defmodule <%= inspect schema.module %> do
   import Ecto.Changeset
   alias <%= inspect schema.module %>
 
-  embedded_schema do
-<%= Mix.Phoenix.Schema.format_fields_for_schema(schema) %>
+  embedded_schema do <%= if !Map.equal?(schema.types, %{}) do %>
+<%= Mix.Phoenix.Schema.format_fields_for_schema(schema) %><% end %>
 <%= for {_, k, _, _} <- schema.assocs do %>    field <%= inspect k %>, <%= if schema.binary_id do %>:binary_id<% else %>:id<% end %>
 <% end %>  end
 

--- a/priv/templates/phx.gen.embedded/embedded_schema.ex
+++ b/priv/templates/phx.gen.embedded/embedded_schema.ex
@@ -5,7 +5,8 @@ defmodule <%= inspect schema.module %> do
 
   embedded_schema do
 <%= Mix.Phoenix.Schema.format_fields_for_schema(schema) %>
-  end
+<%= for {_, k, _, _} <- schema.assocs do %>    field <%= inspect k %>, <%= if schema.binary_id do %>:binary_id<% else %>:id<% end %>
+<% end %>  end
 
   @doc false
   def changeset(%<%= inspect schema.alias %>{} = <%= schema.singular %>, attrs) do

--- a/test/mix/tasks/phx.gen.embedded_test.exs
+++ b/test/mix/tasks/phx.gen.embedded_test.exs
@@ -91,4 +91,18 @@ defmodule Mix.Tasks.Phx.Gen.EmbeddedTest do
       end)
     end)
   end
+
+  test "generates embedded schema with references", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Embedded.run(
+        ~w(Blog.Comment comments body word_count:integer author_id:references:author)
+      )
+
+      assert_file("lib/phoenix/blog/comment.ex", fn file ->
+        assert file =~ "field :author_id, :id"
+        assert file =~ "field :body, :string"
+        assert file =~ "field :word_count, :integer"
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
As mentioned in the [docs](https://hexdocs.pm/phoenix/1.7.0-rc.0/Mix.Tasks.Phx.Gen.Embedded.html#module-attributes) `:references` should be generated when calling it within
 `mix phx.gen.embedded Blog.Comment  author_id:references:author` 
but it only creates an empty schema. I've added the population of `:references` as well as a new test. 

I'm not sure if there needs to be anything else since it's an embedded schema and not an actual schema which is why I left out the primary_key and foreign_key assignments. 

Hope this does it!