### PR TITLE
Dockefile template: decouple builder and runner debian versions

### DIFF
--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -13,10 +13,12 @@
 #
 ARG ELIXIR_VERSION=<%= elixir_vsn %>
 ARG OTP_VERSION=<%= otp_vsn %>
-ARG DEBIAN_VERSION=<%= debian %>-<%= debian_vsn %>-slim
+ARG DEBIAN_RELEASE=<%= debian %>
+ARG DEBIAN_VERSION=<%= debian_vsn %>-slim
+ARG DEBIAN_RUNNER_VERSION=<%= debian_vsn %>-slim
 
-ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
-ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_RELEASE}-${DEBIAN_VERSION}"
+ARG RUNNER_IMAGE="debian:${DEBIAN_RELEASE}-${DEBIAN_RUNNER_VERSION}"
 
 FROM ${BUILDER_IMAGE} as builder
 


### PR DESCRIPTION
hex.pm images are not updated as frequntly as Debian official images, however for security reasons latest debian version should be used for runners since they may contain important bugfixes.

This change allows using a more recent runner version while using the same Debian release for both builder and runner.