### PR TITLE
Add `component/0` Macro for Consistency

### DIFF
--- a/installer/templates/phx_single/lib/app_name_web.ex
+++ b/installer/templates/phx_single/lib/app_name_web.ex
@@ -66,6 +66,14 @@ defmodule <%= @web_namespace %> do
     end
   end
 
+  def component do
+    quote do
+      use Phoenix.Component
+
+      unquote(html_helpers())
+    end
+  end
+
   def html do
     quote do
       use Phoenix.Component


### PR DESCRIPTION
This PR adds a `component/0` macro to `installer/templates/phx_single/lib/app_name_web.ex` to improve consistency with other macros and to provide common HMTL helpers to functional components using the new macro.

**Pending**: A separate PR will be opened on `phoenix_live_view` to update the docs and error messages.

**Before**

Verified routes would require an additional import, otherwise, this would break:

```elixir
defmodule MyAppWeb.SomeComponent do
  use Phoenix.Component

  def render(assigns) do
    ~H"""
      <.link href={~p"/some/path"}>Some Link</.link>
    """
  end
end
```

**After**

The new macro includes the same HTML helpers as the `live_component/0` macro, so verified routes and other conveniences are included by default.

```elixir
defmodule MyAppWeb.SomeComponent do
  use MyAppWeb, :component

  def render(assigns) do
    ~H"""
      <.link href={~p"/some/path"}>Some Link</.link>
    """
  end
end
```
