### PR TITLE
Adding info log if they have http/https set but not server: true set

### DIFF
--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -123,16 +123,17 @@ defmodule Phoenix.Endpoint.Supervisor do
   end
 
   defp server_children(mod, config, server?) do
-    if server? do
-      adapter = config[:adapter] || Phoenix.Endpoint.Cowboy2Adapter
-      adapter.child_specs(mod, config)
-    else
-      if config[:http] || config[:https] do
+    cond do
+      server? ->
+        adapter = config[:adapter] || Phoenix.Endpoint.Cowboy2Adapter
+        adapter.child_specs(mod, config)
+
+      config[:http] || config[:https] ->
         Logger.info(
           "Configuration :server was not enabled for #{inspect(mod)}, http/https services won't start"
         )
-      end
-      []
+        []
+      true -> []
     end
   end
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -127,6 +127,11 @@ defmodule Phoenix.Endpoint.Supervisor do
       adapter = config[:adapter] || Phoenix.Endpoint.Cowboy2Adapter
       adapter.child_specs(mod, config)
     else
+      if config[:http] || config[:https] do
+        Logger.info(
+          "Configuration :server is false or not set for #{inspect(mod)}, will not be starting a webserver"
+        )
+      end
       []
     end
   end

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -129,7 +129,7 @@ defmodule Phoenix.Endpoint.Supervisor do
     else
       if config[:http] || config[:https] do
         Logger.info(
-          "Configuration :server is false or not set for #{inspect(mod)}, will not be starting a webserver"
+          "Configuration :server was not enabled for #{inspect(mod)}, http/https services won't start"
         )
       end
       []

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -132,8 +132,11 @@ defmodule Phoenix.Endpoint.Supervisor do
         Logger.info(
           "Configuration :server was not enabled for #{inspect(mod)}, http/https services won't start"
         )
+
         []
-      true -> []
+
+      true ->
+        []
     end
   end
 

--- a/test/phoenix/endpoint/supervisor_test.exs
+++ b/test/phoenix/endpoint/supervisor_test.exs
@@ -3,8 +3,6 @@ defmodule Phoenix.Endpoint.SupervisorTest do
   alias Phoenix.Endpoint.Supervisor
 
   defmodule HTTPSEndpoint do
-    def init(:supervisor, config), do: {:ok, config}
-    def __sockets__(), do: []
     def config(:otp_app), do: :phoenix
     def config(:https), do: [port: 443]
     def config(:http), do: false
@@ -13,8 +11,6 @@ defmodule Phoenix.Endpoint.SupervisorTest do
   end
 
   defmodule HTTPEndpoint do
-    def init(:supervisor, config), do: {:ok, config}
-    def __sockets__(), do: []
     def config(:otp_app), do: :phoenix
     def config(:https), do: false
     def config(:http), do: [port: 80]


### PR DESCRIPTION
When a user misconfigures their app to not set `server: true` on the endpoint with releases the app just hangs and has no reason to log anything by default. 

See https://github.com/dwyl/phoenix-liveview-chat-example/pull/111#discussion_r1137410990 this should warn them if they have HTTP/HTTPS set but not server: true. 