### PR TITLE
Do something with assigns.errors (otherwise it is just overwitten)

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -289,7 +289,17 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
-    |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
+    |> assign(
+      :errors,
+      Enum.map(
+        if [] == assigns.errors do
+          field.errors
+        else
+          assigns.errors
+        end,
+        &translate_error(&1)
+      )
+    )
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
     |> input()

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -289,7 +289,17 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(%{field: %Phoenix.HTML.FormField{} = field} = assigns) do
     assigns
     |> assign(field: nil, id: assigns.id || field.id)
-    |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
+    |> assign(
+      :errors,
+      Enum.map(
+        if [] == assigns.errors do
+          field.errors
+        else
+          assigns.errors
+        end,
+        &translate_error(&1)
+      )
+    )
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
     |> input()


### PR DESCRIPTION
Another option is to remove the `errors` attr, I'm not sure what was intended.