### PR TITLE
Fix `@moduledoc` table listing `phx.gen.ex` contents created by `CRUD` #5587

### DIFF
--- a/lib/mix/tasks/phx.gen.ex
+++ b/lib/mix/tasks/phx.gen.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Phx.Gen do
   | `phx.gen.embedded` | x |   |   |   |   |   |
   | `phx.gen.schema`   | x | x |   |   |   |   |
   | `phx.gen.context`  | x | x | x |   |   |   |
-  | `phx.gen.live`     | x | x | x |   |   | x |
+  | `phx.gen.live`     |   |   |   |   |   | x |
   | `phx.gen.json`     | x | x | x | x | x |   |
   | `phx.gen.html`     | x | x | x | x | x |   |
   """


### PR DESCRIPTION
Closes/Fixes issue https://github.com/phoenixframework/phoenix/issues/5587