### PR TITLE
Update `Telemetry` installation template

### DIFF
--- a/installer/templates/phx_web/telemetry.ex
+++ b/installer/templates/phx_web/telemetry.ex
@@ -43,7 +43,7 @@ defmodule <%= @web_namespace %>.Telemetry do
       summary("phoenix.socket_connected.duration",
         unit: {:native, :millisecond}
       ),
-      summary("phoenix.channel_join.duration",
+      summary("phoenix.channel_joined.duration",
         unit: {:native, :millisecond}
       ),
       summary("phoenix.channel_handled_in.duration",


### PR DESCRIPTION
I think this is a typo, that the actual event is `[:phoenix, :channel_joined]`.

https://github.com/phoenixframework/phoenix/blob/3f0dfced31a66edb0932c479e2da51125d1c8e30/lib/phoenix/logger.ex#L137
https://github.com/phoenixframework/phoenix/blob/3f0dfced31a66edb0932c479e2da51125d1c8e30/lib/phoenix/logger.ex#L333