### PR TITLE
Fix references to 'Sign in' button rather than nav bar 'Log in' link

### DIFF
--- a/priv/templates/phx.gen.auth/login_live_test.exs
+++ b/priv/templates/phx.gen.auth/login_live_test.exs
@@ -8,7 +8,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     test "renders log in page", %{conn: conn} do
       {:ok, _lv, html} = live(conn, ~p"<%= schema.route_prefix %>/log_in")
 
-      assert html =~ "Log in"
+      assert html =~ "Sign in"
       assert html =~ "Register"
       assert html =~ "Forgot your password?"
     end

--- a/priv/templates/phx.gen.auth/reset_password_live_test.exs
+++ b/priv/templates/phx.gen.auth/reset_password_live_test.exs
@@ -97,7 +97,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         |> render_click()
         |> follow_redirect(conn, ~p"<%= schema.route_prefix %>/log_in")
 
-      assert conn.resp_body =~ "Log in"
+      assert conn.resp_body =~ "Sign in"
     end
 
     test "redirects to registration page when the Register button is clicked", %{


### PR DESCRIPTION
I noticed these tests start failing in my project when I removed the nav bar links. I think the intention was to detect the primary 'Sign in' button, but this has been detecting the 'Log in' link in the nav bar.