### PR TITLE
Align time and duration values in a couple of show / hides

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -602,6 +602,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def show(js \\ %JS{}, selector) do
     JS.show(js,
       to: selector,
+      time: 300,
       transition:
         {"transition-all transform ease-out duration-300",
          "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95",
@@ -612,7 +613,6 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def hide(js \\ %JS{}, selector) do
     JS.hide(js,
       to: selector,
-      time: 200,
       transition:
         {"transition-all transform ease-in duration-200",
          "opacity-100 translate-y-0 sm:scale-100",
@@ -625,6 +625,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     |> JS.show(to: "##{id}")
     |> JS.show(
       to: "##{id}-bg",
+      time: 300,
       transition: {"transition-all transform ease-out duration-300", "opacity-0", "opacity-100"}
     )
     |> show("##{id}-container")

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -613,6 +613,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def hide(js \\ %JS{}, selector) do
     JS.hide(js,
       to: selector,
+      time: 200,
       transition:
         {"transition-all transform ease-in duration-200",
          "opacity-100 translate-y-0 sm:scale-100",

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -602,6 +602,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def show(js \\ %JS{}, selector) do
     JS.show(js,
       to: selector,
+      time: 300,
       transition:
         {"transition-all transform ease-out duration-300",
          "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95",
@@ -625,6 +626,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     |> JS.show(to: "##{id}")
     |> JS.show(
       to: "##{id}-bg",
+      time: 300,
       transition: {"transition-all transform ease-out duration-300", "opacity-0", "opacity-100"}
     )
     |> show("##{id}-container")


### PR DESCRIPTION
This PR aligns the transition time and duration values in a couple of show & hides in the generators. The default transition time for `JS.show` and `JS.hide` is [200ms](https://github.com/phoenixframework/phoenix_live_view/blob/adacdfd985b7282903012057167ac563fb89d983/assets/js/phoenix_live_view/js.js#L5) but the Tailwind durations are set to 300ms.

After making the changes, I noticed there is already an [open PR](https://github.com/phoenixframework/phoenix/pull/5733) with the same change. However, that one changes the time of the animations to the shorter 200ms, whereas this one keeps the longer 300ms version - which I personally prefer. Choose the version you prefer, the shorter or longer animation.