### PR TITLE
Update core input component to support list attribute

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -254,7 +254,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
-  attr :rest, :global, include: ~w(autocomplete cols disabled form max maxlength min minlength
+  attr :rest, :global, include: ~w(autocomplete cols disabled form list max maxlength min minlength
                                    pattern placeholder readonly required rows size step)
   slot :inner_block
 

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -254,7 +254,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
-  attr :rest, :global, include: ~w(autocomplete cols disabled form max maxlength min minlength
+  attr :rest, :global, include: ~w(autocomplete cols disabled form list max maxlength min minlength
                                    pattern placeholder readonly required rows size step)
   slot :inner_block
 


### PR DESCRIPTION
Adds the "list" attribute to the allowed attributes you can pass into the input component. The list attribute is used in conjunction with the `datalist` element to generate auto-complete suggestions on text inputs.

```html
<input name="fruit"  list="fruit-suggestions" />

<datalist id="fruit-suggestions">
  <option value="Apple" />
  <option value="Orange" />
  <option value="Banana" />
</datalist>
```
