### PR TITLE
Allow `<.input type="checkbox">` without `value` attr in core components

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -283,9 +283,9 @@ defmodule <%= @web_namespace %>.CoreComponents do
     |> input()
   end
 
-  def input(%{type: "checkbox", value: value} = assigns) do
+  def input(%{type: "checkbox"} = assigns) do
     assigns =
-      assign_new(assigns, :checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", value) end)
+      assign_new(assigns, :checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value]) end)
 
     ~H"""
     <div phx-feedback-for={@name}>

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -285,7 +285,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def input(%{type: "checkbox"} = assigns) do
     assigns =
-      assign_new(assigns, :checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", asigns[:value]) end)
+      assign_new(assigns, :checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", assigns[:value]) end)
 
     ~H"""
     <div phx-feedback-for={@name}>

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -283,9 +283,9 @@ defmodule <%= @web_namespace %>.CoreComponents do
     |> input()
   end
 
-  def input(%{type: "checkbox", value: value} = assigns) do
+  def input(%{type: "checkbox"} = assigns) do
     assigns =
-      assign_new(assigns, :checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", value) end)
+      assign_new(assigns, :checked, fn -> Phoenix.HTML.Form.normalize_value("checkbox", asigns[:value]) end)
 
     ~H"""
     <div phx-feedback-for={@name}>


### PR DESCRIPTION
Hi!

Currently, the `<.input type="checkbox">` in the core components is "unsafe" to use from a DX point of view:

Using `<.input type="checkbox" checked={true} />` without an attribute `value="…"` raises a runtime exception because the `value` key is not in assigns.

The `@value` is not a required attr in the `def input`, yet, the `def input` for checkbox was pattern matching for it in the function argument, so the `value` attr is de facto required even if announced optional.

I can’t see why the `value` is mandatory, the body of the function is barely using it as a fallback if `@checked` is not set. So I propose to just dropping it from the function pattern matching, and later check if present in the assigns map.


See also [this discussion](https://elixirforum.com/t/semantics-of-the-input-type-checkbox-in-core-components/55356) I started on elixir forum before making this PR.

Thanks for your kind review :pray: !