### PR TITLE
Allow local redirect to paths containing percent encoded characters (with few exceptions)

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -504,11 +504,11 @@ defmodule Phoenix.Controller do
     end
   end
 
-  @invalid_local_url_chars ["\\", "/%", "/\t"]
+  @invalid_local_url_regex ~r/\\|\t|\/%[0-1][0-9A-F]/
   defp validate_local_url("//" <> _ = to), do: raise_invalid_url(to)
 
   defp validate_local_url("/" <> _ = to) do
-    if String.contains?(to, @invalid_local_url_chars) do
+    if String.match?(to, @invalid_local_url_regex) do
       raise ArgumentError, "unsafe characters detected for local redirect in URL #{inspect(to)}"
     else
       to

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -367,6 +367,9 @@ defmodule Phoenix.Controller.ControllerTest do
       conn = redirect(conn(:get, "/"), to: "/<foobar>")
       assert conn.resp_body =~ "/&lt;foobar&gt;"
 
+      conn = redirect(conn(:get, "/"), to: "/%D0%BFfoobar")
+      assert conn.resp_body =~ "/%D0%BFfoobar"
+
       assert_raise ArgumentError, ~r/the :to option in redirect expects a path/, fn ->
         redirect(conn(:get, "/"), to: "http://example.com")
       end
@@ -385,6 +388,10 @@ defmodule Phoenix.Controller.ControllerTest do
 
       assert_raise ArgumentError, ~r/unsafe/, fn ->
         redirect(conn(:get, "/"), to: "/%09/example.com")
+      end
+
+      assert_raise ArgumentError, ~r/unsafe/, fn ->
+        redirect(conn(:get, "/"), to: "/example.com/%1B")
       end
 
       assert_raise ArgumentError, ~r/unsafe/, fn ->


### PR DESCRIPTION
With the phoenix `1.7.3` release  a few tests started failing for a project suddenly (`1.7.2` works just fine).

Digging into it, a recent fix https://github.com/phoenixframework/phoenix/commit/5d737201e09adcdfbea0b95b341aaa93e092c869 for the issue #5415 introduced a problem for us. 

We allow a wider palette of Unicode characters in our URLs and as they get percent encoded we have (for our purpose) valid URLs that can look like that in the browsers address bar:

`http://localhost:4000/Поездка-на-лыжах/:id`

And when copy & pasted from the address bar it's apparent that they are actually percent encoded where required:

`http://localhost:4000/%D0%BF%D0%BE%D0%B5%D0%B7%D0%B4%D0%BA%D0%B0-%D0%BD%D0%B0-%D0%BB%D1%8B%D0%B6%D0%B0%D1%85/:id`

In essence the provided fix deems percent encoded control characters (the range starting with %0 / %1) of the URL for a local redirect invalid, but allows to pass other percent encoded characters. 

I tried to keep the fix as minimal as possible, a regex to test for invalid characters seemed like the more concise approach. If an explicit set of characters is preferred I can adapt the PR accordingly. Do also let me know if the test coverage suffices. 

Thanks!