### PR TITLE
remove `view` from doc

### DIFF
--- a/installer/templates/phx_single/lib/app_name_web.ex
+++ b/installer/templates/phx_single/lib/app_name_web.ex
@@ -105,7 +105,7 @@ defmodule <%= @web_namespace %> do
   end
 
   @doc """
-  When used, dispatch to the appropriate controller/view/etc.
+  When used, dispatch to the appropriate controller/live_view/etc.
   """
   defmacro __using__(which) when is_atom(which) do
     apply(__MODULE__, which, [])


### PR DESCRIPTION
As "view" mentions have been removed from the `moduledoc` and were replaced by "component" I thought it might make sense to remove it from `__using__` doc as well.