### PR TITLE
Guides - ecto - remove alias from example of generated user schema

### DIFF
--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -155,7 +155,6 @@ Here's the `User` schema that Phoenix generated for us.
 defmodule Hello.User do
   use Ecto.Schema
   import Ecto.Changeset
-  alias Hello.User
 
   schema "users" do
     field :bio, :string


### PR DESCRIPTION
Guides - ecto - remove alias from example of generated user schema. Closes #5371