### PR TITLE
Export static `at` path from Endpoint

### DIFF
--- a/installer/templates/phx_single/lib/app_name_web.ex
+++ b/installer/templates/phx_single/lib/app_name_web.ex
@@ -18,6 +18,7 @@ defmodule <%= @web_namespace %> do
   """
 
   def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+  def static_at, do: "/"
 
   def router do
     quote do
@@ -100,7 +101,8 @@ defmodule <%= @web_namespace %> do
       use Phoenix.VerifiedRoutes,
         endpoint: <%= @endpoint_module %>,
         router: <%= @web_namespace %>.Router,
-        statics: <%= @web_namespace %>.static_paths()
+        statics: <%= @web_namespace %>.static_paths(),
+        statics_at: <%= @web_namespace %>.static_at()
     end
   end
 

--- a/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name.ex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/lib/app_name.ex
@@ -18,6 +18,7 @@ defmodule <%= @web_namespace %> do
   """
 
   def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+  def static_at, do: "/"
 
   def router do
     quote do
@@ -100,7 +101,8 @@ defmodule <%= @web_namespace %> do
       use Phoenix.VerifiedRoutes,
         endpoint: <%= @endpoint_module %>,
         router: <%= @web_namespace %>.Router,
-        statics: <%= @web_namespace %>.static_paths()
+        statics: <%= @web_namespace %>.static_paths(),
+        statics_at: <%= @web_namespace %>.static_at()
     end
   end
 

--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -18,7 +18,7 @@ defmodule <%= @endpoint_module %> do
   # You should set gzip to true if you are running phx.digest
   # when deploying your static files in production.
   plug Plug.Static,
-    at: "/",
+    at: <%= @web_namespace %>.static_at(),
     from: :<%= @web_app_name %>,
     gzip: false,
     only: <%= @web_namespace %>.static_paths()

--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -136,9 +136,13 @@ defmodule Phoenix.VerifiedRoutes do
     Module.put_attribute(mod, :router, Keyword.fetch!(opts, :router))
     Module.put_attribute(mod, :endpoint, Keyword.get(opts, :endpoint))
 
+    statics_at =
+      Keyword.get(opts, :statics_at, "/")
+      |> String.trim_leading("/")
+
     statics =
       case Keyword.get(opts, :statics, []) do
-        list when is_list(list) -> list
+        list when is_list(list) -> Enum.map(list, &Path.join(statics_at, &1))
         other -> raise ArgumentError, "expected statics to be a list, got: #{inspect(other)}"
       end
 

--- a/test/phoenix/verified_routes_test.exs
+++ b/test/phoenix/verified_routes_test.exs
@@ -189,6 +189,20 @@ defmodule Phoenix.VerifiedRoutesTest do
     assert warnings == ""
   end
 
+  test "with statics_at set" do
+    defmodule StaticsAtSet do
+      use Phoenix.VerifiedRoutes,
+        endpoint: unquote(@endpoint),
+        router: unquote(@router),
+        statics: ~w(images),
+        statics_at: "/banana"
+
+      def test, do: ~p"/banana/images/test.jpg"
+    end
+
+    assert StaticsAtSet.test() == "/banana/images/test.jpg"
+  end
+
   test "unverified_path" do
     assert unverified_path(conn_with_script_name(), @router, "/posts") == "/api/posts"
     assert unverified_path(@endpoint, @router, "/posts") == "/posts"


### PR DESCRIPTION
Closes #5387

Static plug has a configuration called `at` which the `VerifiedRoutes` does not take into account since it is not aware of it.

This is one possible solution that export the configuration from the `XxxWeb.Endpoint` to `XxxWeb` as a function called `static_at/0`. Later the `VerifiedRoute` module makes use of this with accepting a new config.

Also this PR can use some recommendation regarding the naming of the configuration option `static_at` if it is decided an acceptable approach.

Thanks!