### PR TITLE
Fix small bug in test - reused conn from previous test case

### DIFF
--- a/priv/templates/phx.gen.auth/confirmation_live_test.exs
+++ b/priv/templates/phx.gen.auth/confirmation_live_test.exs
@@ -55,8 +55,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
                "<%= inspect schema.alias %> confirmation link is invalid or it has expired"
 
       # when logged in
+      conn = build_conn()
       {:ok, lv, _html} =
-        build_conn()
+        conn
         |> log_in_<%= schema.singular %>(<%= schema.singular %>)
         |> live(~p"<%= schema.route_prefix %>/confirm/#{token}")
 


### PR DESCRIPTION
I noticed a flaky test from my generated liveview auth. The confirmation liveview has a test to make sure that there's not a flash with an error when confirming as a logged in user. The problem is the connection already had an error flash from a test case that was a little higher in the same test. I was only getting the bug after adding a redirect from my home url ("/") in my pages controller, but then it would have two flashes: 
```
  1) test Confirm user confirms the given token once (MyAppWeb.UserConfirmationLiveTest)
     test/my_app_web/live/user_confirmation_live_test.exs:20
     Expected false or nil, got "User confirmation link is invalid or it has expired."
     code: refute Phoenix.Flash.get(conn.assigns.flash, :error)
     arguments:

         # 1
         %{"error" => "User confirmation link is invalid or it has expired.", "info" => "User confirmed successfully."}

         # 2
         :error
```

This fixes it so that the conn isn't reused across these two scenarios. Perhaps a better long-term solution would be to split these test cases up though.