### PR TITLE
Fix typo in Controllers guide

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -380,7 +380,7 @@ The flash functionality is handy when mixed with redirects. Perhaps you want to 
   def home(conn, _params) do
     conn
     |> put_flash(:error, "Let's pretend we have an error.")
-    |> redirect(to: ~p"/redirect_test"))
+    |> redirect(to: ~p"/redirect_test")
   end
 ```
 


### PR DESCRIPTION
There is a small typo in the [Controllers](https://hexdocs.pm/phoenix/controllers.html#flash-messages) guide, one right parenthesis too many at the end:

```elixir
  def home(conn, _params) do
    conn
    |> put_flash(:error, "Let's pretend we have an error.")
    |> redirect(to: ~p"/redirect_test"))
  end
```