### PR TITLE
fix auth alias order

### DIFF
--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -1,4 +1,4 @@
-  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Notifier, <%= inspect schema.alias %>Token }
+  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Notifier, <%= inspect schema.alias %>Token}
 
   ## Database getters
 

--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -1,4 +1,4 @@
-  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Token, <%= inspect schema.alias %>Notifier}
+  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Notifier, <%= inspect schema.alias %>Token }
 
   ## Database getters
 


### PR DESCRIPTION
credo's readability check catches it as a warning

![image](https://github.com/phoenixframework/phoenix/assets/6567687/0d9f41b3-a2d1-46b9-9338-110e9550edf8)
