### PR TITLE
Allow similar paths with different verbs

### DIFF
--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -21,6 +21,7 @@ defmodule Phoenix.Router.RoutingTest do
     def image(conn, _params), do: text(conn, conn.params["path"] || "show files")
     def move(conn, _params), do: text(conn, "users move")
     def any(conn, _params), do: text(conn, "users any")
+    def similar(conn, _params), do: text(conn, "users similar")
     def raise(_conn, _params), do: raise("boom")
     def exit(_conn, _params), do: exit(:boom)
 
@@ -43,6 +44,7 @@ defmodule Phoenix.Router.RoutingTest do
     get "/", UserController, :index, as: :users
     get "/users/top", UserController, :top, as: :top
     get "/users/:id", UserController, :show, as: :users, metadata: %{access: :user}
+    post "/users/similar", UserController, :similar
     get "/spaced users/:id", UserController, :show
     get "/profiles/profile-:id", UserController, :show
     get "/route_that_crashes", UserController, :crash
@@ -513,5 +515,17 @@ defmodule Phoenix.Router.RoutingTest do
              plug_opts: :not_found,
              route: "/*path"
            }
+  end
+
+  test "different verbs with similar paths" do
+    conn = call(Router, :post, "/users/similar")
+    assert conn.status == 200
+    assert conn.resp_body == "users similar"
+
+    conn = call(Router, :get, "/users/similar")
+    assert conn.status == 200
+    assert conn.resp_body == "users show"
+    assert conn.params["id"] == "similar"
+    assert conn.path_params["id"] == "similar"
   end
 end

--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -43,8 +43,9 @@ defmodule Phoenix.Router.RoutingTest do
 
     get "/", UserController, :index, as: :users
     get "/users/top", UserController, :top, as: :top
-    get "/users/:id", UserController, :show, as: :users, metadata: %{access: :user}
     post "/users/similar", UserController, :similar
+    get "/users/:id", UserController, :show, as: :users, metadata: %{access: :user}
+    post "/users/also_similar", UserController, :similar
     get "/spaced users/:id", UserController, :show
     get "/profiles/profile-:id", UserController, :show
     get "/route_that_crashes", UserController, :crash
@@ -527,5 +528,15 @@ defmodule Phoenix.Router.RoutingTest do
     assert conn.resp_body == "users show"
     assert conn.params["id"] == "similar"
     assert conn.path_params["id"] == "similar"
+
+    conn = call(Router, :post, "/users/also_similar")
+    assert conn.status == 200
+    assert conn.resp_body == "users similar"
+
+    conn = call(Router, :get, "/users/also_similar")
+    assert conn.status == 200
+    assert conn.resp_body == "users show"
+    assert conn.params["id"] == "also_similar"
+    assert conn.path_params["id"] == "also_similar"
   end
 end


### PR DESCRIPTION
This is my first attempt at solving #5156

It is still in a pretty "hacky" state but I just wanted to make sure it was fixable.

I'm opening this PR so we can discuss a better way. Maybe it would be easier to have `__match_route__/3` like before for routing and `route_info` and a `__match_route__/1` for verified routes?