### PR TITLE
Remove extra newline in errors.pot from installer template

### DIFF
--- a/installer/templates/phx_gettext/errors.pot
+++ b/installer/templates/phx_gettext/errors.pot
@@ -7,8 +7,7 @@
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
-<%= if @ecto do %>
-## From Ecto.Changeset.cast/4
+<%= if @ecto do %>## From Ecto.Changeset.cast/4
 msgid "can't be blank"
 msgstr ""
 


### PR DESCRIPTION
After creating a new project, running `mix gettext.extract --merge` would remove that line anyway, causing an unnecessary change.

Related to #5649.