### PR TITLE
Add opt-in modal behaviour to dialogs

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -35,9 +35,11 @@ defmodule <%= @web_namespace %>.CoreComponents do
         This is another modal.
       </.modal>
 
+  To prevent the modal from accidentally closing when clicking on the backdrop, pass the 'modal' attr.
   """
   attr :id, :string, required: true
   attr :show, :boolean, default: false
+  attr :modal, :boolean, default: false
   attr :on_cancel, JS, default: %JS{}
   slot :inner_block, required: true
 
@@ -65,7 +67,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
               id={"#{@id}-container"}
               phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
               phx-key="escape"
-              phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
+              phx-click-away={not @modal and JS.exec("data-cancel", to: "##{@id}")}
               class="shadow-zinc-700/10 ring-zinc-700/10 relative hidden rounded-2xl bg-white p-14 shadow-lg ring-1 transition"
             >
               <div class="absolute top-6 right-5">

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -35,9 +35,11 @@ defmodule <%= @web_namespace %>.CoreComponents do
         This is another modal.
       </.modal>
 
+  To prevent the modal from accidentally closing when clicking on the backdrop, pass the 'modal' attr.
   """
   attr :id, :string, required: true
   attr :show, :boolean, default: false
+  attr :modal, :boolean, default: false
   attr :on_cancel, JS, default: %JS{}
   slot :inner_block, required: true
 
@@ -65,7 +67,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
               id={"#{@id}-container"}
               phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
               phx-key="escape"
-              phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
+              phx-click-away={not @modal and JS.exec("data-cancel", to: "##{@id}")}
               class="shadow-zinc-700/10 ring-zinc-700/10 relative hidden rounded-2xl bg-white p-14 shadow-lg ring-1 transition"
             >
               <div class="absolute top-6 right-5">

--- a/priv/templates/phx.gen.live/index.html.heex
+++ b/priv/templates/phx.gen.live/index.html.heex
@@ -29,7 +29,7 @@
   </:action>
 </.table>
 
-<.modal :if={@live_action in [:new, :edit]} id="<%= schema.singular %>-modal" show on_cancel={JS.patch(~p"<%= schema.route_prefix %>")}>
+<.modal :if={@live_action in [:new, :edit]} id="<%= schema.singular %>-modal" show modal on_cancel={JS.patch(~p"<%= schema.route_prefix %>")}>
   <.live_component
     module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
     id={@<%= schema.singular %>.id || :new}

--- a/priv/templates/phx.gen.live/show.html.heex
+++ b/priv/templates/phx.gen.live/show.html.heex
@@ -14,7 +14,7 @@
 
 <.back navigate={~p"<%= schema.route_prefix %>"}>Back to <%= schema.plural %></.back>
 
-<.modal :if={@live_action == :edit} id="<%= schema.singular %>-modal" show on_cancel={JS.patch(~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}")}>
+<.modal :if={@live_action == :edit} id="<%= schema.singular %>-modal" show modal on_cancel={JS.patch(~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}")}>
   <.live_component
     module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
     id={@<%= schema.singular %>.id}


### PR DESCRIPTION
This PR resolves issue #5660

Changes:
- Added attribute `modal` to `CoreComponents`' `modal` component, which if true prevents the dialog from closing when clicking outside.
- Updated the form templates to use the `modal` attribute.