### PR TITLE
Link module documentation of `leave` and `close` crashing the test process

### DIFF
--- a/lib/phoenix/test/channel_test.ex
+++ b/lib/phoenix/test/channel_test.ex
@@ -223,7 +223,7 @@ defmodule Phoenix.ChannelTest do
 
       test "connect in a task" do
         pid = self()
-        task = Task.async(fn -> 
+        task = Task.async(fn ->
           socket = socket(MyApp.UserSocket, "user_id", %{some: :assign}, test_process: pid)
           broadcast_from!(socket, "default", %{"foo" => "bar"})
           assert_push "default", %{"foo" => "bar"}
@@ -478,6 +478,10 @@ defmodule Phoenix.ChannelTest do
 
   @doc """
   Emulates the client leaving the channel.
+
+  By default this will crash the test process. Run
+  `Process.unlink(socket.channel_pid)` before this to prevent
+  this from happening. See [Leave and close](#module-leave-and-close).
   """
   @spec leave(Socket.t) :: reference()
   def leave(%Socket{} = socket) do
@@ -486,6 +490,10 @@ defmodule Phoenix.ChannelTest do
 
   @doc """
   Emulates the client closing the socket.
+
+  By default this will crash the test process. Run
+  `Process.unlink(socket.channel_pid)` before this to prevent
+  this from happening. See [Leave and close](#module-leave-and-close).
 
   Closing socket is synchronous and has a default timeout
   of 5000 milliseconds.


### PR DESCRIPTION
This at least makes this more discoverable. I still don't really understand why the API wouldn't handle this for the user though.