### PR TITLE
Improved the code consistency of the login_live_test.exs template

### DIFF
--- a/priv/templates/phx.gen.auth/login_live_test.exs
+++ b/priv/templates/phx.gen.auth/login_live_test.exs
@@ -63,7 +63,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
       {:ok, _login_live, login_html} =
         lv
-        |> element(~s|a:fl-contains("Sign up")|)
+        |> element(~s|main a:fl-contains("Sign up")|)
         |> render_click()
         |> follow_redirect(conn, ~p"<%= schema.route_prefix %>/register")
 
@@ -77,7 +77,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
       {:ok, conn} =
         lv
-        |> element(~s{a:fl-contains('Forgot your password?')})
+        |> element(~s|main a:fl-contains("Forgot your password?")|)
         |> render_click()
         |> follow_redirect(conn, ~p"<%= schema.route_prefix %>/reset_password")
 


### PR DESCRIPTION
The [login_live_test.exs](https://github.com/phoenixframework/phoenix/blob/master/priv/templates/phx.gen.auth/login_live_test.exs) template differed from the templates [registration_live_test.exs](https://github.com/phoenixframework/phoenix/blob/master/priv/templates/phx.gen.auth/registration_live_test.exs#L80) and [reset_password_live_test.exs](https://github.com/phoenixframework/phoenix/blob/master/priv/templates/phx.gen.auth/reset_password_live_test.exs#L96) by [not using `main` as part of the selector](https://github.com/phoenixframework/phoenix/blob/master/priv/templates/phx.gen.auth/login_live_test.exs#L66) and [not using a sigil with vertical bars](https://github.com/phoenixframework/phoenix/blob/master/priv/templates/phx.gen.auth/login_live_test.exs#L80).

I'm pedantic and this inconsistency really bugged me :sweat_smile: So I changed it!

All tests still work.