### PR TITLE
Include `{:error, reason}` in `c:Phoenix.Socket.Transport.connect/1`

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -122,9 +122,10 @@ defmodule Phoenix.Socket.Transport do
   Connects to the socket.
 
   The transport passes a map of metadata and the socket
-  returns `{:ok, state}` or `:error`. The state must be
-  stored by the transport and returned in all future
-  operations.
+  returns `{:ok, state}`. `{:error, reason}` or `:error`. 
+  The state must be stored by the transport and returned 
+  in all future operations. `{:error, reason}` can only 
+  be used with websockets.
 
   This function is used for authorization purposes and it
   may be invoked outside of the process that effectively
@@ -142,7 +143,7 @@ defmodule Phoenix.Socket.Transport do
       serializers and their requirements
 
   """
-  @callback connect(transport_info :: map) :: {:ok, state} | :error
+  @callback connect(transport_info :: map) :: {:ok, state} | {:error, term()} | :error
 
   @doc """
   Initializes the socket state.


### PR DESCRIPTION
[`Phoenix.Socket.connect/2`](https://hexdocs.pm/phoenix/Phoenix.Socket.html#c:connect/2) can return `{:error, term()}` tuple, while [`c:Phoenix.Socket.Trasnport.connect/1`](https://hexdocs.pm/phoenix/Phoenix.Socket.Transport.html#c:connect/1) allows only for `:error`. 