### PR TITLE
[Socket Draining] Dynamic socket drainer configuration

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -807,8 +807,12 @@ defmodule Phoenix.Endpoint do
     * `:code_reloader` - enable or disable the code reloader. Defaults to your
       endpoint configuration
 
-    * `:drainer` - a keyword list configuring how to drain sockets
-      on application shutdown. The goal is to notify all channels (and
+    * `:drainer` - a keyword list or a custom MFA function returning a keyword list, for example:
+
+          {MyAppWeb.Socket, :drainer_configuration, []}
+
+      configuring how to drain sockets on application shutdown.
+      The goal is to notify all channels (and
       LiveViews) clients to reconnect. The supported options are:
 
       * `:batch_size` - How many clients to notify at once in a given batch.

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -454,7 +454,7 @@ defmodule Phoenix.Socket do
         end
         {Phoenix.Socket.PoolDrainer, {endpoint, handler, drainer}}
     else
-        :ignore
+      :ignore
     end
   end
 

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -445,9 +445,16 @@ defmodule Phoenix.Socket do
     opts = Keyword.merge(socket_options, opts)
 
     if drainer = Keyword.get(opts, :drainer, []) do
-      {Phoenix.Socket.PoolDrainer, {endpoint, handler, drainer}}
+      drainer =
+        case drainer do
+          {module, function, arguments} ->
+            apply(module, function, arguments)
+          _ ->
+            drainer
+        end
+        {Phoenix.Socket.PoolDrainer, {endpoint, handler, drainer}}
     else
-      :ignore
+        :ignore
     end
   end
 


### PR DESCRIPTION
To configure the socket `drainer`, one must currently set it up during the compile time. I suggest adding an option to pass `{M, F, A}` to return the drainer configuration keyword list, just like the `check_origin` option. This would allow for runtime configuration of the drainer.

However, I could not find any tests related to this feature.