### PR TITLE
Updates the deploy guide to what worked with Phoenix and Liveview as …

### DIFF
--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -187,6 +187,12 @@ defmodule HelloWeb.Endpoint do
 end
 ```
 
+Also set the host in Heroku:
+
+```console
+$ heroku config:set PHX_HOST="mysterious-meadow-6277.herokuapp.com"
+```
+
 This ensures that any idle connections are closed by Phoenix before they reach Heroku's 55-second timeout window.
 
 ## Creating Environment Variables in Heroku
@@ -244,7 +250,7 @@ $ git commit -a -m "Use production config from Heroku ENV variables and decrease
 And deploy:
 
 ```console
-$ git push heroku master
+$ git push heroku main
 Counting objects: 55, done.
 Delta compression using up to 8 threads.
 Compressing objects: 100% (49/49), done.


### PR DESCRIPTION
…of today

Fix for issue
https://github.com/phoenixframework/phoenix/issues/5557

The deploy guide for Heroku is not 100% accurate anymore.
I followed them the best I could but a couple things just did not work correctly.

I could not deploy to `master` as Heroku is using `main` now for Git.
Once deployed web sockets would not connect.
I added the `PHX_HOST` env var and that resolved it.

The `PHX_HOST` issue may be a deeper issue with the config recommendations for adding the host.
That part did seem to not 100% reflect the current state of a new Phoenix application for 1.7.7
The setting the env var may be a band-aid.
If anyone has more insight into that please let me know and I will make changes to this PR.

The example app I tested with: https://github.com/tapickell/url_short_link
