### PR TITLE
phx.gen.release: Add explicit mix assets.setup step

### DIFF
--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -44,7 +44,9 @@ RUN mkdir config
 # to be re-compiled.
 COPY config/config.exs config/${MIX_ENV}.exs config/
 RUN mix deps.compile
-
+<%= if assets_dir_exists? do %>
+RUN mix assets.setup
+<% end %>
 COPY priv priv
 
 COPY lib lib

--- a/test/mix/tasks/phx.gen.release_test.exs
+++ b/test/mix/tasks/phx.gen.release_test.exs
@@ -123,8 +123,9 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
       Gen.Release.run(["--docker"])
 
       assert_file("Dockerfile", fn file ->
+        assert file =~ ~S|RUN mix assets.setup|
         assert file =~ ~S|COPY assets assets|
-        assert file =~ ~S|mix assets.deploy|
+        assert file =~ ~S|RUN mix assets.deploy|
       end)
     end)
   end
@@ -134,8 +135,9 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
       Gen.Release.run(["--docker"])
 
       assert_file("Dockerfile", fn file ->
+        refute file =~ ~S|RUN mix assets.setup|
         refute file =~ ~S|COPY assets assets|
-        refute file =~ ~S|mix assets.deploy|
+        refute file =~ ~S|RUN mix assets.deploy|
       end)
     end)
   end


### PR DESCRIPTION
This step will install Tailwind and esbuild earlier and the container layer shall be cached depending only on dependencies and config (where Tailwind and esbuild tool versions are actually defined).

Code changes in priv, lib and assets shall not cause those tools to be re-downloaded and installed.

Closes #5833.