### PR TITLE
Clarify instructions for using npm install method for third-party JS packages

### DIFF
--- a/guides/asset_management.md
+++ b/guides/asset_management.md
@@ -20,7 +20,7 @@ If you want to import JavaScript dependencies, you have at least three options t
    import topbar from "../vendor/topbar"
    ```
 
-2. Call `npm install topbar --save` inside your assets directory and `esbuild` will be able to automatically pick them up:
+2. Call `npm install topbar --prefix assets` will create `package.json` and `package-lock.json` inside your assets directory and `esbuild` will be able to automatically pick them up:
 
    ```js
    import topbar from "topbar"


### PR DESCRIPTION
In Phoenix `1.7.14`, using `npm install some-package --save` from inside the `assets/` directory doesn't actually appear to do anything while `npm install some-package --prefix assets` creates `package.json` and `package-lock.json` files and is what was suggested in the auto-generated `app.js` that you get with a new Phoenix app. So I attempted to tweak the guide to clarify this + make it match the comments in `app.js`.

Feel free to tweak / ignore as desired.