### PR TITLE
make tests repeatable (--repeat-until-failure)

### DIFF
--- a/installer/test/mix_helper.exs
+++ b/installer/test/mix_helper.exs
@@ -11,24 +11,26 @@ defmodule MixHelper do
   end
 
   defp random_string(len) do
-    len |> :crypto.strong_rand_bytes() |> Base.encode64() |> binary_part(0, len)
+    len |> :crypto.strong_rand_bytes() |> Base.url_encode64() |> binary_part(0, len)
   end
 
   def in_tmp(which, function) do
-    path = Path.join([tmp_path(), random_string(10) <> to_string(which)])
+    base = Path.join([tmp_path(), random_string(10)])
+    path = Path.join([base, to_string(which)])
 
     try do
       File.rm_rf!(path)
       File.mkdir_p!(path)
       File.cd!(path, function)
     after
-      File.rm_rf!(path)
+      File.rm_rf!(base)
     end
   end
 
   def in_tmp_project(which, function) do
     conf_before = Application.get_env(:phoenix, :generators) || []
-    path = Path.join([tmp_path(), random_string(10) <> to_string(which)])
+    base = Path.join([tmp_path(), random_string(10)])
+    path = Path.join([base, to_string(which)])
 
     try do
       File.rm_rf!(path)
@@ -47,14 +49,15 @@ defmodule MixHelper do
         function.()
       end)
     after
-      File.rm_rf!(path)
+      File.rm_rf!(base)
       Application.put_env(:phoenix, :generators, conf_before)
     end
   end
 
   def in_tmp_umbrella_project(which, function) do
     conf_before = Application.get_env(:phoenix, :generators) || []
-    path = Path.join([tmp_path(), random_string(10) <> to_string(which)])
+    base = Path.join([tmp_path(), random_string(10)])
+    path = Path.join([base, to_string(which)])
 
     try do
       apps_path = Path.join(path, "apps")
@@ -72,7 +75,7 @@ defmodule MixHelper do
       File.cd!(apps_path, function)
     after
       Application.put_env(:phoenix, :generators, conf_before)
-      File.rm_rf!(path)
+      File.rm_rf!(base)
     end
   end
 
@@ -81,7 +84,10 @@ defmodule MixHelper do
 
     try do
       capture_io(:stderr, fn ->
-        Mix.Project.in_project(app, path, [prune_code_paths: false], fun)
+        Mix.Project.in_project(app, path, [prune_code_paths: false], fn mod ->
+          fun.(mod)
+          Mix.Project.clear_deps_cache()
+        end)
       end)
     after
       Mix.Project.push(name, file)

--- a/test/mix/tasks/phx.digest.clean_test.exs
+++ b/test/mix/tasks/phx.digest.clean_test.exs
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Phx.Digest.CleanTest do
   use ExUnit.Case
 
   test "fails when the given paths are invalid" do
-    Mix.Tasks.Phx.Digest.Clean.run(["--output", "invalid_path"])
+    Mix.Tasks.Phx.Digest.Clean.run(["--output", "invalid_path", "--no-compile"])
 
     assert_received {:mix_shell, :error, ["The output path \"invalid_path\" does not exist"]}
   end
@@ -10,11 +10,16 @@ defmodule Mix.Tasks.Phx.Digest.CleanTest do
   test "removes old versions", config do
     output_path = Path.join("tmp", to_string(config.test))
     input_path = "priv/static"
-    :ok = File.mkdir_p!(output_path)
 
-    Mix.Tasks.Phx.Digest.Clean.run([input_path, "-o", output_path, "--no-compile"])
+    try do
+      :ok = File.mkdir_p!(output_path)
 
-    msg = "Clean complete for \"#{output_path}\""
-    assert_received {:mix_shell, :info, [^msg]}
+      Mix.Tasks.Phx.Digest.Clean.run([input_path, "-o", output_path, "--no-compile"])
+
+      msg = "Clean complete for \"#{output_path}\""
+      assert_received {:mix_shell, :info, [^msg]}
+    after
+      File.rm_rf!(output_path)
+    end
   end
 end

--- a/test/mix/tasks/phx.digest_test.exs
+++ b/test/mix/tasks/phx.digest_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Phx.DigestTest do
   import MixHelper
 
   test "logs when the path is invalid" do
-    Mix.Tasks.Phx.Digest.run(["invalid_path", "--no-deps-check"])
+    Mix.Tasks.Phx.Digest.run(["invalid_path", "--no-deps-check", "--no-compile"])
     assert_received {:mix_shell, :error, ["The input path \"invalid_path\" does not exist"]}
   end
 

--- a/test/mix/tasks/phx.routes_test.exs
+++ b/test/mix/tasks/phx.routes_test.exs
@@ -24,37 +24,37 @@ defmodule Mix.Tasks.Phx.RoutesTest do
   use ExUnit.Case, async: true
 
   test "format routes for specific router" do
