### PR TITLE
Fix grammar error in 'Mix Tasks Guide'

### DIFF
--- a/guides/mix_tasks.md
+++ b/guides/mix_tasks.md
@@ -309,7 +309,7 @@ in its default location.
 Do you want to create it? [Y/n]
 ```
 
-By pressing confirming, a channel will be created, then you need to connect the socket in your endpoint:
+By confirming, a channel will be created, then you need to connect the socket in your endpoint:
 
 ```console
 Add the socket handler to your `lib/hello_web/endpoint.ex`, for example:


### PR DESCRIPTION
Fixes grammar error in [Mix tasks Guide](https://hexdocs.pm/phoenix/mix_tasks.html): "By pressing confirming" -> "By confirming"