### PR TITLE
Fix put_root_layout/2 test

### DIFF
--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -98,14 +98,15 @@ defmodule Phoenix.Controller.ControllerTest do
     conn = conn(:get, "/")
     assert root_layout(conn) == false
 
-    conn = put_root_layout(conn, {AppView, "root.html"})
-    assert root_layout(conn) == {AppView, "root.html"}
+    conn = put_root_layout(conn, html: {AppView, :root})
+    assert root_layout(conn, "html") == {AppView, :root}
+    assert root_layout(conn, "json") == false
+    assert root_layout(conn) == false
 
-    conn = put_root_layout(conn, "bare.html")
-    assert root_layout(conn) == {AppView, "bare.html"}
-
-    conn = put_root_layout(conn, :print)
-    assert root_layout(conn) == {AppView, :print}
+    conn = put_root_layout(conn, html: :bare)
+    assert root_layout(conn, "html") == {AppView, :bare}
+    assert root_layout(conn, "json") == false
+    assert root_layout(conn) == false
 
     conn = put_root_layout(conn, false)
     assert root_layout(conn) == false


### PR DESCRIPTION
I fix `Phoenix.Controller.put_root_layout/2` second parameter type. (https://github.com/phoenixframework/phoenix/pull/5439)
But I miss test cases. So I fixed it. Now the `layout` can't be of a binary type.
```elixir
  @type layout :: {module(), layout_name :: atom()} | atom() | false
```

@josevalim  How about this?
related https://github.com/phoenixframework/phoenix/commit/e3ebb30013c935f450db20f2e57198d73dea41d0