### PR TITLE
Add as comments the phx.new arguments in mix.exs

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -149,7 +149,7 @@ defmodule Mix.Tasks.Phx.New do
 
       {opts, [base_path | _]} ->
         generator = if opts[:umbrella], do: Umbrella, else: Single
-        generate(base_path, generator, :project_path, opts)
+        generate(base_path, generator, :project_path, opts, argv)
     end
   end
 
@@ -159,15 +159,15 @@ defmodule Mix.Tasks.Phx.New do
 
     case OptionParser.parse!(argv, strict: @switches) do
       {_opts, []} -> Mix.Tasks.Help.run(["phx.new"])
-      {opts, [base_path | _]} -> generate(base_path, generator, path, opts)
+      {opts, [base_path | _]} -> generate(base_path, generator, path, opts, argv)
     end
   end
 
-  defp generate(base_path, generator, path, opts) do
+  defp generate(base_path, generator, path, opts, argv) do
     base_path
     |> Project.new(opts)
     |> generator.prepare_project()
-    |> Generator.put_binding()
+    |> Generator.put_binding(argv)
     |> validate_project(path)
     |> generator.generate()
     |> prompt_to_install_deps(generator, path)

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -181,7 +181,7 @@ defmodule Phx.New.Generator do
     File.exists?(mix_path) && File.exists?(apps_path)
   end
 
-  def put_binding(%Project{opts: opts} = project) do
+  def put_binding(%Project{opts: opts} = project, argv) do
     db = Keyword.get(opts, :database, "postgres")
     ecto = Keyword.get(opts, :ecto, true)
     html = Keyword.get(opts, :html, true)
@@ -247,7 +247,8 @@ defmodule Phx.New.Generator do
       adapter_config: adapter_config,
       generators: nil_if_empty(project.generators ++ adapter_generators(adapter_config)),
       namespaced?: namespaced?(project),
-      dev: dev
+      dev: dev,
+      phx_new_argv: format_phx_new_argv(argv)
     ]
 
     %Project{project | binding: binding}
@@ -255,6 +256,10 @@ defmodule Phx.New.Generator do
 
   defp namespaced?(project) do
     Macro.camelize(project.app) != inspect(project.app_mod)
+  end
+
+  defp format_phx_new_argv(argv) do
+    "# Generated with:\n  #   phx.new #{Enum.intersperse(argv, " ")}"
   end
 
   def gen_ecto_config(%Project{project_path: project_path, binding: binding}) do

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -1,6 +1,7 @@
 defmodule <%= @app_module %>.MixProject do
   use Mix.Project
 
+  <%= @phx_new_argv %>
   def project do
     [
       app: :<%= @app_name %>,

--- a/installer/templates/phx_umbrella/mix.exs
+++ b/installer/templates/phx_umbrella/mix.exs
@@ -1,6 +1,7 @@
 defmodule <%= @root_app_module %>.MixProject do
   use Mix.Project
 
+  <%= @phx_new_argv %>
   def project do
     [
       apps_path: "apps",


### PR DESCRIPTION
This PR allows the main mix.exs file to be documented with the `phx.new` arguments.
Think it might be useful.

The output generated by phx.new is similar to this:
```
 # Generated with:
 #   phx.new my_app --no-ecto
  def project do
    [
      app: :my_app,
      ...
    ]
```