### PR TITLE
Phoenix.Token doc tweaks

### DIFF
--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -225,7 +225,7 @@ defmodule Phoenix.Token do
       when generating the encryption and signing keys. Defaults to `:sha256`
     * `:max_age` - verifies the token only if it has been generated
       "max age" ago in seconds. Defaults to the max age signed in the
-      token (86400)
+      token by `encrypt/4`.
   """
   @spec decrypt(context, binary, binary, [shared_opt | max_age_opt]) :: term()
   def decrypt(context, secret, token, opts \\ []) when is_binary(secret) do

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -200,9 +200,8 @@ defmodule Phoenix.Token do
     * `:key_digest` - option passed to `Plug.Crypto.KeyGenerator`
       when generating the encryption and signing keys. Defaults to `:sha256`
     * `:max_age` - verifies the token only if it has been generated
-      "max age" ago in seconds. A reasonable value is 1 day (86400
-      seconds)
-
+      "max age" ago in seconds. Defaults to the max age signed in the
+      token by `sign/4`.
   """
   @spec verify(context, binary, binary, [shared_opt | max_age_opt]) ::
           {:ok, term} | {:error, :expired | :invalid | :missing}

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -92,7 +92,11 @@ defmodule Phoenix.Token do
 
   require Logger
 
-  @type context :: Plug.Conn.t() | %{required(:endpoint) => atom, optional(atom()) => any()} | atom | binary
+  @type context ::
+          Plug.Conn.t()
+          | %{required(:endpoint) => atom, optional(atom()) => any()}
+          | atom
+          | binary
 
   @type shared_opt ::
           {:key_iterations, pos_integer}

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -116,7 +116,7 @@ defmodule Phoenix.Token do
     * `:signed_at` - set the timestamp of the token in seconds.
       Defaults to `System.system_time(:second)`
     * `:max_age` - the default maximum age of the token. Defaults to
-      86400 seconds (1 day) and it may be overridden on verify/4.
+      86400 seconds (1 day) and it may be overridden on `verify/4`.
 
   """
   @spec sign(context, binary, term, [shared_opt | max_age_opt | signed_at_opt]) :: binary

--- a/lib/phoenix/token.ex
+++ b/lib/phoenix/token.ex
@@ -140,7 +140,7 @@ defmodule Phoenix.Token do
     * `:signed_at` - set the timestamp of the token in seconds.
       Defaults to `System.system_time(:second)`
     * `:max_age` - the default maximum age of the token. Defaults to
-      86400 seconds (1 day) and it may be overridden on verify/4.
+      86400 seconds (1 day) and it may be overridden on `decrypt/4`.
 
   """
   @spec encrypt(context, binary, term, [shared_opt | max_age_opt | signed_at_opt]) :: binary


### PR DESCRIPTION
Adjusts comments for sign and encrypt to mention their counterparts, verify and decrypt. Clarify that the default "max age" value for verify and decrypt comes from the token creation call.