### PR TITLE
Generate text data type as textarea

### DIFF
--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   @moduledoc """
   Generates controller with view, templates, schema and context for an HTML resource.
 
-      mix phx.gen.html Accounts User users name:string age:integer
+      mix phx.gen.html Accounts User users name:string age:integer about:text
 
   The first argument, `Accounts`, is the resource's context.
   A context is an Elixir module that serves as an API boundary for closely related resources.
@@ -12,7 +12,8 @@ defmodule Mix.Tasks.Phx.Gen.Html do
   The second argument, `User`, is the resource's schema.
   A schema is an Elixir module responsible for mapping database fields into an Elixir struct.
   The `User` schema above specifies two fields with their respective colon-delimited data types:
-  `name:string` and `age:integer`. See `mix phx.gen.schema` for more information on attributes.
+  `name:string`, `age:integer` and `about:text`. See `mix phx.gen.schema` for more information
+  on attributes.
 
   > Note: A resource may also be split
   > over distinct contexts (such as `Accounts.User` and `Payments.User`).
@@ -198,7 +199,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
         ~s(<.input field={f[#{inspect(key)}]} type="checkbox" label="#{label(key)}" />)
 
       {key, :text} ->
-        ~s(<.input field={f[#{inspect(key)}]} type="text" label="#{label(key)}" />)
+        ~s(<.input field={f[#{inspect(key)}]} type="textarea" label="#{label(key)}" />)
 
       {key, :date} ->
         ~s(<.input field={f[#{inspect(key)}]} type="date" label="#{label(key)}" />)

--- a/lib/mix/tasks/phx.gen.live.ex
+++ b/lib/mix/tasks/phx.gen.live.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Phx.Gen.Live do
   @moduledoc """
   Generates LiveView, templates, and context for a resource.
 
-      mix phx.gen.live Accounts User users name:string age:integer
+      mix phx.gen.live Accounts User users name:string age:integer about:text
 
   The first argument is the context module.  The context is an Elixir module
   that serves as an API boundary for the given resource. A context often holds
@@ -290,7 +290,7 @@ defmodule Mix.Tasks.Phx.Gen.Live do
         ~s(<.input field={@form[#{inspect(key)}]} type="checkbox" label="#{label(key)}" />)
 
       {key, :text} ->
-        ~s(<.input field={@form[#{inspect(key)}]} type="text" label="#{label(key)}" />)
+        ~s(<.input field={@form[#{inspect(key)}]} type="textarea" label="#{label(key)}" />)
 
       {key, :date} ->
         ~s(<.input field={@form[#{inspect(key)}]} type="date" label="#{label(key)}" />)


### PR DESCRIPTION
Currently, `mix phx.gen.html` (and `mix phx.gen.live`) generate a single-line input field even if the user specifies `text` as the data type. For example:

`mix phx.gen.html Blog Post posts title:string body:text`

will generate the following form which is not what most users would expect.

<img width="724" alt="Posts" src="https://github.com/phoenixframework/phoenix/assets/1687/7378d635-56f7-41db-93e5-cbfe37b174ab">

In essence, there is no distinction between `string` and `text` types as far as the generated HTML goes (though, the distinction exists in the generated migration file). 

This small patch allows for fields declared as `text` to be generated as `<textarea>`.

<img width="732" alt="improved-posts" src="https://github.com/phoenixframework/phoenix/assets/1687/f91d81a3-e204-4b3b-ad1f-7d6a37c6bc16">


