### PR TITLE
Update plug.md guide to match new generator output

### DIFF
--- a/guides/plug.md
+++ b/guides/plug.md
@@ -119,7 +119,7 @@ In the [`init/1`] callback, we pass a default locale to use if none is present i
 To see the assign in action, go to the layout in `lib/hello_web/templates/layout/app.html.heex` and add the following code to the main container:
 
 ```heex
-<main class="container">
+<main class="px-4 py-20 sm:px-6 lg:px-8">
   <p>Locale: <%= @locale %></p>
 ```
 

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -152,14 +152,14 @@ Let's see it in action. Run `iex -S mix` at the root of the project. We'll defin
 
 ```elixir
 iex> defmodule RouteExample do
-...>   use GenTestWeb, :verified_routes
+...>   use HelloWeb, :verified_routes
 ...>
 ...>   def example do
 ...>     ~p"/comments"
 ...>     ~p"/unknown/123"
 ...>   end
 ...> end
-warning: no route path for GenTestWeb.Router matches "/unknown/123"
+warning: no route path for HelloWeb.Router matches "/unknown/123"
   iex:5: RouteExample.example/0
 
 {:module, RouteExample, ...}

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -146,7 +146,7 @@ The `Phoenix.Router.resources/4` macro describes additional options for customiz
 
 ## Verified Routes
 
-Phoenix includes `Phoenix.VerifiedRoutes` module which provides compile-time checks of router paths against your router by using the `~p` sigil. For example, you can write paths in controllers, tests, and templates and the compile will make sure those actually match routes defined in your router.
+Phoenix includes `Phoenix.VerifiedRoutes` module which provides compile-time checks of router paths against your router by using the `~p` sigil. For example, you can write paths in controllers, tests, and templates and the compiler will make sure those actually match routes defined in your router.
 
 Let's see it in action. Run `iex -S mix` at the root of the project. We'll define a throwaway example module that builds a couple `~p` route paths.
 


### PR DESCRIPTION
With the switch to Tailwind this no longer exists `<main class="container">...</main>`

This is a PR that updates the Plug guide to match what the generators are now creating.