### PR TITLE
Prevent session fixation attack (phx.gen.auth + CSRF)

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -60,6 +60,8 @@ defmodule <%= inspect auth_module %> do
   #     end
   #
   defp renew_session(conn) do
+    delete_csrf_token()
+
     conn
     |> configure_session(renew: true)
     |> clear_session()


### PR DESCRIPTION
Plug.CSRFProtection [docs](https://hexdocs.pm/plug/Plug.CSRFProtection.html):
> we recommend developers to invoke delete_csrf_token/0 every time after they log a user in, to avoid CSRF fixation attacks.

I'm curious as to why that advice is not implemented in the `phx.gen.auth` templates.

There probably is a good reason I'm missing. If so, add that reason to the documentation?

Further reading:
https://hexdocs.pm/plug/Plug.CSRFProtection.html
https://security.stackexchange.com/a/22936
https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html