### PR TITLE
Correct example router.ex code in Plug guide

### DIFF
--- a/guides/plug.md
+++ b/guides/plug.md
@@ -106,7 +106,8 @@ defmodule HelloWeb.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
-    plug :fetch_flash
+    plug :fetch_live_flash
+    plug :put_root_layout, html: {HelloWeb.LayoutView, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug HelloWeb.Plugs.Locale, "en"


### PR DESCRIPTION
The first example (adding locale) of router.ex doesn't align with generated code or subsequent examples. There are two issues:

1.  `plug :fetch_flash` should be `plug :fetch_live_flash` 
2. Missing line: `plug :put_root_layout ...`