### PR TITLE
templates: use inspect/1 instead of to_string/1 in errors_on/1

### DIFF
--- a/installer/templates/phx_ecto/data_case.ex
+++ b/installer/templates/phx_ecto/data_case.ex
@@ -50,7 +50,9 @@ defmodule <%= @app_module %>.DataCase do
   def errors_on(changeset) do
     Ecto.Changeset.traverse_errors(changeset, fn {message, opts} ->
       Regex.replace(~r"%{(\w+)}", message, fn _, key ->
-        opts |> Keyword.get(String.to_existing_atom(key), key) |> to_string()
+        opts
+        |> Keyword.get(String.to_existing_atom(key), key)
+        |> inspect()
       end)
     end)
   end


### PR DESCRIPTION
Per https://github.com/elixir-ecto/ecto/issues/4445

I don't see a reason to prefer `to_string` over `inspect` here, maybe I'm missing something :)