### PR TITLE
fix Step 2, template filename

### DIFF
--- a/guides/real_time/channels.md
+++ b/guides/real_time/channels.md
@@ -410,7 +410,7 @@ Now our `conn.assigns` contains the `current_user` and `user_token`.
 
 ### Step 2 - Pass the Token to the JavaScript
 
-Next, we need to pass this token to JavaScript. We can do so inside a script tag in `lib/hello_web/components/layouts/app.html.heex` right above the app.js script, as follows:
+Next, we need to pass this token to JavaScript. We can do so inside a script tag in `lib/hello_web/components/layouts/root.html.heex` right above the app.js script, as follows:
 
 ```heex
 <script>window.userToken = "<%= assigns[:user_token] %>";</script>


### PR DESCRIPTION
Section "Step 2 - Pass the Token to the JavaScript:"
heex template filename 
`lib/hello_web/components/layouts/app.html.heex`
should be
`lib/hello_web/components/layouts/root.html.heex`
which contains the head tag and the mentioned app.js script tag