### PR TITLE
Set default generator timestamp to be :utc_datetime_usec

### DIFF
--- a/installer/lib/phx_new/project.ex
+++ b/installer/lib/phx_new/project.ex
@@ -16,7 +16,7 @@ defmodule Phx.New.Project do
             opts: :unset,
             in_umbrella?: false,
             binding: [],
-            generators: [timestamp_type: :utc_datetime]
+            generators: [timestamp_type: :utc_datetime_usec]
 
   def new(project_path, opts) do
     project_path = Path.expand(project_path)

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file("phx_blog/config/config.exs", fn file ->
         assert file =~ "ecto_repos: [PhxBlog.Repo]"
-        assert file =~ "generators: [timestamp_type: :utc_datetime]"
+        assert file =~ "generators: [timestamp_type: :utc_datetime_usecs]"
         assert file =~ "config :phoenix, :json_library, Jason"
         assert file =~ ~s[cd: Path.expand("../assets", __DIR__),]
         refute file =~ "namespace: PhxBlog"


### PR DESCRIPTION
Exactly what it says on the tin. Every project I've ever done this is one of the first things that needs doing. I wager it's fairly standard practice at this point, so I wanted to open a PR to see if folks would be okay switching.