### PR TITLE
Correct the use of TailwindCSS JIT class

### DIFF
--- a/installer/templates/phx_web/components/layouts/root.html.heex
+++ b/installer/templates/phx_web/components/layouts/root.html.heex
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="[scrollbar-gutter: stable]">
+<html lang="en" class="[scrollbar-gutter:stable]">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
A recent change was made to the root.html.heex layout - "Use tailwind JIT to accommodate CSP"

However, in that change, the syntax used was slightly incorrect (an extra space character), so TailwindCSS was not able to interpret the "arbitrary property" 

Correcting this change by omitting the space character.

(see the [TailwindCSS docs](https://tailwindcss.com/docs/adding-custom-styles#arbitrary-properties) for more information on the expected syntax for "arbitrary properties")

---
Screenshots from Chrome devtools:

**With a space:**
![CleanShot 2023-05-25 at 09 49 20@2x](https://github.com/phoenixframework/phoenix/assets/127204/f4ff2615-41a2-4951-8c6d-cd04ab7bcde7)

**Without a space:**
![CleanShot 2023-05-25 at 09 50 51@2x](https://github.com/phoenixframework/phoenix/assets/127204/bf149376-4ae8-4611-bb75-c2734ef304df)
