### PR TITLE
Add ability to customize the primary key name

### DIFF
--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -89,7 +89,8 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     merge_with_existing_context: :boolean,
     prefix: :string,
     live: :boolean,
-    compile: :boolean
+    compile: :boolean,
+    primary_key: :string
   ]
 
   @default_opts [schema: true, context: true]

--- a/lib/mix/tasks/phx.gen.schema.ex
+++ b/lib/mix/tasks/phx.gen.schema.ex
@@ -86,6 +86,13 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   Generated migration can use `binary_id` for schema's primary key
   and its references with option `--binary-id`.
 
+  ## primary_key
+
+  By default, the primary key in the table is called `id`. This option
+  allows to change the name of the primary key column. For example:
+
+      $ mix phx.gen.schema Blog.post posts --primary-key post_id
+
   ## repo
 
   Generated migration can use `repo` to set the migration repository
@@ -146,7 +153,8 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   alias Mix.Phoenix.Schema
 
   @switches [migration: :boolean, binary_id: :boolean, table: :string, web: :string,
-    context_app: :string, prefix: :string, repo: :string, migration_dir: :string]
+    context_app: :string, prefix: :string, repo: :string, migration_dir: :string,
+    primary_key: :string]
 
   @doc false
   def run(args) do

--- a/priv/templates/phx.gen.context/test_cases.exs
+++ b/priv/templates/phx.gen.context/test_cases.exs
@@ -13,7 +13,7 @@
 
     test "get_<%= schema.singular %>!/1 returns the <%= schema.singular %> with given id" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
-      assert <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id) == <%= schema.singular %>
+      assert <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>) == <%= schema.singular %>
     end
 
     test "create_<%= schema.singular %>/1 with valid data creates a <%= schema.singular %>" do
@@ -38,13 +38,13 @@
     test "update_<%= schema.singular %>/2 with invalid data returns error changeset" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
       assert {:error, %Ecto.Changeset{}} = <%= inspect context.alias %>.update_<%= schema.singular %>(<%= schema.singular %>, @invalid_attrs)
-      assert <%= schema.singular %> == <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id)
+      assert <%= schema.singular %> == <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>)
     end
 
     test "delete_<%= schema.singular %>/1 deletes the <%= schema.singular %>" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
       assert {:ok, %<%= inspect schema.alias %>{}} = <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>)
-      assert_raise Ecto.NoResultsError, fn -> <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id) end
+      assert_raise Ecto.NoResultsError, fn -> <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>) end
     end
 
     test "change_<%= schema.singular %>/1 returns a <%= schema.singular %> changeset" do

--- a/priv/templates/phx.gen.live/index.ex
+++ b/priv/templates/phx.gen.live/index.ex
@@ -5,8 +5,13 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   alias <%= inspect schema.module %>
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(_params, _session, socket) do<%= if schema.opts[:primary_key] do %>
+    {:ok,
+     socket
+     |> stream_configure(:<%= schema.collection %>, dom_id: &"<%= schema.table %>-#{&1.<%= schema.opts[:primary_key] %>}")
+     |> stream(:<%= schema.collection %>, <%= inspect context.alias %>.list_<%= schema.plural %>())}<% else %>
     {:ok, stream(socket, :<%= schema.collection %>, <%= inspect context.alias %>.list_<%= schema.plural %>())}
+<% end %>
   end
 
   @impl true

--- a/priv/templates/phx.gen.live/index.html.heex
+++ b/priv/templates/phx.gen.live/index.html.heex
@@ -21,7 +21,7 @@
   </:action>
   <:action :let={{id, <%= schema.singular %>}}>
     <.link
-      phx-click={JS.push("delete", value: %{id: <%= schema.singular %>.id}) |> hide("##{id}")}
+      phx-click={JS.push("delete", value: %{id: <%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>}) |> hide("##{id}")}
       data-confirm="Are you sure?"
     >
       Delete
@@ -32,7 +32,7 @@
 <.modal :if={@live_action in [:new, :edit]} id="<%= schema.singular %>-modal" show on_cancel={JS.patch(~p"<%= schema.route_prefix %>")}>
   <.live_component
     module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
-    id={@<%= schema.singular %>.id || :new}
+    id={@<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %> || :new}
     title={@page_title}
     action={@live_action}
     <%= schema.singular %>={@<%= schema.singular %>}

--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -49,7 +49,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     test "updates <%= schema.singular %> in listing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       {:ok, index_live, _html} = live(conn, ~p"<%= schema.route_prefix %>")
 
-      assert index_live |> element("#<%= schema.plural %>-#{<%= schema.singular %>.id} a", "Edit") |> render_click() =~
+      assert index_live |> element("#<%= schema.plural %>-#{<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>} a", "Edit") |> render_click() =~
                "Edit <%= schema.human_singular %>"
 
       assert_patch(index_live, ~p"<%= schema.route_prefix %>/#{<%= schema.singular %>}/edit")
@@ -72,8 +72,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     test "deletes <%= schema.singular %> in listing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       {:ok, index_live, _html} = live(conn, ~p"<%= schema.route_prefix %>")
 
-      assert index_live |> element("#<%= schema.plural %>-#{<%= schema.singular %>.id} a", "Delete") |> render_click()
-      refute has_element?(index_live, "#<%= schema.plural %>-#{<%= schema.singular %>.id}")
+      assert index_live |> element("#<%= schema.plural %>-#{<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>} a", "Delete") |> render_click()
+      refute has_element?(index_live, "#<%= schema.plural %>-#{<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>}")
     end
   end
 

