### PR TITLE
Change non-returning map into forEach

### DIFF
--- a/installer/templates/phx_assets/tailwind.config.js
+++ b/installer/templates/phx_assets/tailwind.config.js
@@ -42,7 +42,7 @@ module.exports = {
         ["-mini", "/20/solid"]
       ]
       icons.forEach(([suffix, dir]) => {
-        fs.readdirSync(path.join(iconsDir, dir)).map(file => {
+        fs.readdirSync(path.join(iconsDir, dir)).forEach(file => {
           let name = path.basename(file, ".svg") + suffix
           values[name] = {name, fullPath: path.join(iconsDir, dir, file)}
         })


### PR DESCRIPTION
This is an embarrassingly tiny niggle, but something my linter picked up in a recent project: since the callback passed to `map` does not return anything, `map` returns just an array of `undefined`... and in any case the result of the `map` is thrown away. Therefore it would be semantically nicer to do a `forEach` loop instead (or just a for loop, but the outer loop is already a `forEach` so this fits better stylistically). 