### PR TITLE
Fix bug regarding token deletions upon successful password resets

### DIFF
--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -335,7 +335,7 @@
   def reset_<%= schema.singular %>_password(<%= schema.singular %>, attrs) do
     Ecto.Multi.new()
     |> Ecto.Multi.update(:<%= schema.singular %>, <%= inspect schema.alias %>.password_changeset(<%= schema.singular %>, attrs))
-    |> Ecto.Multi.delete_all(:tokens, <%= inspect schema.alias %>Token.by_<%= schema.singular %>_and_contexts_query(<%= schema.singular %>, :all))
+    |> Ecto.Multi.delete_all(:tokens, <%= inspect schema.alias %>Token.by_<%= schema.singular %>_and_contexts_query(<%= schema.singular %>, ["reset_password"]))
     |> Repo.transaction()
     |> case do
       {:ok, %{<%= schema.singular %>: <%= schema.singular %>}} -> {:ok, <%= schema.singular %>}


### PR DESCRIPTION
In the default authentication system created by the `mix phx.gen.auth`, when a password has been successfully reset, it deletes all of the tokens regardless of their context, however, this is problematic in the following scenario:

- A user has been registered, which creates a token with the `confirm` context and account confirmation instructions delivered via email.
- The user has not clicked on the confirmation email message yet.
- The user requests password reset instructions and gets them via email.
- The user successfully follows the password reset instructions.
- The user tries to click on the confirmation email, but it is no longer valid.

By scoping the deletion to only `reset_password` tokens, the bug is gone and the `confirm` token will still be valid regardless of the abovementioned process.