### PR TITLE
chore: add `layout` to `put_layout*/2 specs

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -637,7 +637,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_layout(Plug.Conn.t(), [{format :: atom, layout}] | false) :: Plug.Conn.t()
+  @spec put_layout(Plug.Conn.t(), [{format :: atom, layout}] | layout | false) :: Plug.Conn.t()
   def put_layout(%Plug.Conn{state: state} = conn, layout) do
     if state in @unsent do
       put_private_layout(conn, :phoenix_layout, :replace, layout)
@@ -753,7 +753,7 @@ defmodule Phoenix.Controller do
 
   Raises `Plug.Conn.AlreadySentError` if `conn` is already sent.
   """
-  @spec put_root_layout(Plug.Conn.t(), [{format :: atom, layout}] | false) ::
+  @spec put_root_layout(Plug.Conn.t(), [{format :: atom, layout}] | layout | false) ::
           Plug.Conn.t()
   def put_root_layout(%Plug.Conn{state: state} = conn, layout) do
     if state in @unsent do


### PR DESCRIPTION
dialyzer shows an issue when using `plug :put_layout, {Layouts, :app}` whilst the syntax is valid (although, as far as I understood, not favoured).

Update the `@spec` of `put_layout/2` and `put_root_layout/2` to match this behaviour.