### PR TITLE
Fix `sigil_p` arity in docs for `url/1`

### DIFF
--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -302,7 +302,7 @@ defmodule Phoenix.VerifiedRoutes do
   @doc ~S'''
   Generates the router url with route verification.
 
-  See `sigil_p/1` for more information.
+  See `sigil_p/2` for more information.
 
   Warns when the provided path does not match against the router specified
   in `use Phoenix.VerifiedRoutes` or the `@router` module attribute.


### PR DESCRIPTION
`sigil_p/1` should be [`sigil_p/2`](https://github.com/phoenixframework/phoenix/blob/84a32e3605824c5190187afd61ffb9596fde9ff1/lib/phoenix/verified_routes.ex#LL202C12-L202C19)
