### PR TITLE
Add link to the "Writing a Channels Client" how-to guide

### DIFF
--- a/guides/real_time/channels.md
+++ b/guides/real_time/channels.md
@@ -165,7 +165,7 @@ If your deployment environment does not support distributed Elixir or direct com
 ### Client Libraries
 
 Any networked device can connect to Phoenix Channels as long as it has a client library.
-The following libraries exist today, and new ones are always welcome; to write your own, see our how-to guide [Writing a Channels Client](https://hexdocs.pm/phoenix/writing_a_channels_client.html).
+The following libraries exist today, and new ones are always welcome; to write your own, see our how-to guide [Writing a Channels Client](writing_a_channels_client.md).
 
 #### Official
 

--- a/guides/real_time/channels.md
+++ b/guides/real_time/channels.md
@@ -165,7 +165,7 @@ If your deployment environment does not support distributed Elixir or direct com
 ### Client Libraries
 
 Any networked device can connect to Phoenix Channels as long as it has a client library.
-The following libraries exist today, and new ones are always welcome; to write your own, see our how-to guide "Writing a Channels Client".
+The following libraries exist today, and new ones are always welcome; to write your own, see our how-to guide [Writing a Channels Client](https://hexdocs.pm/phoenix/writing_a_channels_client.html).
 
 #### Official
 


### PR DESCRIPTION
Reading about Phoenix channels and wondering about client libraries, I was reading the [Client Libraries](https://hexdocs.pm/phoenix/channels.html#client-libraries) section and saw the mention of the [Writing a Channels Client](https://hexdocs.pm/phoenix/writing_a_channels_client.html#content) how-to guide, so I thought it would be useful to directly link to that guide.