### PR TITLE
Enable web console logger for new projects

### DIFF
--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -33,6 +33,13 @@ import "phoenix_html"
 <%= @live_comment %>window.addEventListener("phx:page-loading-start", _info => topbar.show(300))
 <%= @live_comment %>window.addEventListener("phx:page-loading-stop", _info => topbar.hide())
 
+// Enable server log streaming to client.
+<%= @live_comment %>window.addEventListener("phx:live_reload:attached", ({detail: reloader}) => {
+<%= @live_comment %>  reloader.enableServerLogs()
+<%= @live_comment %>  window.liveReloader = reloader
+<%= @live_comment %>})
+
+
 // connect if there are any LiveViews on the page
 <%= @live_comment %>liveSocket.connect()
 

--- a/installer/templates/phx_assets/app.js
+++ b/installer/templates/phx_assets/app.js
@@ -38,8 +38,6 @@ import "phoenix_html"
 <%= @live_comment %>  reloader.enableServerLogs()
 <%= @live_comment %>  window.liveReloader = reloader
 <%= @live_comment %>})
-
-
 // connect if there are any LiveViews on the page
 <%= @live_comment %>liveSocket.connect()
 

--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -45,6 +45,7 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
 # Watch static and templates for browser reloading.
 config :<%= @app_name %>, <%= @endpoint_module %>,
   live_reload: [
+    web_console_logger: true,
     patterns: [
       ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
       ~r"priv/gettext/.*(po)$",<% end %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -45,6 +45,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 # Watch static and templates for browser reloading.
 config :<%= @web_app_name %>, <%= @endpoint_module %>,
   live_reload: [
+    web_console_logger: true,
     patterns: [
       ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
       ~r"priv/gettext/.*(po)$",<% end %>


### PR DESCRIPTION
This article describes a new and useful feature in Live reload 1.5 and later.
I think it could make sense to enable it by default for new projects...

https://fly.io/phoenix-files/phoenix-dev-blog-server-logs-in-the-browser-console/