### PR TITLE
Fix token typespec for socket like struct

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -92,7 +92,7 @@ defmodule Phoenix.Token do
 
   require Logger
 
-  @type context :: Plug.Conn.t() | %{endpoint: atom} | atom | binary
+  @type context :: Plug.Conn.t() | %{required(:endpoint) => atom, optional(atom()) => any()} | atom | binary
 
   @type shared_opt ::
           {:key_iterations, pos_integer}


### PR DESCRIPTION
Hello, I've found a wrong typespec for socket-like struct which was added in that [commit](https://github.com/phoenixframework/phoenix/commit/2aa5c9b0d6d8a6edfb2df2375868928d02780a0a) and dialyzer raise warnings when socket object passes here. Maybe I was wrong, but I wrote some examples with similar typespec, and it's not passed.

Examples:
wrong typespec, dialyzer has not passed:
```
defmodule BackendWeb.Test do
  @type context :: %{endpoint: atom} | atom | binary

  @spec test(context) :: {:ok, context}
  def test(context) do
    {:ok, context}
  end

  def test_spec() do
    test(:atom)
    test("binary")

    test(%Phoenix.Socket{
      endpoint: :atom,
      channel: :atom,
      channel_pid: self(),
      handler: :atom,
      pubsub_server: :atom,
      serializer: :atom,
      topic: "topic",
      transport: :atom,
      transport_pid: self()
    })
  end
end
```

dyalizer error:
```
The function call will not succeed.

BackendWeb.Test.test(%Phoenix.Socket{
  :assigns => %{},
  :channel => :atom,
  :channel_pid => pid(),
  :endpoint => :atom,
  :handler => :atom,
  :id => nil,
  :join_ref => nil,
  :joined => false,
  :private => %{},
  :pubsub_server => :atom,
  :ref => nil,
  :serializer => :atom,
  :topic => <<_::40>>,
  :transport => :atom,
  :transport_pid => pid()
})

breaks the contract
(context()) :: {:ok, context()}
```

with right specs dialyzer has passed"
```
defmodule BackendWeb.Test do
 

  @type context :: %{required(:endpoint) => atom, optional(atom) => any()} | atom | binary

  @spec test(context) :: {:ok, context}
  def test(context) do
    {:ok, context}
  end

  def test_spec() do
    test(:atom)
    test("binary")

    test(%Phoenix.Socket{
      endpoint: :atom,
      channel: :atom,
      channel_pid: self(),
      handler: :atom,
      pubsub_server: :atom,
      serializer: :atom,
      topic: "topic",
      transport: :atom,
      transport_pid: self()
    })
  end
end
```