### PR TITLE
Re-order doc to better match example

### DIFF
--- a/guides/howto/writing_a_channels_client.md
+++ b/guides/howto/writing_a_channels_client.md
@@ -34,8 +34,8 @@ The general format for messages a client sends to a Phoenix Channel is as follow
 [join_reference, message_reference, topic_name, event_name, payload]
 ```
 
-- The `message_reference` is chosen by the client and should be a unique value. The server includes it in its reply so that the client knows which message the reply is for.
 - The `join_reference` is also chosen by the client and should also be a unique value. It only needs to be sent for a `"phx_join"` event; for other messages it can be `null`. It is used as a message reference for `push` messages from the server, meaning those that are not replies to a specific client message. For example, imagine something like "a new user just joined the chat room".
+- The `message_reference` is chosen by the client and should be a unique value. The server includes it in its reply so that the client knows which message the reply is for.
 - The `topic_name` must be a known topic for the socket endpoint, and a client must join that topic before sending any messages on it.
 - The `event_name` must match the first argument of a `handle_in` function on the server channel module.
 - The `payload` should be a map and is passed as the second argument to that `handle_in` function.


### PR DESCRIPTION
Just a small doc change to reduce confusion. It now matches the order of the list on line 34, which is the expected behavior.  👍 