### PR TITLE
Prevent duplicate DOM ids.

### DIFF
--- a/priv/templates/phx.gen.auth/settings_live.ex
+++ b/priv/templates/phx.gen.auth/settings_live.ex
@@ -39,7 +39,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       phx-submit="update_password"
       phx-trigger-action={@trigger_submit}
     >
-      <.input field={@password_form[:email]} type="hidden" value={@current_email} />
+      <.input field={@password_form[:email]} type="hidden" value={@current_email} id="hidden_user_email"/>
       <.input field={@password_form[:password]} type="password" label="New password" required />
       <.input
         field={@password_form[:password_confirmation]}


### PR DESCRIPTION
The template for user settings renders two DOM nodes with the same `id`. One is the visible email input on the change email form and the other is a hidden input on the change password form.

This PR gives the hidden email input a specific id of `hidden_user_email` to ensure valid HTML and prevent the error "Multiple IDs detected: user_email. Ensure unique element ids." from being displayed in the developer console.