### PR TITLE
Add focus classes to modal core component

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -72,7 +72,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
                 <button
                   phx-click={JS.exec("data-cancel", to: "##{@id}")}
                   type="button"
-                  class="-m-3 flex-none p-3 opacity-20 hover:opacity-40"
+                  class="-m-3 flex-none p-3 opacity-20 hover:opacity-40 focus:opacity-40 focus:outline-none focus:ring-2 focus:ring-zinc-300"
                   aria-label=<%= maybe_heex_attr_gettext.("close", @gettext) %>
                 >
                   <.icon name="hero-x-mark-solid" class="h-5 w-5" />

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -72,7 +72,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
                 <button
                   phx-click={JS.exec("data-cancel", to: "##{@id}")}
                   type="button"
-                  class="-m-3 flex-none p-3 opacity-20 hover:opacity-40"
+                  class="-m-3 flex-none p-3 opacity-20 hover:opacity-40 focus:opacity-40 focus:outline-none focus:ring-2 focus:ring-zinc-300"
                   aria-label=<%= maybe_heex_attr_gettext.("close", @gettext) %>
                 >
                   <.icon name="hero-x-mark-solid" class="h-5 w-5" />


### PR DESCRIPTION
While using some components provided by Phoenix, I've noticed that the modal close button still had browser's default design on focusing. This PR intends to improve that.

Before:
![image](https://github.com/phoenixframework/phoenix/assets/76881129/5d76e783-f6d9-47fd-8507-507ea3fafe85)

After:
![image](https://github.com/phoenixframework/phoenix/assets/76881129/e16e594e-c8db-4d26-8d9b-fccb525f387d)

