### PR TITLE
docs: router, fix scope example explanation typo

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -210,15 +210,15 @@ defmodule Phoenix.Router do
 
   Scopes allow us to scope on any path or even on the helper name:
 
-      scope "/v1", MyAppWeb, host: "api." do
+      scope "/api/v1", MyAppWeb, as: :api_v1 do
         get "/pages/:id", PageController, :show
       end
 
   For example, the route above will match on the path `"/api/v1/pages/1"`
-  and the named route will be `api_v1_page_path`, as expected from the
-  values given to `scope/2` option.
+  and the named helper will be `api_v1_page_path`, as expected from the
+  values given to `scope/4` option.
 
-  Like all paths you can define dynamic segments that will be applied as
+  Like all paths, you can define dynamic segments that will be applied as
   parameters in the controller:
 
       scope "/api/:version", MyAppWeb do


### PR DESCRIPTION
This is my first PR, as I was reading through docs as someone new to Phoenix framework and noticed this section of the `Phoenix.Router` docs didn't make sense to me.

This fixes a typo where a host option passed to `scope/2` is described as if it were a part of the `path` param instead. I updated the description instead of fixing the example, because I personally found the example to be useful in better understanding the options available when defining router scopes, but changing the example instead would also work if preferred.

I removed the sentence about named routes because:
1. They aren't explained previously in this documentation.
2. They seem to be related to helpers (deprecated), as the `phx.routes` mix task doesn't output them when helpers are disabled, so it's not clear to me if it's a useful detail to include.

If it's better to keep that sentence, I believe the named route provided is incorrect, since the host value isn't included in the named routes (based only on own local testing). It also could be helpful to link to an explanation of named routes in this case, but I didn't find a good reference for this and don't have the expertise to write it.