### PR TITLE
Use logo asset in umbrella generator

### DIFF
--- a/installer/lib/phx_new/web.ex
+++ b/installer/lib/phx_new/web.ex
@@ -53,7 +53,8 @@ defmodule Phx.New.Web do
      "phx_test/controllers/error_html_test.exs": "test/:web_app/controllers/error_html_test.exs",
      "phx_assets/topbar.js": "assets/vendor/topbar.js",
      "phx_web/components/layouts/root.html.heex": "lib/:web_app/components/layouts/root.html.heex",
-     "phx_web/components/layouts/app.html.heex": "lib/:web_app/components/layouts/app.html.heex"}
+     "phx_web/components/layouts/app.html.heex": "lib/:web_app/components/layouts/app.html.heex"},
+    {:eex, :web, "phx_assets/logo.svg": "priv/static/images/logo.svg"}
   ])
 
   def prepare_project(%Project{app: app} = project) when not is_nil(app) do


### PR DESCRIPTION
This PR includes `logo.svg` into umbrella project generator. 

#### Motivation
This file is currently properly included in "single" projects, thanks to https://github.com/phoenixframework/phoenix/commit/5a01f103371199d60f85c86860e897a7e4dab36b, but is missing in umbrella projects.

![2024-03-24-145837_943x278_scrot](https://github.com/phoenixframework/phoenix/assets/1687851/cb192c2d-e2b5-4aa9-8197-4950328bc154)
