### PR TITLE
`destroy()` method for `Presence`

### DIFF
--- a/assets/js/phoenix/presence.js
+++ b/assets/js/phoenix/presence.js
@@ -18,7 +18,8 @@ export default class Presence {
       onSync: function (){ }
     }
 
-    this.channel.on(events.state, newState => {
+    this.refs = []
+    this.refs.push(this.channel.on(events.state, newState => {
       let {onJoin, onLeave, onSync} = this.caller
 
       this.joinRef = this.channel.joinRef()
@@ -29,9 +30,9 @@ export default class Presence {
       })
       this.pendingDiffs = []
       onSync()
-    })
+    }))
 
-    this.channel.on(events.diff, diff => {
+    this.refs.push(this.channel.on(events.diff, diff => {
       let {onJoin, onLeave, onSync} = this.caller
 
       if(this.inPendingSyncState()){
@@ -40,7 +41,7 @@ export default class Presence {
         this.state = Presence.syncDiff(this.state, diff, onJoin, onLeave)
         onSync()
       }
-    })
+    }))
   }
 
   onJoin(callback){ this.caller.onJoin = callback }
@@ -53,6 +54,10 @@ export default class Presence {
 
   inPendingSyncState(){
     return !this.joinRef || (this.joinRef !== this.channel.joinRef())
+  }
+
+  destroy(){
+    this.refs.forEach(ref => this.channel.off(ref))
   }
 
   // lower-level public static API

--- a/assets/test/presence_test.js
+++ b/assets/test/presence_test.js
@@ -32,11 +32,12 @@ let channelStub = {
 
   on(event, callback){ 
     this.events[event] = callback
-    return event
+    return `${event}-ref`
   },
 
-  off(ref){
-    this.events[ref] = function(){}
+  off(event, ref){
+    if(ref && ref !== `${event}-ref`) throw new Error("invalid ref")
+    this.events[event] = function(){}
   },
 
   trigger(event, data){ this.events[event](data) },


### PR DESCRIPTION
From what I have observed so far, it seems that you cannot stop tracking the presence for a channel. This feature would be useful in the case where you manage the `Presence` independently from the `Channel` in your code because `Presence` can be created and destroyed by the code which is managing the `Presence`. Otherwise you would need to pass in the `Presence` from whatever code is managing the `Channel`.

```js
class ManagePresence {
  constructor(channel){
    this.presence = new Presence(channel)
  }
  
  destroy(){
    this.presence.destroy()
  }
}
```

This feature also allows code which tracks the client presence state in parallel to `Presence` work nicer during reconnects because, without `destroy`, the presence state would remain intact over re-connections. (Meaning if many clients had previously connected but then there was a server reboot there would be unexpected `client_leave`s in the history when the `Presence` re-syncs since the other clients won't be present anymore.

```js
class ManagePresence {
  constructor(channel){
    this.history = []
    this.presence = new Presence(channel)
    this.presence.onJoin(id => history.push({type: 'client_join', id, timestamp: new Date()}))
    this.presence.onLeave(id => history.push({type: 'client_leave', id, timestamp: new Date()}))
  }
  
  destroy(){
    this.presence.destroy()
  }
}
```