### PR TITLE
Fix hero icons mask repeat

### DIFF
--- a/installer/templates/phx_assets/tailwind.config.js
+++ b/installer/templates/phx_assets/tailwind.config.js
@@ -54,6 +54,7 @@ module.exports = {
             [`--hero-${name}`]: `url('data:image/svg+xml;utf8,${content}')`,
             "-webkit-mask": `var(--hero-${name})`,
             "mask": `var(--hero-${name})`,
+            "mask-repeat": "no-repeat",
             "background-color": "currentColor",
             "vertical-align": "middle",
             "display": "inline-block",


### PR DESCRIPTION
Hero icons begin to repeat vertically or horizontally when calculated space shrinks by the layout rules. `mask-repeat` rule set to `no-repeat` fixes these artifacts.

I found this useful but if you think it's too restrictive and rather should be done by tweaking the layout itself, please discard.