### PR TITLE
chore(docs): update docs to reflect 1.7.7 steps

### DIFF
--- a/guides/introduction/up_and_running.md
+++ b/guides/introduction/up_and_running.md
@@ -33,6 +33,7 @@ When it's done, it will ask us if we want it to install our dependencies for us.
 ```console
 Fetch and install dependencies? [Yn] Y
 * running mix deps.get
+* running mix assets.setup
 * running mix deps.compile
 
 We are almost there! The following steps are missing:


### PR DESCRIPTION
Hi, this is not a bug, just a doc update. In 1.7.7 we see the following:
![image](https://github.com/phoenixframework/phoenix/assets/8906358/85edc7de-6131-45fc-a9df-de638af7c22d)
