### PR TITLE
Fetch and extract heroicons in one step

### DIFF
--- a/installer/templates/phx_assets/hero_icons/UPGRADE.md
+++ b/installer/templates/phx_assets/hero_icons/UPGRADE.md
@@ -2,6 +2,5 @@ You are running heroicons v2.0.16. To upgrade in place, you can run the followin
 where your `HERO_VSN` export is your desired version:
 
     export HERO_VSN="2.0.16" ; \
-      curl -L -o optimized.tar.gz "https://github.com/tailwindlabs/heroicons/archive/refs/tags/v${HERO_VSN}.tar.gz" ; \
-      tar --strip-components=1 -xvf optimized.tar.gz heroicons-${HERO_VSN}/optimized ; \
-      rm optimized.tar.gz
+      curl -L "https://github.com/tailwindlabs/heroicons/archive/refs/tags/v${HERO_VSN}.tar.gz" | \
+      tar -xv --strip-components=1 heroicons-${HERO_VSN}/optimized


### PR DESCRIPTION
In UNIX like system, it's a common practice to alias `rm` to less dangerous commands, like:
+ `alias rm="trash"`
+ `alias rm="echo 'please use trash'"`
+ ...

If the developer indeed did so, the commands in `UPGRADE.md` may fail.

A good solution is to not use the "rm" command.

---

This PR is trying to fetching and extracting heroicons in one step, without using `rm`.