### PR TITLE
Add missing gettext invocations in core components

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -152,23 +152,23 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <.flash
         id="client-error"
         kind={:error}
-        title="We can't find the internet"
+        title=<%= if @gettext do %>{dgettext("errors", "We can't find the internet")}<% else %>"We can't find the internet"<% end %>
         phx-disconnected={show(".phx-client-error #client-error")}
         phx-connected={hide("#client-error")}
         hidden
       >
-        Attempting to reconnect <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
+        <%= if @gettext do %><%%= dgettext("errors", "Attempting to reconnect") %><% else %>Attempting to reconnect<% end %> <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
       </.flash>
 
       <.flash
         id="server-error"
         kind={:error}
-        title="Something went wrong!"
+        title=<%= if @gettext do %>{dgettext("errors", "Something went wrong!")}<% else %>"Something went wrong!"<% end %>
         phx-disconnected={show(".phx-server-error #server-error")}
         phx-connected={hide("#server-error")}
         hidden
       >
-        Hang in there while we get back on track
+        <%= if @gettext do %><%%= dgettext("errors", "Hang in there while we get back on track") %><% else %>Hang in there while we get back on track<% end %>
         <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
       </.flash>
     </div>

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -157,7 +157,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
         phx-connected={hide("#client-error")}
         hidden
       >
-        <%= if @gettext do %><%%= dgettext("errors", "Attempting to reconnect") %><% else %>Attempting to reconnect<% end %> <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
+        <%= if @gettext do %><%%= dgettext("errors", "Attempting to reconnect") %><%= "\n" <> String.duplicate("\s", 8) %><% else %>Attempting to reconnect <% end %><.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
       </.flash>
 
       <.flash

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -147,8 +147,8 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def flash_group(assigns) do
     ~H"""
     <div id={@id}>
-      <.flash kind={:info} title="Success!" flash={@flash} />
-      <.flash kind={:error} title="Error!" flash={@flash} />
+      <.flash kind={:info} title=<%= if @gettext do %>{dgettext("errors", "Success!")}<% else %>"Success!"<% end %> flash={@flash} />
+      <.flash kind={:error} title=<%= if @gettext do %>{dgettext("errors", "Error!")}<% else %>"Error!"<% end %> flash={@flash} />
       <.flash
         id="client-error"
         kind={:error}

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -152,23 +152,23 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <.flash
         id="client-error"
         kind={:error}
-        title="We can't find the internet"
+        title=<%= if @gettext do %>{dgettext("errors", "We can't find the internet")}<% else %>"We can't find the internet"<% end %>
         phx-disconnected={show(".phx-client-error #client-error")}
         phx-connected={hide("#client-error")}
         hidden
       >
-        Attempting to reconnect <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
+        <%= if @gettext do %><%%= dgettext("errors", "Attempting to reconnect") %><% else %>Attempting to reconnect<% end %> <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
       </.flash>
 
       <.flash
         id="server-error"
         kind={:error}
-        title="Something went wrong!"
+        title=<%= if @gettext do %>{dgettext("errors", "Something went wrong!")}<% else %>"Something went wrong!"<% end %>
         phx-disconnected={show(".phx-server-error #server-error")}
         phx-connected={hide("#server-error")}
         hidden
       >
-        Hang in there while we get back on track
+        <%= if @gettext do %><%%= dgettext("errors", "Hang in there while we get back on track") %><% else %>Hang in there while we get back on track<% end %>
         <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
       </.flash>
     </div>

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -157,7 +157,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
         phx-connected={hide("#client-error")}
         hidden
       >
-        <%= if @gettext do %><%%= dgettext("errors", "Attempting to reconnect") %><% else %>Attempting to reconnect<% end %> <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
+        <%= if @gettext do %><%%= dgettext("errors", "Attempting to reconnect") %><%= "\n" <> String.duplicate("\s", 8) %><% else %>Attempting to reconnect <% end %><.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
       </.flash>
 
       <.flash


### PR DESCRIPTION
Added `gettext` to `flash_group` default error flashes.

Manually tested by using the modified version of the generator and running `mix gettext.extract`:

![image](https://github.com/phoenixframework/phoenix/assets/11234273/1a451f5e-c643-41df-9f17-6961a10a6780)
