### PR TITLE
docs: add routing cheatsheet

### DIFF
--- a/guides/cheatsheets/router.cheatmd
+++ b/guides/cheatsheets/router.cheatmd
@@ -2,7 +2,7 @@
 
 > Those need to be declared in the correct router module and scope.
 
-A quick reference to the common routing features' syntax. For an exhaustive overview, refer to the [routing guides](routing-1.html).
+A quick reference to the common routing features' syntax. For an exhaustive overview, refer to the [routing guides](routing.md).
 
 ## Routing declaration
 {: .col-2}

--- a/guides/cheatsheets/router.cheatmd
+++ b/guides/cheatsheets/router.cheatmd
@@ -80,4 +80,4 @@ end
 # generated path helpers
 api_v1_user_path(:index) # /api/v1/users
 ```
-For more info check the [scoped routes](routing-1.html#scoped-routes) docs.
+For more info check the [scoped routes](routing.md#scoped-routes) docs.

--- a/guides/cheatsheets/router.cheatmd
+++ b/guides/cheatsheets/router.cheatmd
@@ -14,9 +14,9 @@ get "/users", UserController, :index
 patch "/users/:id", UserController, :update
 ```
 ```elixir
-# generated path helpers
-user_path(conn, :index) #  /users
-user_path(conn, :create, %{id: 9, ...}) #  /users/9
+# generated routes
+~p"/users"
+~p"/users/9" # user_id is 9
 ```
 Also accepts `put`, `patch`, `options`, `delete` and `head`.
 
@@ -34,7 +34,7 @@ Generates `:index`, `:edit`, `:new`, `:show`, `:create`, `:update` and `:delete`
 ```elixir
 resources "/users", UserController, only: [:show]
 resources "/users", UserController, except: [:create, :delete]
-resources "/users", UserController, as: :person # `person_path(...)`
+resources "/users", UserController, as: :person # ~p"/person"
 ```
 
 #### Nested
@@ -45,9 +45,9 @@ resources "/users", UserController do
 end
 ```
 ```elixir
-# generated path helpers
-user_post_path(:index, 17)     # /users/17/posts
-user_post_path(:show, 17, 12)  # /users/17/posts/12
+# generated routes
+~p"/users/3/posts" # user_id is 3
+~p"/users/3/posts/17" # user_id is 3 and post_id = 17
 ```
 For more info check the [resources docs.](routing-1.html#resources)
 
@@ -63,7 +63,7 @@ end
 ```
 ```elixir
 # generated path helpers
-admin_user_path(:index) # /admin/users
+~p"/admin/users"
 ```
 
 #### Nested
@@ -78,6 +78,6 @@ end
 ```
 ```elixir
 # generated path helpers
-api_v1_user_path(:index) # /api/v1/users
+~p"/api/v1/users"
 ```
 For more info check the [scoped routes](routing.md#scoped-routes) docs.

--- a/guides/cheatsheets/routing.cheatmd
+++ b/guides/cheatsheets/routing.cheatmd
@@ -1,0 +1,83 @@
+# Routing cheatsheet
+
+> Those need to be declared in the correct router module and scope.
+
+A quick reference to the common routing features' syntax. For an exhaustive overview, refer to the [routing guides](routing-1.html).
+
+## Routing declaration
+{: .col-2}
+
+### Single route
+
+```elixir
+get "/users", UserController, :index
+patch "/users/:id", UserController, :update
+```
+```elixir
+# generated path helpers
+user_path(conn, :index) #  /users
+user_path(conn, :create, %{id: 9, ...}) #  /users/9
+```
+Also accepts `put`, `patch`, `options`, `delete` and `head`.
+
+### Resources
+
+#### Simple
+
+```elixir
+resources "/users", UserController
+```
+Generates `:index`, `:edit`, `:new`, `:show`, `:create`, `:update` and `:delete`.
+
+#### Options
+
+```elixir
+resources "/users", UserController, only: [:show]
+resources "/users", UserController, except: [:create, :delete]
+resources "/users", UserController, as: :person # `person_path(...)`
+```
+
+#### Nested
+
+```elixir
+resources "/users", UserController do
+  resources "/posts", PostController
+end
+```
+```elixir
+# generated path helpers
+user_post_path(:index, 17)     # /users/17/posts
+user_post_path(:show, 17, 12)  # /users/17/posts/12
+```
+For more info check the [resources docs.](routing-1.html#resources)
+
+### Scopes
+
+#### Simple
+```elixir
+scope "/admin", HelloWeb.Admin do
+  pipe_through :browser
+
+  resources "/users",   UserController
+end
+```
+```elixir
+# generated path helpers
+admin_user_path(:index) # /admin/users
+```
+
+#### Nested
+```elixir
+scope "/api", HelloWeb.Api, as: :api do
+  pipe_through :api
+
+  scope "/v1", V1, as: :v1 do
+    resources "/users", UserController
+  end
+end
+```
+```elixir
+# generated path helpers
+api_v1_user_path(:index) # /api/v1/users
+```
+For more info check the [scoped routes](routing-1.html#scoped-routes) docs.

--- a/mix.exs
+++ b/mix.exs
@@ -171,6 +171,7 @@ defmodule Phoenix.MixProject do
       "guides/howto/file_uploads.md",
       "guides/howto/using_ssl.md",
       "guides/howto/writing_a_channels_client.md",
+      "guides/cheatsheets/routing.cheatmd",
       "CHANGELOG.md"
     ]
   end
@@ -182,6 +183,7 @@ defmodule Phoenix.MixProject do
       Authentication: ~r/guides\/authentication\/.?/,
       "Real-time": ~r/guides\/real_time\/.?/,
       Testing: ~r/guides\/testing\/.?/,
+      Cheatsheets: ~r/guides\/cheatsheets\/.?/,
       Deployment: ~r/guides\/deployment\/.?/,
       "How-to's": ~r/guides\/howto\/.?/
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -171,7 +171,7 @@ defmodule Phoenix.MixProject do
       "guides/howto/file_uploads.md",
       "guides/howto/using_ssl.md",
       "guides/howto/writing_a_channels_client.md",
-      "guides/cheatsheets/routing.cheatmd",
+      "guides/cheatsheets/router.cheatmd",
       "CHANGELOG.md"
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -183,8 +183,8 @@ defmodule Phoenix.MixProject do
       Authentication: ~r/guides\/authentication\/.?/,
       "Real-time": ~r/guides\/real_time\/.?/,
       Testing: ~r/guides\/testing\/.?/,
-      Cheatsheets: ~r/guides\/cheatsheets\/.?/,
       Deployment: ~r/guides\/deployment\/.?/,
+      Cheatsheets: ~r/guides\/cheatsheets\/.?/,
       "How-to's": ~r/guides\/howto\/.?/
     ]
   end


### PR DESCRIPTION
Adding cheatsheets for routing syntax. The Phoenix guidelines are super detailed and awesome, but there are moments when I just need to grab the syntax and go without the deep dive.

I plan to do the same for plugs, however, I'd appreciate community feedback on this one before proceeding.

### Screenshot

![image](https://github.com/phoenixframework/phoenix/assets/9089847/4957352c-9815-4a6e-9b19-d82c0c4e5630)
