### PR TITLE
fix typo in verified routes docs

### DIFF
--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -253,7 +253,7 @@ defmodule Phoenix.VerifiedRoutes do
   @doc ~S'''
   Generates the router path with route verification.
 
-  See `sigil_p/1` for more information.
+  See `sigil_p/2` for more information.
 
   Warns when the provided path does not match against the router specified
   in `use Phoenix.VerifiedRoutes` or the `@router` module attribute.


### PR DESCRIPTION
I believe it should be `sigil_p/2` like in the docs for `url/1` instead of `sigil_p/1`, which does not exist.