### PR TITLE
updated folder structures to match 1.7

### DIFF
--- a/guides/mix_tasks.md
+++ b/guides/mix_tasks.md
@@ -408,8 +408,10 @@ Before we run this task let's inspect the contents of two directories in our hel
 First `priv/static/` which should look similar to this:
 
 ```console
-├── images
-│   └── phoenix.png
+├── assets
+│   ├── app.css
+│   └── app.js
+├── favicon.ico
 └── robots.txt
 ```
 
@@ -417,11 +419,12 @@ And then `assets/` which should look similar to this:
 
 ```console
 ├── css
-│   └── app.css
+│   └── app.css
 ├── js
-│   └── app.js
+│   └── app.js
+├── tailwind.config.js
 └── vendor
-    └── phoenix.js
+    └── topbar.js
 ```
 
 All of these files are our static assets. Now let's run the `mix phx.digest` task.


### PR DESCRIPTION
updated folder structure of `priv/static` and `assets/` as part of `mix.digest` guide to match output from phoenix 1.7