### PR TITLE
Remove 'antialiased' CSS class from root template

### DIFF
--- a/installer/templates/phx_static/home.css
+++ b/installer/templates/phx_static/home.css
@@ -940,11 +940,6 @@ select {
   color: rgb(63 63 70 / var(--tw-text-opacity));
 }
 
-.antialiased {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 .transition {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, -webkit-backdrop-filter;
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;

--- a/installer/templates/phx_web/components/layouts/root.html.heex
+++ b/installer/templates/phx_web/components/layouts/root.html.heex
@@ -11,7 +11,7 @@
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
   </head>
-  <body class="bg-white antialiased">
+  <body class="bg-white">
     <%%= @inner_content %>
   </body>
 </html>


### PR DESCRIPTION
One day, perhaps over a decade ago, it used to bring visual improvement and consistency to font rendering across browsers and operating systems.

But, over the years, the default subpixel-antialising in browsers/OSes produces better results than 'antialiased'.

There are many discussions about this on the web, I mention a few:
- https://github.com/google/fonts/issues/1170
- https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth
- https://web.dev/articles/antialiasing-101
- https://en.wikipedia.org/wiki/Subpixel_rendering