### PR TITLE
Updating phx.gen moduledocs to fix improperly rendered table

### DIFF
--- a/lib/mix/tasks/phx.gen.ex
+++ b/lib/mix/tasks/phx.gen.ex
@@ -5,19 +5,19 @@ defmodule Mix.Tasks.Phx.Gen do
 
   @moduledoc """
   Lists all available Phoenix generators.
-  
+
   ## CRUD related generators
 
   The table below shows a summary of the contents created by the CRUD generators:
 
   | Task | Schema | Migration | Context | Controller | View | LiveView |
   |:------------------ |:-:|:-:|:-:|:-:|:-:|:-:|
-  | `phx.gen.embedded` | ✓ |   |   |   |   |   |
-  | `phx.gen.schema`   | ✓ | ✓ |   |   |   |   |
-  | `phx.gen.context`  | ✓ | ✓ | ✓ |   |   |   |
-  | `phx.gen.live`     | ✓ | ✓ | ✓ |   |   | ✓ |
-  | `phx.gen.json`     | ✓ | ✓ | ✓ | ✓ | ✓ |   |
-  | `phx.gen.html`     | ✓ | ✓ | ✓ | ✓ | ✓ |   |
+  | `phx.gen.embedded` | x |   |   |   |   |   |
+  | `phx.gen.schema`   | x | x |   |   |   |   |
+  | `phx.gen.context`  | x | x | x |   |   |   |
+  | `phx.gen.live`     | x | x | x |   |   | x |
+  | `phx.gen.json`     | x | x | x | x | x |   |
+  | `phx.gen.html`     | x | x | x | x | x |   |
   """
 
   def run(_args) do


### PR DESCRIPTION
When you run `mix help phx.gen` it renders a table. For some reason the checkmarks were taking up two "spaces" which messed up the table alignment. This PR replaces the `✓` with `x` and the table now renders properly.

### Before
<img width="626" alt="Screenshot 2023-03-11 at 1 26 52 PM" src="https://user-images.githubusercontent.com/374054/224512309-d37e22e7-9715-4cc2-b7a1-ea57a76b6471.png">

### After
<img width="626" alt="Screenshot 2023-03-11 at 1 27 06 PM" src="https://user-images.githubusercontent.com/374054/224512315-a8e905d8-deae-4e86-89b0-0b6606c0d552.png">
