### PR TITLE
Fix inconsistency in code vs spec

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1043,8 +1043,7 @@ defmodule Phoenix.Controller do
             put_layout(conn, #{inspect(good_value)})
 
         In this case, the layout without format will always win.
-        However please take a note that layout without format will
-        be deprecated soon.
+        Passing the layout without a format is currently soft-deprecated.
         If you use layouts with formats, make sure that they are
         used everywhere. Also remember to configure your controller
         to use layouts with formats:

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -637,7 +637,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_layout(Plug.Conn.t(), [{format :: atom, layout}] | false) :: Plug.Conn.t()
+  @spec put_layout(Plug.Conn.t(), [{format :: atom, layout}] | false | layout) :: Plug.Conn.t()
   def put_layout(%Plug.Conn{state: state} = conn, layout) do
     if state in @unsent do
       put_private_layout(conn, :phoenix_layout, :replace, layout)
@@ -1043,6 +1043,8 @@ defmodule Phoenix.Controller do
             put_layout(conn, #{inspect(good_value)})
 
         In this case, the layout without format will always win.
+        However please take a note that layout without format will
+        be deprecated soon.
         If you use layouts with formats, make sure that they are
         used everywhere. Also remember to configure your controller
         to use layouts with formats:

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -637,7 +637,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_layout(Plug.Conn.t(), [{format :: atom, layout}] | false | layout) :: Plug.Conn.t()
+  @spec put_layout(Plug.Conn.t(), [{format :: atom, layout}] | false) :: Plug.Conn.t()
   def put_layout(%Plug.Conn{state: state} = conn, layout) do
     if state in @unsent do
       put_private_layout(conn, :phoenix_layout, :replace, layout)


### PR DESCRIPTION
Currently Phoenix support (although it's soon-to-be-deprecated) format of putting layout:
```
plug :put_layout, {AppWeb.LayoutView, :layout}
```

however:
a) the spec doesn't reflect that, which means that code wouldn't pass dialyzer checks
b) warning doesn't mention anything about deprecations, it only suggests using code which wouldn't pass dialyzer:
```
warning: conflicting layouts found. A layout has been set with format, such as:

    put_layout(conn, html: {AppWeb.LayoutView, :layout})

But also without format:

    plug :put_layout, {AppWeb.LayoutView, :layout}

In this case, the layout without format will always win.
If you use layouts with formats, make sure that they are
used everywhere. Also remember to configure your controller
to use layouts with formats:

    use Phoenix.Controller, layouts: [html: {AppWeb.LayoutView, :layout}]
```

this PR fixes spec and adds information about future deprecation for using syntax without format.