### PR TITLE
fix: formatting for core_components generated file

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -280,7 +280,9 @@ defmodule <%= @web_namespace %>.CoreComponents do
       if assigns.multiple, do: name <> "[]", else: name
     end)
     |> assign_new(:id, fn -> Phoenix.HTML.Form.input_id(f, field) end)
-    |> assign_new(:value, fn -> maybe_format_input_value(Phoenix.HTML.Form.input_value(f, field)) end)
+    |> assign_new(:value, fn ->
+      maybe_format_input_value(Phoenix.HTML.Form.input_value(f, field))
+    end)
     |> assign_new(:errors, fn -> translate_errors(f.errors || [], field) end)
     |> input()
   end

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -280,7 +280,9 @@ defmodule <%= @web_namespace %>.CoreComponents do
       if assigns.multiple, do: name <> "[]", else: name
     end)
     |> assign_new(:id, fn -> Phoenix.HTML.Form.input_id(f, field) end)
-    |> assign_new(:value, fn -> maybe_format_input_value(Phoenix.HTML.Form.input_value(f, field)) end)
+    |> assign_new(:value, fn ->
+      maybe_format_input_value(Phoenix.HTML.Form.input_value(f, field))
+    end)
     |> assign_new(:errors, fn -> translate_errors(f.errors || [], field) end)
     |> input()
   end


### PR DESCRIPTION
This should address the integration failing tests as a result of formatting.