### PR TITLE
Channel guide: remove live demo reference

### DIFF
--- a/guides/real_time/channels.md
+++ b/guides/real_time/channels.md
@@ -481,5 +481,3 @@ Phoenix uses an at-most-once strategy when sending messages to clients. If the c
 ## Example Application
 
 To see an example of the application we just built, checkout the project [phoenix_chat_example](https://github.com/chrismccord/phoenix_chat_example).
-
-You can also see a live demo at <https://phoenixchat.herokuapp.com/>.


### PR DESCRIPTION
Since the heroku demo app isn't live anymore, consider removing a reference from the docs (the github repo is still referenced).

If the demo app is supposed to be live, please ignore.