### PR TITLE
Add a new release script to wait_for_migrations

### DIFF
--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -68,6 +68,8 @@ defmodule Mix.Tasks.Phx.Gen.Release do
       Mix.Phoenix.copy_from(paths(), "priv/templates/phx.gen.release", binding, [
         {:eex, "rel/migrate.sh.eex", "rel/overlays/bin/migrate"},
         {:eex, "rel/migrate.bat.eex", "rel/overlays/bin/migrate.bat"},
+        {:eex, "rel/wait_for_migrations.sh.eex", "rel/overlays/bin/wait_for_migrations"},
+        {:eex, "rel/wait_for_migrations.bat.eex", "rel/overlays/bin/wait_for_migrations.bat"},
         {:eex, "release.ex", Mix.Phoenix.context_lib_path(app, "release.ex")}
       ])
     end
@@ -159,6 +161,9 @@ defmodule Mix.Tasks.Phx.Gen.Release do
 
         # To run migrations
         _build/dev/rel/#{app}/bin/migrate
+
+        # To wait for migrations to run
+        _build/dev/rel/#{app}/bin/wait_for_migrations
     """
   end
 

--- a/priv/templates/phx.gen.release/rel/wait_for_migrations.bat.eex
+++ b/priv/templates/phx.gen.release/rel/wait_for_migrations.bat.eex
@@ -1,0 +1,1 @@
+call "%~dp0\<%= otp_app %>" eval <%= app_namespace %>.Release.wait_for_migrations

--- a/priv/templates/phx.gen.release/rel/wait_for_migrations.sh.eex
+++ b/priv/templates/phx.gen.release/rel/wait_for_migrations.sh.eex
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+cd -P -- "$(dirname -- "$0")"
+exec ./<%= otp_app %> eval <%= app_namespace %>.Release.wait_for_migrations

--- a/priv/templates/phx.gen.release/release.ex
+++ b/priv/templates/phx.gen.release/release.ex
@@ -5,6 +5,39 @@ defmodule <%= app_namespace %>.Release do
   """
   @app :<%= otp_app %>
 
+  def wait_for_migrations do
+    load_app()
+    all_migrated? = repos()
+    |> Stream.map(&migrated?/1)
+    |> Enum.all?()
+    if not all_migrated? do
+      raise "Migrations have still not run after the timeout"
+    end
+    IO.puts("Migration check successful!")
+  end
+
+  defp migrated?(repo, retry_count \\ 0)
+  defp migrated?(_, retry_count) when retry_count > 60 do false end
+  defp migrated?(repo, retry_count) when retry_count > 0 do
+    IO.puts("Waiting for migrations to run for #{repo} (#{retry_count}/60)...")
+    Process.sleep(5000)
+    do_migration_check(repo, retry_count)
+  end
+
+  defp migrated?(repo, retry_count) do
+    do_migration_check(repo, retry_count)
+  end
+
+  defp do_migration_check(repo, retry_count) do
+    case Ecto.Migrator.with_repo(repo, &Ecto.Migrator.migrations(&1)) do
+      {:ok, repo_status, _} ->
+        Enum.all?(repo_status, fn {status, _, _} -> status == :up end) || migrated?(repo, retry_count + 1)
+      {:error, error} ->
+        IO.puts(error)
+        migrated?(repo, retry_count + 1)
+    end
+  end
+
   def migrate do
     load_app()
 

--- a/test/mix/tasks/phx.gen.release_test.exs
+++ b/test/mix/tasks/phx.gen.release_test.exs
@@ -37,6 +37,14 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
         assert file =~ "set PHX_SERVER=true\ncall \"%~dp0\\phoenix\" start"
       end)
 
+      assert_file("rel/overlays/bin/wait_for_migrations", fn file ->
+        assert file =~ ~S|exec ./phoenix eval Phoenix.Release.wait_for_migrations|
+      end)
+
+      assert_file("rel/overlays/bin/wait_for_migrations.bat", fn file ->
+        assert file =~ ~S|call "%~dp0\phoenix" eval Phoenix.Release.wait_for_migrations|
+      end)
+
       refute_file("Dockerfile")
       refute_file(".dockerignore")
 
@@ -47,6 +55,8 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
       assert_receive {:mix_shell, :info, ["* creating rel/overlays/bin/migrate.bat"]}
       assert_receive {:mix_shell, :info, ["* creating rel/overlays/bin/server"]}
       assert_receive {:mix_shell, :info, ["* creating rel/overlays/bin/server.bat"]}
+      assert_receive {:mix_shell, :info, ["* creating rel/overlays/bin/wait_for_migrations"]}
+      assert_receive {:mix_shell, :info, ["* creating rel/overlays/bin/wait_for_migrations.bat"]}
       assert_receive {:mix_shell, :info, ["\nYour application is ready to be deployed" <> _]}
     end)
   end
@@ -104,6 +114,14 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
 
       assert_file("rel/overlays/bin/server.bat", fn file ->
         assert file =~ "set PHX_SERVER=true\ncall \"%~dp0\\phoenix\" start"
+      end)
+
+      assert_file("rel/overlays/bin/wait_for_migrations", fn file ->
+        assert file =~ ~S|exec ./phoenix eval Phoenix.Release.wait_for_migrations|
+      end)
+
+      assert_file("rel/overlays/bin/wait_for_migrations.bat", fn file ->
+        assert file =~ ~S|call "%~dp0\phoenix" eval Phoenix.Release.wait_for_migrations|
       end)
 
       assert_file(".dockerignore")


### PR DESCRIPTION
## Problem

When deploying to environments with multiple replicas of a phoenix app (like in Kubernetes), there's a common problem where deploying a new instance of the app requires waiting for migrations to complete. The problem is described in-depth here: https://andrewlock.net/deploying-asp-net-core-applications-to-kubernetes-part-7-running-database-migrations/

To summarize: When you have one instance of a phoenix app, it would be simple to just run `migrate` before the app starts up (like in an `initContainer`). But if you have two instances of a phoenix app (for high availability), you would run the migrations separate from the app startup process (like in a Kubernetes Job) so you don't encounter race conditions from two different processes trying to apply the same migrations. But now you need to somehow tell the apps to wait for the migrations to complete, or else the new app may start up and try to access a column that doesn't exist yet.

## Solution

This PR adds a `wait_for_migrations` release script that essentially checks [`mix ecto.migrations`](https://hexdocs.pm/ecto_sql/Mix.Tasks.Ecto.Migrations.html) every 5 seconds until it shows all have been applied.

You can see an example of this solution in practice here: https://gitlab.com/mac-chaffee/crowdsort/-/tree/master/chart/crowdsort/templates

## Questions
* The wait_for_migrations function is a bit complex and could use tests, but wasn't sure where to put them
* Should this even be in phoenix? perhaps `wait_for_migrations` should be a part of Ecto and Phoenix just calls their function? Or maybe we define the function deeper inside phoenix so we keep `release.ex` minimal?
* Haven't touched elixir in 4 years, so my code may be terrible!
* I didn't make the timeouts configurable, but they probably should be. What's the best way to load that config in this file?
* Also using IO.puts, wasn't sure if logging is accessible to this script or not

Open to all feedback!