### PR TITLE
Pin esbuild version to match the build.js script

### DIFF
--- a/guides/asset_management.md
+++ b/guides/asset_management.md
@@ -75,7 +75,7 @@ The following is an example of a custom build using esbuild via Node.JS. First o
 Then you'll need to add `esbuild` to your Node.js packages and the Phoenix packages. Inside the `assets` directory, run:
 
 ```console
-$ npm install esbuild --save-dev
+$ npm install esbuild@0.16.17  --save-dev
 $ npm install ../deps/phoenix ../deps/phoenix_html ../deps/phoenix_live_view --save
 ```
 


### PR DESCRIPTION
esbuild v0.17 deprecated the watch option: https://github.com/evanw/esbuild/releases/tag/v0.17.0

As such the build.js in the documentation does not work with it.

(next step would be to have an updated version of it)