### PR TITLE
Replace Path.dirname(__ENV__.file) with __DIR__ in SQLite config

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -310,13 +310,13 @@ defmodule Phx.New.Generator do
   defp fs_db_config(app, module) do
     [
       dev: [
-        database: {:literal, ~s|Path.expand("../#{app}_dev.db", Path.dirname(__ENV__.file))|},
+        database: {:literal, ~s|Path.expand("../#{app}_dev.db", __DIR__)|},
         pool_size: 5,
         stacktrace: true,
         show_sensitive_data_on_connection_error: true
       ],
       test: [
-        database: {:literal, ~s|Path.expand("../#{app}_test.db", Path.dirname(__ENV__.file))|},
+        database: {:literal, ~s|Path.expand("../#{app}_test.db", __DIR__)|},
         pool_size: 5,
         pool: Ecto.Adapters.SQL.Sandbox
       ],


### PR DESCRIPTION
Use the frequently seen shortcut for new apps.