### PR TITLE
Update documentation around authenticated routes

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -277,7 +277,9 @@ defmodule Phoenix.Router do
   Perhaps more importantly, it is also very common to define pipelines specific
   to authentication and authorization. For example, you might have a pipeline
   that requires all users are authenticated. Another pipeline may enforce only
-  admin users can access certain routes.
+  admin users can access certain routes. Since routes are matched top to bottom,
+  it is recommended to place the authenticated/authorized routes before the
+  less restricted routes to ensure they are matched first.
 
   Once your pipelines are defined, you reuse the pipelines in the desired
   scopes, grouping your routes around their pipelines. For example, imagine
@@ -294,17 +296,17 @@ defmodule Phoenix.Router do
       end
 
       scope "/" do
-        pipe_through [:browser]
-
-        get "/posts", PostController, :index
-        get "/posts/:id", PostController, :show
-      end
-
-      scope "/" do
         pipe_through [:browser, :auth]
 
         get "/posts/new", PostController, :new
         post "/posts", PostController, :create
+      end
+
+      scope "/" do
+        pipe_through [:browser]
+
+        get "/posts", PostController, :index
+        get "/posts/:id", PostController, :show
       end
 
   Note in the above how the routes are split across different scopes.


### PR DESCRIPTION
This fixes https://github.com/phoenixframework/phoenix/issues/5559

I reversed the order of the scopes in the documentation example to match the authenticated route first and added a small blurb to recommend this approach in other apps. Feel free to remove the blurb if you don't think it's helpful.