### PR TITLE
Suppress dialyzer pattern_match error

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -453,7 +453,7 @@ defmodule Phoenix.Router do
   end
 
   defp match_dispatch() do
-    quote location: :keep do
+    quote location: :keep, generated: true do
       @behaviour Plug
 
       @doc """


### PR DESCRIPTION
This PR suppresses a dialyzer error that shows up in projects depending on phoenix `v1.7.2` (possibly brought in with `v1.7.0`)

Environment
- Elixir version: Elixir 1.14.4 (compiled with Erlang/OTP 23)
- Phoenix version (mix deps): 1.7.2
- OS: Fedora 36

```
deps/phoenix/lib/phoenix/router.ex:514:pattern_match
The pattern can never match the type.

Pattern:
:error

Type:

  {%{
     :conn => nil,
     :log => :debug,
     :path_params => map(),
     :pipe_through => [any(), ...],
     :plug => ArgonApi.AuthController | ArgonApi.NotFound,
     :plug_opts => :index | [],
     :route => <<_::8, _::size(16)>>
   }, (map(), map() -> map()), (map() -> map()),
   {ArgonApi.AuthController, :index} | {Phoenix.Router.Route, {_, _, _}}}
```