### PR TITLE
Fix phx.routes mix task when docs return multiple annotations 

### DIFF
--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -175,9 +175,9 @@ defmodule Mix.Tasks.Phx.Routes do
   defp get_line_number(module, function_name) do
     {_, _, _, _, _, _, functions_list} = Code.fetch_docs(module)
 
-    {_, location_or_annotations, _, _, _}=
+    function_infos =
       functions_list
-      |> Enum.find({nil, [location: nil], nil, nil, nil}, fn {{type, name, _}, _, _, _, _} ->
+      |> Enum.find(fn {{type, name, _}, _, _, _, _} ->
         type == :function and name == function_name
       end)
 

--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -183,7 +183,7 @@ defmodule Mix.Tasks.Phx.Routes do
 
     case function_infos do
       {_, anno, _, _, _} -> :erl_anno.line(anno)
-      _ -> nil
+      nil -> nil
     end
   end
 end

--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -181,9 +181,9 @@ defmodule Mix.Tasks.Phx.Routes do
         type == :function and name == function_name
       end)
 
-    case Keyword.keyword?(location_or_annotations) do
-      false -> location_or_annotations
-      true -> location_or_annotations[:location]
+    case function_infos do
+      {_, anno, _, _, _} -> :erl_anno.line(anno)
+      _ -> nil
     end
   end
 end

--- a/lib/mix/tasks/phx.routes.ex
+++ b/lib/mix/tasks/phx.routes.ex
@@ -175,15 +175,15 @@ defmodule Mix.Tasks.Phx.Routes do
   defp get_line_number(module, function_name) do
     {_, _, _, _, _, _, functions_list} = Code.fetch_docs(module)
 
-    function_infos =
+    {_, location_or_annotations, _, _, _}=
       functions_list
-      |> Enum.find(fn {{type, name, _}, _, _, _, _} ->
+      |> Enum.find({nil, [location: nil], nil, nil, nil}, fn {{type, name, _}, _, _, _, _} ->
         type == :function and name == function_name
       end)
 
-    case function_infos do
-      {_, line, _, _, _} -> line
-      nil -> nil
+    case Keyword.keyword?(location_or_annotations) do
+      false -> location_or_annotations
+      true -> location_or_annotations[:location]
     end
   end
 end


### PR DESCRIPTION
I'm not entirely sure how to reproduce this, not even how it actually happens, but I'm currently working on a codebase where running `mix phx.routes --info [ROUTE]` raises an exception with the following message:

```elixir
Function: :index
** (ArgumentError) cannot convert the given list to a string.

To be converted to a string, a list must either be empty or only
contain the following elements:

  * strings
  * integers representing Unicode code points
  * a list containing one of these three elements

Please check the given list or call inspect/1 to get the list representation, got:

[generated: true, location: 32]

    (elixir 1.15.5) lib/list.ex:1084: List.to_string/1
    (phoenix 1.7.8) lib/mix/tasks/phx.routes.ex:109: Mix.Tasks.Phx.Routes.get_url_info/2
    (mix 1.15.5) lib/mix/task.ex:447: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.15.5) lib/mix/cli.ex:92: Mix.CLI.run_task/2
    /Users/dino/.asdf/installs/elixir/1.15.5-otp-26/bin/mix:2: (file)
```

After reviewing the code for `mix phx.routes` I noticed that it  relies on [`Code.fetch_docs/1`](https://hexdocs.pm/elixir/1.15.7/Code.html#fetch_docs/1) to find the line number for a specific function in a module's file. 

However, it assumes that [`Code.fetch_docs/1`](https://hexdocs.pm/elixir/1.15.7/Code.html#fetch_docs/1) will always return the function's location as the second element of the tuple, which is not always the case, as [`Code.fetch_docs/1`](https://hexdocs.pm/elixir/1.15.7/Code.html#fetch_docs/1) can return a list of annotations - [`:erl_anno.anno()`](https://www.erlang.org/doc/man/erl_anno.html#type-anno) -  as a Keyword list. When that's the case, the line number is actually the value for the `:location` key.

As such, this Pull Request updates the `Mix.Tasks.Phx.Routes.get_line_number/2` to make sure that both situations are supported.