### PR TITLE
Specify which symlink was not created and propose solution

### DIFF
--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -49,7 +49,7 @@ defmodule Phoenix.CodeReloader.Server do
           else
             Logger.warning(
               "Phoenix is unable to create a #{priv_path} symlink, so the code reloader will maintain a copy" <>
-                " of the priv path that does not automatically remove obsolete files and may lag behind newly added assets. " <>
+                " of the priv path that does not automatically remove obsolete files and may lag behind newly added assets." <>
                 os_symlink(:os.type())
             )
           end

--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -48,8 +48,9 @@ defmodule Phoenix.CodeReloader.Server do
             Mix.Project.build_structure()
           else
             Logger.warning(
-              "Phoenix is unable to create symlinks. Phoenix' code reloader will run " <>
-                "considerably faster if symlinks are allowed." <> os_symlink(:os.type())
+              "Phoenix is unable to create a #{priv_path} symlink, so the code reloader will maintain a copy" <>
+                " of the priv path that does not automatically remove obsolete files and may lag behind newly added assets. " <>
+                os_symlink(:os.type())
             )
           end
       end
@@ -114,9 +115,9 @@ defmodule Phoenix.CodeReloader.Server do
 
   defp os_symlink({:win32, _}),
     do:
-      " On Windows, the lack of symlinks may even cause empty assets to be served. " <>
-        "Luckily, you can address this issue by starting your Windows terminal at least " <>
-        "once with \"Run as Administrator\" and then running your Phoenix application."
+      " This can be solved by starting the Phoenix application once from a Windows terminal that was " <>
+        "\"Run as Administrator\" or executing the following command from current PowerShell instance:\n" <>
+        "PS> Start-Process powershell -ArgumentList \"-Command Set-Location '$PWD'; mix phx.server\" -Verb RunAs"
 
   defp os_symlink(_),
     do: ""


### PR DESCRIPTION
Proposing a more specific message shown to a non-elevated Windows user that initially runs Phoenix Server, or does it after deleting the `_build` folder.

### Reasoning
My initial seeing of the message led me to wrong conclusions, even misunderstanding, and resulted in a situation where the uploaded files under `priv/static` continued to be served even after deletion from its source location, simply because the code reloader apparently does not delete obsolete files, supposedly to simplify the cloning process.

The need to run the `mix phx.server` once as administrator has to be a little less vague in my opinion, listing the actual symlink that was not created and making it clear why this is a cause of possible issues.

### One Command
Additionally, I propose a PowerShell command that can actually do the trick without the need to Right-Click and Run as administrator.

```powershell
Start-Process powershell -ArgumentList "-Command Set-Location '$PWD'; mix phx.server" -Verb RunAs
```

This PowerShell command performs the following tasks:

1. Uses the `Start-Process` cmdlet to start a new PowerShell process.
2. Passes two arguments to the new PowerShell process. The first argument is `-Command`, which tells PowerShell to execute a command specified in the second argument.
3. The second argument is `"Set-Location '$PWD'; mix phx.server"`, which is a command that does two things:
  * Sets the current working directory to the directory where the PowerShell command was executed (`Set-Location '$PWD'`).
  * Starts the Phoenix web server for a Phoenix framework application (`mix phx.server`).
4. The `-Verb RunAs` parameter tells PowerShell to start the new process with administrative privileges.

So, when this command is executed, it starts a new PowerShell process with administrative privileges, sets the current working directory to the directory where the command was executed, and starts the Phoenix web server for a Phoenix framework application.