--- a/priv/templates/phx.gen.live/show.html.heex
+++ b/priv/templates/phx.gen.live/show.html.heex
@@ -1,5 +1,5 @@
 <.header>
-  <%= schema.human_singular %> <%%= @<%= schema.singular %>.id %>
+  <%= schema.human_singular %> <%%= @<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %> %>
   <:subtitle>This is a <%= schema.singular %> record from your database.</:subtitle>
   <:actions>
     <.link patch={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/show/edit"} phx-click={JS.push_focus()}>
@@ -17,7 +17,7 @@
 <.modal :if={@live_action == :edit} id="<%= schema.singular %>-modal" show on_cancel={JS.patch(~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}")}>
   <.live_component
     module={<%= inspect context.web_module %>.<%= inspect Module.concat(schema.web_namespace, schema.alias) %>Live.FormComponent}
-    id={@<%= schema.singular %>.id}
+    id={@<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>}
     title={@page_title}
     action={@live_action}
     <%= schema.singular %>={@<%= schema.singular %>}

--- a/priv/templates/phx.gen.schema/migration.exs
+++ b/priv/templates/phx.gen.schema/migration.exs
@@ -2,9 +2,10 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.
   use <%= inspect schema.migration_module %>
 
   def change do
-    create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %><%= if schema.prefix do %>, prefix: :<%= schema.prefix %><% end %>) do
+    create table(:<%= schema.table %><%= if schema.binary_id || schema.opts[:primary_key] do %>, primary_key: false<% end %><%= if schema.prefix do %>, prefix: :<%= schema.prefix %><% end %>) do
 <%= if schema.binary_id do %>      add :<%= schema.opts[:primary_key] || :id %>, :binary_id, primary_key: true
-<% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect Mix.Phoenix.Schema.type_for_migration(v) %><%= schema.migration_defaults[k] %>
+<% else %><%= if schema.opts[:primary_key] do %>      add :<%= schema.opts[:primary_key] %>, :id, primary_key: true
+<% end %><% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect Mix.Phoenix.Schema.type_for_migration(v) %><%= schema.migration_defaults[k] %>
 <% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= inspect(i) %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)
 <% end %>
       timestamps(<%= if schema.timestamp_type != :naive_datetime, do: "type: #{inspect schema.timestamp_type}" %>)

--- a/priv/templates/phx.gen.schema/migration.exs
+++ b/priv/templates/phx.gen.schema/migration.exs
@@ -3,7 +3,7 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.
 
   def change do
     create table(:<%= schema.table %><%= if schema.binary_id do %>, primary_key: false<% end %><%= if schema.prefix do %>, prefix: :<%= schema.prefix %><% end %>) do
-<%= if schema.binary_id do %>      add :id, :binary_id, primary_key: true
+<%= if schema.binary_id do %>      add :<%= schema.opts[:primary_key] || :id %>, :binary_id, primary_key: true
 <% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect Mix.Phoenix.Schema.type_for_migration(v) %><%= schema.migration_defaults[k] %>
 <% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= inspect(i) %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)
 <% end %>

--- a/priv/templates/phx.gen.schema/schema.ex
+++ b/priv/templates/phx.gen.schema/schema.ex
@@ -5,7 +5,9 @@ defmodule <%= inspect schema.module %> do
   @schema_prefix :<%= schema.prefix %><% end %><%= if schema.opts[:primary_key] do %>
   @derive {Phoenix.Param, key: :<%= schema.opts[:primary_key] %>}<% end %><%= if schema.binary_id do %>
   @primary_key {:<%= schema.opts[:primary_key] || :id %>, :binary_id, autogenerate: true}
-  @foreign_key_type :binary_id<% end %>
+  @foreign_key_type :binary_id<% else %><%= if schema.opts[:primary_key] do %>
+  @primary_key {:<%= schema.opts[:primary_key] %>, :id, autogenerate: true}
+  <% end %><% end %>
   schema <%= inspect schema.table %> do
 <%= Mix.Phoenix.Schema.format_fields_for_schema(schema) %>
 <%= for {_, k, _, _} <- schema.assocs do %>    field <%= inspect k %>, <%= if schema.binary_id do %>:binary_id<% else %>:id<% end %>

--- a/priv/templates/phx.gen.schema/schema.ex
+++ b/priv/templates/phx.gen.schema/schema.ex
@@ -2,8 +2,9 @@ defmodule <%= inspect schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
 <%= if schema.prefix do %>
-  @schema_prefix :<%= schema.prefix %><% end %><%= if schema.binary_id do %>
-  @primary_key {:id, :binary_id, autogenerate: true}
+  @schema_prefix :<%= schema.prefix %><% end %><%= if schema.opts[:primary_key] do %>
+  @derive {Phoenix.Param, key: :<%= schema.opts[:primary_key] %>}<% end %><%= if schema.binary_id do %>
+  @primary_key {:<%= schema.opts[:primary_key] || :id %>, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id<% end %>
   schema <%= inspect schema.table %> do
 <%= Mix.Phoenix.Schema.format_fields_for_schema(schema) %>


### PR DESCRIPTION
This change allows to use a custom primary key field name in projects where the `id` is [not a conventional option](https://github.com/jarulraj/sqlcheck/blob/master/docs/logical/1004.md).

## Example
```
$ mix phx.gen.live Schema User user name:string:unique --table user --binary-id --primary-key user_id
```