### PR TITLE
Add ca-certificates package to phx.gen.release/Dockerfile.eex

### DIFF
--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -67,7 +67,8 @@ RUN mix release
 # the compiled release and other runtime necessities
 FROM ${RUNNER_IMAGE}
 
-RUN apt-get update -y && apt-get install -y libstdc++6 openssl libncurses5 locales \
+RUN apt-get update -y && \
+  apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale


### PR DESCRIPTION
I've recently run into a problem:

    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]** (exit) an exception was raised:
    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]    ** (MatchError) no match of right hand side value: {:error, :enoent}
    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]        (public_key 1.14) pubkey_os_cacerts.erl:38: :pubkey_os_cacerts.get/0
    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]        (inets 9.0.1) httpc.erl:476: :httpc.ssl_verify_host_options/1
    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]        (inets 9.0.1) httpc.erl:1015: anonymous fn/0 in :httpc.http_options_default/0
    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]        (inets 9.0.1) httpc.erl:961: :httpc.http_options/3
    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]        (inets 9.0.1) httpc.erl:771: :httpc.handle_request/9
    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]        (tesla 1.6.0) lib/tesla/adapter/httpc.ex:52: Tesla.Adapter.Httpc.request/2
    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]        (tesla 1.6.0) lib/tesla/adapter/httpc.ex:22: Tesla.Adapter.Httpc.call/2
    2023-07-28T09:56:42Z app[e784e1e0b52d48] iad [info]        (oauth2 2.1.0) lib/oauth2/request.ex:37: OAuth2.Request.request/6

In other words,

    :public_key.cacerts_get()

Fails becasue there's no OS provided CA store on this Docker image.

I believe the tradeoff is the ca-certificates package might become stale
as it would only ever be updated if Docker layers beforehand are
changed.
