### PR TITLE
Fix typo in 'Contexts Guide': `ShoppingChart` -> `ShoppingCart`

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -914,7 +914,7 @@ defmodule HelloWeb.CartController do
 end
 ```
 
-We defined a new cart controller to handle the `get "/cart"` route. For showing a cart, we render a `"show.html"` template which we'll create in moment. We know we need to allow the cart items to be changed by quantity updates, so right away we know we'll need a cart changeset. Fortunately, the context generator included a `ShoppingChart.change_cart/1` function, which we'll use. We pass it our cart struct which is already in the connection assigns thanks to the `fetch_current_cart` plug we defined in the router.
+We defined a new cart controller to handle the `get "/cart"` route. For showing a cart, we render a `"show.html"` template which we'll create in moment. We know we need to allow the cart items to be changed by quantity updates, so right away we know we'll need a cart changeset. Fortunately, the context generator included a `ShoppingCart.change_cart/1` function, which we'll use. We pass it our cart struct which is already in the connection assigns thanks to the `fetch_current_cart` plug we defined in the router.
 
 Next, we can implement the view and template. Create a new view file at `lib/hello_web/controllers/cart_html.ex` with the following content:
 


### PR DESCRIPTION
Fixes typo in [Contexts Guide](https://hexdocs.pm/phoenix/contexts.html): `ShoppingChart` -> `ShoppingCart`

