### PR TITLE
Add support for static resources with fragments. Closes #5507

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -578,7 +578,20 @@ defmodule Phoenix.Endpoint do
       @doc """
       Generates a route to a static file in `priv/static`.
       """
-      def static_path(path), do: persistent!().static_path <> elem(static_lookup(path), 0)
+      def static_path(path) do
+        {path, fragment} = path_and_fragment(path)
+
+        persistent!().static_path <> elem(static_lookup(path), 0) <> fragment
+      end
+
+      defp path_and_fragment(path_incl_fragment) do
+        path_incl_fragment
+        |> String.split("#", parts: 2)
+        |> case do
+          [path, fragment] -> {path, "#" <> fragment}
+          [path | _] -> {path, ""}
+        end
+      end
 
       @doc """
       Generates a base64-encoded cryptographic hash (sha512) to a static file

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -178,6 +178,18 @@ defmodule Phoenix.Endpoint.EndpointTest do
     assert Endpoint.static_path("/foo.css") == "/foo-d978852bea6530fcd197b5445ed008fd.css"
   end
 
+  test "uses correct path for resources with fragment identifier" do
+    config = put_in(@config[:cache_manifest_skip_vsn], false)
+    assert Endpoint.config_change([{Endpoint, config}], []) == :ok
+
+    assert Endpoint.static_path("/foo.css#info") ==
+             "/foo-d978852bea6530fcd197b5445ed008fd.css?vsn=d#info"
+
+    # assert that even multiple presences of a number sign are treated as a fragment
+    assert Endpoint.static_path("/foo.css#info#me") ==
+             "/foo-d978852bea6530fcd197b5445ed008fd.css?vsn=d#info#me"
+  end
+
   @tag :capture_log
   test "invokes init/2 callback" do
     defmodule InitEndpoint do


### PR DESCRIPTION
With this PR, you can use the ~p sigil to resolve static assets with fragment identifiers (e.g. useful to address only a specific section of an SVG image).
For instance, if you have a "digest" version of an asset:
Before:
```
~p"/images/icons.svg" == "/images/icons-6051db34009ab48e6232cf685fca2bd4.svg?vsn=d"
~p"/images/icons.svg#warning" == "/images/icons.svg#warning"
```
Now:
```
~p"/images/icons.svg" == "/images/icons-6051db34009ab48e6232cf685fca2bd4.svg?vsn=d"
~p"/images/icons.svg#warning" == "/images/icons-6051db34009ab48e6232cf685fca2bd4.svg?vsn=d#warning"
```

Closes #5507