### PR TITLE
Fix crash of Code Reloader when %Mix.Task.Compiler.Diagnostic{file: nil}

### DIFF
--- a/lib/phoenix/code_reloader/proxy.ex
+++ b/lib/phoenix/code_reloader/proxy.ex
@@ -62,8 +62,12 @@ defmodule Phoenix.CodeReloader.Proxy do
     "\n#{message}\n"
   end
 
-  defp diagnostic_to_chars(%{severity: severity, message: message, file: file, position: position}) do
+  defp diagnostic_to_chars(%{severity: severity, message: message, file: file, position: position}) when is_binary(file) do
     "\n#{severity}: #{message}\n  #{Path.relative_to_cwd(file)}#{position(position)}\n"
+  end
+
+  defp diagnostic_to_chars(%{severity: severity, message: message}) do
+    "\n#{severity}: #{message}\n"
   end
 
   defp position({line, col}), do: ":#{line}:#{col}"


### PR DESCRIPTION
# Bug
The Code Reloader crashes, when there is a `%Mix.Task.Compiler.Diagnostic` with `:file` equal to `nil`.

## Stack trace
```elixir
 ** (FunctionClauseError) no function clause matching in IO.chardata_to_string/1
                (elixir 1.15.2) lib/io.ex:671: IO.chardata_to_string(nil)
                (elixir 1.15.2) lib/path.ex:327: Path.relative_to/2
                (phoenix 1.7.7) lib/phoenix/code_reloader/proxy.ex:66: Phoenix.CodeReloader.Proxy.diagnostic_to_chars/1
                (elixir 1.15.2) lib/enum.ex:1693: Enum."-map/2-lists^map/1-1-"/2
                (phoenix 1.7.7) lib/phoenix/code_reloader/proxy.ex:26: Phoenix.CodeReloader.Proxy.handle_cast/2
```

## Real Live Example
This compiler warning crashes the Code Reloader.

```elixir
[
  %Mix.Task.Compiler.Diagnostic{
    file: nil,
    severity: :warning,
    message: "Locale :de has no associated gettext locale. Cannot translate {:<<>>, [line: 50], [\"/:locale/log_in?_action=registered\"]}",
    position: 0,
    compiler_name: "Elixir",
    details: nil,
    stacktrace: []
  }
]
```

# Proposed fix

Add a check if `:file` is binary. Otherwise, only print `:severity` and `message`. 