### PR TITLE
Add nodePaths to the example code

### DIFF
--- a/guides/asset_management.md
+++ b/guides/asset_management.md
@@ -117,6 +117,7 @@ let opts = {
   target: "es2017",
   outdir: "../priv/static/assets",
   external: ["*.css", "fonts/*", "images/*"],
+  nodePaths: ["../deps"],
   loader: loader,
   plugins: plugins,
 };


### PR DESCRIPTION
When `esbuild` is called by elixir in the default template (`dev.exs`), it has the the following environment set:

```
env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
```

This patch suggest a similar option using a `build.js` file. This helps the developer discover the option.