### PR TITLE
Fix gen.auth template for default password input

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -366,7 +366,27 @@ defmodule <%= @web_namespace %>.CoreComponents do
     """
   end
 
-  # All other inputs text, datetime-local, url, password, etc. are handled here...
+  def input(%{type: "password"} = assigns) do
+    ~H"""
+    <div>
+      <.label for={@id}><%%= @label %></.label>
+      <input
+        type={@type}
+        name={@name}
+        id={@id}
+        class={[
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          @errors == [] && "border-zinc-300 focus:border-zinc-400",
+          @errors != [] && "border-rose-400 focus:border-rose-400"
+        ]}
+        {@rest}
+      />
+      <.error :for={msg <- @errors}><%%= msg %></.error>
+    </div>
+    """
+  end
+
+  # All other inputs text, datetime-local, url, etc. are handled here..
   def input(assigns) do
     ~H"""
     <div>

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -366,7 +366,27 @@ defmodule <%= @web_namespace %>.CoreComponents do
     """
   end
 
-  # All other inputs text, datetime-local, url, password, etc. are handled here...
+  def input(%{type: "password"} = assigns) do
+    ~H"""
+    <div>
+      <.label for={@id}><%%= @label %></.label>
+      <input
+        type={@type}
+        name={@name}
+        id={@id}
+        class={[
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          @errors == [] && "border-zinc-300 focus:border-zinc-400",
+          @errors != [] && "border-rose-400 focus:border-rose-400"
+        ]}
+        {@rest}
+      />
+      <.error :for={msg <- @errors}><%%= msg %></.error>
+    </div>
+    """
+  end
+
+  # All other inputs text, datetime-local, url, etc. are handled here..
   def input(assigns) do
     ~H"""
     <div>


### PR DESCRIPTION
**Background**
Fix for #5837
When using phx.gen.auth (using Phoenix.Controller only) the resulting code displays passwords as plaintext values in HTML whenever the server re-renders form with validation errors.

**Dev notes**

In order to have specific logic for a password input, I've added a method to do this,

`value={Phoenix.HTML.Form.normalize_value(@type, @value)}` was removed for this kind of input

I don't see any test related to this but if I'm missing something please let me know 

**Before the change**
![image](https://github.com/phoenixframework/phoenix/assets/8773014/8a75fceb-9fe8-4ab1-95a2-952cd3045e24)

**After the change**
![image](https://github.com/phoenixframework/phoenix/assets/8773014/49f49e64-d89e-420b-8233-aee7eb3e18db)
