### PR TITLE
Notes about payload serialization

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -347,7 +347,8 @@ defmodule Phoenix.Channel do
   alias Phoenix.Socket
   alias Phoenix.Channel.Server
 
-  @type payload :: map | {:binary, binary}
+  @typedoc "Payload can be any term which the configured serializer can encode."
+  @type payload :: map | term | {:binary, binary}
   @type reply :: status :: atom | {status :: atom, response :: payload}
   @type socket_ref ::
           {transport_pid :: Pid, serializer :: module, topic :: binary, ref :: binary,
@@ -358,6 +359,8 @@ defmodule Phoenix.Channel do
 
   To authorize a socket, return `{:ok, socket}` or `{:ok, reply, socket}`. To
   refuse authorization, return `{:error, reason}`.
+
+  Payloads are serialized before sending with the configured serializer.
 
   ## Example
 
@@ -378,12 +381,13 @@ defmodule Phoenix.Channel do
   @doc """
   Handle incoming `event`s.
 
+  Payloads are serialized before sending with the configured serializer.
+
   ## Example
 
       def handle_in("ping", payload, socket) do
         {:reply, {:ok, payload}, socket}
       end
-
   """
   @callback handle_in(event :: String.t(), payload :: payload, socket :: Socket.t()) ::
               {:noreply, Socket.t()}
@@ -662,6 +666,8 @@ defmodule Phoenix.Channel do
   client message, and each reply will include the client message `ref`. But the
   client may expect only one reply; in that case, `push/3` would be preferable
   for the additional messages.
+
+  Payloads are serialized before sending with the configured serializer.
 
   ## Examples
 

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -347,7 +347,6 @@ defmodule Phoenix.Channel do
   alias Phoenix.Socket
   alias Phoenix.Channel.Server
 
-  @typedoc "Payload can be any term which the configured serializer can encode."
   @type payload :: map | term | {:binary, binary}
   @type reply :: status :: atom | {status :: atom, response :: payload}
   @type socket_ref ::

--- a/lib/phoenix/channel/server.ex
+++ b/lib/phoenix/channel/server.ex
@@ -235,6 +235,8 @@ defmodule Phoenix.Channel.Server do
   @doc """
   Pushes a message with the given topic, event and payload
   to the given process.
+
+  Payloads are serialized before sending with the configured serializer.
   """
   def push(pid, join_ref, topic, event, payload, serializer)
       when is_binary(topic) and is_binary(event) do
@@ -245,6 +247,8 @@ defmodule Phoenix.Channel.Server do
 
   @doc """
   Replies to a given ref to the transport process.
+
+  Payloads are serialized before sending with the configured serializer.
   """
   def reply(pid, join_ref, ref, topic, {status, payload}, serializer)
       when is_binary(topic) do


### PR DESCRIPTION
I was confused by some code which set a struct as a payload until I recalled that payloads get serialized this way and saw that the struct implemented the required protocol. I think this makes the expectation clearer.