### PR TITLE
change bracket syntax to Map.get function

### DIFF
--- a/guides/contexts.md
+++ b/guides/contexts.md
@@ -471,7 +471,10 @@ With our schema associations set up, we can implement the selection of categorie
 
   def change_product(%Product{} = product, attrs \\ %{}) do
 -   Product.changeset(product, attrs)
-+   categories = list_categories_by_id(attrs["category_ids"])
++    categories =
++      attrs
++      |> Map.get(:category_ids)
++      |> list_categories_by_id()
 
 +   product
 +   |> Repo.preload(:categories)


### PR DESCRIPTION
The use of the bracket syntax to access the list of category ids was not collecting the data correctly. After changing the bracket syntax to use the Map.get function, the error was resolved.