### PR TITLE
Fix heroicons upgrade instructions

### DIFF
--- a/installer/templates/phx_assets/heroicons/UPGRADE.md
+++ b/installer/templates/phx_assets/heroicons/UPGRADE.md
@@ -3,4 +3,4 @@ where your `HERO_VSN` export is your desired version:
 
     export HERO_VSN="2.0.16" ; \
       curl -L "https://github.com/tailwindlabs/heroicons/archive/refs/tags/v${HERO_VSN}.tar.gz" | \
-      tar -xv --strip-components=1 heroicons-${HERO_VSN}/optimized
+      tar -xvz --strip-components=1 heroicons-${HERO_VSN}/optimized


### PR DESCRIPTION
When running the current instructions on Ubuntu 22.04, I get the following error

    tar: Archive is compressed. Use -z option
    tar: Error is not recoverable: exiting now
    7  487k    7 37381    0     0  56439      0  0:00:08 --:--:--  0:00:08 56439
    curl: (23) Failure writing output to destination

This adds the -z option to unzip the .tar.gz file so it completes without error.