### PR TITLE
docs: fix code sample in API Authentication guide

### DIFF
--- a/guides/authentication/api_authentication.md
+++ b/guides/authentication/api_authentication.md
@@ -108,7 +108,7 @@ When we ran `mix phx.gen.auth`, it generated a `MyAppWeb.UserAuth` module with s
 
 ```elixir
 def fetch_api_user(conn, _opts) do
-  with ["Bearer " <> token] <- get_req_header("authorization"),
+  with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
        {:ok, user} <- Accounts.fetch_user_by_api_token(token) do
     assign(conn, :current_user, user)
   else


### PR DESCRIPTION
Fixed a missing parameter in a code sample in the API Authentication guide.