### PR TITLE
Clarify allowed arguments for pipe_through & make router auth imports explicit

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -507,7 +507,14 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
     web_prefix = Mix.Phoenix.web_path(ctx_app)
     file_path = Path.join(web_prefix, "router.ex")
     auth_module = Keyword.fetch!(binding, :auth_module)
-    inject = "import #{inspect(auth_module)}"
+    inject = String.trim("""
+          import #{inspect(auth_module)},
+           only: [
+             fetch_current_user: 2,
+             redirect_if_user_is_authenticated: 2,
+             require_authenticated_user: 2
+           ]
+    """)
     use_line = "use #{inspect(context.web_module)}, :router"
 
     help_text = """

--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -509,11 +509,11 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
     auth_module = Keyword.fetch!(binding, :auth_module)
     inject = String.trim("""
           import #{inspect(auth_module)},
-           only: [
-             fetch_current_user: 2,
-             redirect_if_user_is_authenticated: 2,
-             require_authenticated_user: 2
-           ]
+            only: [
+              fetch_current_user: 2,
+              redirect_if_user_is_authenticated: 2,
+              require_authenticated_user: 2
+            ]
     """)
     use_line = "use #{inspect(context.web_module)}, :router"
 

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -846,7 +846,13 @@ defmodule Phoenix.Router do
   @doc """
   Defines a list of plugs (and pipelines) to send the connection through.
 
-  See `pipeline/2` for more information.
+  Plugs are specified using the atom name of any imported 2-arity function
+  which takes a `%Plug.Conn{}` and options and returns a `%Plug.Conn{}`; for
+  example, `:require_authenticated_user`.
+
+  Pipelines are defined in the router; see `pipeline/2` for more information.
+
+        pipe_through [:my_imported_function, :my_pipeline]
   """
   defmacro pipe_through(pipes) do
     pipes =

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -1282,7 +1282,12 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                                  use MyAppWeb, :router
 
                                  # Import authentication plugs
-                                 import MyAppWeb.UserAuth
+                                 import MyAppWeb.UserAuth,
+                                  only: [
+                                    fetch_current_user: 2,
+                                    redirect_if_user_is_authenticated: 2,
+                                    require_authenticated_user: 2
+                                  ]
 
                                  ...
                                end

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -1283,11 +1283,11 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
                                  # Import authentication plugs
                                  import MyAppWeb.UserAuth,
-                                  only: [
-                                    fetch_current_user: 2,
-                                    redirect_if_user_is_authenticated: 2,
-                                    require_authenticated_user: 2
-                                  ]
+                                   only: [
+                                     fetch_current_user: 2,
+                                     redirect_if_user_is_authenticated: 2,
+                                     require_authenticated_user: 2
+                                   ]
 
                                  ...
                                end


### PR DESCRIPTION
I was confused about why `:require_authenticated_user` works, and after investigating, wanted to document it.

Also, update the generated code so that the functions the router `import`s from the auth module are explicitly listed, so that people are not encouraged to `import GiantPileOfFunctions` and make their router pipelines harder to understand.