### PR TITLE
Adjust text size of login and register links.

### DIFF
--- a/priv/templates/phx.gen.auth/forgot_password_live.ex
+++ b/priv/templates/phx.gen.auth/forgot_password_live.ex
@@ -19,7 +19,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           </.button>
         </:actions>
       </.simple_form>
-      <p class="text-center mt-4">
+      <p class="text-center text-sm mt-4">
         <.link href={~p"<%= schema.route_prefix %>/register"}>Register</.link>
         |
         <.link href={~p"<%= schema.route_prefix %>/log_in"}>Log in</.link>

--- a/priv/templates/phx.gen.auth/reset_password_edit.html.heex
+++ b/priv/templates/phx.gen.auth/reset_password_edit.html.heex
@@ -21,7 +21,7 @@
       </.button>
     </:actions>
   </.simple_form>
-  <p class="text-center mt-4">
+  <p class="text-center text-sm mt-4">
     <.link href={~p"<%= schema.route_prefix %>/register"}>Register</.link>
     |
     <.link href={~p"<%= schema.route_prefix %>/log_in"}>Log in</.link>

--- a/priv/templates/phx.gen.auth/reset_password_live.ex
+++ b/priv/templates/phx.gen.auth/reset_password_live.ex
@@ -30,7 +30,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         </:actions>
       </.simple_form>
 
-      <p class="text-center mt-4">
+      <p class="text-center text-sm mt-4">
         <.link href={~p"<%= schema.route_prefix %>/register"}>Register</.link>
         |
         <.link href={~p"<%= schema.route_prefix %>/log_in"}>Log in</.link>

--- a/priv/templates/phx.gen.auth/reset_password_new.html.heex
+++ b/priv/templates/phx.gen.auth/reset_password_new.html.heex
@@ -12,7 +12,7 @@
       </.button>
     </:actions>
   </.simple_form>
-  <p class="text-center mt-4">
+  <p class="text-center text-sm mt-4">
     <.link href={~p"<%= schema.route_prefix %>/register"}>Register</.link>
     |
     <.link href={~p"<%= schema.route_prefix %>/log_in"}>Log in</.link>


### PR DESCRIPTION
Both the login and register links on the bottom of the forgot / reset password screens is larger then any of the other text. I have changed them to the same size as the other text on the page.