### PR TITLE
Clarify user message in phx.gen.json

### DIFF
--- a/guides/mix_tasks.md
+++ b/guides/mix_tasks.md
@@ -154,7 +154,7 @@ $ mix phx.gen.json Blog Post posts title:string content:string
 When `mix phx.gen.json` is done creating files, it helpfully tells us that we need to add a line to our router file as well as run our Ecto migrations.
 
 ```console
-Add the resource to your :api scope in lib/hello_web/router.ex:
+Add the resource to the "/api" scope in lib/hello_web/router.ex:
 
     resources "/posts", PostController, except: [:new, :edit]
 

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -171,7 +171,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
     else
       Mix.shell().info("""
 
-      Add the resource to your :api scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
+      Add the resource to "#{Application.get_env(ctx_app, :generators)[:api_prefix] || "/api"}" scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
 
           resources "/#{schema.plural}", #{inspect(schema.alias)}Controller, except: [:new, :edit]
       """)

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -171,7 +171,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
     else
       Mix.shell().info("""
 
-      Add the resource to "#{Application.get_env(ctx_app, :generators)[:api_prefix] || "/api"}" scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
+      Add the resource to the "#{Application.get_env(ctx_app, :generators)[:api_prefix] || "/api"}" scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
 
           resources "/#{schema.plural}", #{inspect(schema.alias)}Controller, except: [:new, :edit]
       """)

--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
                       [
                         """
 
-                        Add the resource to your :api scope in lib/phoenix_web/router.ex:
+                        Add the resource to the "/api" scope in lib/phoenix_web/router.ex:
 
                             resources "/posts", PostController, except: [:new, :edit]
                         """


### PR DESCRIPTION
The statement "Add the resource to your :api scope" is confusing for new-comers.

Users will open the router.ex file, and quickly find a section:
```
  pipeline :api do
    plug :accepts, ["json"]
  end
```
and paste the line into this block.

Experienced phoenix devs will understand that this is a pipeline and not a scope, but these semantics will not be obvious the newby. 

The pull request changes the line to read:
 "Add the resource to "/api" scope" or ( "Add the resource to "/api/v1" scope"  if you have configured the api_endpoint like this)

I was struggling with this, and this user on the forums as well:
https://elixirforum.com/t/can-someone-please-help-me-with-this-basic-api-creation-rubber-ducky-edition/53684/7

