### PR TITLE
Provide a better error message when getting malformed V1 Socket Payloads

### DIFF
--- a/lib/phoenix/socket/serializers/v1_json_serializer.ex
+++ b/lib/phoenix/socket/serializers/v1_json_serializer.ex
@@ -4,10 +4,6 @@ defmodule Phoenix.Socket.V1.JSONSerializer do
 
   alias Phoenix.Socket.{Broadcast, Message, Reply}
 
-  defmodule MessageFormatException do
-    defexception [:message]
-  end
-
   @impl true
   def fastlane!(%Broadcast{} = msg) do
     map = %Message{topic: msg.topic, event: msg.event, payload: msg.payload}
@@ -39,7 +35,7 @@ defmodule Phoenix.Socket.V1.JSONSerializer do
         Phoenix.Socket.Message.from_map!(payload)
 
       other ->
-        raise MessageFormatException, "V1 JSON Serializer expected a map, got #{inspect(other)}"
+        raise "V1 JSON Serializer expected a map, got #{inspect(other)}"
     end
   end
 

--- a/test/phoenix/socket/v1_json_serializer_test.exs
+++ b/test/phoenix/socket/v1_json_serializer_test.exs
@@ -6,6 +6,7 @@ defmodule Phoenix.Socket.V1.JSONSerializerTest do
   # v1 responses must not contain join_ref
   @serializer V1.JSONSerializer
   @v1_msg_json "{\"event\":\"e\",\"payload\":\"m\",\"ref\":null,\"topic\":\"t\"}"
+  @v1_bad_json "[null,null,\"t\",\"e\",{\"m\":1}]"
   @v1_reply_json "{\"event\":\"phx_reply\",\"payload\":{\"response\":null,\"status\":null},\"ref\":\"null\",\"topic\":\"t\"}"
   @v1_fastlane_json "{\"event\":\"e\",\"payload\":\"m\",\"ref\":null,\"topic\":\"t\"}"
 
@@ -33,7 +34,15 @@ defmodule Phoenix.Socket.V1.JSONSerializerTest do
 
   test "decode!/2 decodes `Phoenix.Socket.Message` from JSON" do
     assert %Message{topic: "t", event: "e", payload: "m"} ==
-      decode!(@serializer, @v1_msg_json, opcode: :text)
+             decode!(@serializer, @v1_msg_json, opcode: :text)
+  end
+
+  test "decode!/2 raise a PayloadFormatException if the JSON doesn't contain a map" do
+    assert_raise(
+      V1.JSONSerializer.MessageFormatException,
+      "V1 JSON Serializer expected a map, got [nil, nil, \"t\", \"e\", %{\"m\" => 1}]",
+      fn -> decode!(@serializer, @v1_bad_json, opcode: :text) end
+    )
   end
 
   test "fastlane!/1 encodes a broadcast into a message as JSON" do

--- a/test/phoenix/socket/v1_json_serializer_test.exs
+++ b/test/phoenix/socket/v1_json_serializer_test.exs
@@ -39,7 +39,7 @@ defmodule Phoenix.Socket.V1.JSONSerializerTest do
 
   test "decode!/2 raise a PayloadFormatException if the JSON doesn't contain a map" do
     assert_raise(
-      V1.JSONSerializer.MessageFormatException,
+      RuntimeError,
       "V1 JSON Serializer expected a map, got [nil, nil, \"t\", \"e\", %{\"m\" => 1}]",
       fn -> decode!(@serializer, @v1_bad_json, opcode: :text) end
     )


### PR DESCRIPTION
Currently, if when establishing a websocket connect, no `vsn` parameter is given, the socket connection defaults to the V1 serializer for encoding and decoding message. If passed a message that doesn't match what the serializer is expecting, a very cryptic message is raised:

```
Ranch listener TenantWeb.Endpoint.HTTP had connection process started with :cowboy_clear:start_link/4 at #PID<0.30056.42> exit with reason: {:function_clause, [{Phoenix.Socket.Message, :from_map!, [[nil, "1", "phoenix", "heartbeat", %{}]], []}, {Phoenix.Socket, :__in__, 2, [file: 'lib/phoenix/socket.ex', line: 471]}, {Phoenix.Endpoint.Cowboy2Handler, :websocket_handle, 2, [file: 'lib/phoenix/endpoint/cowboy2_handler.ex', line: 145]}, {:cowboy_websocket, :handler_call, 6, [file: '/build/deps/cowboy/src/cowboy_websocket.erl', line: 528]}, {:cowboy_http, :loop, 1, [file: '/build/deps/cowboy/src/cowboy_http.erl', line: 257]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}]}
```

This error is not user friendly and it is not immediately obvious what the problem is.

Our application is occassionally hit by scraper/bots/scanners etc who try to send garbage to the websocket, and every time, it takes us some amount of digging before we remember that this is really just a malformed message.