### PR TITLE
Make it easier to enable new phoenix_live_reload features

### DIFF
--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -41,4 +41,39 @@ import "phoenix_html"
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim()
 <%= @live_comment %>window.liveSocket = liveSocket
+
+// Uncomment the lines below to enable quality of life phoenix_live_reload
+// development features:
+//
+//     1. stream server logs to the browser console
+//     2. click on elements to jump to their definitions in your code editor
+//
+// if (process.env.NODE_ENV === "development") {
+//   window.addEventListener("phx:live_reload:attached", ({detail: reloader}) => {
+//     // Enable server log streaming to client.
+//     // Disable with reloader.disableServerLogs()
+//     reloader.enableServerLogs()
+//
+//     // Open configured PLUG_EDITOR at file:line of the clicked element's HEEx component
+//     //
+//     //   * click with "c" key pressed to open at caller location
+//     //   * click with "d" key pressed to open at function component definition location
+//     let keyDown
+//     window.addEventListener("keydown", e => keyDown = e.key)
+//     window.addEventListener("keyup", e => keyDown = null)
+//     window.addEventListener("click", e => {
+//       if(keyDown === "c"){
+//         e.preventDefault()
+//         e.stopImmediatePropagation()
+//         reloader.openEditorAtCaller(e.target)
+//       } else if(keyDown === "d"){
+//         e.preventDefault()
+//         e.stopImmediatePropagation()
+//         reloader.openEditorAtDef(e.target)
+//       }
+//     }, true)
+//
+//     window.liveReloader = reloader
+//   })
+// }
 <% end %>

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -45,6 +45,7 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
 # Watch static and templates for browser reloading.
 config :<%= @app_name %>, <%= @endpoint_module %>,
   live_reload: [
+    web_console_logger: true,
     patterns: [
       ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
       ~r"priv/gettext/.*(po)$",<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -45,6 +45,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 # Watch static and templates for browser reloading.
 config :<%= @web_app_name %>, <%= @endpoint_module %>,
   live_reload: [
+    web_console_logger: true,
     patterns: [
       ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
       ~r"priv/gettext/.*(po)$",<% end %>


### PR DESCRIPTION
Add commented-out JS code to enable in development:

1. Server logs on browser console
2. Browser click to open component on code editor

This should make those useful features more discoverable and easier to enable for new apps.

Code is based on:

- https://github.com/phoenixframework/phoenix_live_reload?tab=readme-ov-file#streaming-serving-logs-to-the-web-console
- https://github.com/phoenixframework/phoenix_live_reload?tab=readme-ov-file#jumping-to-heex-function-definitions

See also:

https://fly.io/phoenix-files/phoenix-dev-blog-server-logs-in-the-browser-console/