### PR TITLE
Channel `handle_in/3` to emit more standardized telemetry events

### DIFF
--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -332,6 +332,12 @@ defmodule Phoenix.Channel.Server do
         metadata = Map.merge(metadata, %{kind: :error, reason: exception, stacktrace: __STACKTRACE__})
         :telemetry.execute([:phoenix, :channel_handle_in, :exception], measurements, metadata)
         reraise exception, __STACKTRACE__
+    catch
+      kind, reason ->
+        measurements = %{duration: System.monotonic_time() - start}
+        metadata = Map.merge(metadata, %{kind: kind, reason: reason, stacktrace: __STACKTRACE__})
+        :telemetry.execute([:phoenix, :channel_handle_in, :exception], measurements, metadata)
+        :erlang.raise(kind, reason, __STACKTRACE__)
     end
   end
 

--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -75,7 +75,7 @@ defmodule Phoenix.Logger do
 
     * `[:phoenix, :channel_handle_in, :exception]` - dispatched after exceptions on dispatching incoming event
       * Measurement: `%{duration: native_time}`
-      * Metadata: `%{conn: Plug.Conn.t, kind: :error, reason: term(), stacktrace: Exception.stacktrace()}`
+      * Metadata: `%{conn: Plug.Conn.t, kind: :throw | :error | :exit, reason: term(), stacktrace: Exception.stacktrace()}`
       * Disable logging: This event is not logged
 
   To see an example of how Phoenix LiveDashboard uses these events to create

--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -63,10 +63,20 @@ defmodule Phoenix.Logger do
       * Metadata: `%{result: :ok | :error, params: term, socket: Phoenix.Socket.t}`
       * Disable logging: This event cannot be disabled
 
-    * `[:phoenix, :channel_handled_in]` - dispatched at the end of a channel handle in
+    * `[:phoenix, :channel_handle_in, :start]` - dispatched before channel handles incoming event
+      * Measurement: `%{system_time: system_time}`
+      * Metadata: `%{event: binary, params: term, socket: Phoenix.Socket.t}`
+      * Disable logging: This event is not logged
+
+    * `[:phoenix, :channel_handle_in, :stop]` - dispatched after channel successfully handled incoming event
       * Measurement: `%{duration: native_time}`
       * Metadata: `%{event: binary, params: term, socket: Phoenix.Socket.t}`
       * Disable logging: This event cannot be disabled
+
+    * `[:phoenix, :channel_handle_in, :exception]` - dispatched after exceptions on dispatching incoming event
+      * Measurement: `%{duration: native_time}`
+      * Metadata: `%{conn: Plug.Conn.t, kind: :error, reason: term(), stacktrace: Exception.stacktrace()}`
+      * Disable logging: This event is not logged
 
   To see an example of how Phoenix LiveDashboard uses these events to create
   metrics, visit <https://hexdocs.pm/phoenix_live_dashboard/metrics.html>.

--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -135,7 +135,7 @@ defmodule Phoenix.Logger do
       [:phoenix, :error_rendered] => &__MODULE__.phoenix_error_rendered/4,
       [:phoenix, :socket_connected] => &__MODULE__.phoenix_socket_connected/4,
       [:phoenix, :channel_joined] => &__MODULE__.phoenix_channel_joined/4,
-      [:phoenix, :channel_handled_in] => &__MODULE__.phoenix_channel_handled_in/4
+      [:phoenix, :channel_handle_in, :stop] => &__MODULE__.phoenix_channel_handle_in_stop/4
     }
 
     for {key, fun} <- handlers do
@@ -354,7 +354,7 @@ defmodule Phoenix.Logger do
   ## Event: [:phoenix, :channel_handle_in]
 
   @doc false
-  def phoenix_channel_handled_in(_, %{duration: duration}, %{socket: socket} = metadata, _) do
+  def phoenix_channel_handle_in_stop(_, %{duration: duration}, %{socket: socket} = metadata, _) do
     channel_log(:log_handle_in, socket, fn ->
       %{event: event, params: params} = metadata
 


### PR DESCRIPTION
_Opening a PR for https://github.com/phoenixframework/phoenix/issues/4831 as suggested by @jeregrine_

Currently `handle_in` only emits `[:phoenix, :channel_handeled_in]` telemetry event after success.

I'd like to propose standardized set of `:telemetry` events for channel `handle_in/3` callback, similar to those emitted by `Phoenix.Router`:
 - `[:phoenix, :channel_handele_in, :start]`
 - `[:phoenix, :channel_handele_in, :stop]`
 - `[:phoenix, :channel_handele_in, :exception]`
 
As if they were emitted by `:telemetry.span/3`. And, probably, "soft-deprecate" the existing `[:phoenix, :channel_handeled_in]` in favor of new events.

That would provide with better info for observability.