### PR TITLE
Support dynamic port for `c:Endpoint.url/0`

### DIFF
--- a/lib/phoenix/endpoint/cowboy2_adapter.ex
+++ b/lib/phoenix/endpoint/cowboy2_adapter.ex
@@ -80,7 +80,7 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
       Application.ensure_all_started(:ssl)
     end
 
-    ref = Module.concat(endpoint, scheme |> Atom.to_string() |> String.upcase())
+    ref = build_ref(endpoint, scheme)
 
     plug =
       if code_reloader? do
@@ -131,6 +131,18 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
     end
   rescue
     _ -> scheme
+  end
+
+  @doc false
+  def dynamic_port(endpoint, scheme) do
+    case :ranch.get_addr(build_ref(endpoint, scheme)) do
+      {:local, _unix_path} -> raise "Trying to determine dynamic port, but the adapter is configured to use unix sockets. Remove the configuration for `[port: 0]` on the #{scheme} scheme."
+      {_addr, port} -> port
+    end
+  end
+
+  defp build_ref(endpoint, scheme) do
+    Module.concat(endpoint, scheme |> Atom.to_string() |> String.upcase())
   end
 
   # TODO: Remove this once {:system, env_var} deprecation is removed

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -391,8 +391,9 @@ defmodule Phoenix.Endpoint.Supervisor do
         true -> []
       end
 
-    if server?(config) do
-      adapter = endpoint.config(:adapter) || Phoenix.Endpoint.Cowboy2Adapter
+    adapter = endpoint.config(:adapter) || Phoenix.Endpoint.Cowboy2Adapter
+
+    if function_exported?(adapter, :dynamic_port, 2) and server?(config) do
       adapter.dynamic_port(endpoint, scheme)
     else
       0

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -207,12 +207,12 @@ defmodule Phoenix.Endpoint.EndpointTest do
 
   @tag :capture_log
   test "uses bound dynamic port if server is started" do
-    Application.put_env(:phoenix, __MODULE__.DynamicPortEndpoint, http: [port: 0], server: true)
-    defmodule DynamicPortEndpoint do
+    Application.put_env(:phoenix, __MODULE__.DynamicPortStartedEndpoint, http: [port: 0], server: true)
+    defmodule DynamicPortStartedEndpoint do
       use Phoenix.Endpoint, otp_app: :phoenix
     end
-    DynamicPortEndpoint.start_link()
-    assert %{port: port} = DynamicPortEndpoint.url() |> URI.parse()
+    DynamicPortStartedEndpoint.start_link()
+    assert %{port: port} = DynamicPortStartedEndpoint.url() |> URI.parse()
     assert port > 1023
   end
 

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -206,6 +206,28 @@ defmodule Phoenix.Endpoint.EndpointTest do
   end
 
   @tag :capture_log
+  test "uses bound dynamic port if server is started" do
+    Application.put_env(:phoenix, __MODULE__.DynamicPortEndpoint, http: [port: 0], server: true)
+    defmodule DynamicPortEndpoint do
+      use Phoenix.Endpoint, otp_app: :phoenix
+    end
+    DynamicPortEndpoint.start_link()
+    assert %{port: port} = DynamicPortEndpoint.url() |> URI.parse()
+    assert port > 1023
+  end
+
+  @tag :capture_log
+  test "uses dynamic port 0 if server is not started" do
+    Application.put_env(:phoenix, __MODULE__.DynamicPortEndpoint, http: [port: 0], server: false)
+    defmodule DynamicPortEndpoint do
+      use Phoenix.Endpoint, otp_app: :phoenix
+    end
+    DynamicPortEndpoint.start_link()
+    assert %{port: port} = DynamicPortEndpoint.url() |> URI.parse()
+    assert port == 0
+  end
+
+  @tag :capture_log
   test "uses url configuration for static path" do
     Application.put_env(:phoenix, __MODULE__.UrlEndpoint, url: [path: "/api"])
     defmodule UrlEndpoint do


### PR DESCRIPTION
This is a naive implementation, as it doesn't yet support the adapter crashing and potentially getting assigned a new port. I'm not sure if cowboy or bandit for the matter crash all the way up to the endpoint in such a case, so phoenix could react to a new port or if there would need to be some other mechanism to make phoenix aware of the changed port.

That should still be better than leaving the `:0`, as it works right now, I think.

Relates to #4186