### PR TITLE
Use `origin` to protect against CSWSH instead of CSRF token

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -213,6 +213,13 @@ defmodule Phoenix.Endpoint do
 
     * `:log_access_url` - log the access url once the server boots
 
+    * `:cswsh_check` - configure the CSWSH (Cross-Site WebSocket Hijacking) check
+    mechanism for the endpoint. When `:crsf_token` (the default), a CRSF token is
+    used. This mechanism uses the session and is stateful. When `:origin`, the
+    `origin` header is checked according to the rule set by the `:origin` option,
+    without requiring the use of cookies, but at the cost of not supporting older
+    browsers that don't send this header or other non-browser-based clients.
+
   Note that you can also store your own configurations in the Phoenix.Endpoint.
   For example, [Phoenix LiveView](https://hexdocs.pm/phoenix_live_view) expects
   its own configuration under the `:live_view` key. In such cases, you should


### PR DESCRIPTION
This is a draft PR following discussion on https://elixirforum.com/t/http-caching-liveviews-first-render/59180

## Initial use-case

The use-case is HTTP caching of liveviews. Some liveviews contain none or almost no private data, and HTTP caching (with [`plug_http_cache`](https://github.com/tanguilp/plug_http_cache) for instance - I'm the author) could help speeding up first paint for the client. This was also requested to me to improve SEO ranking.

## The problem

Websockets are not constrained by same-origin policy, and are thus subject to [Cross-Site WebSocket hijacking](https://christian-schneider.net/CrossSiteWebSocketHijacking.html). In short, `evil.com` can open a WS to `example.com` and session data (cookies) are sent along. There are two ways of dealing with that:
- use session's CSRF token, and check it when opening the WS
- check the `origin` header

Phoenix uses CSRF tokens to mitigate against CSWSH. Therefore a LiveView, even a public one, cannot be cached by a public cache by default because the initial rendered HTML page contains a CSRF token that is unique to a session.

It is possible to disable session for a liveview: after all if a session is used, it means that there's some private data on that page. For example by configuring the socket this way:

```elixir
socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: []]**
```

instead of:

```elixir
socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
```

However, one might want to still have a session configured on a socket because:
- there are public and private pages and, for instance, `live_session` should still be enabled between these pages
- it allows publicly-cacheable private LiveViews

## Additional use-case

I've been thinking of *publicly-cacheable private LiveViews* lately (if you find a better name, you're welcome!). The idea is the following:
- on initial render, only public data is rendered. This HTML page can be cached
- when the liveview is mounted, it updates (hydrates?) the initially rendered page with private information

This pattern would not be suited for highly private pages. However some types of pages could benefit from it. Take for instance a typical catalog page of an ecommerce platform:
- most of the items of the page is public, cacheable and potentially costly to read in the DB: article title, price, rating, number of reviews, potential discount...
- top-right of the screen, typically, is the number of items in your basket, number of unread messages and so on, related to the user's account

Currently the CSRF check performed prevents from caching it.

I've seen some advice on elixirforums on doing the heavily loading not on initial render but after the liveview is mounted, so the pattern already exist, although the use-case is different.

Undoubtedly, this new pattern would offer new ways of shooting oneself in the foot. Some can be mitigated (a plug to prevent setting cookies on such liveviews), others probably not.

This is not a totally new idea in the world of HTTP caching: some have used ESI includes to do exactly that. The difference is that with the *publicly-cacheable private LiveViews*, the cached LiveView remains cacheable with uniquely public information. With the ESI approach, the generated page from cache becomes private and so another cache on the path to the browser cannot cache it.

## Proposed changes

I've opened this draft PR so as to discuss it.

- Is that a good idea in the first place? Are they some technical or security concerns that would advocate against doing that? I've tested caching a page on disk and it's still working after 2 days. Only top-level LiveViews can be cached.
- The PR misses tests and potentially other changes (`:cswsh_check` as a transport option like `:check_origin?`)
- Although it works well when a cookie is set, it doesn't when there's no cookie because of https://github.com/phoenixframework/phoenix_live_view/blob/main/lib/phoenix_live_view/channel.ex#L988: when `:session` is passed in `connect_info`, a session is mandatory (usually set by the `protect_from_forgery` plug). We might want to reconsider this as a user could land on such a liveview without any cookie (from direct link for instance). In this case we can still redirect to a page setting an cookie and redirecting back to the initial page though
- We'd need to update LiveView's javascript from:

```javascript
let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})    
```

to something like:

```javascript
let params = {}
if (document.querySelector("meta[name='csrf-token']")) {
  params = {_csrf_token: document.querySelector("meta[name='csrf-token']").getAttribute("content")}
}                                                                                                    
                                                                                                    
let liveSocket = new LiveSocket("/live", Socket, {params: params})
```

I'm very curious what you think about this proposal ☺ Please let me know if you consider I should go on with this idea and continue improving the PR, or if on the contrary there are some fundamental reasons not going further in this direction. Cheers!