### PR TITLE
Disable fallback checkbox in Core Components if FormField is disabled as well

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -311,7 +311,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     ~H"""
     <div>
       <label class="flex items-center gap-4 text-sm leading-6 text-zinc-600">
-        <input type="hidden" name={@name} value="false" disabled={@rest[:disabled] || false} />
+        <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} />
         <input
           type="checkbox"
           id={@id}

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -311,7 +311,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     ~H"""
     <div>
       <label class="flex items-center gap-4 text-sm leading-6 text-zinc-600">
-        <input type="hidden" name={@name} value="false" />
+        <input type="hidden" name={@name} value="false" disabled={@rest[:disabled] || false} />
         <input
           type="checkbox"
           id={@id}

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -311,7 +311,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     ~H"""
     <div>
       <label class="flex items-center gap-4 text-sm leading-6 text-zinc-600">
-        <input type="hidden" name={@name} value="false" disabled={@rest[:disabled] || false} />
+        <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} />
         <input
           type="checkbox"
           id={@id}

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -311,7 +311,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     ~H"""
     <div>
       <label class="flex items-center gap-4 text-sm leading-6 text-zinc-600">
-        <input type="hidden" name={@name} value="false" />
+        <input type="hidden" name={@name} value="false" disabled={@rest[:disabled] || false} />
         <input
           type="checkbox"
           id={@id}


### PR DESCRIPTION
This is a tiny bugfix for the `checkbox` input component in the core components.

The problem here is that if I have a FormField with a boolean value of `true` and I render a checkbox input using the core components for it, the value of the field will not be sent properly if I disable the checkbox because the `disable` attribute is only set on the "true" checkbox input, not on the fallback "false" one. Because disabled inputs are not sent when the form is submitted, this means that the fallback "false" value will be sent even though the real value of the FormField is "true".

This bugfix sets the `disabled` attribute also on the "false" fallback checkbox input. This completely removes the field value from being submitted, which is the expected behaviour because disabled inputs are not submitted. If no `disabled` attribute is set or if it's `false`, then the `disabled` attribute will be omitted on the fallback checkbox as well.