### PR TITLE
Ensure sourcemaps have the .js.map extension

### DIFF
--- a/lib/phoenix/digester.ex
+++ b/lib/phoenix/digester.ex
@@ -146,8 +146,15 @@ defmodule Phoenix.Digester do
     content = File.read!(file_path)
 
     basename = Path.basename(file_path)
-    rootname = Path.rootname(basename)
-    extension = Path.extname(basename)
+
+    rootname =
+      if String.ends_with?(basename, ".js.map"),
+        do: Path.rootname(basename) |> Path.rootname(),
+        else: Path.rootname(basename)
+
+    extension =
+      if String.ends_with?(basename, ".js.map"), do: ".js.map", else: Path.extname(basename)
+
     digest = Base.encode16(:erlang.md5(content), case: :lower)
 
     %{

--- a/test/phoenix/digester_test.exs
+++ b/test/phoenix/digester_test.exs
@@ -18,7 +18,8 @@ defmodule Phoenix.DigesterTest do
 
   describe "compile" do
     test "fails when the given paths are invalid" do
-      assert {:error, :invalid_path} = Phoenix.Digester.compile("nonexistent path", "/ ?? /path", true)
+      assert {:error, :invalid_path} =
+               Phoenix.Digester.compile("nonexistent path", "/ ?? /path", true)
     end
 
     test "digests and compress files" do
@@ -276,7 +277,7 @@ defmodule Phoenix.DigesterTest do
 
       digested_js_map_filename =
         assets_files(@output_path)
-        |> Enum.find(&(&1 =~ ~r"app.js-#{@hash_regex}.map"))
+        |> Enum.find(&(&1 =~ ~r"app-#{@hash_regex}.js.map"))
 
       digested_js_filename =
         assets_files(@output_path)
@@ -297,7 +298,7 @@ defmodule Phoenix.DigesterTest do
 
       digested_js_map_filename =
         assets_files(@output_path)
-        |> Enum.find(&(&1 =~ ~r"app.js-#{@hash_regex}.map"))
+        |> Enum.find(&(&1 =~ ~r"app-#{@hash_regex}.js.map"))
 
       digested_js_filename =
         assets_files(@output_path)


### PR DESCRIPTION
Normally, we'd expect sourcemaps to have the .js.map extension but the ones generated by the digester have the following format:
`"app.js-a4ef30371d563677c64cc9583ad6b305.map"`
The hash should be in included in the filename, not in the extension:
`"app-a4ef30371d563677c64cc9583ad6b305.js.map"`

While in some cases, this doesn't matter because the unminifiers would look at the sourceMappingURL in .js file, there are use cases like [datadog](https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps/?tab=webpackjs) where the expected format is having the extension `.js.map`, otherwise they are not recognised as valid sourcemaps and some manual filename manipulation would be needed to adhere to the expected format.