### PR TITLE
Pass all_args to compile task in digest tasks

### DIFF
--- a/lib/mix/tasks/phx.digest.clean.ex
+++ b/lib/mix/tasks/phx.digest.clean.ex
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Phx.Digest.Clean do
   def run(all_args) do
     # Ensure all compressors are compiled.
     if "--no-compile" not in all_args do
-      Mix.Task.run("compile")
+      Mix.Task.run("compile", all_args)
     end
 
     {:ok, _} = Application.ensure_all_started(:phoenix)

--- a/lib/mix/tasks/phx.digest.clean.ex
+++ b/lib/mix/tasks/phx.digest.clean.ex
@@ -33,6 +33,8 @@ defmodule Mix.Tasks.Phx.Digest.Clean do
 
     * `--all` - specifies that all compiled assets (including the manifest)
       will be removed. Note this overrides the age and keep switches.
+
+    * `--no-compile` - do not run mix compile
   """
 
   @switches [output: :string, age: :integer, keep: :integer, all: :boolean]

--- a/lib/mix/tasks/phx.digest.ex
+++ b/lib/mix/tasks/phx.digest.ex
@@ -40,6 +40,15 @@ defmodule Mix.Tasks.Phx.Digest do
 
   It is possible to digest the stylesheet asset references without the query
   string "?vsn=d" with the option `--no-vsn`.
+
+  ## Options
+
+    * `-o, --output` - indicates the path to your compiled
+      assets directory. Defaults to `priv/static`
+
+    * --no-vsn - do not add version query string to assets
+
+    * --no-compile - do not run mix compile
   """
 
   @default_opts [vsn: true]

--- a/lib/mix/tasks/phx.digest.ex
+++ b/lib/mix/tasks/phx.digest.ex
@@ -46,9 +46,9 @@ defmodule Mix.Tasks.Phx.Digest do
     * `-o, --output` - indicates the path to your compiled
       assets directory. Defaults to `priv/static`
 
-    * --no-vsn - do not add version query string to assets
+    * `--no-vsn` - do not add version query string to assets
 
-    * --no-compile - do not run mix compile
+    * `--no-compile` - do not run mix compile
   """
 
   @default_opts [vsn: true]

--- a/lib/mix/tasks/phx.digest.ex
+++ b/lib/mix/tasks/phx.digest.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Phx.Digest do
   def run(all_args) do
     # Ensure all compressors are compiled.
     if "--no-compile" not in all_args do
-      Mix.Task.run("compile")
+      Mix.Task.run("compile", all_args)
     end
 
     Mix.Task.reenable("phx.digest")

--- a/test/mix/tasks/phx.digest_test.exs
+++ b/test/mix/tasks/phx.digest_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Phx.DigestTest do
   import MixHelper
 
   test "logs when the path is invalid" do
-    Mix.Tasks.Phx.Digest.run(["invalid_path", "--no-deps-check", "--no-compile"])
+    Mix.Tasks.Phx.Digest.run(["invalid_path", "--no-compile"])
     assert_received {:mix_shell, :error, ["The input path \"invalid_path\" does not exist"]}
   end
 
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Phx.DigestTest do
   test "digests and compress files" do
     in_tmp @output_path, fn ->
       File.mkdir_p!("priv/static")
-      Mix.Tasks.Phx.Digest.run(["priv/static", "-o", @output_path, "--no-deps-check", "--no-compile"])
+      Mix.Tasks.Phx.Digest.run(["priv/static", "-o", @output_path, "--no-compile"])
       assert_received {:mix_shell, :info, ["Check your digested files at \"mix_phoenix_digest\""]}
     end
   end
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Phx.DigestTest do
   test "digests and compress files without the input path" do
     in_tmp @output_path, fn ->
       File.mkdir_p!("priv/static")
-      Mix.Tasks.Phx.Digest.run(["-o", @output_path, "--no-deps-check", "--no-compile"])
+      Mix.Tasks.Phx.Digest.run(["-o", @output_path, "--no-compile"])
       assert_received {:mix_shell, :info, ["Check your digested files at \"mix_phoenix_digest_no_input\""]}
     end
   end
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Phx.DigestTest do
   test "uses the input path as output path when no output path is given" do
     in_tmp @input_path, fn ->
       File.mkdir_p!(@input_path)
-      Mix.Tasks.Phx.Digest.run([@input_path, "--no-deps-check", "--no-compile"])
+      Mix.Tasks.Phx.Digest.run([@input_path, "--no-compile"])
       assert_received {:mix_shell, :info, ["Check your digested files at \"input_path\""]}
     end
   end


### PR DESCRIPTION
 Args like "--no-deps-check" do not get passed through causing `compile` to fail in instances where it's important to not check deps. For example this broke our nix build which handles deps in its own way.

It breaks these instructions: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/beam.section.md?plain=1#L215

Also adds command line docs and removes `--no-deps-check` flag on tests that use `--no-compile`