### PR TITLE
Persist `remote_ip` during recycling of a conn

### DIFF
--- a/lib/phoenix/test/conn_test.ex
+++ b/lib/phoenix/test/conn_test.ex
@@ -476,6 +476,7 @@ defmodule Phoenix.ConnTest do
   def recycle(conn, headers \\ ~w(accept accept-language authorization)) do
     build_conn()
     |> Map.put(:host, conn.host)
+    |> Map.put(:remote_ip, conn.remote_ip)
     |> Plug.Test.recycle_cookies(conn)
     |> Plug.Test.put_peer_data(Plug.Conn.get_peer_data(conn))
     |> copy_headers(conn.req_headers, headers)

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -180,6 +180,14 @@ defmodule Phoenix.Test.ConnTest do
       assert conn.host == "localhost"
     end
 
+    test "remove_ip is persisted" do
+      conn =
+        %Plug.Conn{build_conn(:get, "http://localhost/", nil) | remote_ip: {192, 168, 0, 1}}
+        |> recycle()
+
+      assert conn.remote_ip == {192, 168, 0, 1}
+    end
+
     test "cookies are persisted" do
       conn =
         build_conn()

--- a/test/phoenix/test/conn_test.exs
+++ b/test/phoenix/test/conn_test.exs
@@ -180,7 +180,7 @@ defmodule Phoenix.Test.ConnTest do
       assert conn.host == "localhost"
     end
 
-    test "remove_ip is persisted" do
+    test "remote_ip is persisted" do
       conn =
         %Plug.Conn{build_conn(:get, "http://localhost/", nil) | remote_ip: {192, 168, 0, 1}}
         |> recycle()


### PR DESCRIPTION
Currently, if you set `remote_ip` during a test when building a conn, calling a `dispatch` call e.g `get` will run the conn through `recycle` which will lose this information. This PR changes that so it is maintained similar to `host`.