### PR TITLE
bugfix: flash component not closing

### DIFF
--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -112,7 +112,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     <div
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
       id={@id}
-      phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
+      phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("#{@id}")}
       role="alert"
       class={[
         "fixed top-2 right-2 mr-2 w-80 sm:w-96 z-50 rounded-lg p-3 ring-1",


### PR DESCRIPTION
The flash messages from the flash core component are not closing when clicking on the "cross".

The id in the component has an extra `#` symbol, so the click was not matching the proper id, after removing it I could test locally that the flash message is now closing properly.