### PR TITLE
Add `--method` option to phx.routes mix task

### DIFF
--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -34,6 +34,7 @@ defmodule Mix.Tasks.Phx.Routes do
   ## Options
 
     * `--info` - locate the controller function definition called by the given url
+    * `--method` - what HTTP method to use with the given url, only works when used with `--info` and defaults to `get`
 
   ## Examples
 
@@ -51,6 +52,13 @@ defmodule Mix.Tasks.Phx.Routes do
         Module: RouteInfoTestWeb.PageController
         Function: :index
         /home/my_app/controllers/page_controller.ex:4
+
+  Print information about the controller function called by a specified url and HTTP method:
+
+      $ mix phx.routes --info http://0.0.0.0:4000/users --method post
+        Module: RouteInfoTestWeb.UserController
+        Function: :create
+        /home/my_app/controllers/user_controller.ex:24
   """
 
   @doc false
@@ -78,10 +86,11 @@ defmodule Mix.Tasks.Phx.Routes do
     end
   end
 
-  def get_url_info(url, {router_mod, _opts}) do
+  def get_url_info(url, {router_mod, opts}) do
     %{path: path} = URI.parse(url)
 
-    meta = Phoenix.Router.route_info(router_mod, "GET", path, "")
+    method = opts |> Keyword.get(:method, "get") |> String.upcase()
+    meta = Phoenix.Router.route_info(router_mod, method, path, "")
     %{plug: plug, plug_opts: plug_opts} = meta
 
     {module, func_name} =


### PR DESCRIPTION
This Pull Request updates the list of valid options in `Mix.Tasks.Phx.Routes`, adding a new `--method` option, which, when combined with the `--info` option, allows users to specify what HTTP method should be used in conjunction with the specified URL.

This should help in cases where the same URL matches multiple controller actions, depending on the HTTP method. For example, an application with a URL such as `/api/v1/users` might use it to list users, with the `GET` method, or to create a new user, with the `POST` method.

# Tests

I noticed that, currently, there aren't any tests for the `--info` option and ended up trying to add some. However, I ran into an issue where `Code.fetch_docs/1` was not able to find the controller module. I am assuming that's also the reason why there are no tests for this option right now.

In any case, here's the simple test case I was trying to run, for reference:

```elixir
  test "--info returns information about module" do
    Mix.Tasks.Phx.Routes.run(["--info", "/"], PhoenixTestWeb)
    assert_received {:mix_shell, :info, [routes]}
    assert routes =~ "Module: PageController"
  end
```

and the exception that's being raised:


```
❯ mix test ./test/mix/tasks/phx.routes_test.exs
.....

  1) test --info returns information about module (Mix.Tasks.Phx.RoutesTest)
     test/mix/tasks/phx.routes_test.exs:62
     ** (MatchError) no match of right hand side value: {:error, :module_not_found}
     code: Mix.Tasks.Phx.Routes.run(["--info", "/"], PhoenixTestWeb)
     stacktrace:
       (phoenix 1.7.7) lib/mix/tasks/phx.routes.ex:176: Mix.Tasks.Phx.Routes.get_line_number/2
       (phoenix 1.7.7) lib/mix/tasks/phx.routes.ex:108: Mix.Tasks.Phx.Routes.get_url_info/2
       test/mix/tasks/phx.routes_test.exs:63: (test)

.
Finished in 0.2 seconds (0.2s async, 0.00s sync)
7 tests, 1 failure

Randomized with seed 59413
```