### PR TITLE
Stringify lists in the ChannelTest module

### DIFF
--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -692,6 +692,8 @@ defmodule Phoenix.ChannelTest do
     do: struct
   def __stringify__(%{} = params),
     do: Enum.into(params, %{}, &stringify_kv/1)
+  def __stringify__(params) when is_list(params),
+    do: Enum.map(params, &__stringify__/1)
   def __stringify__(other),
     do: other
 

--- a/test/phoenix/test/channel_test.exs
+++ b/test/phoenix/test/channel_test.exs
@@ -290,6 +290,12 @@ defmodule Phoenix.Test.ChannelTest do
     assert_reply ref, :ok, %{"resp" => "foo"}
   end
 
+  test "works with list data structures" do
+    {:ok, _, socket} = join(socket(UserSocket), Channel, "foo:ok")
+    ref = push(socket, "reply", %{req: [%{bar: "baz"}, %{bar: "foo"}]})
+    assert_reply ref, :ok, %{"resp" => [%{"bar" => "baz"}, %{"bar" => "foo"}]}
+  end
+
   test "receives async replies" do
     {:ok, _, socket} = join(socket(UserSocket), Channel, "foo:ok")
 


### PR DESCRIPTION
When testing with channels, map keys are stringified to replicate what would happen in the browser. This allows a test such as:

    push(socket, "topic", %{foo: "bar"})

The ChannelTest module will modify this to reflect a real client, resulting in the channel receiving:

    %{"foo" => "bar"}

This commit also includes arrays, making the behaviour consistent when pushing data containing an array.

This closes #5423