### PR TITLE
Set the default for mailer depending on the value of ecto

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ecto.ex
+++ b/installer/lib/mix/tasks/phx.new.ecto.ex
@@ -59,6 +59,10 @@ defmodule Mix.Tasks.Phx.New.Ecto do
       Mix.raise("The ecto task can only be run within an umbrella's apps directory")
     end
 
-    Mix.Tasks.Phx.New.run(args ++ ["--no-assets", "--ecto"], Phx.New.Ecto, :app_path)
+    Mix.Tasks.Phx.New.run(
+      args ++ ["--no-assets", "--ecto"],
+      Phx.New.Ecto,
+      :app_path
+    )
   end
 end

--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -176,7 +176,7 @@ defmodule Phx.New.Generator do
     assets = Keyword.get(opts, :assets, true)
     esbuild = Keyword.get(opts, :esbuild, assets)
     tailwind = Keyword.get(opts, :tailwind, assets)
-    mailer = Keyword.get(opts, :mailer, true)
+    mailer = Keyword.get(opts, :mailer, !ecto)
     dev = Keyword.get(opts, :dev, false)
     phoenix_path = phoenix_path(project, dev, false)
     phoenix_path_umbrella_root = phoenix_path(project, dev, true)
@@ -188,7 +188,8 @@ defmodule Phx.New.Generator do
     {adapter_app, adapter_module, adapter_config} =
       get_ecto_adapter(db, String.downcase(project.app), project.app_mod)
 
-    {web_adapter_app, web_adapter_vsn, web_adapter_module, web_adapter_docs} = get_web_adapter(web_adapter)
+    {web_adapter_app, web_adapter_vsn, web_adapter_module, web_adapter_docs} =
+      get_web_adapter(web_adapter)
 
     pubsub_server = get_pubsub_server(project.app_mod)
 
@@ -304,8 +305,16 @@ defmodule Phx.New.Generator do
     Mix.raise("Unknown database #{inspect(db)}")
   end
 
-  defp get_web_adapter("cowboy"), do: {:plug_cowboy, "~> 2.7", Phoenix.Endpoint.Cowboy2Adapter, "https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html"}
-  defp get_web_adapter("bandit"), do: {:bandit, "~> 1.2", Bandit.PhoenixAdapter, "https://hexdocs.pm/bandit/Bandit.html#t:options/0"}
+  defp get_web_adapter("cowboy"),
+    do:
+      {:plug_cowboy, "~> 2.7", Phoenix.Endpoint.Cowboy2Adapter,
+       "https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html"}
+
+  defp get_web_adapter("bandit"),
+    do:
+      {:bandit, "~> 1.2", Bandit.PhoenixAdapter,
+       "https://hexdocs.pm/bandit/Bandit.html#t:options/0"}
+
   defp get_web_adapter(other), do: Mix.raise("Unknown web adapter #{inspect(other)}")
 
   defp fs_db_config(app, module) do


### PR DESCRIPTION
Sets the default value for the mailer binding (previously true) to the complement of the value of the ecto binding. That way the mailer gets disabled for Ecto projects by default but it is still possible to enable it using the `--mailer` command line flag. Fixes issue #5786.