### PR TITLE
Support passing false as the second argument in put_root_layout

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -755,7 +755,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_root_layout(Plug.Conn.t(), [{format :: atom, layout}]) ::
+  @spec put_root_layout(Plug.Conn.t(), [{format :: atom, layout}] | false) ::
           Plug.Conn.t()
   def put_root_layout(%Plug.Conn{state: state} = conn, layout) do
     if state in @unsent do


### PR DESCRIPTION
When a root layout is defined as a plug for example, and we want to disable it in a particular controller action, `put_root_layout(conn, html: false)` doesn't work.
The same way that we use to disable layouts `put_layout(conn, false)` can be used to disable root layouts, however the type spec was not supporting that, so apps using dialyzer get errors.
This adds spec support for passing `false` as second argument.