### PR TITLE
Update comment in socket.ex

### DIFF
--- a/priv/templates/phx.gen.socket/socket.ex
+++ b/priv/templates/phx.gen.socket/socket.ex
@@ -42,7 +42,7 @@ defmodule <%= module %>Socket do
     {:ok, socket}
   end
 
-  # Socket id's are topics that allow you to identify all sockets for a given user:
+  # Socket IDs are topics that allow you to identify all sockets for a given user:
   #
   #     def id(socket), do: "user_socket:#{socket.assigns.user_id}"
   #


### PR DESCRIPTION
Very small docs correction. Saw it as I was reading the docs myself. Incorrect use of possessive as plural. I picked upcase for acronym "ID". Downcase would be fine too.