### PR TITLE
Use `get_env/3` rather than `fetch_env!/2` in conditional check

### DIFF
--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -18,7 +18,7 @@ defmodule Phoenix do
       :erlang.system_flag(:backtrace_depth, stacktrace_depth)
     end
 
-    if Application.fetch_env!(:phoenix, :logger) do
+    if Application.get_env(:phoenix, :logger) do
       Phoenix.Logger.install()
     end
 


### PR DESCRIPTION
[`Application.fetch_env!/2`](https://hexdocs.pm/elixir/1.16.1/Application.html#fetch_env!/2) will raise if the key is not found, crashing the Phoenix application. By using [`Application.get_env/3`](https://hexdocs.pm/elixir/1.16.1/Application.html#get_env/3) instead, this conditional check works as intended, calling `Phoenix.Logger.install()` only when the logger is configured and the value of the configuration is truthy.


## Context

While reading the phoenix source code, I noticed what I _think_ is a (harmless) error in `Phoenix.start/2`. We're checking for the value of the `:logger` configuration in an `if` conditional, but we're getting the value by calling `Application.fetch_env!/2`, which raises if the value is not found. It looks like we should be using `Application.get_env/3` instead, which returns `nil` in case the value is not found.

Now, it's possible that I've misread this situation, and we expect `:logger` configuration to always be present, in which case we don't need this change 😄 