### PR TITLE
Add unique ids flashes in flash_group

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -143,8 +143,8 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def flash_group(assigns) do
     ~H"""
-    <.flash kind={:info} title="Success!" flash={@flash} />
-    <.flash kind={:error} title="Error!" flash={@flash} />
+    <.flash id="flash-info" kind={:info} title="Success!" flash={@flash} />
+    <.flash id="flash-error" kind={:error} title="Error!" flash={@flash} />
     <.flash
       id="client-error"
       kind={:error}

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -143,8 +143,8 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def flash_group(assigns) do
     ~H"""
-    <.flash kind={:info} title="Success!" flash={@flash} />
-    <.flash kind={:error} title="Error!" flash={@flash} />
+    <.flash id="flash-info" kind={:info} title="Success!" flash={@flash} />
+    <.flash if="flash-error" kind={:error} title="Error!" flash={@flash} />
     <.flash
       id="client-error"
       kind={:error}


### PR DESCRIPTION
This should solve #5486 

# Description

The user-provided flashes for `:info` and `:error` in the `<.flash_group />` component render using the `<flash />` component, but do not specify an id, causing the default id of `"flash"` to be used for both.

Since the logic around flashes allow for both info and error to be present, this may result in neither rendering, or one rendering over another.

Providing a unique ID results in things working in a less confusing way.

This updates the generator for core components to provide this unique id.

# Notes

- I'm not aware of a rule for specifying ids. If these do not match an expected format, I'm happy to update 
- The solution could be smaller - only one of the two flashes could be given an id, allowing the other to use the default
- It could also be solved by adding some  logic to the component to ensure only one flash could be rendered.