### PR TITLE
fix pluralization in live generator delete template

### DIFF
--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -71,7 +71,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       {:ok, index_live, _html} = live(conn, ~p"<%= schema.route_prefix %>")
 
       assert index_live |> element("#<%= schema.plural %>-#{<%= schema.singular %>.id} a", "Delete") |> render_click()
-      refute has_element?(index_live, "#<%= schema.singular %>-#{<%= schema.singular %>.id}")
+      refute has_element?(index_live, "#<%= schema.plural %>-#{<%= schema.singular %>.id}")
     end
   end
 


### PR DESCRIPTION
There is a small error in the template of the Liveview generator.

```elixir
test "deletes post in listing", %{conn: conn, post: post} do
  {:ok, index_live, _html} = live(conn, ~p"/posts")

  assert has_element?(index_live, "#post-#{post.id}")
  assert index_live |> element("#posts-#{post.id} a", "Delete") |> render_click()
  refute has_element?(index_live, "#post-#{post.id}")
end
```
this fails because "#post-#{post.id}" was never there in the first place, yet in `master` template this is passing. Making the selectors match fixes the false positive.