### PR TITLE
Fix mix phx.server command bug - it halts if command line args separator -- has been used

### DIFF
--- a/lib/mix/tasks/phx.server.ex
+++ b/lib/mix/tasks/phx.server.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Phx.Server do
   @impl true
   def run(args) do
     Application.put_env(:phoenix, :serve_endpoints, true, persistent: true)
-    Mix.Tasks.Run.run(open_args(args) ++ run_args())
+    Mix.Tasks.Run.run(run_args() ++ open_args(args))
   end
 
   defp iex_running? do


### PR DESCRIPTION
When `mix phx.server -- arg1` command has been run, it starts server, then halts it immediately.

This PR fixes that bug, so once you run command it does not halt server.

More details on [issue tracker](https://github.com/phoenixframework/phoenix/issues/5867#issue-2406001001)
 