### PR TITLE
Add default max_age to Phoenix.Token sign and encrypt typespec

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -115,9 +115,11 @@ defmodule Phoenix.Token do
       when generating the encryption and signing keys. Defaults to `:sha256`
     * `:signed_at` - set the timestamp of the token in seconds.
       Defaults to `System.system_time(:second)`
+    * `:max_age` - the default maximum age of the token. Defaults to
+      86400 seconds (1 day) and it may be overridden on verify/4.
 
   """
-  @spec sign(context, binary, term, [shared_opt | signed_at_opt]) :: binary
+  @spec sign(context, binary, term, [shared_opt | max_age_opt | signed_at_opt]) :: binary
   def sign(context, salt, data, opts \\ []) when is_binary(salt) do
     context
     |> get_key_base()
@@ -137,9 +139,11 @@ defmodule Phoenix.Token do
       when generating the encryption and signing keys. Defaults to `:sha256`
     * `:signed_at` - set the timestamp of the token in seconds.
       Defaults to `System.system_time(:second)`
+    * `:max_age` - the default maximum age of the token. Defaults to
+      86400 seconds (1 day) and it may be overridden on verify/4.
 
   """
-  @spec encrypt(context, binary, term, [shared_opt | signed_at_opt]) :: binary
+  @spec encrypt(context, binary, term, [shared_opt | max_age_opt | signed_at_opt]) :: binary
   def encrypt(context, secret, data, opts \\ []) when is_binary(secret) do
     context
     |> get_key_base()


### PR DESCRIPTION
https://github.com/phoenixframework/phoenix/commit/0587b9d0dc03267b6acf6d96ad14fa0095247407 added typespecs to Phoenix.Token, but did not include the `max_age` option for `Phoenix.Token.sign/4` and `Phoenix.Token.encrypt/4`. It also removed the documentation for `max_age` from these functions - I don't know why.
https://github.com/elixir-plug/plug_crypto/blob/5884b466766676f7db7f79d62cadead47f161d36/lib/plug/crypto.ex#L171 includes max_age for sign and encrypt.

This PR re-adds the documentation and also adds the max_age option to the typespec.