### PR TITLE
Respect MIX_DEPS_PATH in generated config. Fix #5890. Fix #5414.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,7 +14,7 @@ if Mix.env() == :dev do
     [
       args: ~w(./js/phoenix --bundle) ++ args,
       cd: Path.expand("../assets", __DIR__),
-      env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+      env: %{"NODE_PATH" => System.get_env("MIX_DEPS_PATH", Path.expand("../deps", __DIR__))}
     ]
   end
 

--- a/installer/templates/phx_assets/tailwind.config.js
+++ b/installer/templates/phx_assets/tailwind.config.js
@@ -33,7 +33,11 @@ module.exports = {
     // See your `CoreComponents.icon/1` for more information.
     //
     plugin(function({matchComponents, theme}) {
-      let iconsDir = path.join(__dirname, "..<%= if @in_umbrella, do: "/../.." %>/deps/heroicons/optimized")
+      let deps_path = path.join(__dirname, "..<%= if @in_umbrella, do: "/../.." %>/deps")
+      if (typeof process.env.MIX_DEPS_PATH === "string") {
+        deps_path = process.env.MIX_DEPS_PATH
+      }
+      let iconsDir = path.join(deps_path, "heroicons/optimized")
       let values = {}
       let icons = [
         ["", "/24/outline"],

--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -40,7 +40,7 @@ config :esbuild,
     args:
       ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
     cd: Path.expand("..<%= if @in_umbrella, do: "/apps/#{@app_name}" %>/assets", __DIR__),
-    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+    env: %{"NODE_PATH" => System.get_env("MIX_DEPS_PATH", Path.expand("../deps", __DIR__))}
   ]<% end %><%= if @css do %>
 
 # Configure tailwind (the version is required)

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
@@ -24,7 +24,7 @@ config :esbuild,
     args:
       ~w(js/app.js --bundle --target=es2017 --outdir=../priv/static/assets --external:/fonts/* --external:/images/*),
     cd: Path.expand("../apps/<%= @web_app_name %>/assets", __DIR__),
-    env: %{"NODE_PATH" => Path.expand("../deps", __DIR__)}
+    env: %{"NODE_PATH" => System.get_env("MIX_DEPS_PATH", Path.expand("../deps", __DIR__))}
   ]<% end %><%= if @css do %>
 
 # Configure tailwind (the version is required)


### PR DESCRIPTION
Make the tailwind config use `MIX_DEPS_PATH` if set to determine path to the assets.