### PR TITLE
Add class attr to input component.

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -269,6 +269,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <.input name="my-input" errors={["oh no!"]} />
   """
   attr :id, :any, default: nil
+  attr :class, :string, default: nil
   attr :name, :any
   attr :label, :string, default: nil
   attr :value, :any
@@ -318,7 +319,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
           name={@name}
           value="true"
           checked={@checked}
-          class="rounded border-zinc-300 text-zinc-900 focus:ring-0"
+          class={["rounded border-zinc-300 text-zinc-900 focus:ring-0", @class]}
           {@rest}
         />
         <%%= @label %>
@@ -335,7 +336,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <select
         id={@id}
         name={@name}
-        class="mt-2 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
+        class={["mt-2 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm", @class]}
         multiple={@multiple}
         {@rest}
       >
@@ -357,7 +358,8 @@ defmodule <%= @web_namespace %>.CoreComponents do
         class={[
           "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6 min-h-[6rem]",
           @errors == [] && "border-zinc-300 focus:border-zinc-400",
-          @errors != [] && "border-rose-400 focus:border-rose-400"
+          @errors != [] && "border-rose-400 focus:border-rose-400",
+          @class
         ]}
         {@rest}
       ><%%= Phoenix.HTML.Form.normalize_value("textarea", @value) %></textarea>
@@ -379,7 +381,8 @@ defmodule <%= @web_namespace %>.CoreComponents do
         class={[
           "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
           @errors == [] && "border-zinc-300 focus:border-zinc-400",
-          @errors != [] && "border-rose-400 focus:border-rose-400"
+          @errors != [] && "border-rose-400 focus:border-rose-400",
+          @class
         ]}
         {@rest}
       />


### PR DESCRIPTION
I'd like to propose adding a `class` attr for CoreComponents input component. As an example, I'm trying to make a form with a username field with an attached '@' span. I'd like to drop the round corners on the left side of the input by doing `<.input class="rounded-none rounded-r-lg" />` but it currently doesn't work and looks like this:

<img width="302" alt="Screenshot 2024-05-26 at 11 55 55 PM" src="https://github.com/phoenixframework/phoenix/assets/2041/101bcf1f-2056-42ee-a33f-8b4a6219dfe0">

With my proposed PR I can pass in those classes and it looks like this:

<img width="294" alt="Screenshot 2024-05-26 at 11 57 12 PM" src="https://github.com/phoenixframework/phoenix/assets/2041/e91d9d7f-5370-4d2e-bb5b-c6c922ae5875">
