### PR TITLE
Add :fun option to __deriving__ of Phoenix.Param

### DIFF
--- a/lib/phoenix/param.ex
+++ b/lib/phoenix/param.ex
@@ -50,7 +50,7 @@ defprotocol Phoenix.Param do
 
   @fallback_to_any true
 
-  @spec to_param(term) :: String.t
+  @spec to_param(term) :: String.t()
   def to_param(term)
 end
 
@@ -79,25 +79,51 @@ end
 defimpl Phoenix.Param, for: Map do
   def to_param(map) do
     raise ArgumentError,
-      "maps cannot be converted to_param. A struct was expected, got: #{inspect map}"
+          "maps cannot be converted to_param. A struct was expected, got: #{inspect(map)}"
   end
 end
 
 defimpl Phoenix.Param, for: Any do
+  defmacro __deriving__(module, _struct, fun: fun) when is_function(fun, 1) do
+    quote do
+      defimpl Phoenix.Param, for: unquote(module) do
+        def to_param(struct) do
+          case unquote(fun).(struct) do
+            nil ->
+              raise ArgumentError,
+                    "cannot convert #{inspect(unquote(module))} to param, " <>
+                      "result of function #{inspect(unquote(fun))} is a nil value"
+
+            params when is_integer(params) ->
+              Integer.to_string(params)
+
+            params when is_binary(params) ->
+              params
+
+            params ->
+              Phoenix.Param.to_param(params)
+          end
+        end
+      end
+    end
+  end
+
   defmacro __deriving__(module, struct, options) do
     key = Keyword.get(options, :key, :id)
 
     unless Map.has_key?(struct, key) do
-      raise ArgumentError, "cannot derive Phoenix.Param for struct #{inspect module} " <>
-                           "because it does not have key #{inspect key}. Please pass " <>
-                           "the :key option when deriving"
+      raise ArgumentError,
+            "cannot derive Phoenix.Param for struct #{inspect(module)} " <>
+              "because it does not have key #{inspect(key)} or fun. Please pass " <>
+              "the :key or :fun option when deriving"
     end
 
     quote do
       defimpl Phoenix.Param, for: unquote(module) do
         def to_param(%{unquote(key) => nil}) do
-          raise ArgumentError, "cannot convert #{inspect unquote(module)} to param, " <>
-                               "key #{inspect unquote(key)} contains a nil value"
+          raise ArgumentError,
+                "cannot convert #{inspect(unquote(module))} to param, " <>
+                  "key #{inspect(unquote(key))} contains a nil value"
         end
 
         def to_param(%{unquote(key) => key}) when is_integer(key), do: Integer.to_string(key)
@@ -110,15 +136,16 @@ defimpl Phoenix.Param, for: Any do
   def to_param(%{id: nil}) do
     raise ArgumentError, "cannot convert struct to param, key :id contains a nil value"
   end
+
   def to_param(%{id: id}) when is_integer(id), do: Integer.to_string(id)
   def to_param(%{id: id}) when is_binary(id), do: id
   def to_param(%{id: id}), do: Phoenix.Param.to_param(id)
 
   def to_param(map) when is_map(map) do
     raise ArgumentError,
-      "structs expect an :id key when converting to_param or a custom implementation " <>
-      "of the Phoenix.Param protocol (read Phoenix.Param docs for more information), " <>
-      "got: #{inspect map}"
+          "structs expect an :id key when converting to_param or a custom implementation " <>
+            "of the Phoenix.Param protocol (read Phoenix.Param docs for more information), " <>
+            "got: #{inspect(map)}"
   end
 
   def to_param(data) do

--- a/test/phoenix/param_test.exs
+++ b/test/phoenix/param_test.exs
@@ -27,33 +27,59 @@ defmodule Phoenix.ParamTest do
   end
 
   test "to_param for structs" do
-    defmodule Foo do
+    defmodule Test1 do
       defstruct [:id]
     end
-    assert to_param(struct(Foo, id: 1)) == "1"
-    assert to_param(struct(Foo, id: "foo")) == "foo"
+
+    assert to_param(struct(Test1, id: 1)) == "1"
+    assert to_param(struct(Test1, id: "foo")) == "foo"
   end
 
-  test "to_param for derivable structs without id" do
-    msg = ~r"cannot derive Phoenix.Param for struct Phoenix.ParamTest.Bar"
+  test "to_param for derivable structs without key and id" do
+    msg = ~r"cannot derive Phoenix.Param for struct Phoenix.ParamTest.Test2"
+
     assert_raise ArgumentError, msg, fn ->
-      defmodule Bar do
+      defmodule Test2 do
         @derive Phoenix.Param
         defstruct [:uuid]
       end
     end
+  end
 
-    defmodule Bar do
+  test "to_param for derivable structs with key" do
+    defmodule Test3 do
       @derive {Phoenix.Param, key: :uuid}
       defstruct [:uuid]
     end
 
-    assert to_param(struct(Bar, uuid: 1)) == "1"
-    assert to_param(struct(Bar, uuid: "foo")) == "foo"
+    assert to_param(struct(Test3, uuid: 1)) == "1"
+    assert to_param(struct(Test3, uuid: "foo")) == "foo"
 
-    msg = ~r"cannot convert Phoenix.ParamTest.Bar to param, key :uuid contains a nil value"
+    msg = ~r"cannot convert Phoenix.ParamTest.Test3 to param, key :uuid contains a nil value"
+
     assert_raise ArgumentError, msg, fn ->
-      to_param(struct(Bar, uuid: nil))
+      to_param(struct(Test3, uuid: nil))
+    end
+  end
+
+  test "to_param for derivable structs with fun" do
+    defmodule Test4 do
+      @derive {Phoenix.Param, fun: &__MODULE__.uuid/1}
+      defstruct [:uuid]
+
+      def uuid(%__MODULE__{uuid: uuid}) do
+        uuid
+      end
+    end
+
+    assert to_param(struct(Test4, uuid: 1)) == "1"
+    assert to_param(struct(Test4, uuid: "foo")) == "foo"
+
+    msg =
+      ~r"cannot convert Phoenix.ParamTest.Test4 to param, result of function &Phoenix.ParamTest.Test4.uuid/1 is a nil value"
+
+    assert_raise ArgumentError, msg, fn ->
+      to_param(struct(Test4, uuid: nil))
     end
   end
 end


### PR DESCRIPTION
Sometimes I want to convert a struct to a Phoenix param using a function instead of a key. For this purpose, I added the `:fun` option. arbitrary function is not allowed of an error likes below.

`error: invalid quoted expression: #Function<0.26537881 in file:test/phoenix/param_test.exs>`