### PR TITLE
Fix broken reference to app.config in "Creating our own Mix task" docs

### DIFF
--- a/guides/mix_tasks.md
+++ b/guides/mix_tasks.md
@@ -804,7 +804,7 @@ Indeed it does.
 If you want to make your new Mix task to use your application's infrastructure, you need to make sure the application is started and configure when Mix task is being executed. This is particularly useful if you need to access your database from within the Mix task. Thankfully, Mix makes it really easy for us via the `@requirements` module attribute:
 
 ```elixir
-  @requirements ["app.config"]
+  @requirements ["app.start"]
 
   @impl Mix.Task
   def run(_args) do


### PR DESCRIPTION
To use an application's infrastructure, the docs say `@requirements ["app.config"]` should work, but it doesn’t:

```
→ mix task.name
Compiling 1 file (.ex)
** (RuntimeError) could not lookup Ecto repo App.Repo because it was not started or it does not exist
    (ecto 3.11.1) lib/ecto/repo/registry.ex:22: Ecto.Repo.Registry.lookup/1
    (ecto 3.11.1) lib/ecto/repo/supervisor.ex:160: Ecto.Repo.Supervisor.tuplet/2
    (app 0.1.0) lib/app/repo.ex:2: App.Repo.all/2
    (app 0.1.0) lib/mix/tasks/task.name.ex:13: Mix.Tasks.App.Ingest.run/1
    (mix 1.16.0) lib/mix/task.ex:478: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.16.0) lib/mix/cli.ex:96: Mix.CLI.run_task/2
    /Users/jyc/.asdf/installs/elixir/1.16.0-otp-26/bin/mix:2: (file)
```

I asked on the forums and it turns out that `app.start` is the correct name: https://elixirforum.com/t/accessing-an-ecto-repo-inside-of-a-mix-task-in-phoenix/60942/2