### PR TITLE
Fix flaky test for `Phoenix.Controller.current_path/2`

### DIFF
--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -788,7 +788,7 @@ defmodule Phoenix.Controller.ControllerTest do
 
     test "current_path/2 allows custom nested query params" do
       conn = build_conn_for_path("/")
-      assert current_path(conn, %{foo: %{bar: [:baz], baz: :qux}}) == "/?foo[bar][]=baz&foo[baz]=qux"
+      assert current_path(conn, [foo: [bar: [:baz], baz: :qux]]) == "/?foo[bar][]=baz&foo[baz]=qux"
     end
 
     test "current_url/1 with root path includes trailing slash" do


### PR DESCRIPTION
With Elixir 1.15.7 and OTP26.2, this test randomly fails:

```
  1) test path and url generation current_path/2 allows custom nested query params (Phoenix.Controller.ControllerTest)
     test/phoenix/controller/controller_test.exs:789
     Assertion with == failed
     code:  assert current_path(conn, %{foo: %{bar: [:baz], baz: :qux}}) == "/?foo[bar][]=baz&foo[baz]=qux"
     left:  "/?foo[baz]=qux&foo[bar][]=baz"
     right: "/?foo[bar][]=baz&foo[baz]=qux"
     stacktrace:
       test/phoenix/controller/controller_test.exs:791: (test)
```

It relied on ordering of a map. Switching to a keyword list, we avoid this pitfall.