### PR TITLE
update heroicons upgrade instructions

### DIFF
--- a/installer/templates/phx_assets/hero_icons/UPGRADE.md
+++ b/installer/templates/phx_assets/hero_icons/UPGRADE.md
@@ -2,6 +2,6 @@ You are running heroicons v2.0.16. To upgrade in place, you can run the followin
 where your `HERO_VSN` export is your desired version:
 
     export HERO_VSN="2.0.16" ; \
-      curl -L -o optimized.zip "https://github.com/tailwindlabs/heroicons/archive/refs/tags/v${HERO_VSN}.zip" ; \
-      tar --strip-components=1 -xvf optimized.zip heroicons-${HERO_VSN}/optimized ; \
-      rm optimized.zip
+      curl -L -o optimized.tar.gz "https://github.com/tailwindlabs/heroicons/archive/refs/tags/v${HERO_VSN}.tar.gz" ; \
+      tar --strip-components=1 -xvf optimized.tar.gz heroicons-${HERO_VSN}/optimized ; \
+      rm optimized.tar.gz


### PR DESCRIPTION
Due to some differences between BSD and GNU `tar`, it may be better to use the `tar.gz` artifact so that the instructions remain consistent across different environments when updating heroicons. This should address the error below when following the instructions with GNU tar installed.

```
tar: This does not look like a tar archive
tar: Skipping to next header
tar: heroicons-2.0.16/optimized: Not found in archive
tar: Exiting with failure status due to previous errors
```

Should the generator be updated to use `optimized.tar.gz` and `:erl_tar.extract/2`?