### PR TITLE
Assign generated id to reuse in flash template

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -106,10 +106,11 @@ defmodule <%= @web_namespace %>.CoreComponents do
   slot :inner_block, doc: "the optional inner block that renders the flash message"
 
   def flash(assigns) do
+    assigns = assign(assigns, :id, assigns.id || "flash-#{assigns.kind}")
     ~H"""
     <div
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
-      id={@id || "flash-#{@kind}"}
+      id={@id}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       role="alert"
       class={[

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -107,6 +107,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def flash(assigns) do
     assigns = assign(assigns, :id, assigns.id || "flash-#{assigns.kind}")
+
     ~H"""
     <div
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -106,7 +106,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   slot :inner_block, doc: "the optional inner block that renders the flash message"
 
   def flash(assigns) do
-    assigns = assign(assigns, :id, assigns.id || "flash-#{assigns.kind}")
+    assigns = assign_new(assigns, :id, fn -> "flash-#{assigns.kind}" end)
 
     ~H"""
     <div

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -106,10 +106,11 @@ defmodule <%= @web_namespace %>.CoreComponents do
   slot :inner_block, doc: "the optional inner block that renders the flash message"
 
   def flash(assigns) do
+    assigns = assign(assigns, :id, assigns.id || "flash-#{assigns.kind}")
     ~H"""
     <div
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
-      id={@id || "flash-#{@kind}"}
+      id={@id}
       phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
       role="alert"
       class={[

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -107,6 +107,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def flash(assigns) do
     assigns = assign(assigns, :id, assigns.id || "flash-#{assigns.kind}")
+
     ~H"""
     <div
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -106,7 +106,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   slot :inner_block, doc: "the optional inner block that renders the flash message"
 
   def flash(assigns) do
-    assigns = assign(assigns, :id, assigns.id || "flash-#{assigns.kind}")
+    assigns = assign_new(assigns, :id, fn -> "flash-#{assigns.kind}" end)
 
     ~H"""
     <div


### PR DESCRIPTION
It fixes a bug introduced in 10891447eddc023bd79e1b9f8b46f8a3344542bb, which does not allow to close flash when id is not given.