### PR TITLE
Changed <.flash_group> location to root.html.heex

### DIFF
--- a/installer/templates/phx_web/components/layouts/app.html.heex
+++ b/installer/templates/phx_web/components/layouts/app.html.heex
@@ -37,7 +37,6 @@
 </header>
 <main class="px-4 py-20 sm:px-6 lg:px-8">
   <div class="mx-auto max-w-2xl">
-    <.flash_group flash={@flash} />
     <%%= @inner_content %>
   </div>
 </main>

--- a/installer/templates/phx_web/components/layouts/root.html.heex
+++ b/installer/templates/phx_web/components/layouts/root.html.heex
@@ -12,6 +12,7 @@
     </script>
   </head>
   <body class="bg-white antialiased">
+    <.flash_group flash={@flash} />
     <%%= @inner_content %>
   </body>
 </html>

--- a/installer/templates/phx_web/controllers/page_html/home.html.heex
+++ b/installer/templates/phx_web/controllers/page_html/home.html.heex
@@ -1,4 +1,3 @@
-<.flash_group flash={@flash} />
 <div class="fixed inset-y-0 right-0 left-[40rem] hidden lg:block xl:left-[50rem]">
   <svg
     viewBox="0 0 1480 957"


### PR DESCRIPTION
Pull Request for #5247
_I made an error while merging in the earlier pull request #5256 so creating a new one as the master changed._

As master has changed to `<.flash_group>`; it is updated accordingly. Since flash_group has also been added to `home.html.heex` since we last discussed, I have added it `<.flash_group>` to `root.html.heex` which supersedes all layouts and remove it from everywhere else. 

I hope this is the correct way to go about it. 