### PR TITLE
Improve user prompt for gen auth

### DIFF
--- a/guides/authentication/mix_phx_gen_auth.md
+++ b/guides/authentication/mix_phx_gen_auth.md
@@ -12,13 +12,13 @@ Let's start by running the following command from the root of our app (or `apps/
 $ mix phx.gen.auth Accounts User users
 
 An authentication system can be created in two different ways:
-- Using Phoenix.LiveView (default)
-- Using Phoenix.Controller only
+  1) Using Phoenix.LiveView (default)
+  2) Using Phoenix.Controller only
 
-Do you want to create a LiveView based authentication system? [Y/n] Y
+Which option (1,2) do you want to use? (Leave empty for default): 
 ```
 
-The authentication generators support Phoenix LiveView, for enhanced UX, so we'll answer `Y` here. You may also answer `n` for a controller based authentication system.
+The authentication generators support Phoenix LiveView, for enhanced UX, so we'll answer `1` here. You may also answer `2` for a controller based authentication system.
 
 Either approach will create an `Accounts` context with an `Accounts.User` schema module. The final argument is the plural version of the schema module, which is used for generating database table names and route paths. The `mix phx.gen.auth` generator is similar to `mix phx.gen.html` except it does not accept a list of additional fields to add to the schema, and it generates many more context functions.
 

--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -852,14 +852,20 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
         _ ->
           Mix.shell().info("""
           An authentication system can be created in two different ways:
-          - Using Phoenix.LiveView (default)
-          - Using Phoenix.Controller only\
+            1) Using Phoenix.LiveView (default)
+            2) Using Phoenix.Controller only\
           """)
 
-          if Mix.shell().yes?("Do you want to create a LiveView based authentication system?") do
-            Keyword.put_new(schema.opts, :live, true)
-          else
-            Keyword.put_new(schema.opts, :live, false)
+          case Mix.shell().prompt("Which option (1,2) do you want to use? (Leave empty for default):") do
+            "1\n" ->
+              Keyword.put_new(schema.opts, :live, true)
+
+            "2\n" ->
+              Keyword.put_new(schema.opts, :live, false)
+
+            _ ->
+              Mix.shell().info("Using Phoenix.LiveView (default)")
+              Keyword.put_new(schema.opts, :live, true)
           end
       end
 

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -4,7 +4,6 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
   use ExUnit.Case
 
   @moduletag :mix_phx_new
-  @liveview_option_message "Do you want to create a LiveView based authentication system?"
 
   import MixHelper
   alias Mix.Tasks.Phx.Gen
@@ -86,15 +85,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
   test "generates with defaults (Prompt: --no-live)", config do
     in_tmp_phx_project(config.test, fn ->
-      send self(), {:mix_shell_input, :yes?, false}
+      send self(), {:mix_shell_input, :prompt, "2\n"}
 
       Gen.Auth.run(
         ~w(Accounts User users),
         ecto_adapter: Ecto.Adapters.Postgres,
         validate_dependencies?: false
       )
-
-      assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
       assert_file("config/test.exs", fn file ->
         assert file =~ "config :bcrypt_elixir, :log_rounds, 1"
@@ -223,15 +220,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
   test "generates with defaults (Prompt: --live)", config do
     in_tmp_phx_project(config.test, fn ->
-      send self(), {:mix_shell_input, :yes?, true}
+      send self(), {:mix_shell_input, :prompt, "1\n"}
 
       Gen.Auth.run(
         ~w(Accounts User users),
         ecto_adapter: Ecto.Adapters.Postgres,
         validate_dependencies?: false
       )
-
-      assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
       assert_file("config/test.exs", fn file ->
         assert file =~ "config :bcrypt_elixir, :log_rounds, 1"
@@ -491,15 +486,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
   test "generates with --web option", config do
     in_tmp_phx_project(config.test, fn ->
-      send self(), {:mix_shell_input, :yes?, false}
+      send self(), {:mix_shell_input, :prompt, "2\n"}
 
       Gen.Auth.run(
         ~w(Accounts User users --web warehouse),
         ecto_adapter: Ecto.Adapters.Postgres,
         validate_dependencies?: false
       )
-
-      assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
       assert_file("lib/my_app/accounts.ex")
       assert_file("lib/my_app/accounts/user.ex")
@@ -720,15 +713,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
   describe "--database option" do
     test "when the database is postgres", config do
       in_tmp_phx_project(config.test, fn ->
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users),
           ecto_adapter: Ecto.Adapters.Postgres,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert [migration] = Path.wildcard("priv/repo/migrations/*_create_users_auth_tables.exs")
 
@@ -774,15 +765,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
     test "when the database is mysql", config do
       in_tmp_phx_project(config.test, fn ->
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users),
           ecto_adapter: Ecto.Adapters.MyXQL,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert [migration] = Path.wildcard("priv/repo/migrations/*_create_users_auth_tables.exs")
 
@@ -828,15 +817,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
     test "when the database is sqlite3", config do
       in_tmp_phx_project(config.test, fn ->
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users),
           ecto_adapter: Ecto.Adapters.SQLite3,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert [migration] = Path.wildcard("priv/repo/migrations/*_create_users_auth_tables.exs")
 
@@ -882,15 +869,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
     test "when the database is mssql", config do
       in_tmp_phx_project(config.test, fn ->
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users),
           ecto_adapter: Ecto.Adapters.TDS,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert [migration] = Path.wildcard("priv/repo/migrations/*_create_users_auth_tables.exs")
 
@@ -937,15 +922,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
   test "supports --binary-id option", config do
     in_tmp_phx_project(config.test, fn ->
-      send self(), {:mix_shell_input, :yes?, false}
+      send self(), {:mix_shell_input, :prompt, "2\n"}
 
       Gen.Auth.run(
         ~w(Accounts User users --binary-id),
         ecto_adapter: Ecto.Adapters.Postgres,
         validate_dependencies?: false
       )
-
-      assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
       assert_file("lib/my_app/accounts/user.ex", fn file ->
         assert file =~ "@primary_key {:id, :binary_id, autogenerate: true}"
@@ -970,7 +953,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
   describe "--hashing-lib option" do
     test "when bcrypt", config do
       in_tmp_phx_project(config.test, fn ->
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users --hashing-lib bcrypt),
@@ -978,7 +961,6 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
           validate_dependencies?: false
         )
 
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert_file("mix.exs", fn file ->
           assert file =~ ~s|{:bcrypt_elixir, "~> 3.0"}|
@@ -996,15 +978,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
     test "when pbkdf2", config do
       in_tmp_phx_project(config.test, fn ->
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users --hashing-lib pbkdf2),
           ecto_adapter: Ecto.Adapters.Postgres,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert_file("mix.exs", fn file ->
           assert file =~ ~s|{:pbkdf2_elixir, "~> 2.0"}|
@@ -1022,7 +1002,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
     test "when argon2", config do
       in_tmp_phx_project(config.test, fn ->
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users --hashing-lib argon2),
@@ -1030,7 +1010,6 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
           validate_dependencies?: false
         )
 
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert_file("mix.exs", fn file ->
           assert file =~ ~s|{:argon2_elixir, "~> 3.0"}|
@@ -1051,7 +1030,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
 
   test "with --table option", config do
     in_tmp_phx_project(config.test, fn ->
-      send self(), {:mix_shell_input, :yes?, false}
+      send self(), {:mix_shell_input, :prompt, "2\n"}
 
       Gen.Auth.run(
         ~w(Accounts User users --table my_users),
@@ -1059,7 +1038,6 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         validate_dependencies?: false
       )
 
-      assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
       assert_file("lib/my_app/accounts/user.ex", fn file ->
         assert file =~ ~S|schema "my_users" do|
@@ -1083,7 +1061,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       in_tmp_phx_umbrella_project(config.test, fn ->
         in_project(:my_app, "apps/my_app", fn _module ->
           with_generator_env(:my_app_web, [context_app: nil], fn ->
-            send self(), {:mix_shell_input, :yes?, false}
+            send self(), {:mix_shell_input, :prompt, "2\n"}
 
             Gen.Auth.run(
               ~w(Accounts User users),
@@ -1091,7 +1069,6 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
               validate_dependencies?: false
             )
 
-            assert_received {:mix_shell, :yes?, [@liveview_option_message]}
           end)
         end)
 
@@ -1142,7 +1119,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       in_tmp_phx_umbrella_project(config.test, fn ->
         in_project(:my_app_web, "apps/my_app_web", fn _module ->
           with_generator_env(:my_app_web, [context_app: :my_app], fn ->
-            send self(), {:mix_shell_input, :yes?, false}
+            send self(), {:mix_shell_input, :prompt, "2\n"}
 
             Gen.Auth.run(
               ~w(Accounts User users),
@@ -1150,7 +1127,6 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
               validate_dependencies?: false
             )
 
-            assert_received {:mix_shell, :yes?, [@liveview_option_message]}
           end)
         end)
 
@@ -1229,15 +1205,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       in_tmp_phx_project(config.test, fn ->
         File.write!("mix.exs", "")
 
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users),
           ecto_adapter: Ecto.Adapters.Postgres,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert_received {:mix_shell, :info,
                          [
@@ -1262,15 +1236,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
           String.replace(file, "use MyAppWeb, :router", "")
         end)
 
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users),
           ecto_adapter: Ecto.Adapters.Postgres,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert_received {:mix_shell, :info,
                          [
@@ -1298,15 +1270,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
           String.replace(file, "plug :put_secure_browser_headers\n", "")
         end)
 
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users),
           ecto_adapter: Ecto.Adapters.Postgres,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert_received {:mix_shell, :info,
                          [
@@ -1330,15 +1300,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         File.rm!("lib/my_app_web/components/layouts/root.html.heex")
         File.rm!("lib/my_app_web/components/layouts/app.html.heex")
 
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users),
           ecto_adapter: Ecto.Adapters.Postgres,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         assert_receive {:mix_shell, :error, [error]}
 
@@ -1407,15 +1375,13 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
           ""
         end)
 
-        send self(), {:mix_shell_input, :yes?, false}
+        send self(), {:mix_shell_input, :prompt, "2\n"}
 
         Gen.Auth.run(
           ~w(Accounts User users),
           ecto_adapter: Ecto.Adapters.Postgres,
           validate_dependencies?: false
         )
-
-        assert_received {:mix_shell, :yes?, [@liveview_option_message]}
 
         help_text = """
 
@@ -1475,7 +1441,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
       File.mkdir_p!("priv/templates/phx.gen.auth")
       File.write!("priv/templates/phx.gen.auth/auth.ex", "#it works!")
 
-      send self(), {:mix_shell_input, :yes?, false}
+      send self(), {:mix_shell_input, :prompt, "2\n"}
 
       Gen.Auth.run(
         ~w(Accounts Admin admins),
@@ -1483,7 +1449,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         validate_dependencies?: false
       )
 
-      assert_received {:mix_shell, :yes?, [@liveview_option_message]}
+
 
       assert_file("lib/my_app_web/admin_auth.ex", fn file ->
         assert file =~ ~S|it works!|


### PR DESCRIPTION
When running the gen auth mix command, e.g `mix phx.gen.auth Accounts User users` the user prompt can be somewhat confusing. In particular the use of the term twice "authentication system" in both the option description and the question posed to the user.

Current prompt:

```
An authentication system can be created in two different ways:
- Using Phoenix.LiveView (default)
- Using Phoenix.Controller only
Do you want to create a LiveView based authentication system? [Yn] n
```

This pr proposes:

```
An authentication system can be created in two different ways:
  1) Using Phoenix.LiveView (default)
  2) Using Phoenix.Controller only
Which option (1,2) do you want to use? (Leave empty for default): 
```