### PR TITLE
Fix tailwind config for umbrella apps

### DIFF
--- a/installer/templates/phx_assets/tailwind.config.js
+++ b/installer/templates/phx_assets/tailwind.config.js
@@ -8,8 +8,8 @@ const path = require("path")
 module.exports = {
   content: [
     "./js/**/*.js",
-    "../lib/*_web.ex",
-    "../lib/*_web/**/*.*ex"
+    "../lib/<%= @lib_web_name || @app_name %>.ex",
+    "../lib/<%= @lib_web_name || @app_name %>/**/*.ex"
   ],
   theme: {
     extend: {

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -149,7 +149,11 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       # tailwind
       assert_file("phx_blog/assets/css/app.css")
-      assert_file("phx_blog/assets/tailwind.config.js")
+      assert_file "phx_blog/assets/tailwind.config.js", fn file ->
+        assert file =~ "phx_blog_web.ex"
+        assert file =~ "phx_blog_web/**/*.ex"
+      end
+
       assert_file("phx_blog/assets/vendor/heroicons/LICENSE.md")
       assert_file("phx_blog/assets/vendor/heroicons/UPGRADE.md")
       assert_file("phx_blog/assets/vendor/heroicons/optimized/24/outline/cake.svg")

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -183,6 +183,11 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file(web_path(@app, ".gitignore"), ~r/\n$/)
       assert_file(web_path(@app, "assets/css/app.css"))
 
+      assert_file web_path(@app, "assets/tailwind.config.js"), fn file ->
+        assert file =~ "phx_umb_web.ex"
+        assert file =~ "phx_umb_web/**/*.ex"
+      end
+
       assert_file(web_path(@app, "priv/static/favicon.ico"))
 
       refute File.exists?(web_path(@app, "priv/static/assets/app.css"))

--- a/installer/test/phx_new_web_test.exs
+++ b/installer/test/phx_new_web_test.exs
@@ -63,4 +63,15 @@ defmodule Mix.Tasks.Phx.New.WebTest do
       assert_received {:mix_shell, :info, ["Start your Phoenix app" <> _]}
     end
   end
+
+  test "app_name is included in tailwind config" do
+    in_tmp_umbrella_project "new with defaults", fn ->
+      Mix.Tasks.Phx.New.Web.run(["testweb"])
+
+      assert_file "testweb/assets/tailwind.config.js", fn file ->
+        assert file =~ "testweb.ex"
+        assert file =~ "testweb/**/*.ex"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Previously, the tailwind config assumed that an app name ended in `_web` and used that for the config to import.

This commit changes it so that the app name is used instead.

This closes https://github.com/phoenixframework/phoenix/issues/5403