### PR TITLE
Remove error_html_test on new without html

### DIFF
--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -28,7 +28,6 @@ defmodule Phx.New.Web do
      "#{@pre}/gitignore": ".gitignore",
      "#{@pre}/test/test_helper.exs": "test/test_helper.exs",
      "phx_test/support/conn_case.ex": "test/support/conn_case.ex",
-     "phx_test/controllers/error_html_test.exs": "test/:web_app/controllers/error_html_test.exs",
      "phx_test/controllers/error_json_test.exs": "test/:web_app/controllers/error_json_test.exs",
      "#{@pre}/formatter.exs": ".formatter.exs"}
   ])
@@ -51,6 +50,7 @@ defmodule Phx.New.Web do
        "lib/:web_app/controllers/page_html/home.html.heex",
      "phx_test/controllers/page_controller_test.exs":
        "test/:web_app/controllers/page_controller_test.exs",
+     "phx_test/controllers/error_html_test.exs": "test/:web_app/controllers/error_html_test.exs",
      "phx_assets/topbar.js": "assets/vendor/topbar.js",
      "phx_web/components/layouts/root.html.heex": "lib/:web_app/components/layouts/root.html.heex",
      "phx_web/components/layouts/app.html.heex": "lib/:web_app/components/layouts/app.html.heex"}

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -376,8 +376,9 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       # No HTML
       assert File.exists?(web_path(@app, "test/#{@app}_web/controllers"))
+      refute File.exists?(web_path(@app, "test/#{@app}_web/controllers/error_html_test.exs"))
       assert File.exists?(web_path(@app, "lib/#{@app}_web/controllers"))
-      refute File.exists?(web_path(@app, "test/controllers/pager_controller_test.exs"))
+      refute File.exists?(web_path(@app, "test/controllers/page_controller_test.exs"))
       refute File.exists?(web_path(@app, "lib/#{@app}_web/controllers/page_controller.ex"))
       refute File.exists?(web_path(@app, "lib/#{@app}_web/controllers/error_html.ex"))
       refute File.exists?(web_path(@app, "lib/#{@app}_web/controllers/page_html.ex"))
@@ -474,6 +475,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file(root_path(@app, "mix.exs"), fn file ->
         assert file =~ "defp deps do\n    []"
       end)
+
+      refute_file(web_path(@app, "test/#{@app}_web/controllers/error_html_test.exs"))
 
       assert_file(web_path(@app, "mix.exs"), fn file ->
         refute file =~ ~s|:phoenix_live_view|


### PR DESCRIPTION
When generating projects without html in umbrella (`mix phx.new my-app --umbrella --no-html`), the file `error_html_test.exs` still get created.

If you run `mix test` on a newly created project, it fails because it expects html.

I fixed that by moving the generation of that file from the "new" template to the "html" template. I updated the tests to match the expected behaviour. All other tests are passing fine.

I also took advantage of the same commit to fix a typo of `pager_controller_test.exs`, which should be `page_controller_test.exs`.

Cheers from Brazil, @chrismccord @josevalim!   🧡