### PR TITLE
CoreComponents: Add Levels for "headers"

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -417,8 +417,25 @@ defmodule <%= @web_namespace %>.CoreComponents do
   end
 
   @doc """
-  Renders a header with title.
+  Renders a header with a title, optional subtitle and actions.
+
+  ## Examples
+
+      <.header>
+        Title
+        <:actions>
+          Subtitle
+        </:actions>
+        <:actions>
+          ...
+        </:actions>
+      </.header>
+
+      <.header level="2" class="mt-10">
+        Title
+      </.header>
   """
+  attr :level, :string, default: "1"
   attr :class, :string, default: nil
 
   slot :inner_block, required: true
@@ -426,12 +443,30 @@ defmodule <%= @web_namespace %>.CoreComponents do
   slot :actions
 
   def header(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :default_header_classes,
+        "font-semibold leading-8 text-zinc-800"
+      )
+
     ~H"""
     <header class={[@actions != [] && "flex items-center justify-between gap-6", @class]}>
       <div>
-        <h1 class="text-lg font-semibold leading-8 text-zinc-800">
-          <%%= render_slot(@inner_block) %>
-        </h1>
+        <%= case @level do %>
+          <% "1" -> %>
+            <h1 class={["text-3xl", @default_header_classes]}><%%= render_slot(@inner_block) %></h1>
+          <% "2" -> %>
+            <h2 class={["text-2xl", @default_header_classes]}><%%= render_slot(@inner_block) %></h2>
+          <% "3" -> %>
+            <h3 class={["text-xl", @default_header_classes]}><%%= render_slot(@inner_block) %></h3>
+          <% "4" -> %>
+            <h4 class={["text-lg", @default_header_classes]}><%%= render_slot(@inner_block) %></h4>
+          <% "5" -> %>
+            <h5 class={["text-md", @default_header_classes]}><%%= render_slot(@inner_block) %></h5>
+          <% _   -> %>
+            <h6 class={["text-sm", @default_header_classes]}><%%= render_slot(@inner_block) %></h6>
+        <% end %>
         <p :if={@subtitle != []} class="mt-2 text-sm leading-6 text-zinc-600">
           <%%= render_slot(@subtitle) %>
         </p>

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -417,8 +417,25 @@ defmodule <%= @web_namespace %>.CoreComponents do
   end
 
   @doc """
-  Renders a header with title.
+  Renders a header with a title, optional subtitle and actions.
+
+  ## Examples
+
+      <.header>
+        Title
+        <:actions>
+          Subtitle
+        </:actions>
+        <:actions>
+          ...
+        </:actions>
+      </.header>
+
+      <.header level="2" class="mt-10">
+        Title
+      </.header>
   """
+  attr :level, :string, default: "1"
   attr :class, :string, default: nil
 
   slot :inner_block, required: true
@@ -426,12 +443,30 @@ defmodule <%= @web_namespace %>.CoreComponents do
   slot :actions
 
   def header(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :default_header_classes,
+        "font-semibold leading-8 text-zinc-800"
+      )
+
     ~H"""
     <header class={[@actions != [] && "flex items-center justify-between gap-6", @class]}>
       <div>
-        <h1 class="text-lg font-semibold leading-8 text-zinc-800">
-          <%%= render_slot(@inner_block) %>
-        </h1>
+        <%= case @level do %>
+          <% "1" -> %>
+            <h1 class={["text-3xl", @default_header_classes]}><%%= render_slot(@inner_block) %></h1>
+          <% "2" -> %>
+            <h2 class={["text-2xl", @default_header_classes]}><%%= render_slot(@inner_block) %></h2>
+          <% "3" -> %>
+            <h3 class={["text-xl", @default_header_classes]}><%%= render_slot(@inner_block) %></h3>
+          <% "4" -> %>
+            <h4 class={["text-lg", @default_header_classes]}><%%= render_slot(@inner_block) %></h4>
+          <% "5" -> %>
+            <h5 class={["text-md", @default_header_classes]}><%%= render_slot(@inner_block) %></h5>
+          <% _   -> %>
+            <h6 class={["text-sm", @default_header_classes]}><%%= render_slot(@inner_block) %></h6>
+        <% end %>
         <p :if={@subtitle != []} class="mt-2 text-sm leading-6 text-zinc-600">
           <%%= render_slot(@subtitle) %>
         </p>


### PR DESCRIPTION
Using the "headers" function of the CoreComponents always creates h1 headers. That's a bit limiting.

This pull request introduces the new attribute "level" for the header function which is used to determine what heading level should be shown. There are officially 6 levels, the default is always h1 (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements).

Here is how it looks:

<img width="351" alt="header-levels" src="https://github.com/phoenixframework/phoenix/assets/4161349/00566bf8-fd1c-4a0b-980a-2cb431378f42">

And here is the code to check it out yourself:

```heex
<.header level="1" class="mt-[1em]">
  Header Level 1 (text-3xl)
</.header>

<.header level="2" class="mt-[1em]">
  Header Level 2 (text-2xl)
</.header>

<.header level="3" class="mt-[1em]">
  Header Level 3 (text-xl)
</.header>

<.header level="4" class="mt-[1em]">
  Header Level 4 (text-lg)
</.header>

<.header level="5" class="mt-[1em]">
  Header Level 5 (text-md)
</.header>

<.header level="6" class="mt-[1em]">
  Header Level 6 (text-sm)
</.header>
```

At the momemt, running `mix test` results in serveral warnings that all look like this:

> .warning: assign @level not available in EEx template. Please ensure all assigns are given as options.

It would be great if someone with more Elixir/Phoenix knowledge could have a look at this, because I don't really understand the issue. The attribute "level" has been defined, the type info and default value have been added. Accessing it via "@level" doesn't differ from accessing @class, for example. A pointer into the right direction would be helpful, I'm of course willing to add the necessary changes to fix these warnings.