### PR TITLE
Fix warning for string keys on form for phx.gen.auth on login_live.ex

### DIFF
--- a/priv/templates/phx.gen.auth/login_live.ex
+++ b/priv/templates/phx.gen.auth/login_live.ex
@@ -37,7 +37,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   def mount(_params, _session, socket) do
     email = live_flash(socket.assigns.flash, :email)
-    form = to_form(%{email: email}, as: "<%= schema.singular %>")
+    form = to_form(%{"email" => email}, as: "<%= schema.singular %>")
     {:ok, assign(socket, form: form), temporary_assigns: [form: form]}
   end
 end


### PR DESCRIPTION
warning: a map with atom keys was given to a form. Maps are always considered parameters and therefore must have string keys, got: %{email: nil}
  (phoenix_html 3.3.1) lib/phoenix_html/form_data.ex:83: Phoenix.HTML.FormData.Map.name_params_and_opts/2
  (phoenix_html 3.3.1) lib/phoenix_html/form_data.ex:53: Phoenix.HTML.FormData.Map.to_form/2