### PR TITLE
Fix CSS transition duration in generators

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -605,7 +605,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     JS.show(js,
       to: selector,
       transition:
-        {"transition-all transform ease-out duration-300",
+        {"transition-all transform ease-out duration-200",
          "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95",
          "opacity-100 translate-y-0 sm:scale-100"}
     )
@@ -614,7 +614,6 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def hide(js \\ %JS{}, selector) do
     JS.hide(js,
       to: selector,
-      time: 200,
       transition:
         {"transition-all transform ease-in duration-200",
          "opacity-100 translate-y-0 sm:scale-100",
@@ -627,7 +626,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     |> JS.show(to: "##{id}")
     |> JS.show(
       to: "##{id}-bg",
-      transition: {"transition-all transform ease-out duration-300", "opacity-0", "opacity-100"}
+      transition: {"transition-all transform ease-out duration-200", "opacity-0", "opacity-100"}
     )
     |> show("##{id}-container")
     |> JS.add_class("overflow-hidden", to: "body")

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -605,7 +605,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     JS.show(js,
       to: selector,
       transition:
-        {"transition-all transform ease-out duration-300",
+        {"transition-all transform ease-out duration-200",
          "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95",
          "opacity-100 translate-y-0 sm:scale-100"}
     )
@@ -614,7 +614,6 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def hide(js \\ %JS{}, selector) do
     JS.hide(js,
       to: selector,
-      time: 200,
       transition:
         {"transition-all transform ease-in duration-200",
          "opacity-100 translate-y-0 sm:scale-100",
@@ -627,7 +626,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     |> JS.show(to: "##{id}")
     |> JS.show(
       to: "##{id}-bg",
-      transition: {"transition-all transform ease-out duration-300", "opacity-0", "opacity-100"}
+      transition: {"transition-all transform ease-out duration-200", "opacity-0", "opacity-100"}
     )
     |> show("##{id}-container")
     |> JS.add_class("overflow-hidden", to: "body")


### PR DESCRIPTION
The value of the Tailwind CSS transition duration class should match the value of the `:time` option passed to [`Phoenix.LiveView.JS.show/1`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.JS.html#show/1) and [`Phoenix.LiveView.JS.hide/1`](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.JS.html#hide/1).

This PR fixes cases where the Tailwind `duration-300` class was used when the `:time` option was left at the default of `200`.