### PR TITLE
Fix hard coded paths in tests generated by `phx.gen.auth`

### DIFF
--- a/priv/templates/phx.gen.auth/forgot_password_live_test.exs
+++ b/priv/templates/phx.gen.auth/forgot_password_live_test.exs
@@ -12,8 +12,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       {:ok, lv, html} = live(conn, ~p"<%= schema.route_prefix %>/reset_password")
 
       assert html =~ "Forgot your password?"
-      assert has_element?(lv, ~s|a[href="#{~p"/users/register"}"]|, "Register")
-      assert has_element?(lv, ~s|a[href="#{~p"/users/log_in"}"]|, "Log in")
+      assert has_element?(lv, ~s|a[href="#{~p"<%= schema.route_prefix %>/register"}"]|, "Register")
+      assert has_element?(lv, ~s|a[href="#{~p"<%= schema.route_prefix %>/log_in"}"]|, "Log in")
     end
 
     test "redirects if already logged in", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/registration_controller_test.exs
+++ b/priv/templates/phx.gen.auth/registration_controller_test.exs
@@ -8,8 +8,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"<%= schema.route_prefix %>/register")
       response = html_response(conn, 200)
       assert response =~ "Register"
-      assert response =~ ~p"/users/log_in"
-      assert response =~ ~p"/users/register"
+      assert response =~ ~p"<%= schema.route_prefix %>/log_in"
+      assert response =~ ~p"<%= schema.route_prefix %>/register"
     end
 
     test "redirects if already logged in", %{conn: conn} do
@@ -36,8 +36,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
       assert response =~ email
-      assert response =~ ~p"/users/settings"
-      assert response =~ ~p"/users/log_out"
+      assert response =~ ~p"<%= schema.route_prefix %>/settings"
+      assert response =~ ~p"<%= schema.route_prefix %>/log_out"
     end
 
     test "render errors for invalid data", %{conn: conn} do

--- a/priv/templates/phx.gen.auth/session_controller_test.exs
+++ b/priv/templates/phx.gen.auth/session_controller_test.exs
@@ -12,7 +12,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"<%= schema.route_prefix %>/log_in")
       response = html_response(conn, 200)
       assert response =~ "Log in"
-      assert response =~ ~p"/users/register"
+      assert response =~ ~p"<%= schema.route_prefix %>/register"
       assert response =~ "Forgot your password?"
     end
 
@@ -36,8 +36,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       conn = get(conn, ~p"/")
       response = html_response(conn, 200)
       assert response =~ <%= schema.singular %>.email
-      assert response =~ ~p"/users/settings"
-      assert response =~ ~p"/users/log_out"
+      assert response =~ ~p"<%= schema.route_prefix %>/settings"
+      assert response =~ ~p"<%= schema.route_prefix %>/log_out"
     end
 
     test "logs the <%= schema.singular %> in with remember me", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do


### PR DESCRIPTION
In some tests generated by `phx.gen.auth` the paths are hard coded to `~p"/users/..."`, so the tests fail when a different schema module or web namespace is used.

To fix this problem, interpolate `<%= schema.route_prefix %>` into `~p` instead of hard coding `/users`.
 
I tested this PR manually with two examples from the official documentation:

```
$ mix phx.gen.auth Accounts User users --web Warehouse
$ mix phx.gen.auth Backoffice Admin admins
```

Please let me know if you would like additional assertions in `test/mix/tasks/phx.gen.auth_test.exs` for this PR. By reading through the existing tests I came to the conclusion that this bug is too specific to warrant its own regression test. Maybe adding a test for a schema module other than `User` might be a good idea, though?