### PR TITLE
run asset compression in parallel

### DIFF
--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -28,7 +28,10 @@ defmodule Phoenix.Digester do
       digested_files = Enum.map(files, &digested_contents(&1, latest, with_vsn?))
 
       save_manifest(digested_files, latest, digests, output_path)
-      Enum.each(digested_files, &write_to_disk(&1, output_path))
+
+      digested_files
+      |> Task.async_stream(&write_to_disk(&1, output_path), ordered: false, timeout: :infinity)
+      |> Stream.run()
     else
       {:error, :invalid_path}
     end


### PR DESCRIPTION
If a project has a lot of assets or uses slow compressors (e.g. brotli), compressing in parallel can save a noticable amount of time. On my ~2019 4+4 core laptop CPU, with Phoenix' built in gzipper, ~150Mi assets in ~9000 files:

```
// sequential
24,33s user   3,67s system   142% cpu   19,585 total
// parallel
31,49s user   4,54s system   408% cpu    8,815 total
```

On freshly created phx.new v1.6.15, the difference is negligible, as the Elixir start up time dominates the total time. Below are two example runs, which are not statistically significant. I'm including these mostly to serve as comparison point to the numbers above.

```
// sequential
1,08s user    0,10s system   147% cpu    0,803 total
// parallel
0,95s user    0,13s system   146% cpu    0,736 total
```

If you're wondering about the use case; I'm generating OpenStreetMap vector tiles and would like to re-use Phoenix' asset pipeline for compression. For the project scope handling these separately makes little sense. The numbers presented above are from that setup and not an artificial dataset.