### PR TITLE
Omit meaningless markup from hidden input in core components

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -366,6 +366,17 @@ defmodule <%= @web_namespace %>.CoreComponents do
     """
   end
 
+  def input(%{type: "hidden"} = assigns) do
+    ~H"""
+    <input
+      type="hidden"
+      name={@name}
+      id={@id}
+      value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+    />
+    """
+  end
+
   # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(assigns) do
     ~H"""

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -373,6 +373,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       name={@name}
       id={@id}
       value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+      {@rest}
     />
     """
   end

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -368,13 +368,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def input(%{type: "hidden"} = assigns) do
     ~H"""
-    <input
-      type="hidden"
-      name={@name}
-      id={@id}
-      value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-      {@rest}
-    />
+    <input type="hidden" name={@name} id={@id} value={@value} {@rest} />
     """
   end
 

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -366,6 +366,17 @@ defmodule <%= @web_namespace %>.CoreComponents do
     """
   end
 
+  def input(%{type: "hidden"} = assigns) do
+    ~H"""
+    <input
+      type="hidden"
+      name={@name}
+      id={@id}
+      value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+    />
+    """
+  end
+
   # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(assigns) do
     ~H"""

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -373,6 +373,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       name={@name}
       id={@id}
       value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+      {@rest}
     />
     """
   end

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -368,13 +368,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def input(%{type: "hidden"} = assigns) do
     ~H"""
-    <input
-      type="hidden"
-      name={@name}
-      id={@id}
-      value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-      {@rest}
-    />
+    <input type="hidden" name={@name} id={@id} value={@value} {@rest} />
     """
   end
 


### PR DESCRIPTION
## Motivation

The current version of core components given 
```
<.input type="hidden" field={@form[:user_id]} value={@current_user.id} />
```
produces next markup
```
<div phx-feedback-for="message[user_id]" data-phx-id="..." class="phx-no-feedback">
  <label for="message_user_id" class="block text-sm font-semibold leading-6 text-zinc-800" data-phx-id="..."></label>
  <input type="hidden" name="message[user_id]" id="message_user_id" value="2" class="mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6 phx-no-feedback:border-zinc-300 phx-no-feedback:focus:border-zinc-400 border-zinc-300 focus:border-zinc-400">
</div>
```

Most of that is completely meaningless for hidden fields.

## Change

After implementing these changes, it'll generate next markup:

```
<input type="hidden" name="message[user_id]" id="message_user_id" value="2" data-phx-id="...">
```
