### PR TITLE
Add `false` value to disable `watchers`

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -181,6 +181,8 @@ defmodule Phoenix.Endpoint do
 
           [another: {Mod, :fun, [arg1, arg2]}]
 
+      When `false`, watchers can be disabled.
+
     * `:force_watchers` - when `true`, forces your watchers to start
       even when the `:server` option is set to `false`.
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -161,8 +161,10 @@ defmodule Phoenix.Endpoint.Supervisor do
   end
 
   defp watcher_children(_mod, conf, server?) do
+    watchers = conf[:watchers] || []
+
     if server? || conf[:force_watchers] do
-      Enum.map(conf[:watchers], &{Phoenix.Endpoint.Watcher, &1})
+      Enum.map(watchers, &{Phoenix.Endpoint.Watcher, &1})
     else
       []
     end

--- a/test/phoenix/endpoint/supervisor_test.exs
+++ b/test/phoenix/endpoint/supervisor_test.exs
@@ -145,6 +145,16 @@ defmodule Phoenix.Endpoint.SupervisorTest do
              end)
     end
 
+    test "init/1 doesn't start watchers when `:server` config is true and `:watchers` is false" do
+      Application.put_env(:phoenix, WatchersEndpoint, server: true, watchers: false)
+      {:ok, {_, children}} = Supervisor.init({:phoenix, WatchersEndpoint, []})
+
+      refute Enum.any?(children, fn
+               %{start: {Phoenix.Endpoint.Watcher, :start_link, _config}} -> true
+               _ -> false
+             end)
+    end
+
     test "init/1 doesn't start watchers when `:server` config is false" do
       Application.put_env(:phoenix, WatchersEndpoint, server: false, watchers: @watchers)
       {:ok, {_, children}} = Supervisor.init({:phoenix, WatchersEndpoint, []})


### PR DESCRIPTION
This is useful to override `watchers` when we want to override the config.
keywords are not overridable. ref. https://hexdocs.pm/elixir/main/Config.html#config/3
