### PR TITLE
Update documentation for :log option on both scope/2 and match/5

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -691,8 +691,11 @@ defmodule Phoenix.Router do
       a helper. Has no effect when using verified routes exclusively
     * `:alias` - configure if the scope alias should be applied to the route.
       Defaults to true, disables scoping if false.
-    * `:log` - the level to log the route dispatching under,
-      may be set to false. Defaults to `:debug`
+    * `:log` - the level to log the route dispatching under, may be set to false. Defaults to
+      `:debug`. Route dispatching contains information about how the route is handled (which controller
+      action is called, what parameters are available and which pipelines are used) and is separate from
+      the plug level logging. To alter the plug log level, please see
+      https://hexdocs.pm/phoenix/Phoenix.Logger.html#module-dynamic-log-level.
     * `:private` - a map of private data to merge into the connection
       when a route matches
     * `:assigns` - a map of data to merge into the connection when a route matches

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -1021,8 +1021,11 @@ defmodule Phoenix.Router do
       ie `"foo.bar.com"`, `"foo."`
     * `:private` - a map of private data to merge into the connection when a route matches
     * `:assigns` - a map of data to merge into the connection when a route matches
-    * `:log` - the level to log the route dispatching under,
-      may be set to false. Defaults to `:debug`
+    * `:log` - the level to log the route dispatching under, may be set to false. Defaults to
+      `:debug`. Route dispatching contains information about how the route is handled (which controller
+      action is called, what parameters are available and which pipelines are used) and is separate from
+      the plug level logging. To alter the plug log level, please see
+      https://hexdocs.pm/phoenix/Phoenix.Logger.html#module-dynamic-log-level.
 
   """
   defmacro scope(options, do: context) do


### PR DESCRIPTION
While looking into [this issue](https://github.com/phoenixframework/phoenix/issues/5463), it was noted that maybe the documentation for `Phoenix.Router.scope/2` did not make it clear that the `:log` option only controls the log level for the router dispatching message logged by Phoenix.

[It was suggested](https://github.com/phoenixframework/phoenix/issues/5463#issuecomment-1720947223) that updating the documentation for this option can help clarify this, while also pointing users to documentation on how they can also control plug level logging.

As such, this Pull Request does exactly that, by updating the documentation for both `Phoenix.Router.scope/2` and `Phoenix.Router.match/5` in regards to the `:log` option.