### PR TITLE
Add `--depends-on` Flag To Umbrella Web Generator

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -134,6 +134,7 @@ defmodule Mix.Tasks.Phx.New do
     html: :boolean,
     gettext: :boolean,
     umbrella: :boolean,
+    depends_on: :string,
     verbose: :boolean,
     live: :boolean,
     dashboard: :boolean,

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -219,6 +219,8 @@ defmodule Phx.New.Generator do
       signing_salt: random_string(8),
       lv_signing_salt: random_string(8),
       in_umbrella: project.in_umbrella?,
+      depends_on_app: project.depends_on_app,
+      depends_on_mod: inspect(project.depends_on_mod) || inspect(project.app_mod),
       asset_builders: Enum.filter([tailwind && :tailwind, esbuild && :esbuild], & &1),
       javascript: esbuild,
       css: tailwind,

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -186,7 +186,7 @@ defmodule Phx.New.Generator do
     # means creating a database like FoO is the same as foo in
     # some storages.
     {adapter_app, adapter_module, adapter_config} =
-      get_ecto_adapter(db, String.downcase(project.app), project.app_mod)
+      get_ecto_adapter(db, String.downcase(project.app), project.depends_on_mod)
 
     {web_adapter_app, web_adapter_vsn, web_adapter_module} = get_web_adapter(web_adapter)
 

--- a/installer/lib/phx_new/project.ex
+++ b/installer/lib/phx_new/project.ex
@@ -15,6 +15,8 @@ defmodule Phx.New.Project do
             web_path: nil,
             opts: :unset,
             in_umbrella?: false,
+            depends_on_app: nil,
+            depends_on_mod: nil,
             binding: [],
             generators: [timestamp_type: :utc_datetime]
 

--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -125,6 +125,8 @@ defmodule Phx.New.Single do
     %Project{
       project
       | web_app: app,
+        depends_on_app: app,
+        depends_on_mod: project.root_mod,
         lib_web_name: "#{app}_web",
         web_namespace: Module.concat(["#{project.root_mod}Web"]),
         web_path: project.base_path

--- a/installer/lib/phx_new/umbrella.ex
+++ b/installer/lib/phx_new/umbrella.ex
@@ -40,6 +40,8 @@ defmodule Phx.New.Umbrella do
       | web_app: web_app,
         lib_web_name: web_app,
         web_namespace: web_namespace,
+        depends_on_app: app,
+        depends_on_mod: project.app_mod,
         generators: [context_app: :"#{app}"],
         web_path: Path.join(project.project_path, "apps/#{web_app}/")
     }

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -56,9 +56,10 @@ defmodule Phx.New.Web do
      "phx_web/components/layouts/app.html.heex": "lib/:web_app/components/layouts/app.html.heex"}
   ])
 
-  def prepare_project(%Project{app: app} = project) when not is_nil(app) do
+  def prepare_project(%Project{app: app, opts: opts} = project) when not is_nil(app) do
     web_path = Path.expand(project.base_path)
     project_path = Path.dirname(Path.dirname(web_path))
+    depends_on = Keyword.get(opts, :depends_on, false)
 
     %Project{
       project
@@ -66,7 +67,9 @@ defmodule Phx.New.Web do
         project_path: project_path,
         web_path: web_path,
         web_app: app,
-        generators: [context_app: false],
+        depends_on_app: depends_on,
+        depends_on_mod: depends_on && Module.concat([Macro.camelize(depends_on)]),
+        generators: [context_app: :"#{depends_on}"],
         web_namespace: project.app_mod
     }
   end

--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -67,8 +67,9 @@ defmodule Phx.New.Web do
         project_path: project_path,
         web_path: web_path,
         web_app: app,
-        depends_on_app: depends_on,
-        depends_on_mod: depends_on && Module.concat([Macro.camelize(depends_on)]),
+        depends_on_app: depends_on || app,
+        depends_on_mod:
+          (depends_on && Module.concat([Macro.camelize(depends_on)])) || project.app_mod,
         generators: [context_app: :"#{depends_on}"],
         web_namespace: project.app_mod
     }

--- a/installer/templates/phx_test/support/conn_case.ex
+++ b/installer/templates/phx_test/support/conn_case.ex
@@ -32,7 +32,7 @@ defmodule <%= @web_namespace %>.ConnCase do
   end<%= if @ecto do %>
 
   setup tags do
