### PR TITLE
Use logged-in `conn` when following redirect

### DIFF
--- a/priv/templates/phx.gen.auth/confirmation_live_test.exs
+++ b/priv/templates/phx.gen.auth/confirmation_live_test.exs
@@ -54,13 +54,12 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
                "<%= inspect schema.alias %> confirmation link is invalid or it has expired"
 
-      conn = build_conn()
-
       # when logged in
-      {:ok, lv, _html} =
-        conn
+      conn =
+        build_conn()
         |> log_in_<%= schema.singular %>(<%= schema.singular %>)
-        |> live(~p"<%= schema.route_prefix %>/confirm/#{token}")
+
+      {:ok, lv, _html} = live(conn, ~p"<%= schema.route_prefix %>/confirm/#{token}")
 
       result =
         lv


### PR DESCRIPTION
Hi 👋

Ran into a small bug with the auto-generated (`mix phx.gen.auth`) test file for user confirmations. If you change the confirmations LiveView to redirect to a route that requires authentication, it fails since the redirect is followed with a `conn` that isn't logged in via (e.g. for a user schema) `log_in_user`