### PR TITLE
Context Guide: add `+` markers for `get_cart_by_user_uuid` in diff

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -800,17 +800,17 @@ Let's implement the new interface for the `ShoppingCart` context API in `lib/hel
 -  alias Hello.ShoppingCart.Cart
 +  alias Hello.ShoppingCart.{Cart, CartItem}
 
-  def get_cart_by_user_uuid(user_uuid) do
-    Repo.one(
-      from(c in Cart,
-        where: c.user_uuid == ^user_uuid,
-        left_join: i in assoc(c, :items),
-        left_join: p in assoc(i, :product),
-        order_by: [asc: i.inserted_at],
-        preload: [items: {i, product: p}]
-      )
-    )
-  end
++  def get_cart_by_user_uuid(user_uuid) do
++    Repo.one(
++      from(c in Cart,
++        where: c.user_uuid == ^user_uuid,
++        left_join: i in assoc(c, :items),
++        left_join: p in assoc(i, :product),
++        order_by: [asc: i.inserted_at],
++        preload: [items: {i, product: p}]
++      )
++    )
++  end
 
 - def create_cart(attrs \\ %{}) do
 -   %Cart{}


### PR DESCRIPTION
I've just been working through the Contexts guide (https://hexdocs.pm/phoenix/contexts.html), and I feel like the code for `get_cart_by_user_uuid` should have `+` diff markers, like the other functions that are added in the same diff.

See screenshot:
![image](https://github.com/phoenixframework/phoenix/assets/1540054/7d3ebb2e-21e1-43b0-9493-02df39c4bbb8)


The line below the diff even says `We started by implementing get_cart_by_user_uuid/1`, so I feel like this was probably the original intention.

Thanks!