### PR TITLE
Remove reference to pow.cs from Phoenix.Endpoint docs

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -188,8 +188,6 @@ defmodule Phoenix.Endpoint do
     * `:live_reload` - configuration for the live reload option.
       Configuration requires a `:patterns` option which should be a list of
       file patterns to watch. When these files change, it will trigger a reload.
-      If you are using a tool like [pow](http://pow.cx) in development,
-      you may need to set the `:url` option appropriately.
 
           live_reload: [
             url: "ws://localhost:4000",


### PR DESCRIPTION
* The domain for pow.cx has lapsed and is now a domain seller landing page.
* The repo at https://github.com/basecamp/pow has also been archived.