### PR TITLE
Do not run swoosh memory storage process in production

### DIFF
--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -8,7 +8,10 @@ import Config<%= if @javascript or @css do %>
 config :<%= @web_app_name %>, <%= @endpoint_module %>, cache_static_manifest: "priv/static/cache_manifest.json"<% end %><%= if @mailer do %>
 
 # Configures Swoosh API Client
-config :swoosh, api_client: Swoosh.ApiClient.Finch, finch_name: <%= @app_module %>.Finch<% end %>
+config :swoosh, api_client: Swoosh.ApiClient.Finch, finch_name: <%= @app_module %>.Finch
+
+# Disable Swoosh Local Memory Storage
+config :swoosh, local: false<% end %>
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/installer/templates/phx_umbrella/config/prod.exs
+++ b/installer/templates/phx_umbrella/config/prod.exs
@@ -2,7 +2,10 @@ import Config
 
 <%= if @mailer do %>
 # Configures Swoosh API Client
-config :swoosh, :api_client, <%= @app_module %>.Finch<% end %>
+config :swoosh, :api_client, <%= @app_module %>.Finch
+
+# Disable Swoosh Local Memory Storage
+config :swoosh, local: false<% end %>
 
 # Do not print debug messages in production
 config :logger, level: :info


### PR DESCRIPTION
Swoosh starts an in memory storage for mails by [default](https://hexdocs.pm/swoosh/Swoosh.html#module-production)
I do not think anybody uses this in production, so I think adding this to the generated `prod.exs` file makes sense.
