### PR TITLE
Fix typespec for Phoenix.put_new_layout

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -690,7 +690,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_new_layout(Plug.Conn.t(), [{format :: atom, layout}]) :: Plug.Conn.t()
+  @spec put_new_layout(Plug.Conn.t(), [{format :: atom, layout}] | layout) :: Plug.Conn.t()
   def put_new_layout(%Plug.Conn{state: state} = conn, layout)
       when (is_tuple(layout) and tuple_size(layout) == 2) or is_list(layout) or layout == false do
     unless state in @unsent, do: raise(AlreadySentError)


### PR DESCRIPTION
Relates to: https://github.com/phoenixframework/phoenix/issues/5278#issuecomment-1432896755

```elixir
@spec put_new_layout(Plug.Conn.t(), [{format :: atom, layout}] | layout) :: Plug.Conn.t()
  def put_new_layout(%Plug.Conn{state: state} = conn, layout)
      when (is_tuple(layout) and tuple_size(layout) == 2) or is_list(layout) or layout == false do
```

The typespec is now in sync with the guards and allows to pass a `layout()` without a `format`.

# Reason
The problem starts when [default layouts](https://github.com/phoenixframework/phoenix/blob/v1.7.0-rc.3/lib/phoenix/controller.ex#L230) are set in the Phoenix.Controller and the error case of [__view__](https://github.com/phoenixframework/phoenix/blob/v1.7.0-rc.3/lib/phoenix/controller.ex#L1823)
and [__layout__ ](https://github.com/phoenixframework/phoenix/blob/v1.7.0-rc.3/lib/phoenix/controller.ex#L1860), don't return a `format`. This makes the return incompatible with new layout definition.

I guess all those function will be removed very soon.

