### PR TITLE
only compress once if asset content and digest are equal

### DIFF
--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -169,15 +169,22 @@ defmodule Phoenix.Digester do
     Enum.each(compressors, fn compressor ->
       [file_extension | _] = compressor.file_extensions
 
-      with {:ok, compressed_digested} <-
-             compressor.compress_file(file.digested_filename, file.digested_content) do
+      compressed_digested_result =
+        compressor.compress_file(file.digested_filename, file.digested_content)
+
+      with {:ok, compressed_digested} <- compressed_digested_result do
         File.write!(
           Path.join(path, file.digested_filename <> file_extension),
           compressed_digested
         )
       end
 
-      with {:ok, compressed} <- compressor.compress_file(file.filename, file.content) do
+      compress_result =
+        if file.digested_content == file.content,
+          do: compressed_digested_result,
+          else: compressor.compress_file(file.filename, file.content)
+
+      with {:ok, compressed} <- compress_result do
         File.write!(
           Path.join(path, file.filename <> file_extension),
           compressed


### PR DESCRIPTION
Phoenix compresses all assets twice, even when their contents are the same. While this is unlikely for non trivial CSS/JS assets, it's always the case for all other kinds of assets. The issue is only noticable when using slow compressors and/or a lot of assets.

Technically the compressor might return a different result for the digest and regular version, since it also receives the filename as metadata. However, the behaviour doesn't promise anything in this regard, nor do any of the public implementations on Github use the filename in the actual compression. The specific search used was
https://github.com/search?l=Elixir&q=%22behaviour+Phoenix.Digester.Compressor%22&type=Code -- most of the results are from vendoring Phoenix, there are only a couple of independent implementations.

Below results are for a ~2019 4+4 core laptop CPU using only the standard Phoenix gzip compressor. The files are not an artificial scenario, but auto generated OpenStreetMap vector tiles for which I would like to reuse the Phoenix asset pipeline. All results are on top of https://github.com/phoenixframework/phoenix/pull/5246 .

```
Benchmark 1: few files, double compress
  Time (mean ± σ):      1.467 s ±  0.048 s    [User: 1.990 s, System: 0.407 s]
  Range (min … max):    1.389 s …  1.559 s    20 runs

Benchmark 2: few files, content compare
  Time (mean ± σ):      1.481 s ±  0.081 s    [User: 2.004 s, System: 0.403 s]
  Range (min … max):    1.366 s …  1.615 s    20 runs
```

"many files" are ~150 Mi in ~9000 files:

```
Benchmark 3: many files, double compress
  Time (mean ± σ):     13.614 s ±  0.497 s    [User: 43.400 s, System: 7.573 s]
  Range (min … max):   13.058 s … 14.579 s    7 runs

Benchmark 4: many files, content compare
  Time (mean ± σ):     11.309 s ±  0.372 s    [User: 29.574 s, System: 6.649 s]
  Range (min … max):   10.881 s … 11.963 s    7 runs
```