### PR TITLE
Use correct form field name in reset_password_live_test template

### DIFF
--- a/priv/templates/phx.gen.auth/reset_password_live_test.exs
+++ b/priv/templates/phx.gen.auth/reset_password_live_test.exs
@@ -40,7 +40,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         lv
         |> element("#reset_password_form")
         |> render_change(
-          <%= schema.singular %>: %{"password" => "secret12", "confirmation_password" => "secret123456"}
+          <%= schema.singular %>: %{"password" => "secret12", "password_confirmation" => "secret123456"}
         )
 
       assert result =~ "should be at least 12 character"


### PR DESCRIPTION
Currently, the form submits "confirmation_password", which (I believe) could lead to false positives. Instead, this template should use the expected key, "password_confirmation".