### PR TITLE
Clarify log level for Phoenix.Channel

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -335,13 +335,16 @@ defmodule Phoenix.Channel do
   ## Logging
 
   By default, channel `"join"` and `"handle_in"` events are logged, using
-  the level `:info` and `:debug`, respectively. Logs can be customized per
-  event type or disabled by setting the `:log_join` and `:log_handle_in`
-  options when using `Phoenix.Channel`. For example, the following
-  configuration logs join events as `:info`, but disables logging for
+  the level `:info` and `:debug`, respectively. You can change the level used
+  for each event, or disable logs, per event type by setting the `:log_join`
+  and `:log_handle_in` options when using `Phoenix.Channel`. For example, the
+  following configuration logs join events as `:info`, but disables logging for
   incoming events:
 
       use Phoenix.Channel, log_join: :info, log_handle_in: false
+
+  Note that changing an event type's level doesn't affect what is logged,
+  unless you set it to `false`; it affects the associated level.
 
   """
   alias Phoenix.Socket


### PR DESCRIPTION
The previous language wasn't explicit enough that setting the log level changes which level is used, not which logs are emitted — I thought `log_join: :debug` would add additional messages, not make `"join"` events be debug-level.