### PR TITLE
Changelog: pluralize "Deprecations" for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ future styling).
   * Support new `longPollFallbackMs` option to auto fallback when websocket fails to connect
   * Support new `debug` option to enable verbose logging
 
-### Deprecation
+### Deprecations
   * Deprecate the `c:init/2` callback in endpoints in favor of `config/runtime.exs` or in favor of `{Phoenix.Endpoint, options}`
 
 ## 1.7.10 (2023-11-03)


### PR DESCRIPTION
While searching the docs for information on the deprecation warning, I didn't at first find this deprecation as I was grepping for `Deprecations`, and so only saw the 1.7.0-rc deprecation.