### PR TITLE
Upgrade Heroicons to v2.1.1 with support for the new `-micro` variant.

### DIFF
--- a/installer/templates/phx_assets/tailwind.config.js
+++ b/installer/templates/phx_assets/tailwind.config.js
@@ -39,7 +39,8 @@ module.exports = {
       let icons = [
         ["", "/24/outline"],
         ["-solid", "/24/solid"],
-        ["-mini", "/20/solid"]
+        ["-mini", "/20/solid"],
+        ["-micro", "/16/solid"]
       ]
       icons.forEach(([suffix, dir]) => {
         fs.readdirSync(path.join(iconsDir, dir)).forEach(file => {
@@ -50,6 +51,7 @@ module.exports = {
       matchComponents({
         "hero": ({name, fullPath}) => {
           let content = fs.readFileSync(fullPath).toString().replace(/\r?\n|\r/g, "")
+          let spacing = name.endsWith("-micro") ? theme("spacing.4") : theme("spacing.5")
           return {
             [`--hero-${name}`]: `url('data:image/svg+xml;utf8,${content}')`,
             "-webkit-mask": `var(--hero-${name})`,
@@ -58,8 +60,8 @@ module.exports = {
             "background-color": "currentColor",
             "vertical-align": "middle",
             "display": "inline-block",
-            "width": theme("spacing.5"),
-            "height": theme("spacing.5")
+            "width": spacing,
+            "height": spacing
           }
         }
       }, {values})

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -49,7 +49,7 @@ defmodule <%= @app_module %>.MixProject do
       {:tailwind, "~> 0.2", runtime: Mix.env() == :dev},
       {:heroicons,
        github: "tailwindlabs/heroicons",
-       tag: "v2.0.18",
+       tag: "v2.1.1",
        app: false,
        compile: false,
        sparse: "optimized"},<% end %><%= if @mailer do %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
@@ -47,7 +47,7 @@ defmodule <%= @web_namespace %>.MixProject do
       {:tailwind, "~> 0.2", runtime: Mix.env() == :dev},
       {:heroicons,
        github: "tailwindlabs/heroicons",
-       tag: "v2.0.18",
+       tag: "v2.1.1",
        app: false,
        compile: false,
        sparse: "optimized"},<% end %>

--- a/integration_test/mix.exs
+++ b/integration_test/mix.exs
@@ -58,7 +58,7 @@ defmodule Phoenix.Integration.MixProject do
       {:tailwind, "~> 0.2"},
       {:heroicons,
        github: "tailwindlabs/heroicons",
-       tag: "v2.0.18",
+       tag: "v2.1.1",
        app: false,
        compile: false,
        sparse: "optimized"},


### PR DESCRIPTION
The `-micro` variant was released yesterday ([announced in the blog post](https://tailwindcss.com/blog/heroicons-micro)). The `-micro` variant is a new set of `16x16px` icons.

I have updated the `mix.exs` generators to Heroicons tag `v2.1.1`. To support the smaller size correctly, I have made a minor change to use `theme("spacing.4")` for the `width` and `height` only for `-micro` icons, by default.