### PR TITLE
Set default Endpoint check_origin value to :conn

### DIFF
--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -14,6 +14,7 @@ config :<%= @app_name %><%= if @namespaced? do %>,
 
 # Configures the endpoint
 config :<%= @app_name %>, <%= @endpoint_module %>,
+  check_origin: :conn,
   url: [host: "localhost"],
   render_errors: [
     formats: [<%= if @html do%>html: <%= @web_namespace %>.ErrorHTML, <% end %>json: <%= @web_namespace %>.ErrorJSON],

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
@@ -6,6 +6,7 @@ config :<%= @web_app_name %><%= if @namespaced? do %>,
 
 <% end %># Configures the endpoint
 config :<%= @web_app_name %>, <%= @endpoint_module %>,
+  check_origin: :conn,
   url: [host: "localhost"],
   render_errors: [
     formats: [<%= if @html do%>html: <%= @web_namespace %>.ErrorHTML, <% end %>json: <%= @web_namespace %>.ErrorJSON],

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -123,7 +123,7 @@ defmodule Phoenix.Endpoint do
       `false`.
 
     * `:check_origin` - configure the default `:check_origin` setting for
-      transports. See `socket/3` for options. Defaults to `true`.
+      transports. See `socket/3` for options. Defaults to `:conn`.
 
     * `:secret_key_base` - a secret key used as a base to generate secrets
       for encrypting and signing data. For example, cookies and tokens

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -174,7 +174,7 @@ defmodule Phoenix.Endpoint.Supervisor do
 
       # Runtime config
       cache_static_manifest: nil,
-      check_origin: true,
+      check_origin: :conn,
       http: false,
       https: false,
       reloadable_apps: nil,


### PR DESCRIPTION
Per [this conversation](https://community.fly.io/t/phoenix-liveview-constantly-refreshes-with-custom-domain/3384/5) the `check_origin: :conn` option introduced in Phoenix 1.6.6 is superior to `check_origin: true` and comes with no drawbacks. The post mentions the desire for this to be the default value going forward. This PR sets that default in both of the templates and in the endpoint supervisor defaults.