### PR TITLE
Call Exception.message instead of accessing message field

### DIFF
--- a/lib/phoenix/endpoint/cowboy2_adapter.ex
+++ b/lib/phoenix/endpoint/cowboy2_adapter.ex
@@ -146,7 +146,7 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
 
     {:ok, address}
   rescue
-    e -> {:error, e.message}
+    e -> {:error, Exception.message(e)}
   end
 
   defp make_ref(endpoint, scheme) do


### PR DESCRIPTION
fixes typechecker error
```
     warning: unknown key .message in expression:

         e.message

     where "e" was given the type:

         # type: %{..., __exception__: true, __struct__: atom()}
         # from: lib/phoenix/endpoint/cowboy2_adapter.ex:149
         rescue e ->

     hint: when you rescue without specifying exception names, the variable is assigned a type of a struct but all of its fields are unknown

     typing violation found at:
     │
 149 │     e -> {:error, e.message}
     │                     ~
     │
     └─ lib/phoenix/endpoint/cowboy2_adapter.ex:149:21: Phoenix.Endpoint.Cowboy2Adapter.server_info/2
```