### PR TITLE
[docs] Update `Phoenix.Controller.action_fallback/1` documentation

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -307,7 +307,7 @@ defmodule Phoenix.Controller do
 
         def call(conn, {:error, :unauthorized}) do
           conn
-          |> put_status(403)
+          |> put_status(:forbidden)
           |> put_view(MyErrorView)
           |> render(:"403")
         end


### PR DESCRIPTION
Maintain consistency in the documentation examples between passing the status code to `put_status/2` as either an integer or an atom. 

Give preference here to the atom format since the HTTP code is visible when passing the template name to `Phoenix.Controller.render/2`.