### PR TITLE
fix broken link

### DIFF
--- a/guides/deployment/fly.md
+++ b/guides/deployment/fly.md
@@ -390,11 +390,11 @@ $ fly scale count 2
 
 Refer to the [Fly.io Elixir documentation](https://fly.io/docs/getting-started/elixir) for additional information.
 
-[Working with Fly.io applications](https://fly.io/docs/getting-started/working-with-fly-apps/) covers things like:
+[The Fly.io docs](https://fly.io/docs/) covers things like:
 
-* Status and logs
-* Custom domains
-* Certificates
+* [Status](https://fly.io/docs/flyctl/status/) and [logs](https://fly.io/docs/monitoring/logging-overview/)
+* [Custom domains](https://fly.io/docs/networking/custom-domain/)
+* [Certificates](https://fly.io/docs/networking/custom-domain-api/)
 
 ## Troubleshooting
 


### PR DESCRIPTION
I am trying to fix a broken link [Working with Fly.io applications](https://fly.io/docs/getting-started/working-with-fly-apps/). 
According to what I see from [IA](https://web.archive.org/web/20200812153205/https://fly.io/docs/getting-started/working-with-fly-apps/#viewing-applications), the page doesn't exist anymore and they separated it into different parts.