### PR TITLE
Use umbrella apps names instead of "default"

### DIFF
--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -36,7 +36,7 @@ config :<%= @app_name %>, <%= @app_module %>.Mailer, adapter: Swoosh.Adapters.Lo
 # Configure esbuild (the version is required)
 config :esbuild,
   version: "0.17.11",
-  default: [
+  <%= @app_name %>: [
     args:
       ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
     cd: Path.expand("..<%= if @in_umbrella, do: "/apps/#{@app_name}" %>/assets", __DIR__),
@@ -46,7 +46,7 @@ config :esbuild,
 # Configure tailwind (the version is required)
 config :tailwind,
   version: "3.3.2",
-  default: [
+  <%= @app_name %>: [
     args: ~w(
       --config=tailwind.config.js
       --input=css/app.css

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -15,8 +15,8 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
   debug_errors: true,
   secret_key_base: "<%= @secret_key_base_dev %>",
   watchers: <%= if @javascript or @css do %>[<%= if @javascript do %>
-    esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]}<%= if @css, do: "," %><% end %><%= if @css do %>
-    tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}<% end %>
+    esbuild: {Esbuild, :install_and_run, [:<%= @app_name %>, ~w(--sourcemap=inline --watch)]}<%= if @css, do: "," %><% end %><%= if @css do %>
+    tailwind: {Tailwind, :install_and_run, [:<%= @app_name %>, ~w(--watch)]}<% end %>
   ]<% else %>[]<% end %>
 
 # ## SSL Support

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -77,8 +77,10 @@ defmodule <%= @app_module %>.MixProject do
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %><%= if @asset_builders != [] do %>,
       "assets.setup": <%= inspect Enum.map(@asset_builders, &"#{&1}.install --if-missing") %>,
-      "assets.build": <%= inspect Enum.map(@asset_builders, &"#{&1} default") %>,
-      "assets.deploy": <%= inspect Enum.map(@asset_builders, &"#{&1} default --minify") ++ ["phx.digest"] %><% end %>
+      "assets.build": <%= inspect Enum.map(@asset_builders, &"#{&1} #{@app_name}") %>,
+      "assets.deploy": [
+<%= Enum.map(@asset_builders, &"        \"#{&1} #{@app_name} --minify\",\n") ++ ["        \"phx.digest\""] %>
+      ]<% end %>
     ]
   end
 end

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
@@ -20,7 +20,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 # Configure esbuild (the version is required)
 config :esbuild,
   version: "0.17.11",
-  default: [
+  <%= @web_app_name %>: [
     args:
       ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
     cd: Path.expand("../apps/<%= @web_app_name %>/assets", __DIR__),
@@ -30,7 +30,7 @@ config :esbuild,
 # Configure tailwind (the version is required)
 config :tailwind,
   version: "3.3.2",
-  default: [
+  <%= @web_app_name %>: [
     args: ~w(
       --config=tailwind.config.js
       --input=css/app.css

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -15,8 +15,8 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
   debug_errors: true,
   secret_key_base: "<%= @secret_key_base_dev %>",
   watchers: <%= if @javascript or @css do %>[<%= if @javascript do %>
-    esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]}<%= if @css, do: "," %><% end %><%= if @css do %>
-    tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}<% end %>
+    esbuild: {Esbuild, :install_and_run, [:<%= @web_app_name %>, ~w(--sourcemap=inline --watch)]}<%= if @css, do: "," %><% end %><%= if @css do %>
+    tailwind: {Tailwind, :install_and_run, [:<%= @web_app_name %>, ~w(--watch)]}<% end %>
   ]<% else %>[]<% end %>
 
 # ## SSL Support

--- a/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
@@ -68,8 +68,10 @@ defmodule <%= @web_namespace %>.MixProject do
       setup: ["deps.get"<%= if @asset_builders != [] do %>, "assets.setup", "assets.build"<% end %>]<%= if @ecto do %>,
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %><%= if @asset_builders != [] do %>,
       "assets.setup": <%= inspect Enum.map(@asset_builders, &"#{&1}.install --if-missing") %>,
-      "assets.build": <%= inspect Enum.map(@asset_builders, &"#{&1} default") %>,
-      "assets.deploy": <%= inspect Enum.map(@asset_builders, &"#{&1} default --minify") ++ ["phx.digest"] %><% end %>
+      "assets.build": <%= inspect Enum.map(@asset_builders, &"#{&1} #{@web_app_name}") %>,
+      "assets.deploy": [
+<%= Enum.map(@asset_builders, &"        \"#{&1} #{@web_app_name} --minify\",\n") ++ ["        \"phx.digest\""] %>
+      ]<% end %>
     ]
   end
 end


### PR DESCRIPTION
When adding more than one app to your umbrella project you can't use default for tailwind and esbuild configurations or they will clash between them. By using their names instead of "default" the issue is fixed.

Closes #5631

Steps to test it (assuming you are [using phoenix mix from source code](https://github.com/phoenixframework/phoenix#generating-a-phoenix-project-from-unreleased-versions)):

1. `mix phx.new --umbrella /tmp/a`
2. `mix phx.new.web /tmp/a_umbrella/apps/b`
3. Change `config/runtime.exs` &  `config/dev.exs` to change one of the apps to listen in something that isn't `4000`.
4. `cd /tmp/a_umbrella && mix ecto.migrate`