### PR TITLE
Improve the error message for mix phx.gen.release

### DIFF
--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -228,7 +228,11 @@ defmodule Mix.Tasks.Phx.Gen.Release do
         ])
 
       :error ->
-        raise "unable to fetch supported Docker image for Elixir #{elixir_vsn} and Erlang #{otp_vsn}"
+        raise """
+          unable to fetch supported Docker image for Elixir #{elixir_vsn} and Erlang #{otp_vsn}.
+          Please check https://hub.docker.com/r/hexpm/elixir/tags?page=1&name=#{otp_vsn}\
+          for a suitable Elixir version
+        """
     end
   end
 


### PR DESCRIPTION
If a suitable image is not found, the user is now given a URL to find a version that matches the erlang version.