### PR TITLE
Extend test matrix to cover supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.12.0
+          - elixir: 1.11.4
+            otp: 21.3
+
+          - elixir: 1.12.3
             otp: 22.3
 
-          - elixir: 1.14.3
-            otp: 25.1
+          - elixir: 1.14.5
+            otp: 25.3
+
+          - elixir: 1.16.0
+            otp: 26.2
             lint: true
             installer: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         include:
           - elixir: 1.11.4
-            otp: 21.3
+            otp: 22.3
 
           - elixir: 1.12.3
-            otp: 22.3
+            otp: 23.3
 
           - elixir: 1.14.5
             otp: 25.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 See the [upgrade guide](https://gist.github.com/chrismccord/00a6ea2a96bc57df0cce526bd20af8a7) to upgrade from Phoenix 1.6.x.
 
-Phoenix v1.7 requires Elixir v1.11+.
+Phoenix v1.7 requires Elixir v1.11+ & Erlang v22.1+.
 
 ## Introduction of Verified Routes
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ See the official site at <https://www.phoenixframework.org/>.
 
 Install the latest version of Phoenix by following the instructions at <https://hexdocs.pm/phoenix/installation.html#phoenix>.
 
+Phoenix requires Elixir v1.11+ & Erlang v22.1+.
+
 ## Documentation
 
 API documentation is available at <https://hexdocs.pm/phoenix>.

--- a/lib/phoenix/endpoint/cowboy2_adapter.ex
+++ b/lib/phoenix/endpoint/cowboy2_adapter.ex
@@ -139,9 +139,12 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
   defp port_to_integer(port) when is_integer(port), do: port
 
   def server_info(endpoint, scheme) do
-    make_ref(endpoint, scheme)
-    |> :ranch.get_addr()
-    |> then(&{:ok, &1})
+    address =
+      endpoint
+      |> make_ref(scheme)
+      |> :ranch.get_addr()
+
+    {:ok, address}
   rescue
     e -> {:error, e.message}
   end


### PR DESCRIPTION
Not sure about the testing CI/strategy but I tried to extend it to cover all supported versions :)

* Test against newest elixir & otp
* Test against oldest supported elixir (Changelog and mix say 1.11) and I think we should test against it to avoid accidental brekage
* updated patch versions for elixir versions


Thanks as always for your excellent work! :green_heart: 