### PR TITLE
Allow `mix ecto.setup` from the umbrella root.

### DIFF
--- a/installer/templates/phx_umbrella/apps/app_name/mix.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/mix.exs
@@ -52,7 +52,7 @@ defmodule <%= @app_module %>.MixProject do
   defp aliases do
     [
       setup: ["deps.get"<%= if @ecto do %>, "ecto.setup"<% end %>]<%= if @ecto do %>,
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
+      "ecto.setup": ["ecto.create", "ecto.migrate", "run #{__DIR__}/priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"]<% end %>
     ]


### PR DESCRIPTION
This PR allows running `mix ecto.setup` from the root of an umbrella project.