### PR TITLE
fix: check ECTO_IPV6 for falsey values to enable ipv6

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -356,7 +356,8 @@ defmodule Phx.New.Generator do
           For example: ecto://USER:PASS@HOST/DATABASE
           \"""
 
-      maybe_ipv6 = if System.get_env("ECTO_IPV6"), do: [:inet6], else: []
+      maybe_ipv6 = if System.get_env("ECTO_IPV6") not in ["", "0", "false"], do: [:inet6], else: []
+
       """,
       prod_config: """
       # ssl: true,

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -356,7 +356,7 @@ defmodule Phx.New.Generator do
           For example: ecto://USER:PASS@HOST/DATABASE
           \"""
 
-      maybe_ipv6 = if System.get_env("ECTO_IPV6") in ["true", "1"], do: [:inet6], else: []
+      maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []
 
       """,
       prod_config: """

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -356,7 +356,7 @@ defmodule Phx.New.Generator do
           For example: ecto://USER:PASS@HOST/DATABASE
           \"""
 
-      maybe_ipv6 = if System.get_env("ECTO_IPV6") not in ["", "0", "false"], do: [:inet6], else: []
+      maybe_ipv6 = if System.get_env("ECTO_IPV6") in ["true", "1"], do: [:inet6], else: []
 
       """,
       prod_config: """

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -180,7 +180,7 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~ config
 
         assert file =~
-                 ~S|maybe_ipv6 = if System.get_env("ECTO_IPV6") in ["true", "1"], do: [:inet6], else: []|
+                 ~S|maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []|
 
         assert file =~ ~S|socket_options: maybe_ipv6|
 

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -178,7 +178,10 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file("phx_blog/config/runtime.exs", fn file ->
         assert file =~ config
-        assert file =~ ~S|maybe_ipv6 = if System.get_env("ECTO_IPV6"), do: [:inet6], else: []|
+
+        assert file =~
+                 ~S|maybe_ipv6 = if System.get_env("ECTO_IPV6") not in ["", "0", "false"], do: [:inet6], else: []|
+
         assert file =~ ~S|socket_options: maybe_ipv6|
 
         assert file =~ """

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -180,7 +180,7 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~ config
 
         assert file =~
-                 ~S|maybe_ipv6 = if System.get_env("ECTO_IPV6") not in ["", "0", "false"], do: [:inet6], else: []|
+                 ~S|maybe_ipv6 = if System.get_env("ECTO_IPV6") in ["true", "1"], do: [:inet6], else: []|
 
         assert file =~ ~S|socket_options: maybe_ipv6|
 

--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
 
       Add the following to your config/runtime.exs:
 
-          maybe_ipv6 = if System.get_env("ECTO_IPV6"), do: [:inet6], else: []
+          maybe_ipv6 = if System.get_env("ECTO_IPV6") not in ["", "0", "false"], do: [:inet6], else: []
 
           config :#{app}, #{app_namespace}.Repo,
             ...,

--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
 
       Add the following to your config/runtime.exs:
 
-          maybe_ipv6 = if System.get_env("ECTO_IPV6") not in ["", "0", "false"], do: [:inet6], else: []
+          maybe_ipv6 = if System.get_env("ECTO_IPV6") in ["true", "1"], do: [:inet6], else: []
 
           config :#{app}, #{app_namespace}.Repo,
             ...,

--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
 
       Add the following to your config/runtime.exs:
 
-          maybe_ipv6 = if System.get_env("ECTO_IPV6") in ["true", "1"], do: [:inet6], else: []
+          maybe_ipv6 = if System.get_env("ECTO_IPV6") in ~w(true 1), do: [:inet6], else: []
 
           config :#{app}, #{app_namespace}.Repo,
             ...,


### PR DESCRIPTION
This PR implements the backward compatible approach suggested by @ijdickinson in [this comment](https://github.com/phoenixframework/phoenix/issues/5164#issuecomment-1399218037).

We enable ipv6 when `ECTO_IPV6` is not empty, or `0`, or `false`.

Fixes #5164.

Built with ❤️ in Milan during [![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)