### PR TITLE
Add HTTP verb to VerifiedRoutes

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -573,7 +573,7 @@ defmodule Phoenix.Router do
     verify_catch_all =
       quote generated: true do
         @doc false
-        def __verify_route__(_path_info) do
+        def __verify_route__(_path_info, _verb) do
           :error
         end
       end
@@ -635,6 +635,7 @@ defmodule Phoenix.Router do
 
   defp build_verify(path, routes_per_path) do
     routes = Map.get(routes_per_path, path)
+    verbs = Enum.map(routes, &Atom.to_string(&1.verb))
 
     forward_plug =
       Enum.find_value(routes, fn
@@ -645,8 +646,8 @@ defmodule Phoenix.Router do
     warn_on_verify? = Enum.all?(routes, & &1.warn_on_verify?)
 
     quote generated: true do
-      def __verify_route__(unquote(path)) do
-        {unquote(forward_plug), unquote(warn_on_verify?)}
+      def __verify_route__(unquote(path), verb) do
+        {unquote(forward_plug), unquote(warn_on_verify?), verb in unquote(verbs)}
       end
     end
   end

--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -173,7 +173,7 @@ defmodule Phoenix.VerifiedRoutes do
 
         {:error, :noverb} ->
           IO.warn(
-            "no route for #{inspect(route.router)} matches #{route.inspected_route}#{route.http_verb}",
+            "no route for #{inspect(route.router)} matches #{route.inspected_route}",
             route.stacktrace
           )
 
@@ -211,12 +211,12 @@ defmodule Phoenix.VerifiedRoutes do
       """
   '''
   defmacro sigil_p({:<<>>, _meta, _segments} = route, extra) do
+    validate_sigil_p!(extra)
     endpoint = attr!(__CALLER__, :endpoint)
     router = attr!(__CALLER__, :router)
-    http_verb = sigil_p_verb(extra)
 
     route
-    |> build_route(route, http_verb, __CALLER__, endpoint, router)
+    |> build_route(route, __CALLER__, endpoint, router)
     |> inject_path(__CALLER__)
   end
 
@@ -249,10 +249,10 @@ defmodule Phoenix.VerifiedRoutes do
     end
   end
 
-  defp sigil_p_verb([]), do: "*"
+  defp validate_sigil_p!([]), do: :ok
 
-  defp sigil_p_verb(method) do
-    List.to_string(method)
+  defp validate_sigil_p!(extra) do
+    raise ArgumentError, "~p does not support modifiers after closing, got: #{extra}"
   end
 
   defp raise_invalid_route(ast) do
@@ -287,10 +287,10 @@ defmodule Phoenix.VerifiedRoutes do
              router,
              {:sigil_p, _, [{:<<>>, _meta, _segments} = route, extra]} = sigil_p
            ) do
-    http_verb = sigil_p_verb(extra)
+    validate_sigil_p!(extra)
 
     route
-    |> build_route(sigil_p, http_verb, __CALLER__, conn_or_socket_or_endpoint_or_uri, router)
+    |> build_route(sigil_p, __CALLER__, conn_or_socket_or_endpoint_or_uri, router)
     |> inject_path(__CALLER__)
   end
 
@@ -300,11 +300,11 @@ defmodule Phoenix.VerifiedRoutes do
              conn_or_socket_or_endpoint_or_uri,
              {:sigil_p, _, [{:<<>>, _meta, _segments} = route, extra]} = sigil_p
            ) do
+    validate_sigil_p!(extra)
     router = attr!(__CALLER__, :router)
-    http_verb = sigil_p_verb(extra)
 
     route
-    |> build_route(sigil_p, http_verb, __CALLER__, conn_or_socket_or_endpoint_or_uri, router)
+    |> build_route(sigil_p, __CALLER__, conn_or_socket_or_endpoint_or_uri, router)
     |> inject_path(__CALLER__)
   end
 
@@ -352,12 +352,12 @@ defmodule Phoenix.VerifiedRoutes do
   such as `~p"/admin/users"`.
   '''
   defmacro url({:sigil_p, _, [{:<<>>, _meta, _segments} = route, extra]} = sigil_p) do
+    validate_sigil_p!(extra)
     endpoint = attr!(__CALLER__, :endpoint)
     router = attr!(__CALLER__, :router)
-    http_verb = sigil_p_verb(extra)
 
     route
-    |> build_route(sigil_p, http_verb, __CALLER__, endpoint, router)
+    |> build_route(sigil_p, __CALLER__, endpoint, router)
     |> inject_url(__CALLER__)
   end
 
@@ -372,11 +372,11 @@ defmodule Phoenix.VerifiedRoutes do
              conn_or_socket_or_endpoint_or_uri,
              {:sigil_p, _, [{:<<>>, _meta, _segments} = route, extra]} = sigil_p
            ) do
+    validate_sigil_p!(extra)
     router = attr!(__CALLER__, :router)
-    http_verb = sigil_p_verb(extra)
 
     route
-    |> build_route(sigil_p, http_verb, __CALLER__, conn_or_socket_or_endpoint_or_uri, router)
+    |> build_route(sigil_p, __CALLER__, conn_or_socket_or_endpoint_or_uri, router)
     |> inject_url(__CALLER__)
   end
 
@@ -392,11 +392,11 @@ defmodule Phoenix.VerifiedRoutes do
              router,
              {:sigil_p, _, [{:<<>>, _meta, _segments} = route, extra]} = sigil_p
            ) do
+    validate_sigil_p!(extra)
     router = Macro.expand(router, __CALLER__)
-    http_verb = sigil_p_verb(extra)
 
     route
-    |> build_route(sigil_p, http_verb, __CALLER__, conn_or_socket_or_endpoint_or_uri, router)
+    |> build_route(sigil_p, __CALLER__, conn_or_socket_or_endpoint_or_uri, router)
     |> inject_url(__CALLER__)
   end
 
@@ -731,7 +731,7 @@ defmodule Phoenix.VerifiedRoutes do
     end
   end
 
-  defp build_route(route_ast, sigil_p, http_verb, env, endpoint_ctx, router) do
+  defp build_route(route_ast, sigil_p, env, endpoint_ctx, router) do
     statics = Module.get_attribute(env.module, :phoenix_verified_statics, [])
 
     router =
@@ -755,7 +755,7 @@ defmodule Phoenix.VerifiedRoutes do
       stacktrace: Macro.Env.stacktrace(env),
       inspected_route: Macro.to_string(sigil_p),
       test_path: test_path,
-      http_verb: http_verb
+      http_verb: "*"
     }
 
     {route, static?, endpoint_ctx, route_ast, path_ast, static_ast}

--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -340,7 +340,8 @@ defmodule Phoenix.VerifiedRoutes do
   Forwarded paths in your main application router will be verified as usual,
   such as `~p"/admin/users"`.
   '''
-  defmacro url({:sigil_p, _, [{:<<>>, _meta, _segments} = route, _]} = sigil_p) do
+  defmacro url({:sigil_p, _, [{:<<>>, _meta, _segments} = route, extra]} = sigil_p) do
+    validate_sigil_p!(extra)
     endpoint = attr!(__CALLER__, :endpoint)
     router = attr!(__CALLER__, :router)
 
@@ -358,8 +359,9 @@ defmodule Phoenix.VerifiedRoutes do
   """
   defmacro url(
              conn_or_socket_or_endpoint_or_uri,
-             {:sigil_p, _, [{:<<>>, _meta, _segments} = route, _]} = sigil_p
+             {:sigil_p, _, [{:<<>>, _meta, _segments} = route, extra]} = sigil_p
            ) do
+    validate_sigil_p!(extra)
     router = attr!(__CALLER__, :router)
 
     route
@@ -377,8 +379,9 @@ defmodule Phoenix.VerifiedRoutes do
   defmacro url(
              conn_or_socket_or_endpoint_or_uri,
              router,
-             {:sigil_p, _, [{:<<>>, _meta, _segments} = route, _]} = sigil_p
+             {:sigil_p, _, [{:<<>>, _meta, _segments} = route, extra]} = sigil_p
            ) do
+    validate_sigil_p!(extra)
     router = Macro.expand(router, __CALLER__)
 
     route

--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -163,11 +163,15 @@ defmodule Phoenix.VerifiedRoutes do
   @doc false
   def __verify__(routes) when is_list(routes) do
     Enum.each(routes, fn %__MODULE__{} = route ->
-      unless match_route?(route.router, route.test_path) do
-        IO.warn(
-          "no route path for #{inspect(route.router)} matches #{route.inspected_route}",
-          route.stacktrace
-        )
+      case match_route(route.router, route.test_path) do
+        {:error, :nopath} ->
+          IO.warn(
+            "no route path for #{inspect(route.router)} matches #{route.inspected_route}",
+            route.stacktrace
+          )
+
+        :ok ->
+          :ok
       end
     end)
   end
@@ -680,7 +684,7 @@ defmodule Phoenix.VerifiedRoutes do
   defp to_param(true), do: "true"
   defp to_param(data), do: Phoenix.Param.to_param(data)
 
-  defp match_route?(router, test_path) when is_binary(test_path) do
+  defp match_route(router, test_path) when is_binary(test_path) do
     split_path =
       test_path
       |> String.split("#")
@@ -688,24 +692,24 @@ defmodule Phoenix.VerifiedRoutes do
       |> String.split("/")
       |> Enum.filter(fn segment -> segment != "" end)
 
-    match_route?(router, split_path)
+    match_route(router, split_path)
   end
 
-  defp match_route?(router, split_path) when is_list(split_path) do
+  defp match_route(router, split_path) when is_list(split_path) do
     case router.__verify_route__(split_path) do
-      {_forward_plug, true = _warn_on_verify?} -> false
-      {nil = _forward_plug, false = _warn_on_verify?} -> true
-      {fwd_plug, false = _warn_on_verify?} -> match_forward_route?(router, fwd_plug, split_path)
-      :error -> false
+      {_forward_plug, true = _warn_on_verify?} -> {:error, :nopath}
+      {nil = _forward_plug, false = _warn_on_verify?} -> :ok
+      {fwd_plug, false = _warn_on_verify?} -> match_forward_route(router, fwd_plug, split_path)
+      :error -> {:error, :nopath}
     end
   end
 
-  defp match_forward_route?(router, forward_router, split_path) do
+  defp match_forward_route(router, forward_router, split_path) do
     if function_exported?(forward_router, :__routes__, 0) do
       script_name = router.__forward__(forward_router)
-      match_route?(forward_router, split_path -- script_name)
+      match_route(forward_router, split_path -- script_name)
     else
-      true
+      :ok
     end
   end
 

--- a/test/phoenix/verified_routes_test.exs
+++ b/test/phoenix/verified_routes_test.exs
@@ -34,7 +34,6 @@ defmodule Phoenix.VerifiedRoutesTest do
     get "/posts/file/*file", PostController, :file
     get "/posts/skip", PostController, :skip
     get "/should-warn/*all", PostController, :all, warn_on_verify: true
-    match :customverb, "/posts/custom", PostController, []
 
     scope "/", host: "users." do
       post "/host_users/:id/info", UserController, :create
@@ -154,21 +153,6 @@ defmodule Phoenix.VerifiedRoutesTest do
     assert ~p"/posts/#{struct}?foo=bar" == "/posts/post-123?foo=bar"
   end
 
-  test "~p with http verb" do
-    assert ~p"/posts/1"get == "/posts/1"
-  end
-
-  test "path with http verb" do
-    assert path(Endpoint, ~p"/posts/top"get) == "/posts/top"
-    assert path(Endpoint, AdminRouter, ~p"/dashboard"get)
-  end
-
-  test "url with http verb" do
-    assert url(~p"/posts/skip"get) == "https://example.com/posts/skip"
-    assert url(Endpoint, ~p"/posts/custom"customverb) == "https://example.com/posts/custom"
-    assert url(Endpoint, AdminRouter, ~p"/dashboard"get) == "https://example.com/dashboard"
-  end
-
   test "~p with scoped host" do
     assert ~p"/host_users/1/info" == "/host_users/1/info"
   end
@@ -217,6 +201,15 @@ defmodule Phoenix.VerifiedRoutesTest do
     assert unverified_url(@endpoint, "/posts") == "https://example.com/posts"
     assert unverified_url(@endpoint, "/posts", %{}) == "https://example.com/posts"
     assert unverified_url(@endpoint, "/posts", a: "b") == "https://example.com/posts?a=b"
+  end
+
+  test "~p raises on leftover sigil" do
+    assert_raise ArgumentError, "~p does not support modifiers after closing, got: foo", fn ->
+      defmodule LeftOver do
+        use Phoenix.VerifiedRoutes, endpoint: unquote(@endpoint), router: unquote(@router)
+        def test, do: ~p"/posts/1"foo
+      end
+    end
   end
 
   test "~p raises on dynamic interpolation" do
@@ -509,18 +502,13 @@ defmodule Phoenix.VerifiedRoutesTest do
       test "~p warns on unmatched path" do
         warnings =
           ExUnit.CaptureIO.capture_io(:stderr, fn ->
-            defmodule UnmatchedPath do
+            defmodule Unmatched do
               use Phoenix.VerifiedRoutes, endpoint: unquote(@endpoint), router: unquote(@router)
 
               def test do
                 ~p"/unknown"
                 ~p"/unknown/123"
                 ~p"/unknown/#{123}"
-                ~p"/unknown/456"get
-                # Valid path, do not warn
-                ~p"/posts"
-                ~p"/posts"get
-                ~p"/posts/custom"customverb
               end
             end
           end)
@@ -533,40 +521,6 @@ defmodule Phoenix.VerifiedRoutesTest do
 
         assert warnings =~
                  ~s|no route path for Phoenix.VerifiedRoutesTest.Router matches "/unknown/#{123}"|
-
-        assert warnings =~
-                 ~s|no route path for Phoenix.VerifiedRoutesTest.Router matches "/unknown/456"|
-      end
-
-      test "~p warns on unmatched http verb" do
-        warnings =
-          ExUnit.CaptureIO.capture_io(:stderr, fn ->
-            defmodule UnmatchedHttpVerb do
-              use Phoenix.VerifiedRoutes, endpoint: unquote(@endpoint), router: unquote(@router)
-
-              def test do
-                ~p"/posts/1"post
-                ~p"/posts/2"put
-                ~p"/posts/3/info"patch
-                ~p"/posts/custom"notcustom
-                # Valid path, does not warn
-                ~p"/posts/1"get
-                ~p"/posts/custom"customverb
-              end
-            end
-          end)
-
-        assert warnings =~
-                 ~s|no route for Phoenix.VerifiedRoutesTest.Router matches "/posts/1"post|
-
-        assert warnings =~
-                 ~s|no route for Phoenix.VerifiedRoutesTest.Router matches "/posts/2"put|
-
-        assert warnings =~
-                 ~s|no route for Phoenix.VerifiedRoutesTest.Router matches "/posts/3/info"patch|
-
-        assert warnings =~
-                 ~s|no route for Phoenix.VerifiedRoutesTest.Router matches "/posts/custom"notcustom|
       end
 
       test "~p warns on warn_on_verify: true route" do
@@ -587,9 +541,7 @@ defmodule Phoenix.VerifiedRoutesTest do
         warnings =
           ExUnit.CaptureIO.capture_io(:stderr, fn ->
             defmodule VerifyFalseTrueMatchesFirst do
-              use Phoenix.VerifiedRoutes,
-                endpoint: unquote(@endpoint),
-                router: CatchAllWarningRouter
+              use Phoenix.VerifiedRoutes, endpoint: unquote(@endpoint), router: CatchAllWarningRouter
 
               def test, do: ~p"/"
             end


### PR DESCRIPTION
This PR is a follow-up of the proposal on the Elixir Forum: [Proposal for Phoenix: add HTTP verb to VerifiedRoutes](https://elixirforum.com/t/proposal-for-phoenix-add-http-verb-to-verifiedroutes/63319).

*tldr;* I propose to add a way for VerifiedRoutes to know if they’re used for get, post, etc to make them even more robust, and safer to refactor. This solution could be to add a “tag” to verified routes, like so: `~p"/user/#{user}"get`. More context and details can be found on the original post.

Please tell me what you think about this proposition. The code in the PR is functional, although I'd rather have more people re-read the test cases carefully to ensure the behaviour is the one expected. Also, I didn't update the documentation yet.
Here's the behaviour I expected to introduce (this is a copy-paste of the "add tests explaining behaviour" commit description):

> Add tests to VerifiedRoutes ensuring the correctness
of the introduced behaviour.
We want to ensure the following is respected:
> * runtime behaviour isn't altered at all: a ~p
  with http verb modifier emits the path as a
  string,
> * existing warning behaviour isn't altered:
  a ~p - with or without an http verb - not
  matching a route emits a warning,
> * (new) a ~p matching an existing route without
  a matching http verb emits a warning too,
> * (new) a ~p matching an existing route with
  a matching http verb does not emit a warning.

PS: I know the proposal wasn't validated or anything, but I figured this wouldn't take me too long to make a POC anyway, so I don't mind reworking the solution if this one isn't the one we ought to keep for any reason.