### PR TITLE
[Fix] Using `--no-html` flag test config doesn't generate live_view config

### DIFF
--- a/installer/templates/phx_single/config/test.exs
+++ b/installer/templates/phx_single/config/test.exs
@@ -20,6 +20,8 @@ config :logger, level: :warning
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 
+<%= if @live do %>
 config :phoenix_live_view,
   # Enable helpful, but potentially expensive runtime checks
   enable_expensive_runtime_checks: true
+<% end %>

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -474,6 +474,10 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~ ~s|# socket "/live"|
         refute file =~ ~s|plug Phoenix.LiveDashboard.RequestLogger|
       end)
+
+      assert_file("phx_blog/config/test.exs", fn file ->
+        refute file =~ ~s|config :phoenix_live_view|
+      end)
     end)
   end
 
@@ -511,6 +515,10 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file("phx_blog/lib/phx_blog_web/router.ex", fn file ->
         refute file =~ ~s|pipeline :browser|
         assert file =~ ~s|pipe_through [:fetch_session, :protect_from_forgery]|
+      end)
+
+      assert_file("phx_blog/config/test.exs", fn file ->
+        refute file =~ ~s|config :phoenix_live_view|
       end)
     end)
   end


### PR DESCRIPTION
Fixes #5790 