### PR TITLE
Correctly describe Head Plug

### DIFF
--- a/guides/plug.md
+++ b/guides/plug.md
@@ -156,7 +156,7 @@ The default endpoint plugs do quite a lot of work. Here they are in order:
 
 - `Plug.MethodOverride` - converts the request method to PUT, PATCH or DELETE for POST requests with a valid `_method` parameter.
 
-- `Plug.Head` - converts HEAD requests to GET requests and strips the response body.
+- `Plug.Head` - converts HEAD requests to GET requests.
 
 - `Plug.Session` - a plug that sets up session management. Note that `fetch_session/2` must still be explicitly called before using the session, as this plug just sets up how the session is fetched.
 


### PR DESCRIPTION
The [Head Plug](https://github.com/elixir-plug/plug/blob/85f03493afd78441b1ee2692b198641ccbee6bdc/lib/plug/head.ex#L18) doesn't strip the body from the response, it just converts `HEAD` requests to `GET` requests.