-    Mix.Tasks.Phx.Routes.run(["PhoenixTestWeb.Router"])
+    Mix.Tasks.Phx.Routes.run(["PhoenixTestWeb.Router", "--no-compile"])
     assert_received {:mix_shell, :info, [routes]}
     assert routes =~ "page_path  GET  /  PageController :index"
   end
 
   test "prints error when explicit router cannot be found" do
     assert_raise Mix.Error, "the provided router, Foo.UnknownBar.CantFindBaz, does not exist", fn ->
-      Mix.Tasks.Phx.Routes.run(["Foo.UnknownBar.CantFindBaz"])
+      Mix.Tasks.Phx.Routes.run(["Foo.UnknownBar.CantFindBaz", "--no-compile"])
     end
   end
 
   test "prints error when implicit router cannot be found" do
     assert_raise Mix.Error, ~r/no router found at FooWeb.Router or Foo.Router/, fn ->
-      Mix.Tasks.Phx.Routes.run([], Foo)
+      Mix.Tasks.Phx.Routes.run(["--no-compile"], Foo)
     end
   end
 
   test "implicit router detection for web namespace" do
-    Mix.Tasks.Phx.Routes.run([], PhoenixTest)
+    Mix.Tasks.Phx.Routes.run(["--no-compile"], PhoenixTest)
     assert_received {:mix_shell, :info, [routes]}
     assert routes =~ "page_path  GET  /  PageController :index"
   end
 
   test "implicit router detection fallback for old namespace" do
-    Mix.Tasks.Phx.Routes.run([], PhoenixTestOld)
+    Mix.Tasks.Phx.Routes.run(["--no-compile"], PhoenixTestOld)
     assert_received {:mix_shell, :info, [routes]}
     assert routes =~ "page_path  GET  /old  PageController :index"
   end
 
   test "overrides module name for route with :log_module metadata" do
-    Mix.Tasks.Phx.Routes.run(["PhoenixTestLiveWeb.Router"])
+    Mix.Tasks.Phx.Routes.run(["PhoenixTestLiveWeb.Router", "--no-compile"])
     assert_received {:mix_shell, :info, [routes]}
     assert routes =~ "page_path  GET  /  PageLive.Index :index"
   end

--- a/test/phoenix/controller/render_test.exs
+++ b/test/phoenix/controller/render_test.exs
@@ -176,6 +176,7 @@ defmodule Phoenix.Controller.RenderTest do
 
     setup context do
       :telemetry.attach_many(context.test, @render_events, &__MODULE__.message_pid/4, self())
+      on_exit(fn -> :telemetry.detach(context.test) end)
     end
 
     def message_pid(event, measures, metadata, test_pid) do

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -214,6 +214,9 @@ defmodule Phoenix.Endpoint.EndpointTest do
     UrlEndpoint.start_link()
     assert UrlEndpoint.path("/phoenix.png") =~ "/api/phoenix.png"
     assert UrlEndpoint.static_path("/phoenix.png") =~ "/api/phoenix.png"
+  after
+    :code.purge(__MODULE__.UrlEndpoint)
+    :code.delete(__MODULE__.UrlEndpoint)
   end
 
   @tag :capture_log
@@ -227,6 +230,9 @@ defmodule Phoenix.Endpoint.EndpointTest do
     StaticEndpoint.start_link()
     assert StaticEndpoint.path("/phoenix.png") =~ "/phoenix.png"
     assert StaticEndpoint.static_path("/phoenix.png") =~ "/static/phoenix.png"
+  after
+    :code.purge(__MODULE__.StaticEndpoint)
+    :code.delete(__MODULE__.StaticEndpoint)
   end
 
   @tag :capture_log
@@ -243,6 +249,9 @@ defmodule Phoenix.Endpoint.EndpointTest do
     AddressEndpoint.start_link()
     assert {:ok, {{127, 0, 0, 1}, port}} = AddressEndpoint.server_info(:http)
     assert is_integer(port)
+  after
+    :code.purge(__MODULE__.AddressEndpoint)
+    :code.delete(__MODULE__.AddressEndpoint)
   end
 
   test "injects pubsub broadcast with configured server" do

--- a/test/phoenix/param_test.exs
+++ b/test/phoenix/param_test.exs
@@ -32,6 +32,9 @@ defmodule Phoenix.ParamTest do
     end
     assert to_param(struct(Foo, id: 1)) == "1"
     assert to_param(struct(Foo, id: "foo")) == "foo"
+  after
+    :code.purge(__MODULE__.Foo)
+    :code.delete(__MODULE__.Foo)
   end
 
   test "to_param for derivable structs without id" do
@@ -55,5 +58,10 @@ defmodule Phoenix.ParamTest do
     assert_raise ArgumentError, msg, fn ->
       to_param(struct(Bar, uuid: nil))
     end
+  after
+    :code.purge(Module.concat(Phoenix.Param, __MODULE__.Bar))
+    :code.delete(Module.concat(Phoenix.Param, __MODULE__.Bar))
+    :code.purge(__MODULE__.Bar)
+    :code.delete(__MODULE__.Bar)
   end
 end

