### PR TITLE
Add guard to skip map attributes when generating heex templates

### DIFF
--- a/priv/templates/phx.gen.html/index.html.heex
+++ b/priv/templates/phx.gen.html/index.html.heex
@@ -7,7 +7,7 @@
   </:actions>
 </.header>
 
-<.table id="<%= schema.plural %>" rows={@<%= schema.collection %>} row_click={&JS.navigate(~p"<%= schema.route_prefix %>/#{&1}")}><%= for {k, _} <- schema.attrs do %>
+<.table id="<%= schema.plural %>" rows={@<%= schema.collection %>} row_click={&JS.navigate(~p"<%= schema.route_prefix %>/#{&1}")}><%= for {k, v} when not is_map(v) <- schema.attrs do %>
   <:col :let={<%= schema.singular %>} label="<%= Phoenix.Naming.humanize(Atom.to_string(k)) %>"><%%= <%= schema.singular %>.<%= k %> %></:col><% end %>
   <:action :let={<%= schema.singular %>}>
     <div class="sr-only">

--- a/priv/templates/phx.gen.html/show.html.heex
+++ b/priv/templates/phx.gen.html/show.html.heex
@@ -8,7 +8,7 @@
   </:actions>
 </.header>
 
-<.list><%= for {k, _} <- schema.attrs do %>
+<.list><%= for {k, v} when not is_map(v) <- schema.attrs do %>
   <:item title="<%= Phoenix.Naming.humanize(Atom.to_string(k)) %>"><%%= @<%= schema.singular %>.<%= k %> %></:item><% end %>
 </.list>
 

--- a/priv/templates/phx.gen.live/index.html.heex
+++ b/priv/templates/phx.gen.live/index.html.heex
@@ -7,7 +7,7 @@
   </:actions>
 </.header>
 
-<.table id="<%= schema.plural %>" rows={@<%= schema.collection %>} row_click={&JS.navigate(~p"<%= schema.route_prefix %>/#{&1}")}><%= for {k, _} <- schema.attrs do %>
+<.table id="<%= schema.plural %>" rows={@<%= schema.collection %>} row_click={&JS.navigate(~p"<%= schema.route_prefix %>/#{&1}")}><%= for {k, v} when not is_map(v) <- schema.attrs do %>
   <:col :let={<%= schema.singular %>} label="<%= Phoenix.Naming.humanize(Atom.to_string(k)) %>"><%%= <%= schema.singular %>.<%= k %> %></:col><% end %>
   <:action :let={<%= schema.singular %>}>
     <div class="sr-only">

--- a/priv/templates/phx.gen.live/show.html.heex
+++ b/priv/templates/phx.gen.live/show.html.heex
@@ -8,7 +8,7 @@
   </:actions>
 </.header>
 
-<.list><%= for {k, _} <- schema.attrs do %>
+<.list><%= for {k, v} when not is_map(v) <- schema.attrs do %>
   <:item title="<%= Phoenix.Naming.humanize(Atom.to_string(k)) %>"><%%= @<%= schema.singular %>.<%= k %> %></:item><% end %>
 </.list>
 


### PR DESCRIPTION
Skip over map data type attributes from jsonb columns that currently cause the mix tasks `phx.gen.live` and `phx.gen.html` to generate broken heex templates. Here's an [old stackoverflow question](https://stackoverflow.com/questions/35549618/mix-phoenix-gen-html-with-map-field-type) on this.