### PR TITLE
Fix phx.gen.socket moduledoc grammar and example path

### DIFF
--- a/lib/mix/tasks/phx.gen.socket.ex
+++ b/lib/mix/tasks/phx.gen.socket.ex
@@ -18,7 +18,7 @@ defmodule Mix.Tasks.Phx.Gen.Socket do
   For an umbrella application:
 
     * a client in `apps/my_app_web/assets/js`
-    * a socket in `apps/my_app_web/lib/app_name_web/channels`
+    * a socket in `apps/my_app_web/lib/my_app_web/channels`
 
   You can then generate channels with `mix phx.gen.channel`.
   """


### PR DESCRIPTION
Hi there.

This fixes some small grammar inconsistencies, as well as the path for the umbrella app example.