### PR TITLE
input validation errors must disappear when resolved

### DIFF
--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -280,7 +280,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   attr :field, Phoenix.HTML.FormField,
     doc: "a form field struct retrieved from the form, for example: @form[:email]"
 
-  attr :errors, :list, default: []
+  attr :errors, :list
   attr :checked, :boolean, doc: "the checked flag for checkbox inputs"
   attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"


### PR DESCRIPTION
I came across an interesting a corner case.

Validation errors for an input field would never disappear, even after user amends their input to be valid. I noticed that heex template would be re-rendered on the server (`input()` method was called), but UI would never remove the last errors from the view.
   
Getting rid of `defaults: []` fixed this. It seems this is safe to do as errors are always assigned with 

```
    |> assign(:errors, Enum.map(field.errors, &translate_error(&1)))
````

Critical look at this pr is advised as I am newbie here.

Thank You for your work on this amazing work, I enjoyed myself exploring it during the last 14 days.