### PR TITLE
Update example esbuild script for esbuild 0.17+

### DIFF
--- a/guides/asset_management.md
+++ b/guides/asset_management.md
@@ -89,55 +89,54 @@ $ yarn add ../deps/phoenix ../deps/phoenix_html ../deps/phoenix_live_view
 Next, add a custom JavaScript build script. We'll call the example `assets/build.js`:
 
 ```js
-const esbuild = require('esbuild')
+const esbuild = require("esbuild");
 
-const args = process.argv.slice(2)
-const watch = args.includes('--watch')
-const deploy = args.includes('--deploy')
+const args = process.argv.slice(2);
+const watch = args.includes('--watch');
+const deploy = args.includes('--deploy');
 
 const loader = {
   // Add loaders for images/fonts/etc, e.g. { '.svg': 'file' }
-}
+};
 
 const plugins = [
   // Add and configure plugins here
-]
+];
 
+// Define esbuild options
 let opts = {
-  entryPoints: ['js/app.js'],
+  entryPoints: ["js/app.js"],
   bundle: true,
-  target: 'es2017',
-  outdir: '../priv/static/assets',
-  logLevel: 'info',
-  loader,
-  plugins
-}
-
-if (watch) {
-  opts = {
-    ...opts,
-    watch,
-    sourcemap: 'inline'
-  }
-}
+  logLevel: "info",
+  target: "es2017",
+  outdir: "../priv/static/assets",
+  external: ["*.css", "fonts/*", "images/*"],
+  loader: loader,
+  plugins: plugins,
+};
 
 if (deploy) {
   opts = {
     ...opts,
-    minify: true
-  }
+    minify: true,
+  };
 }
 
-const promise = esbuild.build(opts)
-
 if (watch) {
-  promise.then(_result => {
-    process.stdin.on('close', () => {
-      process.exit(0)
+  opts = {
+    ...opts,
+    sourcemap: "inline",
+  };
+  esbuild
+    .context(opts)
+    .then((ctx) => {
+      ctx.watch();
     })
-
-    process.stdin.resume()
-  })
+    .catch((_error) => {
+      process.exit(1);
+    });
+} else {
+  esbuild.build(opts);
 }
 ```
 


### PR DESCRIPTION
`esbuild` 0.17.0 [changed the API](https://github.com/evanw/esbuild/releases/tag/v0.17.0) and the existing script from the docs no longer works in watch mode.

It fails with the following error:

```
➜ node build.js --watch
✘ [ERROR] Invalid option in build() call: "watch"

    /Users/dino/dev/phoenix-with-npm/assets/node_modules/esbuild/lib/main.js:255:12:
      255 │       throw new Error(`Invalid option ${where}: ${quote(key)}`);
          ╵             ^

    at checkForInvalidFlags (/Users/dino/dev/phoenix-with-npm/assets/node_modules/esbuild/lib/main.js:255:13)
    at flagsForBuildOptions (/Users/dino/dev/phoenix-with-npm/assets/node_modules/esbuild/lib/main.js:457:3)
    at buildOrContextContinue (/Users/dino/dev/phoenix-with-npm/assets/node_modules/esbuild/lib/main.js:1009:9)
    at buildOrContextImpl (/Users/dino/dev/phoenix-with-npm/assets/node_modules/esbuild/lib/main.js:993:5)
    at Object.buildOrContext (/Users/dino/dev/phoenix-with-npm/assets/node_modules/esbuild/lib/main.js:776:5)
    at /Users/dino/dev/phoenix-with-npm/assets/node_modules/esbuild/lib/main.js:2163:15
    at new Promise (<anonymous>)
    at Object.build (/Users/dino/dev/phoenix-with-npm/assets/node_modules/esbuild/lib/main.js:2162:25)
    at Object.build (/Users/dino/dev/phoenix-with-npm/assets/node_modules/esbuild/lib/main.js:2011:51)
    at Object.<anonymous> (/Users/dino/dev/phoenix-with-npm/assets/build.js:40:25)
```

The proposed change fixes the issue by using the new API.