### PR TITLE
[Fix] Fix phx.auth's context functions ordering

### DIFF
--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -1,4 +1,4 @@
-  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Token, <%= inspect schema.alias %>Notifier}
+  alias <%= inspect context.module %>.{<%= inspect schema.alias %>, <%= inspect schema.alias %>Notifier, <%= inspect schema.alias %>Token}
 
   ## Database getters
 


### PR DESCRIPTION
I know that some people are against of alpha ordering, but it's a default check in `credo` so it would be nice to follow it here

![Screenshot from 2024-05-07 17-21-20](https://github.com/phoenixframework/phoenix/assets/6567687/9de9cbde-1769-4b7e-ad0f-81012541f968)