--- a/test/phoenix/router/routing_test.exs
+++ b/test/phoenix/router/routing_test.exs
@@ -323,6 +323,7 @@ defmodule Phoenix.Router.RoutingTest do
         end,
         nil
       )
+      on_exit(fn -> :telemetry.detach(test_name) end)
     end
 
     test "phoenix.router_dispatch.start and .stop are emitted on success" do

--- a/test/phoenix/verified_routes_test.exs
+++ b/test/phoenix/verified_routes_test.exs
@@ -187,6 +187,9 @@ defmodule Phoenix.VerifiedRoutesTest do
       end)
 
     assert warnings == ""
+  after
+    :code.purge(__MODULE__.Hash)
+    :code.delete(__MODULE__.Hash)
   end
 
   test "unverified_path" do
@@ -210,6 +213,9 @@ defmodule Phoenix.VerifiedRoutesTest do
         def test, do: ~p"/posts/1"foo
       end
     end
+  after
+    :code.purge(__MODULE__.LeftOver)
+    :code.delete(__MODULE__.LeftOver)
   end
 
   test "~p raises on dynamic interpolation" do
@@ -221,6 +227,9 @@ defmodule Phoenix.VerifiedRoutesTest do
         def test, do: ~p"/posts/#{1}#{2}"
       end
     end
+  after
+    :code.purge(__MODULE__.DynamicDynamic)
+    :code.delete(__MODULE__.DynamicDynamic)
   end
 
   test "~p raises when not prefixed by /" do
@@ -235,6 +244,9 @@ defmodule Phoenix.VerifiedRoutesTest do
                      def test, do: ~p"posts/1"
                    end
                  end
+  after
+    :code.purge(__MODULE__.SigilPPrefix)
+    :code.delete(__MODULE__.SigilPPrefix)
   end
 
   test "path arities" do
@@ -262,6 +274,9 @@ defmodule Phoenix.VerifiedRoutesTest do
         def test, do: path(%URI{}, "/posts/1")
       end
     end
+  after
+    :code.purge(__MODULE__.MissingPathPrefix)
+    :code.delete(__MODULE__.MissingPathPrefix)
   end
 
   test "url raises when non ~p is passed" do
@@ -271,6 +286,9 @@ defmodule Phoenix.VerifiedRoutesTest do
         def test, do: url("/posts/1")
       end
     end
+  after
+    :code.purge(__MODULE__.MissingURLPrefix)
+    :code.delete(__MODULE__.MissingURLPrefix)
   end
 
   test "static_integrity" do
@@ -334,6 +352,9 @@ defmodule Phoenix.VerifiedRoutesTest do
         end
       end
     end
+  after
+    :code.purge(__MODULE__.InvalidQuery)
+    :code.delete(__MODULE__.InvalidQuery)
   end
 
   test "~p with complex ids" do
@@ -500,6 +521,10 @@ defmodule Phoenix.VerifiedRoutesTest do
 
         assert warnings =~
                  ~r"test/phoenix/verified_routes_test.exs:#{line}:(\d+:)? Phoenix.VerifiedRoutesTest.Forwards.test/0"
+
+      after
+        :code.purge(__MODULE__.Forwards)
+        :code.delete(__MODULE__.Forwards)
       end
 
       test "~p warns on unmatched path" do
@@ -524,6 +549,9 @@ defmodule Phoenix.VerifiedRoutesTest do
 
         assert warnings =~
                  ~s|no route path for Phoenix.VerifiedRoutesTest.Router matches "/unknown/#{123}"|
+      after
+        :code.purge(__MODULE__.Unmatched)
+        :code.delete(__MODULE__.Unmatched)
       end
 
       test "~p warns on warn_on_verify: true route" do
@@ -538,6 +566,9 @@ defmodule Phoenix.VerifiedRoutesTest do
 
         assert warnings =~
                  ~s|no route path for Phoenix.VerifiedRoutesTest.Router matches "/should-warn/foobar"|
+      after
+        :code.purge(__MODULE__.VerifyFalse)
+        :code.delete(__MODULE__.VerifyFalse)
       end
 
       test "~p does not warn if route without warn_on_verify: true matches first" do
@@ -553,6 +584,9 @@ defmodule Phoenix.VerifiedRoutesTest do
           end)
 
         assert warnings == ""
+      after
+        :code.purge(__MODULE__.VerifyFalseTrueMatchesFirst)
+        :code.delete(__MODULE__.VerifyFalseTrueMatchesFirst)
       end
     end
   end


### PR DESCRIPTION
This allows to use the new `mix test --repeat-until-failure` feature to run the unit tests.

I also found some more issues where mix compile was called in tests leading to missing modules if you had bad luck. This is now fixed by always passing `--no-compile`.

Furthermore, all directories in the `tmp` folder are now properly cleaned up. https://github.com/phoenixframework/phoenix/pull/5623 already tried to do this, but this still left directories if the generated test name or random string contained a `/` character.