### PR TITLE
Allow running phx.digest task multiple times

### DIFF
--- a/lib/mix/tasks/phx.digest.ex
+++ b/lib/mix/tasks/phx.digest.ex
@@ -49,6 +49,8 @@ defmodule Mix.Tasks.Phx.Digest do
   def run(all_args) do
     # Ensure all compressors are compiled.
     Mix.Task.run "compile", all_args
+    Mix.Task.reenable("phx.digest")
+
     {:ok, _} = Application.ensure_all_started(:phoenix)
 
     {opts, args, _} = OptionParser.parse(all_args, switches: @switches, aliases: [o: :output])

--- a/lib/mix/tasks/phx.digest.ex
+++ b/lib/mix/tasks/phx.digest.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Phx.Digest do
   @doc false
   def run(all_args) do
     # Ensure all compressors are compiled.
-    Mix.Task.run "compile", all_args
+    Mix.Task.run("compile", all_args)
     Mix.Task.reenable("phx.digest")
 
     {:ok, _} = Application.ensure_all_started(:phoenix)


### PR DESCRIPTION
Reenable phx.digest task to allow running the task with different arguments for different assets  paths.

Fixes #5752