### PR TITLE
Set Heroicon default size to native icon size

### DIFF
--- a/installer/templates/phx_assets/tailwind.config.js
+++ b/installer/templates/phx_assets/tailwind.config.js
@@ -51,7 +51,12 @@ module.exports = {
       matchComponents({
         "hero": ({name, fullPath}) => {
           let content = fs.readFileSync(fullPath).toString().replace(/\r?\n|\r/g, "")
-          let spacing = name.endsWith("-micro") ? theme("spacing.4") : theme("spacing.5")
+          let size = theme("spacing.6")
+          if (name.endsWith("-mini")) {
+            size = theme("spacing.5")
+          } else if (name.endsWith("-micro")) {
+            size = theme("spacing.4")
+          }
           return {
             [`--hero-${name}`]: `url('data:image/svg+xml;utf8,${content}')`,
             "-webkit-mask": `var(--hero-${name})`,
@@ -60,8 +65,8 @@ module.exports = {
             "background-color": "currentColor",
             "vertical-align": "middle",
             "display": "inline-block",
-            "width": spacing,
-            "height": spacing
+            "width": size,
+            "height": size
           }
         }
       }, {values})


### PR DESCRIPTION
We recently added support for the new 'micro' variant with proper sizing (16x16 pixels).

This change updates the default size of the original icons (no suffix) and their 'solid' variant to be their native size (24x24 pixels).

The 'mini' variant remains at their native size (20x20 pixels).