### PR TITLE
Extending phx.gen.* functions to support custom generation type handlers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# Intellij
+.idea/
+installer/phx_new.iml
+installer/templates/phx_single/phx_single.iml
+installer/templates/phx_umbrella/apps/app_name/app_name.iml
+installer/templates/phx_umbrella/apps/app_name_web/app_name_web.iml
+installer/templates/phx_umbrella/phx_umbrella.iml
+integration_test/phoenix_integration.iml
+phoenix.iml
+
 /_build/
 /deps/
 /doc/

--- a/lib/mix/phoenix/custom_generator_behavior.ex
+++ b/lib/mix/phoenix/custom_generator_behavior.ex
@@ -1,0 +1,82 @@
+defmodule Mix.Phoenix.CustomGeneratorBehaviour do
+  @moduledoc """
+  This module defines the behavior for custom generators.
+  Implement modules that implement this behavior and use with mix phx.gen.live,phx.gen.schema,phx.gen.context to
+  extend default generators with project specific types and form components.
+
+  For example if using a postgres user type enums you can use type_for_migration/1 to return the user type as an atom and
+  type_and_opts_for_schema/1 to return an Ecto.Enum, values: [] string
+  by implementing a custom generator along the lines of MyProject.CustomEnumGenerator passed to mix phx.gen.schema as
+  "field:MyProject.CustomEnumGenerator:custom_user_type:list:of:allowed:values"
+  """
+
+  @doc """
+  Unpack custom generator and it's options.
+  Return {key, {:custom, __MODULE__, unpacked_options | nil}}
+  """
+  @callback validate_attr!(attrs :: tuple) :: {name :: atom, {:custom, provider :: atom, opts :: any}} | {term, term}
+
+  @doc """
+  return the string that will be used to populate schema field e.g. a string like "Ecto.Enum, values: [:a,:b,:c]"
+  """
+  @callback type_and_opts_for_schema(attrs :: any) :: String.t()
+
+  @doc """
+  return the ecto migration field type term. e.g. {:enum, [:a,:b,:c]}
+  """
+  @callback type_for_migration(opts :: any) :: term
+
+  @doc """
+  return the default value for the field type used by live view and ecto tests.
+  """
+  @callback type_to_default(key :: atom, opts :: any, action :: atom) :: any
+
+  @doc """
+  return the input/live component used to display this custom field type in a live view form.
+  """
+  @callback live_form_input(key :: atom, opts :: any) :: String.t() | nil
+
+  @doc """
+  used for unpacking a complex type that requires serialization from one or more form params.
+  For example if your live_form_input routes to a live component that uses a hidden input field containing json that needs
+  to be unpacked before passing to the module's changeset.
+  return params if no special processing required.
+  """
+  @callback hydrate_form_input(key :: atom, params :: Map.t, opts :: any) :: Map.t
+
+
+  @doc """
+  Pass to behavior provider. @see validate_attr!/1
+  """
+  def validate_attr!(provider, attrs) do
+    apply(provider, :validate_attr!, [attrs])
+  end
+
+  @doc """
+  Pass to behavior provider. @see type_and_opts_for_schema/1
+  """
+  def type_and_opts_for_schema(provider, opts) do
+    apply(provider, :type_and_opts_for_schema, [opts])
+  end
+
+  @doc """
+  Pass to behavior provider. @see type_for_migration/1
+  """
+  def type_for_migration(provider, opts) do
+    apply(provider, :type_for_migration, [opts])
+  end
+
+  @doc """
+  Pass to behavior provider. @see `type_to_default/3`
+  """
+  def type_to_default(provider, key, opts, action) do
+    apply(provider, :type_to_default, [key, opts, action])
+  end
+
+  @doc """
+  Pass to behavior provider. @see live_form_input/2
+  """
+  def live_form_input(provider, key, opts) do
+    apply(provider, :live_form_input, [key, opts])
+  end
+end

--- a/lib/mix/tasks/phx.gen.live.ex
+++ b/lib/mix/tasks/phx.gen.live.ex
@@ -326,9 +326,12 @@ defmodule Mix.Tasks.Phx.Gen.Live do
         />
         """
 
+      {key, {:custom, provider, opts}} ->
+        Mix.Phoenix.CustomGeneratorBehaviour.live_form_input(provider, key, opts)
+
       {key, _} ->
         ~s(<.input field={@form[#{inspect(key)}]} type="text" label="#{label(key)}" />)
-    end)
+    end) |> Enum.reject(&is_nil/1)
   end
 
   defp default_options({:array, :string}),

--- a/priv/templates/phx.gen.live/form_component.ex
+++ b/priv/templates/phx.gen.live/form_component.ex
@@ -40,6 +40,18 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   @impl true
   def handle_event("validate", %{"<%= schema.singular %>" => <%= schema.singular %>_params}, socket) do
+    <%=
+    Enum.filter(schema.types,
+        fn
+          {_, {:custom, _, _}} -> true
+          _ -> false
+        end)
+    |> Enum.map_join("\n    ",
+        fn
+           {key, {:custom, provider, opts}} ->
+                   "#{ schema.singular }_params = #{inspect provider}.hydrate_form_input(#{inspect key}, #{ schema.singular }_params, #{inspect opts, limit: :infinity})"
+        end)
+    %>
     changeset =
       socket.assigns.<%= schema.singular %>
       |> <%= inspect context.alias %>.change_<%= schema.singular %>(<%= schema.singular %>_params)
@@ -49,6 +61,18 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def handle_event("save", %{"<%= schema.singular %>" => <%= schema.singular %>_params}, socket) do
+    <%=
+    Enum.filter(schema.types,
+        fn
+          {_, {:custom, _, _}} -> true
+          _ -> false
+        end)
+    |> Enum.map_join("\n    ",
+        fn
+           {key, {:custom, provider, opts}} ->
+                   "#{ schema.singular }_params = #{inspect provider}.hydrate_form_input(#{inspect key}, #{ schema.singular }_params, #{inspect opts, limit: :infinity})"
+        end)
+    %>
     save_<%= schema.singular %>(socket, socket.assigns.action, <%= schema.singular %>_params)
   end
 


### PR DESCRIPTION
Custom generators provide an appropriate migration field type, schema field type, live view form input and input hydration hooks. This allows projects to build out custom/house type live view form input handlers and use of engine specific type mapping such as postgres user types, jsonb, etc. without the need to manually edit generated live views.