### PR TITLE
WebSockets: support passing through sec-websocket-protocol header

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -257,7 +257,7 @@ defmodule Phoenix.Socket.Transport do
 
     connect_info =
       Enum.map(connect_info, fn
-        key when key in [:peer_data, :trace_context_headers, :uri, :user_agent, :x_headers] ->
+        key when key in [:peer_data, :trace_context_headers, :uri, :user_agent, :x_headers, :sec_websocket_protocol] ->
           key
 
         {:session, session} ->
@@ -268,7 +268,7 @@ defmodule Phoenix.Socket.Transport do
 
         other ->
           raise ArgumentError,
-                ":connect_info keys are expected to be one of :peer_data, :trace_context_headers, :x_headers, :uri, or {:session, config}, " <>
+                ":connect_info keys are expected to be one of :peer_data, :trace_context_headers, :x_headers, :user_agent, :sec_websocket_protocol, :uri, or {:session, config}, " <>
                   "optionally followed by custom keyword pairs, got: #{inspect(other)}"
       end)
 
@@ -458,6 +458,8 @@ defmodule Phoenix.Socket.Transport do
 
     * `:user_agent` - the value of the "user-agent" request header
 
+    * `:sec_websocket_protocol` - the value of the "sec-websocket-protocol" header
+
   """
   def connect_info(conn, endpoint, keys) do
     for key <- keys, into: %{} do
@@ -476,6 +478,9 @@ defmodule Phoenix.Socket.Transport do
 
         :user_agent ->
           {:user_agent, fetch_user_agent(conn)}
+
+        :sec_websocket_protocol ->
+          {:sec_websocket_protocol, Plug.Conn.get_req_header(conn, "sec-websocket-protocol")}
 
         {:session, session} ->
           {:session, connect_session(conn, endpoint, session)}


### PR DESCRIPTION
Opening this MR to begin a wider discussion on this.

Let's start with the current state of things: in Phoenix it's not possible to access any headers of Websocket connections except the X-Foo headers if you explicitly enable it with `connect_info: [:x_headers]`. The [docs](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#socket/3-connect-info) are very clear about this limitation:

> Phoenix only gives you limited access to the connection headers for security reasons...

However, this severely limits the capabilities of Phoenix. We converted Pleroma from Phoenix+Cowboy for websockets to `Phoenix.Socket.Transport` so we could support both Cowboy and Bandit. In the process I encountered a [weird test case](https://git.pleroma.social/pleroma/pleroma/-/merge_requests/4064/diffs#bef485859b4b4e2501c0f84a2432a35b7c01f53d_271_271) we had written that validated you could pass through an auth token in the `Sec-WebSocket-Protocol` header.

Nobody could remember at the time why this existed.

It turns out, this is actually how the Mastodon client protocol authenticates over websockets!

At first I thought this was a case of abusing this header for something it wasn't meant for. The RFC doesn't make it sound like this is the purpose of the header. So why were they doing it this way?

As it turns out, [lots of applications do this](https://github.com/search?q=Sec-WebSocket-Protocol+auth&type=code). [Here's one](https://github.com/zerobugdebug/websocket-authorizer) from 3 weeks ago doing it in AWS Lambda.

So how can we make sure Phoenix is a suitable framework for all types of Websocket applications/protocols as the current limitations are very narrow-sighted? I do not want to have to [maintain a fork](https://git.pleroma.social/pleroma/pleroma/-/merge_requests/4206) of Phoenix to support this.