### PR TITLE
Fix `CoreComponents` margin between inputs and labels

### DIFF
--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -331,11 +331,11 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div>
-      <.label for={@id}><%%= @label %></.label>
+      <.label class="mb-2" for={@id}><%%= @label %></.label>
       <select
         id={@id}
         name={@name}
-        class="mt-2 block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
+        class="block w-full rounded-md border border-gray-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
         multiple={@multiple}
         {@rest}
       >
@@ -350,12 +350,12 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(%{type: "textarea"} = assigns) do
     ~H"""
     <div>
-      <.label for={@id}><%%= @label %></.label>
+      <.label class="mb-2" for={@id}><%%= @label %></.label>
       <textarea
         id={@id}
         name={@name}
         class={[
-          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6 min-h-[6rem]",
+          "block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6 min-h-[6rem]",
           @errors == [] && "border-zinc-300 focus:border-zinc-400",
           @errors != [] && "border-rose-400 focus:border-rose-400"
         ]}
@@ -370,14 +370,14 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(assigns) do
     ~H"""
     <div>
-      <.label for={@id}><%%= @label %></.label>
+      <.label class="mb-2" for={@id}><%%= @label %></.label>
       <input
         type={@type}
         name={@name}
         id={@id}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
-          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          "block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
           @errors == [] && "border-zinc-300 focus:border-zinc-400",
           @errors != [] && "border-rose-400 focus:border-rose-400"
         ]}
@@ -391,12 +391,14 @@ defmodule <%= @web_namespace %>.CoreComponents do
   @doc """
   Renders a label.
   """
+  attr :class, :string, default: nil
   attr :for, :string, default: nil
+
   slot :inner_block, required: true
 
   def label(assigns) do
     ~H"""
-    <label for={@for} class="block text-sm font-semibold leading-6 text-zinc-800">
+    <label for={@for} class={["block text-sm font-semibold leading-6 text-zinc-800"], @class}>
       <%%= render_slot(@inner_block) %>
     </label>
     """

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -331,7 +331,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div>
-      <.label class="mb-2" for={@id}><%%= @label %></.label>
+      <.label for={@id} class="mb-2"><%%= @label %></.label>
       <select
         id={@id}
         name={@name}
@@ -350,7 +350,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(%{type: "textarea"} = assigns) do
     ~H"""
     <div>
-      <.label class="mb-2" for={@id}><%%= @label %></.label>
+      <.label for={@id} class="mb-2"><%%= @label %></.label>
       <textarea
         id={@id}
         name={@name}
@@ -370,7 +370,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(assigns) do
     ~H"""
     <div>
-      <.label class="mb-2" for={@id}><%%= @label %></.label>
+      <.label for={@id} class="mb-2"><%%= @label %></.label>
       <input
         type={@type}
         name={@name}


### PR DESCRIPTION
## Description 

This is a minor issue with the input component from the `core_components.ex` file (used in phx.gen.live)
A margin top is added by default on inputs for the spacing between the label and the input.

However it is not removed if a label is not provided. Which causes alignment issue when combining the input component with other elements.

[As suggested by José Valim](https://github.com/phoenixframework/phoenix/issues/5832#issuecomment-2218486504), putting the margin on the label itself is more appropriate. 


## Changes

- Added a class `attr` to the `label` component
- Remove `mt-2` from inputs in `CoreComponents`
- Add `mb-2` to `label` with `input` 

Closes #5832 

| **before:** margin on the input | **after:** margin on the label |
|-------|------|
| ![image](https://github.com/user-attachments/assets/a8fce2bf-c282-40fb-afae-0e3fb1fec59e) |  ![demo](https://github.com/user-attachments/assets/dc9a4da1-ce6f-443e-8620-7e8d62fbd651) |