### PR TITLE
Make generated release scripts safer

### DIFF
--- a/priv/templates/phx.gen.release/rel/migrate.sh.eex
+++ b/priv/templates/phx.gen.release/rel/migrate.sh.eex
@@ -1,3 +1,5 @@
 #!/bin/sh
+set -eu
+
 cd -P -- "$(dirname -- "$0")"
 exec ./<%= otp_app %> eval <%= app_namespace %>.Release.migrate

--- a/priv/templates/phx.gen.release/rel/server.sh.eex
+++ b/priv/templates/phx.gen.release/rel/server.sh.eex
@@ -1,3 +1,5 @@
 #!/bin/sh
+set -eu
+
 cd -P -- "$(dirname -- "$0")"
 PHX_SERVER=true exec ./<%= otp_app %> start


### PR DESCRIPTION
Shell script defaults are not great.
By default a script will keep executing even if a command fails or if it tries to expand a variable which isn't set.

It's unlikely the commands generated here would fail, but people might be making changes to these scripts and expanding them later.
It's better to generate a safer starting point.

`-e` will make the shell exit with an error if a command fails.
`-u` will make the shell exit if it tries to expand an unset variable.


I also wanted to set `-o pipefail` which would cause a pipeline to fail if any of the commands in the pipeline fail (rather than just the last one, as is the default).
However, that option is not part of the POSIX standard so it won't be there in all shells.

See [manual](https://man7.org/linux/man-pages/man1/set.1p.html) for more details.

I also considered changing the shell from `sh` to `bash`, but I know alpine linux doesn't ship with `bash`.