### PR TITLE
replace deprecated live_flash for Phoenix.Flash.get in phx.gen.auth

### DIFF
--- a/priv/templates/phx.gen.auth/login_live.ex
+++ b/priv/templates/phx.gen.auth/login_live.ex
@@ -36,7 +36,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
   end
 
   def mount(_params, _session, socket) do
-    email = live_flash(socket.assigns.flash, :email)
+    email = Phoenix.Flash.get(socket.assigns.flash, :email)
     form = to_form(%{"email" => email}, as: "<%= schema.singular %>")
     {:ok, assign(socket, form: form), temporary_assigns: [form: form]}
   end


### PR DESCRIPTION
The [Phoenix docs say](https://hexdocs.pm/phoenix_live_view/0.20.12/Phoenix.Component.html#live_flash/2):
> `live_flash(other, key)`
> This function is deprecated. Use Phoenix.Flash.get/2 in Phoenix v1.7+. 

But the live_flash is still being used on generated auth, this PR fixes it.
I didn't find any other place that uses the `live_flash/2`.

Thanks!