-    <%= @app_module %>.DataCase.setup_sandbox(tags)
+    <%= @depends_on_mod %>.DataCase.setup_sandbox(tags)
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end<% else %>
 

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
@@ -3,7 +3,7 @@ import Config
 <%= if @namespaced? || @ecto || @generators do %>
 config :<%= @web_app_name %><%= if @namespaced? do %>,
   namespace: <%= @web_namespace %><% end %><%= if @ecto do %>,
-  ecto_repos: [<%= @app_module %>.Repo]<% end %><%= if @generators do %>,
+  ecto_repos: [<%= @depends_on_mod %>.Repo]<% end %><%= if @generators do %>,
   generators: <%= inspect @generators %><% end %>
 
 <% end %># Configures the endpoint
@@ -14,7 +14,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
     formats: [<%= if @html do%>html: <%= @web_namespace %>.ErrorHTML, <% end %>json: <%= @web_namespace %>.ErrorJSON],
     layout: false
   ],
-  pubsub_server: <%= @app_module %>.PubSub,
+  pubsub_server: <%= @depends_on_mod %>.PubSub,
   live_view: [signing_salt: "<%= @lv_signing_salt %>"]<%= if @javascript do %>
 
 # Configure esbuild (the version is required)

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/runtime.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/runtime.exs
@@ -69,7 +69,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 # Also, you may need to configure the Swoosh API client of your choice if you
 # are not using SMTP. Here is an example of the configuration:
 #
-#     config :<%= @app_name %>, <%= @app_module %>.Mailer,
+#     config :<%= @app_name %>, <%= @depends_on_mod %>.Mailer,
 #       adapter: Swoosh.Adapters.Mailgun,
 #       api_key: System.get_env("MAILGUN_API_KEY"),
 #       domain: System.get_env("MAILGUN_DOMAIN")

--- a/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/mix.exs
@@ -54,8 +54,8 @@ defmodule <%= @web_namespace %>.MixProject do
        depth: 1},<% end %>
       {:telemetry_metrics, "~> 0.6"},
       {:telemetry_poller, "~> 1.0"},<%= if @gettext do %>
-      {:gettext, "~> 0.20"},<% end %><%= if @app_name != @web_app_name do %>
-      {:<%= @app_name %>, in_umbrella: true},<% end %>
+      {:gettext, "~> 0.20"},<% end %><%= if @in_umbrella do %>
+      {:<%= @depends_on_app %>, in_umbrella: true},<% end %>
       {:jason, "~> 1.2"},
       {<%= inspect @web_adapter_app %>, "<%= @web_adapter_vsn %>"}
     ]

--- a/installer/templates/phx_web/telemetry.ex
+++ b/installer/templates/phx_web/telemetry.ex
@@ -52,23 +52,23 @@ defmodule <%= @web_namespace %>.Telemetry do
       ),<%= if @ecto do %>
 
       # Database Metrics
-      summary("<%= @app_name %>.repo.query.total_time",
+      summary("<%= @depends_on_app %>.repo.query.total_time",
         unit: {:native, :millisecond},
         description: "The sum of the other measurements"
       ),
-      summary("<%= @app_name %>.repo.query.decode_time",
+      summary("<%= @depends_on_app %>.repo.query.decode_time",
         unit: {:native, :millisecond},
         description: "The time spent decoding the data received from the database"
       ),
-      summary("<%= @app_name %>.repo.query.query_time",
+      summary("<%= @depends_on_app %>.repo.query.query_time",
         unit: {:native, :millisecond},
         description: "The time spent executing the query"
       ),
-      summary("<%= @app_name %>.repo.query.queue_time",
+      summary("<%= @depends_on_app %>.repo.query.queue_time",
         unit: {:native, :millisecond},
         description: "The time spent waiting for a database connection"
       ),
-      summary("<%= @app_name %>.repo.query.idle_time",
+      summary("<%= @depends_on_app %>.repo.query.idle_time",
         unit: {:native, :millisecond},
         description:
           "The time the connection spent waiting before being checked out for the query"


### PR DESCRIPTION
Resolves #5690 

I can't avoid the feeling that there is room for improvement with `app`, `app_mod`, `root_app`, `root_mod`, and now `depends_on_app` and `depends_on_mod` all having very similar data in most instances. But they do all serve slightly different purposes in some unique instances.