### PR TITLE
Reintroduce the File Uploads guide

### DIFF
--- a/guides/howto/file_uploads.md
+++ b/guides/howto/file_uploads.md
@@ -2,6 +2,12 @@
 
 One common task for web applications is uploading files. These files might be images, videos, PDFs, or files of any other type. In order to upload files through an HTML interface, we need a `file` input tag in a multipart form.
 
+> #### Looking for the LiveView Uploads guide? {: .neutral}
+>
+> This guide explains multipart HTTP file uploads via `Plug.Upload`.
+> For more information about LiveView file uploads, including direct-to-cloud external uploads on
+> the client, refer to the [LiveView Uploads guide](https://hexdocs.pm/phoenix_live_view/uploads.html).
+
 Plug provides a `Plug.Upload` struct to hold the data from the `file` input. A `Plug.Upload` struct will automatically appear in our request parameters if a user has selected a file when they submit the form.
 
 Let's take this one piece at a time.

--- a/guides/howto/file_uploads.md
+++ b/guides/howto/file_uploads.md
@@ -1,0 +1,124 @@
+# File Uploads
+
+One common task for web applications is uploading files. These files might be images, videos, PDFs, or files of any other type. In order to upload files through an HTML interface, we need a `file` input tag in a multipart form.
+
+Plug provides a `Plug.Upload` struct to hold the data from the `file` input. A `Plug.Upload` struct will automatically appear in our request parameters if a user has selected a file when they submit the form.
+
+Let's take this one piece at a time.
+
+In the [`Ecto Models Guide`](ecto_models.html), we generated an HTML resource for users. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please see that guide for instructions on generating the users resource we'll be using here.
+
+The first thing we need to do is change our form into a multipart form. The `form_for/4` function accepts a keyword list of options where we can specify this.
+
+Here is the form from `lib/hello_web/templates/user/form.html.eex` with that change in place.
+
+```elixir
+<%= form_for @changeset, @action, [multipart: true], fn f -> %>
+. . .
+```
+
+Once we have a multipart form, we need a `file` input. Here's how we would do that, also in `form.html.eex`.
+
+```html
+. . .
+  <div class="form-group">
+    <label>Photo</label>
+    <%= file_input f, :photo, class: "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>
+```
+
+When rendered, here's what the HTML for that input looks like.
+
+```html
+<div class="form-group">
+  <label>Photo</label>
+  <input class="form-control" id="user_photo" name="user[photo]" type="file">
+</div>
+```
+
+Note the `name` attribute of our `file` input. This will create the `"photo"` key in the `user_params` map which will be available in our controller action.
+
+That's it from the form side. Now when users submit the form, a `POST` request will route to our `Hello.UserController` `create/2` action.
+
+> Note: This photo input does not need to be part of our model for it to come across in the `user_params`. If we want to persist any properties of the photo in a database, however, we would need to add it to our `Hello.User` model's schema.
+
+Before we begin, let's add `IO.inspect user_params` to the top of our `Hello.create/2` action in `lib/hello_web/controllers/user_controller.ex`. This will show the `user_params` in our development log so we can better see what's happening.
+
+```elixir
+. . .
+  def create(conn, %{"user" => user_params}) do
+    IO.inspect user_params
+. . .
+```
+
+Since we generated an HTML resource, we can now start our server with `mix phoenix.server`, visit [http://localhost:4000/users/new](http://localhost:4000/users/new), and create a new user with a photo.
+
+When we do that, this is what our `user_params` look like in the log.
+
+```elixir
+%{"bio" => "Guitarist", "email" => "dweezil@example.com", "name" => "Dweezil Zappa", "number_of_pets" => "3",
+"photo" => %Plug.Upload{content_type: "image/jpg", filename: "cute-kitty.jpg", path: "/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/multipart-558399-917557-1"}}
+```
+
+We have a "photo" key which maps to the pre-populated `Plug.Upload` struct representing our uploaded photo.
+
+To make this easier to read, let's just focus on the struct itself.
+
+```elixir
+%Plug.Upload{content_type: "image/jpg", filename: "cute-kitty.jpg", path: "/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/multipart-558399-917557-1"}
+```
+
+`Plug.Upload` provides the file's content type, original filename, and path to the temporary file which Plug created for us. In our case, `"/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/"` is the directory which Plug created to put uploaded files in. It will persist across requests. `"multipart-558399-917557-1"` is the name Plug gave to our uploaded file. If we had multiple `file` inputs and if the user selected photos for all of them, we would have multiple files scattered in temporary directories. Plug will make sure all the filenames are unique.
+
+> Note: This file is temporary, and Plug will remove it from the directory as the request completes. If we need to do anything with this file, we need to do it before then.
+
+Once we have the `Plug.Upload` struct available in our controller, we can perform any operation on it we want. We can check to make sure the file exists with `File.exists?/1`, copy it somewhere else on the filesystem with `File.cp/2`, send it to S3 with an external library, or even send it back to the client with [Plug.Conn.send_file/5](http://hexdocs.pm/plug/Plug.Conn.html#send_file/5).
+
+For example, in production system, we may want to copy the file to a root directory, such as `/media`. When doing so, it is important to guarantee the names are unique. For instance, if we are allowing users to upload profile pictures, we could use the user id to generate a unique name:
+
+```elixir
+if upload = user_params["photo"] do
+  extension = Path.extname(upload.filename)
+  File.cp(upload.path, "/media/#{user.id}-profile#{extension}")
+end
+```
+
+Then a Plug.Static plug could be set in your `lib/my_app/endpoint.ex` to serve the files at "/media":
+
+```elixir
+plug Plug.Static, at: "/uploads", from: "/media"
+```
+
+The uploaded file can now be accessed from your browsers using a path such as "/uploads/1-profile.jpg". In practice, there are other concerns you want to handle when uploading files, such validating extensions, encoding names and so on. Many times, using a library that already handles such cases, is prefered.
+
+Finally, notice that when there is no data from the `file` input, we get neither the "photo" key nor a `Plug.Upload` struct. Here are the `user_params` from the log.
+
+```elixir
+%{"bio" => "Guitarist", "email" => "dweezil@example.com", "name" => "Dweezil Zappa", "number_of_pets" => "3"}
+```
+
+## Configuring upload limits
+
+The conversion from the data being sent by the form to an actual `Plug.Upload` is done by the `Plug.Parsers` plug which we can find inside `HelloWeb.Endpoint`:
+
+```elixir
+plug Plug.Parsers,
+  parsers: [:urlencoded, :multipart, :json],
+  pass: ["*/*"],
+  json_decoder: Poison
+```
+
+Besides the options above, `Plug.Parsers` accepts other options to control data upload:
+
+  * `:length` - sets the max body length to read, defaults to `8_000_000` bytes
+  * `:read_length` - set the amount of bytes to read at one time, defaults to `1_000_000` bytes
+  * `:read_timeout` - set the timeout for each chunk received, defaults to `15_000` ms
+
+The first option configures the maximum data allowed. The remaining ones configure how much data we expect to read and its frequency. If the client cannot push data fast enough, the connection will be terminated. Phoenix ships with reasonable defaults but you may want to customize it under special circumstances, for example, if you are expecting really slow clients to send large chunks of data.
+
+It is also worth pointing out those limits are important as a security mechanism. For example, if we don't set a limit for data upload, attackers could open up thousands of connections to your application and send one byte every 2 minutes, which would take very long to complete while using up all connections to your server. The limits above expect at least a reasonable amount of progress, making attackers' lives a bit harder.

--- a/guides/howto/file_uploads.md
+++ b/guides/howto/file_uploads.md
@@ -12,18 +12,18 @@ Plug provides a `Plug.Upload` struct to hold the data from the `file` input. A `
 
 Let's take this one piece at a time.
 
-In the [`Contexts guide`](contexts.md), we generated an HTML resource for users. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please see that guide for instructions on generating the users resource we'll be using here.
+In the [`Contexts guide`](contexts.md), we generated an HTML resource for products. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please see that guide for instructions on generating the product resource you will be using here.
 
-The first thing we need to do is change our form into a multipart form. The `form/1` component accepts a `multipart` attribute where we can specify this.
+The first thing you need to do is change your form into a multipart form. The `form/1` component accepts a `multipart` attribute where you can specify this.
 
-Here is the form from `lib/hello_web/controllers/product_html/product_form.html.heex` with that change in place.
+Here is the form from `lib/hello_web/controllers/product_html/product_form.html.heex` with that change in place:
 
 ```elixir
 <.form for={@form} action={~p"/products"} multipart>
 . . .
 ```
 
-Once we have a multipart form, we need a `file` input. Here's how we would do that, also in `product_form.html.heex`.
+Once you have a multipart form, you need a `file` input. Here's how you would do that, also in `product_form.html.heex`:
 
 ```html
 . . .
@@ -38,7 +38,7 @@ Once we have a multipart form, we need a `file` input. Here's how we would do th
 </.form>
 ```
 
-When rendered, here's what the HTML for that input looks like.
+When rendered, here is the HTML for the file input:
 
 ```html
 <div>
@@ -47,13 +47,13 @@ When rendered, here's what the HTML for that input looks like.
 </div>
 ```
 
-Note the `name` attribute of our `file` input. This will create the `"photo"` key in the `product_params` map which will be available in our controller action.
+Note the `name` attribute of your `file` input. This will create the `"photo"` key in the `product_params` map which will be available in your controller action.
 
-That's it from the form side. Now when users submit the form, a `POST` request will route to our `HelloWeb.ProductController` `create/2` action.
+That's it from the form side. Now when users submit the form, a `POST` request will route to your `HelloWeb.ProductController` `create/2` action.
 
-> Note: This photo input does not need to be part of our schema for it to come across in the `product_params`. If we want to persist any properties of the photo in a database, however, we would need to add it to our `Hello.Product` schema.
+> Note: This photo input does not need to be part of our schema for it to come across in the `product_params`. If you want to persist any properties of the photo in a database, however, you would need to add it to your `Hello.Product` schema.
 
-Before we begin, let's add `IO.inspect product_params` to the top of our `Hello.create/2` action in `lib/hello_web/controllers/user_controller.ex`. This will show the `product_params` in our development log so we can better see what's happening.
+Before you begin, add `IO.inspect product_params` to the top of your `Hello.create/2` action in `lib/hello_web/controllers/user_controller.ex`. This will show the `product_params` in your development log so you can get a better sense of what's happening.
 
 ```elixir
 . . .
@@ -62,30 +62,30 @@ Before we begin, let's add `IO.inspect product_params` to the top of our `Hello.
 . . .
 ```
 
-Since we generated an HTML resource, we can now start our server with `mix phx.server`, visit [http://localhost:4000/products/new](http://localhost:4000/products/new), and create a new product with a photo.
+Since you generated an HTML resource, you can now start your server with `mix phx.server`, visit [http://localhost:4000/products/new](http://localhost:4000/products/new), and create a new product with a photo.
 
-When we do that, this is what our `product_params` look like in the log.
+When you do that, this is what your `product_params` will output in the log:
 
 ```elixir
 %{"title" => "Metaprogramming Elixir", "description" => "Write Less Code, Get More Done (and Have Fun!)", "price" => "15.000000", "views" => "0",
 "photo" => %Plug.Upload{content_type: "image/png", filename: "meta-cover.png", path: "/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/multipart-558399-917557-1"}}
 ```
 
-We have a "photo" key which maps to the pre-populated `Plug.Upload` struct representing our uploaded photo.
+You have a "photo" key which maps to the pre-populated `Plug.Upload` struct representing your uploaded photo.
 
-To make this easier to read, let's just focus on the struct itself.
+To make this easier to read, focus on the struct itself:
 
 ```elixir
 %Plug.Upload{content_type: "image/png", filename: "meta-cover.png", path: "/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/multipart-558399-917557-1"}
 ```
 
-`Plug.Upload` provides the file's content type, original filename, and path to the temporary file which Plug created for us. In our case, `"/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/"` is the directory which Plug created to put uploaded files in. It will persist across requests. `"multipart-558399-917557-1"` is the name Plug gave to our uploaded file. If we had multiple `file` inputs and if the user selected photos for all of them, we would have multiple files scattered in temporary directories. Plug will make sure all the filenames are unique.
+`Plug.Upload` provides the file's content type, original filename, and path to the temporary file which Plug created for you. In this case, `"/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/"` is the directory which Plug created to put uploaded files in. It will persist across requests. `"multipart-558399-917557-1"` is the name Plug gave to your uploaded file. If you had multiple `file` inputs and if the user selected photos for all of them, you would have multiple files scattered in temporary directories. Plug will make sure all the filenames are unique.
 
-> Note: This file is temporary, and Plug will remove it from the directory as the request completes. If we need to do anything with this file, we need to do it before then.
+> Note: This file is temporary, and Plug will remove it from the directory as the request completes. If you need to do anything with this file, you need to do it before then, or [give it away](`Plug.Upload.give_away/3`), but that is outside the scope of this guide.
 
-Once we have the `Plug.Upload` struct available in our controller, we can perform any operation on it we want. We can check to make sure the file exists with `File.exists?/1`, copy it somewhere else on the filesystem with `File.cp/2`, send it to S3 with an external library, or even send it back to the client with `Plug.Conn.send_file/5`.
+Once you have the `Plug.Upload` struct available in your controller, you can perform any operation on it you want. You can check to make sure the file exists with `File.exists?/1`, copy it somewhere else on the filesystem with `File.cp/2`, send it to S3 with an external library, or even send it back to the client with `Plug.Conn.send_file/5`.
 
-For example, in production system, we may want to copy the file to a root directory, such as `/media`. When doing so, it is important to guarantee the names are unique. For instance, if we are allowing users to upload product cover images, we could use the product id to generate a unique name:
+For example, in production system, you may want to copy the file to a root directory, such as `/media`. When doing so, it is important to guarantee the names are unique. For instance, if you are allowing users to upload product cover images, you could use the product id to generate a unique name:
 
 ```elixir
 if upload = product_params["photo"] do
@@ -102,7 +102,7 @@ plug Plug.Static, at: "/uploads", from: "/media"
 
 The uploaded file can now be accessed from your browsers using a path such as "/uploads/1-cover.jpg". In practice, there are other concerns you want to handle when uploading files, such validating extensions, encoding names, and so on. Many times, using a library that already handles such cases, is preferred.
 
-Finally, notice that when there is no data from the `file` input, we get neither the "photo" key nor a `Plug.Upload` struct. Here are the `product_params` from the log.
+Finally, notice that when there is no data from the `file` input, you get neither the "photo" key nor a `Plug.Upload` struct. Here are the `product_params` from the log.
 
 ```elixir
 %{"title" => "Metaprogramming Elixir", "description" => "Write Less Code, Get More Done (and Have Fun!)", "price" => "15.000000", "views" => "0"}
@@ -110,7 +110,7 @@ Finally, notice that when there is no data from the `file` input, we get neither
 
 ## Configuring upload limits
 
-The conversion from the data being sent by the form to an actual `Plug.Upload` is done by the `Plug.Parsers` plug which we can find inside `HelloWeb.Endpoint`:
+The conversion from the data being sent by the form to an actual `Plug.Upload` is done by the `Plug.Parsers` plug which you can find inside `HelloWeb.Endpoint`:
 
 ```elixir
 # lib/hello_web/endpoint.ex
@@ -128,4 +128,4 @@ Besides the options above, `Plug.Parsers` accepts other options to control data 
 
 The first option configures the maximum data allowed. The remaining ones configure how much data we expect to read and its frequency. If the client cannot push data fast enough, the connection will be terminated. Phoenix ships with reasonable defaults but you may want to customize it under special circumstances, for example, if you are expecting really slow clients to send large chunks of data.
 
-It is also worth pointing out those limits are important as a security mechanism. For example, if we don't set a limit for data upload, attackers could open up thousands of connections to your application and send one byte every 2 minutes, which would take very long to complete while using up all connections to your server. The limits above expect at least a reasonable amount of progress, making attackers' lives a bit harder.
+It is also worth pointing out those limits are important as a security mechanism. For example, if you don't set a limit for data upload, attackers could open up thousands of connections to your application and send one byte every 2 minutes, which would take very long to complete while using up all connections to your server. The limits above expect at least a reasonable amount of progress, making attackers' lives a bit harder.

--- a/guides/howto/file_uploads.md
+++ b/guides/howto/file_uploads.md
@@ -12,15 +12,13 @@ Plug provides a `Plug.Upload` struct to hold the data from the `file` input. A `
 
 In this guide you will do the following:
 
-  * Configure a multipart form
+  1.  Configure a multipart form
 
-  * Add a file input element to the form
+  2. Add a file input element to the form
 
-  * Verify your upload params
+  3. Verify your upload params
 
-  * Copy the uploaded file to a permanent location
-
-  * Serve uploaded files with `Plug.Static`
+  4. Manage your uploaded files
 
 In the [`Contexts guide`](contexts.md), we generated an HTML resource for products. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please refer to that guide for instructions on generating the product resource you will be using here.
 
@@ -100,11 +98,21 @@ To make this easier to read, focus on the struct itself:
 >
 > Plug removes uploads from its directory as the request completes. If you need to do anything with this file, you need to do it before then (or [give it away](`Plug.Upload.give_away/3`), but that is outside the scope of this guide).
 
-### Copy the file to a permanent location
+### Manage your uploaded files
 
-Once you have the `Plug.Upload` struct available in your controller, you can perform any operation on it you want. You can check to make sure the file exists with `File.exists?/1`, copy it somewhere else on the filesystem with `File.cp/2`, send it to S3 with an external library, or even send it back to the client with `Plug.Conn.send_file/5`.
+Once you have the `Plug.Upload` struct available in your controller, you can perform any operation on it you want. For example, you may want to do one or more of the following:
 
-For example, in production system, you may want to copy the file to a root directory, such as `/media`. When doing so, it is important to guarantee the names are unique. For instance, if you are allowing users to upload product cover images, you could use the product id to generate a unique name:
+* Check to make sure the file exists with `File.exists?/1`
+
+* Copy the file somewhere else on the filesystem with `File.cp/2`
+
+* Give the file away to another Elixir process with `Plug.Upload.give_away/3`
+
+* Send it to S3 with an external library
+
+* Send it back to the client with `Plug.Conn.send_file/5`
+
+In a production system, you may want to copy the file to a root directory, such as `/media`. When doing so, it is important to guarantee the names are unique. For instance, if you are allowing users to upload product cover images, you could use the product id to generate a unique name:
 
 ```elixir
 if upload = product_params["photo"] do
@@ -113,15 +121,13 @@ if upload = product_params["photo"] do
 end
 ```
 
-### Serve uploaded files with Plug.Static
-
-Then a `Plug.Static` plug could be set in your `lib/my_app_web/endpoint.ex` to serve the files at `"/media"`:
+Then a `Plug.Static` plug could be added in your `lib/my_app_web/endpoint.ex` to serve the files at `"/media"`:
 
 ```elixir
 plug Plug.Static, at: "/uploads", from: "/media"
 ```
 
-The uploaded file can now be accessed from your browsers using a path such as `"/uploads/1-cover.jpg"`. In practice, there are other concerns you want to handle when uploading files, such validating extensions, encoding names, and so on. Many times, using a library that already handles such cases, is preferred.
+The uploaded file can now be accessed from your browsers using a path such as `"/uploads/1-cover.jpg"`. In practice, there are other concerns you want to handle when uploading files, such validating extensions, encoding names, and so on. Many times, using a library that already handles such cases is preferred.
 
 Finally, notice that when there is no data from the `file` input, you get neither the `"photo"` key nor a `Plug.Upload` struct. Here are the `product_params` from the log.
 

--- a/guides/howto/file_uploads.md
+++ b/guides/howto/file_uploads.md
@@ -8,15 +8,15 @@ One common task for web applications is uploading files. These files might be im
 > For more information about LiveView file uploads, including direct-to-cloud external uploads on
 > the client, refer to the [LiveView Uploads guide](https://hexdocs.pm/phoenix_live_view/uploads.html).
 
-Plug provides a `Plug.Upload` struct to hold the data from the `file` input. A `Plug.Upload` struct will automatically appear in our request parameters if a user has selected a file when they submit the form.
+Plug provides a `Plug.Upload` struct to hold the data from the `file` input. A `Plug.Upload` struct will automatically appear in your request parameters if a user has selected a file when they submit the form.
 
 In this guide you will do the following:
 
-  * Configure a form as a multipart form
+  * Configure a multipart form
 
   * Add a file input element to the form
 
-  * Test your form params
+  * Verify your upload params
 
   * Copy the uploaded file to a permanent location
 
@@ -26,12 +26,12 @@ In the [`Contexts guide`](contexts.md), we generated an HTML resource for produc
 
 ### Configure a multipart form
 
-The first thing you need to do is change your form into a multipart form. The `form/1` component accepts a `multipart` attribute where you can specify this.
+The first thing you need to do is change your form into a multipart form. The `HelloWeb.CoreComponents` `simple_form/1` component accepts a `multipart` attribute where you can specify this.
 
 Here is the form from `lib/hello_web/controllers/product_html/product_form.html.heex` with that change in place:
 
-```elixir
-<.form for={@form} action={~p"/products"} multipart>
+```heex
+<.simple_form :let={f} for={@changeset} action={@action} multipart>
 . . .
 ```
 
@@ -39,37 +39,38 @@ Here is the form from `lib/hello_web/controllers/product_html/product_form.html.
 
 Once you have a multipart form, you need a `file` input. Here's how you would do that, also in `product_form.html.heex`:
 
-```html
+```heex
 . . .
-  <div>
-    <label>Photo</label>
-    <%= Phoenix.HTML.Form.file_input @form[:photo] %>
-  </div>
+  <.input field={f[:photo]} type="file" label="Photo" />
 
-  <div>
-    <button type="submit">Submit</button>
-  </div>
-</.form>
+  <:actions>
+    <.button>Save Product</.button>
+  </:actions>
+</.simple_form>
 ```
 
-When rendered, here is the HTML for the file input:
+When rendered, here is the HTML for the default `HelloWeb.CoreComponents` `input/1` component:
 
 ```html
-<div>
-  <label>Photo</label>
-  <input id="product_photo" name="product[photo]" type="file">
+<div phx-feedback-for="product[photo]">
+  <label for="product_photo" class="block text-sm...">Photo</label>
+  <input type="file" name="product[photo]" id="product_photo" class="mt-2 block w-full...">
 </div>
 ```
 
 Note the `name` attribute of your `file` input. This will create the `"photo"` key in the `product_params` map which will be available in your controller action.
 
-That's it from the form side. Now when users submit the form, a `POST` request will route to your `HelloWeb.ProductController` `create/2` action.
+This is all from the form side. Now when users submit the form, a `POST` request will route to your `HelloWeb.ProductController` `create/2` action.
 
 > #### Should I add photo to my Ecto schema? {: .neutral}
 >
 > The photo input does not need to be part of your schema for it to come across in the `product_params`. If you want to persist any properties of the photo in a database, however, you would need to add it to your `Hello.Product` schema.
 
-Before you begin, add `IO.inspect product_params` to the top of your `Hello.create/2` action in `lib/hello_web/controllers/user_controller.ex`. This will show the `product_params` in your development log so you can get a better sense of what's happening.
+### Verify your upload params
+
+Since you generated an HTML resource, you can now start your server with `mix phx.server`, visit [http://localhost:4000/products/new](http://localhost:4000/products/new), and create a new product with a photo.
+
+Before you begin, add `IO.inspect product_params` to the top of your `ProductController.create/2` action in `lib/hello_web/controllers/product_controller.ex`. This will show the `product_params` in your development log so you can get a better sense of what's happening.
 
 ```elixir
 . . .
@@ -77,10 +78,6 @@ Before you begin, add `IO.inspect product_params` to the top of your `Hello.crea
     IO.inspect product_params
 . . .
 ```
-
-### Test your form params
-
-Since you generated an HTML resource, you can now start your server with `mix phx.server`, visit [http://localhost:4000/products/new](http://localhost:4000/products/new), and create a new product with a photo.
 
 When you do that, this is what your `product_params` will output in the log:
 

--- a/guides/howto/file_uploads.md
+++ b/guides/howto/file_uploads.md
@@ -10,9 +10,21 @@ One common task for web applications is uploading files. These files might be im
 
 Plug provides a `Plug.Upload` struct to hold the data from the `file` input. A `Plug.Upload` struct will automatically appear in our request parameters if a user has selected a file when they submit the form.
 
-Let's take this one piece at a time.
+In this guide you will do the following:
 
-In the [`Contexts guide`](contexts.md), we generated an HTML resource for products. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please see that guide for instructions on generating the product resource you will be using here.
+  * Configure a form as a multipart form
+
+  * Add a file input element to the form
+
+  * Test your form params
+
+  * Copy the uploaded file to a permanent location
+
+  * Serve uploaded files with `Plug.Static`
+
+In the [`Contexts guide`](contexts.md), we generated an HTML resource for products. We can reuse the form we generated there in order to demonstrate how file uploads work in Phoenix. Please refer to that guide for instructions on generating the product resource you will be using here.
+
+### Configure a multipart form
 
 The first thing you need to do is change your form into a multipart form. The `form/1` component accepts a `multipart` attribute where you can specify this.
 
@@ -23,13 +35,15 @@ Here is the form from `lib/hello_web/controllers/product_html/product_form.html.
 . . .
 ```
 
+### Add a file input
+
 Once you have a multipart form, you need a `file` input. Here's how you would do that, also in `product_form.html.heex`:
 
 ```html
 . . .
   <div>
     <label>Photo</label>
-    <%= file_input @form[:photo] %>
+    <%= Phoenix.HTML.Form.file_input @form[:photo] %>
   </div>
 
   <div>
@@ -51,7 +65,9 @@ Note the `name` attribute of your `file` input. This will create the `"photo"` k
 
 That's it from the form side. Now when users submit the form, a `POST` request will route to your `HelloWeb.ProductController` `create/2` action.
 
-> Note: This photo input does not need to be part of our schema for it to come across in the `product_params`. If you want to persist any properties of the photo in a database, however, you would need to add it to your `Hello.Product` schema.
+> #### Should I add photo to my Ecto schema? {: .neutral}
+>
+> The photo input does not need to be part of your schema for it to come across in the `product_params`. If you want to persist any properties of the photo in a database, however, you would need to add it to your `Hello.Product` schema.
 
 Before you begin, add `IO.inspect product_params` to the top of your `Hello.create/2` action in `lib/hello_web/controllers/user_controller.ex`. This will show the `product_params` in your development log so you can get a better sense of what's happening.
 
@@ -62,6 +78,8 @@ Before you begin, add `IO.inspect product_params` to the top of your `Hello.crea
 . . .
 ```
 
+### Test your form params
+
 Since you generated an HTML resource, you can now start your server with `mix phx.server`, visit [http://localhost:4000/products/new](http://localhost:4000/products/new), and create a new product with a photo.
 
 When you do that, this is what your `product_params` will output in the log:
@@ -71,7 +89,7 @@ When you do that, this is what your `product_params` will output in the log:
 "photo" => %Plug.Upload{content_type: "image/png", filename: "meta-cover.png", path: "/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/multipart-558399-917557-1"}}
 ```
 
-You have a "photo" key which maps to the pre-populated `Plug.Upload` struct representing your uploaded photo.
+You have a `"photo"` key which maps to the pre-populated `Plug.Upload` struct representing your uploaded photo.
 
 To make this easier to read, focus on the struct itself:
 
@@ -79,9 +97,13 @@ To make this easier to read, focus on the struct itself:
 %Plug.Upload{content_type: "image/png", filename: "meta-cover.png", path: "/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/multipart-558399-917557-1"}
 ```
 
-`Plug.Upload` provides the file's content type, original filename, and path to the temporary file which Plug created for you. In this case, `"/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/"` is the directory which Plug created to put uploaded files in. It will persist across requests. `"multipart-558399-917557-1"` is the name Plug gave to your uploaded file. If you had multiple `file` inputs and if the user selected photos for all of them, you would have multiple files scattered in temporary directories. Plug will make sure all the filenames are unique.
+`Plug.Upload` provides the file's content type, original filename, and path to the temporary file which Plug created for you. In this case, `"/var/folders/_6/xbsnn7tx6g9dblyx149nrvbw0000gn/T//plug-1434/"` is the directory created by Plug in which to put uploaded files. The directory will persist across requests. `"multipart-558399-917557-1"` is the name Plug gave to your uploaded file. If you had multiple `file` inputs and if the user selected photos for all of them, you would have multiple files scattered in temporary directories. Plug will make sure all the filenames are unique.
 
-> Note: This file is temporary, and Plug will remove it from the directory as the request completes. If you need to do anything with this file, you need to do it before then, or [give it away](`Plug.Upload.give_away/3`), but that is outside the scope of this guide.
+> #### Plug.Upload files are temporary {: .info}
+>
+> Plug removes uploads from its directory as the request completes. If you need to do anything with this file, you need to do it before then (or [give it away](`Plug.Upload.give_away/3`), but that is outside the scope of this guide).
+
+### Copy the file to a permanent location
 
 Once you have the `Plug.Upload` struct available in your controller, you can perform any operation on it you want. You can check to make sure the file exists with `File.exists?/1`, copy it somewhere else on the filesystem with `File.cp/2`, send it to S3 with an external library, or even send it back to the client with `Plug.Conn.send_file/5`.
 
@@ -94,15 +116,17 @@ if upload = product_params["photo"] do
 end
 ```
 
-Then a Plug.Static plug could be set in your `lib/my_app/endpoint.ex` to serve the files at "/media":
+### Serve uploaded files with Plug.Static
+
+Then a `Plug.Static` plug could be set in your `lib/my_app_web/endpoint.ex` to serve the files at `"/media"`:
 
 ```elixir
 plug Plug.Static, at: "/uploads", from: "/media"
 ```
 
-The uploaded file can now be accessed from your browsers using a path such as "/uploads/1-cover.jpg". In practice, there are other concerns you want to handle when uploading files, such validating extensions, encoding names, and so on. Many times, using a library that already handles such cases, is preferred.
+The uploaded file can now be accessed from your browsers using a path such as `"/uploads/1-cover.jpg"`. In practice, there are other concerns you want to handle when uploading files, such validating extensions, encoding names, and so on. Many times, using a library that already handles such cases, is preferred.
 
-Finally, notice that when there is no data from the `file` input, you get neither the "photo" key nor a `Plug.Upload` struct. Here are the `product_params` from the log.
+Finally, notice that when there is no data from the `file` input, you get neither the `"photo"` key nor a `Plug.Upload` struct. Here are the `product_params` from the log.
 
 ```elixir
 %{"title" => "Metaprogramming Elixir", "description" => "Write Less Code, Get More Done (and Have Fun!)", "price" => "15.000000", "views" => "0"}

--- a/mix.exs
+++ b/mix.exs
@@ -167,6 +167,7 @@ defmodule Phoenix.MixProject do
       "guides/deployment/fly.md",
       "guides/deployment/heroku.md",
       "guides/howto/custom_error_pages.md",
+      "guides/howto/file_uploads.md",
       "guides/howto/using_ssl.md",
       "CHANGELOG.md"
     ]


### PR DESCRIPTION
If you search for `elixir phoenix upload` your first result will be a page that is about six years old

<img width="609" alt="Screenshot 2023-04-20 at 4 35 47 PM" src="https://user-images.githubusercontent.com/168677/233508206-a233dc13-d050-4d28-b50a-bc8835ce7f8b.png">

If you are very unlucky, you might find a link on the forums to a guide on `phoenixframework.org` and it will 404

This PR reintroduces the File Uploads guide, updated to work with the current Contexts guide.
