### PR TITLE
Show the git diff of any bad formatting to make debugging significantly easier

### DIFF
--- a/integration_test/test/support/code_generator_case.ex
+++ b/integration_test/test/support/code_generator_case.ex
@@ -86,7 +86,12 @@ defmodule Phoenix.Integration.CodeGeneratorCase do
   end
 
   def assert_passes_formatter_check(app_path) do
-    mix_run!(~w(format --check-formatted), app_path)
+    try do
+      mix_run!(~w(format --check-formatted), app_path)
+    rescue
+      RuntimeError ->
+        System.cmd("git", ["--no-pager", "diff"], [stderr_to_stdout: true, cd: Path.expand(app_path)])
+    end
   end
 
   def assert_no_compilation_warnings(app_path) do

--- a/integration_test/test/support/code_generator_case.ex
+++ b/integration_test/test/support/code_generator_case.ex
@@ -90,6 +90,13 @@ defmodule Phoenix.Integration.CodeGeneratorCase do
   def assert_passes_formatter_check(app_path) do
     mix_run!(~w(format --check-formatted), app_path, [], fn ->
       System.cmd("git", ["--no-pager", "diff"], [stderr_to_stdout: true, cd: Path.expand(app_path)])
+      |> case do
+        {output, 0} ->
+          output
+
+        {output, _} ->
+          output
+      end
     end)
   end
 

--- a/integration_test/test/support/code_generator_case.ex
+++ b/integration_test/test/support/code_generator_case.ex
@@ -26,28 +26,7 @@ defmodule Phoenix.Integration.CodeGeneratorCase do
     {app_root_path, output}
   end
 
-  def mix_run!(args, app_path, opts \\ [])
-      when is_list(args) and is_binary(app_path) and is_list(opts) do
-    case mix_run(args, app_path, opts) do
-      {output, 0} ->
-        output
-
-      {output, exit_code} ->
-        raise """
-        mix command failed with exit code: #{inspect(exit_code)}
-
-        mix #{Enum.join(args, " ")}
-
-        #{output}
-
-        Options
-        cd: #{Path.expand(app_path)}
-        env: #{opts |> Keyword.get(:env, []) |> inspect()}
-        """
-    end
-  end
-
-  def mix_run!(args, app_path, after_callback, opts \\ [])
+  def mix_run!(args, app_path, opts \\ [], after_callback \\ fn -> "" end)
       when is_list(args) and is_binary(app_path) and is_list(opts) do
     case mix_run(args, app_path, opts) do
       {output, 0} ->
@@ -109,7 +88,7 @@ defmodule Phoenix.Integration.CodeGeneratorCase do
   end
 
   def assert_passes_formatter_check(app_path) do
-    mix_run!(~w(format --check-formatted), app_path, fn ->
+    mix_run!(~w(format --check-formatted), app_path, [], fn ->
       System.cmd("git", ["--no-pager", "diff"], [stderr_to_stdout: true, cd: Path.expand(app_path)])
     end)
   end

--- a/integration_test/test/support/code_generator_case.ex
+++ b/integration_test/test/support/code_generator_case.ex
@@ -88,9 +88,8 @@ defmodule Phoenix.Integration.CodeGeneratorCase do
   def assert_passes_formatter_check(app_path) do
     try do
       mix_run!(~w(format --check-formatted), app_path)
-    rescue
-      RuntimeError ->
-        System.cmd("git", ["--no-pager", "diff"], [stderr_to_stdout: true, cd: Path.expand(app_path)])
+    after
+      System.cmd("git", ["--no-pager", "diff"], [stderr_to_stdout: true, cd: Path.expand(app_path)])
     end
   end
 


### PR DESCRIPTION
When tests are failing due to the generators creating files that don't pass the formatter check it's incredibly hard to find read the bad output . This is a caveman approach, using git to show the difference.