### PR TITLE
[GUIDE] Fix incorrect pipeline name in routing guide

### DIFF
--- a/guides/routing.md
+++ b/guides/routing.md
@@ -521,7 +521,7 @@ end
 
 The above assumes there is a plug called `HelloWeb.Authentication` that performs authentication and is now part of the `:auth` pipeline.
 
-Note that pipelines themselves are plugs, so we can plug a pipeline inside another pipeline. For example, we could rewrite the `review_checks` pipeline above to automatically invoke `browser`, simplifying the downstream pipeline call:
+Note that pipelines themselves are plugs, so we can plug a pipeline inside another pipeline. For example, we could rewrite the `auth` pipeline above to automatically invoke `browser`, simplifying the downstream pipeline call:
 
 ```elixir
   pipeline :auth do


### PR DESCRIPTION
Hi, there!

Thank you for the fantastic guides. I was learning Elixir / Phoenix today, and noticed a reference to an incorrect pipeline name in the routing guide.

![Screenshot 2023-08-11 at 10 33 50 PM](https://github.com/phoenixframework/phoenix/assets/25947043/df05bc4f-dcb0-41c6-bd6e-998132de9fda)

The guide mentions the `review_checks` pipeline which is not in the guide. I believe it is actually referring to the `auth` pipeline:

![image](https://github.com/phoenixframework/phoenix/assets/25947043/4c57e74e-1406-4179-905c-e765505af476)

Do let me know if this is intentional. Thank you!