### PR TITLE
Favor format-specific view module over default

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -589,13 +589,13 @@ defmodule Phoenix.Controller do
   def view_module(conn, format \\ nil) do
     format = format || get_safe_format(conn)
 
-    # TODO: Deprecate if we fall on the first branch
+    # TODO: Deprecate if we fall on the second branch
     # But we should only deprecate this after non-format is deprecated on put_*
     case conn.private[:phoenix_view] do
-      %{_: value} when value != nil ->
+      %{^format => value} ->
         value
 
-      %{^format => value} ->
+      %{_: value} when value != nil ->
         value
 
       formats ->

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -224,10 +224,17 @@ defmodule Phoenix.Controller.ControllerTest do
     assert view_module(conn) == HelloJSON
     assert view_module(conn, "json") == HelloJSON
 
-    conn = put_format(conn, "json")
-    conn = put_new_view(conn, Hello)
+    conn =
+      conn(:get, "/")
+      |> put_format("json")
+      |> put_new_view(Hello)
+
     assert view_module(conn) == Hello
     assert view_module(conn, "json") == Hello
+
+    conn = put_view(conn, json: HelloJSON)
+    assert view_module(conn) == HelloJSON
+    assert view_module(conn, "json") == HelloJSON
 
     assert_raise Plug.Conn.AlreadySentError, fn ->
       put_new_view sent_conn(), html: Hello


### PR DESCRIPTION
Given a controller with default and format-specific view set, need to check for format-specific first, otherwise default view is always used. That said, since the desire is to deprecate non-format views this change may not be desirable.

Thanks for the amazing framework!