### PR TITLE
Add default argument to changeset generator in schema

### DIFF
--- a/priv/templates/phx.gen.schema/schema.ex
+++ b/priv/templates/phx.gen.schema/schema.ex
@@ -13,7 +13,7 @@ defmodule <%= inspect schema.module %> do
   end
 
   @doc false
-  def changeset(<%= schema.singular %>, attrs) do
+  def changeset(<%= schema.singular %>, attrs \\ %{}) do
     <%= schema.singular %>
     |> cast(attrs, [<%= Enum.map_join(schema.attrs, ", ", &inspect(elem(&1, 0))) %>])
     |> validate_required([<%= Enum.map_join(Mix.Phoenix.Schema.required_fields(schema), ", ", &inspect(elem(&1, 0))) %>])


### PR DESCRIPTION
Just a little proposal: I have seen this pattern a lot working with Phoenix and I think it's a better default, but if there's a great reason not to do it let me know. I think the default generators should really produce changesets with a default `%{}` parameter for the attrs parameter.