### PR TITLE
fix old link in doc

### DIFF
--- a/guides/deployment/fly.md
+++ b/guides/deployment/fly.md
@@ -398,6 +398,6 @@ Refer to the [Fly.io Elixir documentation](https://fly.io/docs/getting-started/e
 
 ## Troubleshooting
 
-See [Troubleshooting](https://fly.io/docs/getting-started/troubleshooting/#welcome-message)
+See [Troubleshooting](https://fly.io/docs/getting-started/troubleshooting/) and [Elixir Troubleshooting](https://fly.io/docs/elixir/the-basics/troubleshooting/)
 
 Visit the [Fly.io Community](https://community.fly.io/) to find solutions and ask questions.

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -52,13 +52,13 @@ $ git add .
 $ git commit -m "Initial commit"
 ```
 
-Heroku offers some great information on how it is using Git [here](https://devcenter.heroku.com/articles/git#tracking-your-app-in-git).
+Heroku offers some great information on how it is using Git [here](https://devcenter.heroku.com/articles/git#prerequisites-install-git-and-the-heroku-cli).
 
 ## Signing up for Heroku
 
 Signing up to Heroku is very simple, just head over to [https://signup.heroku.com/](https://signup.heroku.com/) and fill in the form.
 
-The Free plan will give us one web [dyno](https://devcenter.heroku.com/articles/dynos#dynos) and one worker dyno, as well as a PostgreSQL and Redis instance for free.
+The Free plan will give us one web [dyno](https://devcenter.heroku.com/articles/dynos) and one worker dyno, as well as a PostgreSQL and Redis instance for free.
 
 These are meant to be used for testing and development, and come with some limitations. In order to run a production application, please consider upgrading to a paid plan.
 

--- a/guides/howto/using_ssl.md
+++ b/guides/howto/using_ssl.md
@@ -31,7 +31,7 @@ Without the `otp_app:` key, we need to provide absolute paths to the files where
 Path.expand("../../../some/path/to/ssl/key.pem", __DIR__)
 ```
 
-The options under the `https:` key are passed to the Plug adapter, typically `Plug.Cowboy`, which in turn uses `Plug.SSL` to select the TLS socket options. Please refer to the documentation for [Plug.SSL.configure/1](https://hexdocs.pm/plug/Plug.SSL.html#configure/1) for more information on the available options and their defaults. The [Plug HTTPS Guide](https://hexdocs.pm/plug/https.html) and the [Erlang/OTP ssl](https://erlang.org/doc/man/ssl.html) documentation also provide valuable information.
+The options under the `https:` key are passed to the Plug adapter, typically `Plug.Cowboy`, which in turn uses `Plug.SSL` to select the TLS socket options. Please refer to the documentation for [Plug.SSL.configure/1](https://hexdocs.pm/plug/Plug.SSL.html#configure/1) for more information on the available options and their defaults. The [Plug HTTPS Guide](https://hexdocs.pm/plug/https.html) and the [Erlang/OTP ssl](https://www.erlang.org/doc/man/ssl.html) documentation also provide valuable information.
 
 ## SSL in Development
 

--- a/guides/introduction/community.md
+++ b/guides/introduction/community.md
@@ -24,15 +24,15 @@ There are a number of places to connect with community members at all experience
 
   * [Programming Phoenix LiveView - Interactive Elixir Web Programming Without Writing Any JavaScript - 2021 (by Bruce Tate and Sophie DeBenedetto)](https://pragprog.com/titles/liveview/programming-phoenix-liveview/)
 
-  * [Real-Time Phoenix - Build Highly Scalable Systems with Channels (by Stephen Bussey - 2020)](https://pragprog.com/book/sbsockets/real-time-phoenix)
+  * [Real-Time Phoenix - Build Highly Scalable Systems with Channels (by Stephen Bussey - 2020)](https://pragprog.com/titles/sbsockets/real-time-phoenix/)
 
-  * [Programming Phoenix 1.4 (by Bruce Tate and Phoenix core team members Chris McCord and José Valim - 2019)](https://pragprog.com/book/phoenix14/programming-phoenix-1-4)
+  * [Programming Phoenix 1.4 (by Bruce Tate and Phoenix core team members Chris McCord and José Valim - 2019)](https://pragprog.com/titles/phoenix14/programming-phoenix-1-4/)
 
   * [Phoenix in Action (by Geoffrey Lessel - 2019)](https://manning.com/books/phoenix-in-action)
 
   * [Phoenix Inside Out - Book Series (by Shankar Dhanasekaran - 2017)](https://shankardevy.com/phoenix-book/)
 
-  * [Functional Web Development with Elixir, OTP, and Phoenix Rethink the Modern Web App (by Lance Halvorsen - 2017)](https://pragprog.com/book/lhelph/functional-web-development-with-elixir-otp-and-phoenix)
+  * [Functional Web Development with Elixir, OTP, and Phoenix Rethink the Modern Web App (by Lance Halvorsen - 2017)](https://pragprog.com/titles/lhelph/functional-web-development-with-elixir-otp-and-phoenix/)
 
 ## Screencasts/Courses
 


### PR DESCRIPTION
Reading the doc I found some old links and I do this pr to correct them.

- In [`guides/howto/using_ssl.md`](https://hexdocs.pm/phoenix/using_ssl.html) the [link](https://erlang.org/doc/man/ssl.html) does not work without the "www" (all other links to the erlang doc use the "www").
- In [`guides/introduction/community.md`](https://hexdocs.pm/phoenix/community.html#books) the links to the pragprog books changed (none work except the last one).
- In [`guides/deployment/heroku.md`](https://hexdocs.pm/phoenix/heroku.html#initializing-git-repository) the [`#tracking-your-app-in-git`](https://web.archive.org/web/20210319082555/https://devcenter.heroku.com/articles/git#tracking-your-app-in-git) part was removed and now it should be `#prerequisites-install-git-and-the-heroku-cli`. Similarly, in another [link](https://devcenter.heroku.com/articles/dynos#dynos) the `#dynos` did not exist anymore.
- In [`guides/deployment/fly.md`](https://hexdocs.pm/phoenix/fly.html) The `#welcome-message` part is no longer there on [this](https://fly.io/docs/getting-started/troubleshooting/#welcome-message) and can be deleted, and can be added https://fly.io/docs/elixir/the-basics/troubleshooting to the doc.

Finally in [`guides/real_time/channels.md`](https://hexdocs.pm/phoenix/channels.html#example-application) the [app-to-heroku](https://phoenixchat.herokuapp.com/) is broken but it is more complicated to fix. I open a separate issue for that.