### PR TITLE
Use the new input component in the Context guide

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -493,30 +493,27 @@ Next, let's expose our new feature to the web by adding the category input to ou
 defmodule HelloWeb.ProductHTML do
   use HelloWeb, :html
 
-  def category_select(f, changeset) do
+  def category_select(changeset) do
     existing_ids =
       changeset
       |> Ecto.Changeset.get_change(:categories, [])
       |> Enum.map(& &1.data.id)
 
-    category_opts =
-      for cat <- Hello.Catalog.list_categories(),
-          do: [key: cat.title, value: cat.id, selected: cat.id in existing_ids]
-
-    multiple_select(f, :category_ids, category_opts)
+    for cat <- Hello.Catalog.list_categories(),
+        do: [key: cat.title, value: cat.id, selected: cat.id in existing_ids]
   end
 end
 ```
 
-We added a new `category_select/2` function which uses `Phoenix.HTML`'s `multiple_select/3` to generate a multiple select tag. We calculated the existing category IDs from our changeset, then used those values when we generate the select options for the input tag. We did this by enumerating over all of our categories and returning the appropriate `key`, `value`, and `selected` values. We marked an option as selected if the category ID was found in those category IDs in our changeset.
+We added a new `category_select/1` to generate a list of options. We calculated the existing category IDs from our changeset, then used those values when we generate the select options for the input tag. We did this by enumerating over all of our categories and returning the appropriate `key`, `value`, and `selected` values. We marked an option as selected if the category ID was found in those category IDs in our changeset.
 
-With our `category_select` function in place, we can open up `lib/hello_web/controllers/product_html/form.html.heex` and add:
+With our `category_select` function in place, we can open up `lib/hello_web/controllers/product_html/edit.html.heex` and `lib/hello_web/controllers/product_html/new.html.heex` and add:
 
 ```diff
   ...
   <.input type="number" field={{f, :views}} label="Views" />
 
-+ <%= category_select f, @changeset %>
++ <.input type="select" field={{f, :category_ids}} label="Categories" multiple options={category_select(@changeset)} />
 
   <:actions>
     <.button>Save Product</.button>

--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -493,7 +493,7 @@ Next, let's expose our new feature to the web by adding the category input to ou
 defmodule HelloWeb.ProductHTML do
   use HelloWeb, :html
 
-  def category_select(changeset) do
+  def category_options(changeset) do
     existing_ids =
       changeset
       |> Ecto.Changeset.get_change(:categories, [])
@@ -505,22 +505,22 @@ defmodule HelloWeb.ProductHTML do
 end
 ```
 
-We added a new `category_select/1` to generate a list of options. We calculated the existing category IDs from our changeset, then used those values when we generate the select options for the input tag. We did this by enumerating over all of our categories and returning the appropriate `key`, `value`, and `selected` values. We marked an option as selected if the category ID was found in those category IDs in our changeset.
+We added a new `category_options/1` to generate a list of options. We calculated the existing category IDs from our changeset, then used those values when we generate the select options for the input tag. We did this by enumerating over all of our categories and returning the appropriate `key`, `value`, and `selected` values. We marked an option as selected if the category ID was found in those category IDs in our changeset.
 
-With our `category_select` function in place, we can open up `lib/hello_web/controllers/product_html/edit.html.heex` and `lib/hello_web/controllers/product_html/new.html.heex` and add:
+With our `category_options` function in place, we can open up `lib/hello_web/controllers/product_html/edit.html.heex` and `lib/hello_web/controllers/product_html/new.html.heex` and add:
 
 ```diff
   ...
   <.input type="number" field={{f, :views}} label="Views" />
 
-+ <.input type="select" field={{f, :category_ids}} label="Categories" multiple options={category_select(@changeset)} />
++ <.input type="select" field={{f, :category_ids}} label="Categories" multiple options={category_options(@changeset)} />
 
   <:actions>
     <.button>Save Product</.button>
   </:actions>
 ```
 
-We added a `category_select` above our save button. Now let's try it out. Next, let's show the product's categories in the product show template. Add the following code to the list in `lib/hello_web/controllers/product_html/show.html.heex`:
+We added a `category_options` above our save button. Now let's try it out. Next, let's show the product's categories in the product show template. Add the following code to the list in `lib/hello_web/controllers/product_html/show.html.heex`:
 
 ```heex
 <.list>


### PR DESCRIPTION
The instructions in the [Contexts guide](https://hexdocs.pm/phoenix/1.7.0-rc.2/contexts.html) aren't using the new `input` component. This PR updates the guide to use it.

It also looks like we're not generating the `form.html.heex` file anymore. So, for now, I've also updated the instructions to mention we need to update both `edit.html.heex` and `new.html.heex`.

However, I think it may be a good idea to bring back the `form` file to avoid duplicating those inputs.

Feel free to make any changes you see fit to this PR.