### PR TITLE
Remove unnecessary control-flow from registration_live.ex

### DIFF
--- a/priv/templates/phx.gen.auth/registration_live.ex
+++ b/priv/templates/phx.gen.auth/registration_live.ex
@@ -77,11 +77,6 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   defp assign_form(socket, %Ecto.Changeset{} = changeset) do
     form = to_form(changeset, as: "<%= schema.singular %>")
-
-    if changeset.valid? do
-      assign(socket, form: form, check_errors: false)
-    else
-      assign(socket, form: form)
-    end
+    assign(socket, form: form, check_errors: not changeset.valid?)
   end
 end


### PR DESCRIPTION
It replaces the `if` branches by the `changeset.valid?` boolean.
Just a very small change, please dismiss if you find it less clear.

Also a question, does the `to_form` call right above really needs the `as:` option?

Thanks!