### PR TITLE
Fixed new home-page to not overflow on Chrome/Firefox

### DIFF
--- a/installer/templates/phx_web/controllers/page_html/home.html.heex
+++ b/installer/templates/phx_web/controllers/page_html/home.html.heex
@@ -37,7 +37,7 @@
     />
   </svg>
 </div>
-<div class="px-4 py-10 sm:py-28 sm:px-6 lg:px-8 xl:py-32 xl:px-28">
+<div class="h-screen flex items-center px-4 sm:px-6 lg:px-8 xl:px-28">
   <div class="mx-auto max-w-xl lg:mx-0">
     <svg viewBox="0 0 71 48" class="h-12" aria-hidden="true">
       <path


### PR DESCRIPTION
Hi all, 
I have noticed that the new home page is overflowing in Firefox/Chrome, but not in Safari. This PR should fix it on all browsers until content really needs to overflow. 

Before:
<img width="1244" alt="Screenshot 2023-02-02 at 13 15 44" src="https://user-images.githubusercontent.com/4885852/216322362-30e9b10f-1426-41d7-a6f5-dbda11115d3d.png">
After:
<img width="1244" alt="Screenshot 2023-02-02 at 13 15 58" src="https://user-images.githubusercontent.com/4885852/216322395-6c123918-7632-4d80-834f-24af5aaa8391.png">
