### PR TITLE
Improved the visual consistency of the select input core component.

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -314,7 +314,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <select
         id={@id}
         name={@name}
-        class="mt-1 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
+        class="mt-2 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
         multiple={@multiple}
         {@rest}
       >

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -314,7 +314,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <select
         id={@id}
         name={@name}
-        class="mt-1 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
+        class="mt-2 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
         multiple={@multiple}
         {@rest}
       >


### PR DESCRIPTION
In the core components, [textarea inputs](https://github.com/phoenixframework/phoenix/blob/a310102eb0e20b918624bb2323a6afb124fcaddd/priv/templates/phx.gen.live/core_components.ex#L337) and [nearly all others](https://github.com/phoenixframework/phoenix/blob/a310102eb0e20b918624bb2323a6afb124fcaddd/priv/templates/phx.gen.live/core_components.ex#L360) have a "mt-2" class, only the [select input](https://github.com/phoenixframework/phoenix/blob/a310102eb0e20b918624bb2323a6afb124fcaddd/priv/templates/phx.gen.live/core_components.ex#L317) has a "mt-1" class. This makes things look inconsistent when, for example a text input is horizontally positioned next to a select input. This commit fixes that.

Before (Please don't mind the German :smile:):
![phoenix-select-input-old](https://user-images.githubusercontent.com/4161349/235371408-ef8436be-8342-44db-b6ec-38244cd14106.png)

After:
![phoenix-select-input-new](https://user-images.githubusercontent.com/4161349/235371421-c55bdd2e-94bf-4b8c-adbf-2f1c493b8160.png)