### PR TITLE
Automatically migrate when starting the server using sqlite3

### DIFF
--- a/priv/templates/phx.gen.release/rel/server.bat.eex
+++ b/priv/templates/phx.gen.release/rel/server.bat.eex
@@ -1,2 +1,4 @@
-set PHX_SERVER=true
+set PHX_SERVER=true<%= if auto_migrate? do %>
+call "%~dp0\<%= otp_app %>" eval <%= app_namespace %>.Release.migrate
+<% end %>
 call "%~dp0\<%= otp_app %>" start

--- a/priv/templates/phx.gen.release/rel/server.sh.eex
+++ b/priv/templates/phx.gen.release/rel/server.sh.eex
@@ -1,3 +1,4 @@
 #!/bin/sh
-cd -P -- "$(dirname -- "$0")"
-PHX_SERVER=true exec ./<%= otp_app %> start
+cd -P -- "$(dirname -- "$0")"<%= if auto_migrate? do %>
+exec ./<%= otp_app %> eval <%= app_namespace %>.Release.migrate
+<% end %>PHX_SERVER=true exec ./<%= otp_app %> start


### PR DESCRIPTION
When using the sqlite3 postgres adapter, the generator for the server overlay will automatically run the migrations first.

The tests have been updated to allow the adapter to be stubbed out to allow for testing the behaviour with various ecto adapters.