### PR TITLE
Fix docs when generating with --adapter=cowboy

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -188,7 +188,7 @@ defmodule Phx.New.Generator do
     {adapter_app, adapter_module, adapter_config} =
       get_ecto_adapter(db, String.downcase(project.app), project.app_mod)
 
-    {web_adapter_app, web_adapter_vsn, web_adapter_module} = get_web_adapter(web_adapter)
+    {web_adapter_app, web_adapter_vsn, web_adapter_module, web_adapter_docs} = get_web_adapter(web_adapter)
 
     pubsub_server = get_pubsub_server(project.app_mod)
 
@@ -235,6 +235,7 @@ defmodule Phx.New.Generator do
       web_adapter_app: web_adapter_app,
       web_adapter_module: web_adapter_module,
       web_adapter_vsn: web_adapter_vsn,
+      web_adapter_docs: web_adapter_docs,
       generators: nil_if_empty(project.generators ++ adapter_generators(adapter_config)),
       namespaced?: namespaced?(project),
       dev: dev
@@ -303,8 +304,8 @@ defmodule Phx.New.Generator do
     Mix.raise("Unknown database #{inspect(db)}")
   end
 
-  defp get_web_adapter("cowboy"), do: {:plug_cowboy, "~> 2.7", Phoenix.Endpoint.Cowboy2Adapter}
-  defp get_web_adapter("bandit"), do: {:bandit, "~> 1.2", Bandit.PhoenixAdapter}
+  defp get_web_adapter("cowboy"), do: {:plug_cowboy, "~> 2.7", Phoenix.Endpoint.Cowboy2Adapter, "https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html"}
+  defp get_web_adapter("bandit"), do: {:bandit, "~> 1.2", Bandit.PhoenixAdapter, "https://hexdocs.pm/bandit/Bandit.html#t:options/0"}
   defp get_web_adapter(other), do: Mix.raise("Unknown web adapter #{inspect(other)}")
 
   defp fs_db_config(app, module) do

--- a/installer/templates/phx_single/config/runtime.exs
+++ b/installer/templates/phx_single/config/runtime.exs
@@ -43,7 +43,7 @@ if config_env() == :prod do
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
-      # See the documentation on https://hexdocs.pm/bandit/Bandit.html#t:options/0
+      # See the documentation on <%= @web_adapter_docs %>
       # for details about using IPv6 vs IPv4 and loopback vs public addresses.
       ip: {0, 0, 0, 0, 0, 0, 0, 0},
       port: port


### PR DESCRIPTION
Fixes the endpoint config comment when generating a new project with `mix phx.new --adapter=cowboy`. Currently it always links to Bandit.

[diff](https://elixirstream.dev/gendiff/phx_new/4D359BC0A7DA7B6C0E8C41FCA9D6F904#68944278--61) for `VERSION=1.7.10 phx.new my_app` x `VERSION=1.7.11 phx.new my_app --adapter=cowboy`
