### PR TITLE
Adds radio input case to `input` function definition in `CoreComponents`

### DIFF
--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -319,6 +319,23 @@ defmodule <%= @web_namespace %>.CoreComponents do
     """
   end
 
+  def input(%{type: "radio"} = assigns) do
+    ~H"""
+      <label class="flex items-center gap-2 text-sm leading-6 text-zinc-600">
+        <input
+          type="radio"
+          id={@id}
+          name={@name}
+          value={@value}
+          checked={@checked}
+          class="rounded border-zinc-300 text-zinc-900 focus:ring-0"
+          {@rest}
+        />
+        <%= @label %>
+      </label>
+    """
+  end
+
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div phx-feedback-for={@name}>


### PR DESCRIPTION
This code is a slightly modified version of @codeanpeace's work here: https://elixirforum.com/t/radio-buttons-using-the-corecomponents-module-in-phoenix-1-7/56856/5

That thread illustrates the pitfalls that can happen with radio inputs omitted from the `input` function. If it does not make sense to handle the radio input case this way (since it is a bit of an odd-input-out in terms of how it works), then an alternative to handling it might be to add some sort of explicit warning or error that pops up for developers who try to use the `input` function to make a radio input.