### PR TITLE
Automatically migrate when release starts using sqlite 3

### DIFF
--- a/installer/templates/phx_single/lib/app_name/application.ex
+++ b/installer/templates/phx_single/lib/app_name/application.ex
@@ -38,6 +38,6 @@ defmodule <%= @app_module %>.Application do
 
   defp skip_migrations?() do
     # By default, sqlite migrations are run when using a release
-    !!System.get_env("RELEASE_NAME")
+    System.get_env("RELEASE_NAME") != nil
   end<% end %>
 end

--- a/installer/templates/phx_single/lib/app_name/application.ex
+++ b/installer/templates/phx_single/lib/app_name/application.ex
@@ -9,7 +9,10 @@ defmodule <%= @app_module %>.Application do
   def start(_type, _args) do
     children = [
       <%= @web_namespace %>.Telemetry,<%= if @ecto do %>
-      <%= @app_module %>.Repo,<% end %>
+      <%= @app_module %>.Repo,<% end %><%= if @adapter_app == :ecto_sqlite3 do %>
+      {Ecto.Migrator,
+        repos: Application.fetch_env!(<%= inspect String.to_atom(@app_name) %>, :ecto_repos),
+        skip: skip_migrations?()},<% end %>
       {Phoenix.PubSub, name: <%= @app_module %>.PubSub},<%= if @mailer do %>
       # Start the Finch HTTP client for sending emails
       {Finch, name: <%= @app_module %>.Finch},<% end %>
@@ -31,5 +34,10 @@ defmodule <%= @app_module %>.Application do
   def config_change(changed, _new, removed) do
     <%= @endpoint_module %>.config_change(changed, removed)
     :ok
-  end
+  end<%= if @adapter_app == :ecto_sqlite3 do %>
+
+  defp skip_migrations?() do
+    # By default, sqlite migrations are run when using a release
+    !!System.get_env("RELEASE_NAME")
+  end<% end %>
 end

--- a/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
@@ -8,7 +8,10 @@ defmodule <%= @app_module %>.Application do
   @impl true
   def start(_type, _args) do
     children = [<%= if @ecto do %>
-      <%= @app_module %>.Repo,<% end %>
+      <%= @app_module %>.Repo,<% end %><%= if @adapter_app == :ecto_sqlite3 do %>
+      {Ecto.Migrator,
+        repos: Application.fetch_env!(<%= inspect String.to_atom(@app_name) %>, :ecto_repos),
+        skip: skip_migrations?()},<% end %>
       {Phoenix.PubSub, name: <%= @app_module %>.PubSub}<%= if @mailer do %>,
       # Start the Finch HTTP client for sending emails
       {Finch, name: <%= @app_module %>.Finch}<% end %>
@@ -17,5 +20,10 @@ defmodule <%= @app_module %>.Application do
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one, name: <%= @app_module %>.Supervisor)
-  end
+  end<%= if @adapter_app == :ecto_sqlite3 do %>
+
+  defp skip_migrations?() do
+    # By default, sqlite migrations are run when using a release
+    !!System.get_env("RELEASE_NAME")
+  end<% end %>
 end

--- a/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
@@ -24,6 +24,6 @@ defmodule <%= @app_module %>.Application do
 
   defp skip_migrations?() do
     # By default, sqlite migrations are run when using a release
-    !!System.get_env("RELEASE_NAME")
+    System.get_env("RELEASE_NAME") != nil
   end<% end %>
 end

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -695,6 +695,15 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file("custom_path/config/runtime.exs", [~r/database: database_path/])
       assert_file("custom_path/lib/custom_path/repo.ex", "Ecto.Adapters.SQLite3")
 
+      assert_file("custom_path/lib/custom_path/application.ex", fn file ->
+        assert file =~ "{Ecto.Migrator"
+        assert file =~ "repos: Application.fetch_env!(:custom_path, :ecto_repos)"
+        assert file =~ "skip: skip_migrations?()"
+
+        assert file =~ "defp skip_migrations?() do"
+        assert file =~ ~s/!!System.get_env("RELEASE_NAME")/
+      end)
+
       assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(tags)")
 
       assert_file(

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -654,6 +654,15 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file(app_path(app, "mix.exs"), ":ecto_sqlite3")
       assert_file(app_path(app, "lib/custom_path/repo.ex"), "Ecto.Adapters.SQLite3")
 
+      assert_file(app_path(app, "lib/custom_path/application.ex"), fn file ->
+        assert file =~ "{Ecto.Migrator"
+        assert file =~ "repos: Application.fetch_env!(:custom_path, :ecto_repos)"
+        assert file =~ "skip: skip_migrations?()"
+
+        assert file =~ "defp skip_migrations?() do"
+        assert file =~ ~s/!!System.get_env("RELEASE_NAME")/
+      end)
+
       assert_file(root_path(app, "config/dev.exs"), [~r/database: .*_dev.db/])
       assert_file(root_path(app, "config/test.exs"), [~r/database: .*_test.db/])
       assert_file(root_path(app, "config/runtime.exs"), [~r/database: database_path/])


### PR DESCRIPTION
When using the sqlite3 ecto adapter, the new and umbrella generators will add the `Ecto.Migrator` to run the migrations.

By default these run only when inside of a release, but the intent is to allow the end user to customize this in a way that suits their production environment.

This closes #5262 