### PR TITLE
Correct migration step in phx.gen.auth docs

### DIFF
--- a/guides/authentication/mix_phx_gen_auth.md
+++ b/guides/authentication/mix_phx_gen_auth.md
@@ -1,12 +1,14 @@
 # mix phx.gen.auth
 
+> This guide assumes that you have gone through the [introductory guides](overview.html) and have a Phoenix application [up and running](up_and_running.html).
+
 The `mix phx.gen.auth` command generates a flexible, pre-built authentication system into your Phoenix app. This generator allows you to quickly move past the task of adding authentication to your codebase and stay focused on the real-world problem your application is trying to solve.
 
 ## Getting started
 
 > Before running this command, consider committing your work as it generates multiple files.
 
-Let's start by running the following command from the root of our app (or `apps/my_app_web` in an umbrella app):
+Let's start by running the following command from the root of our app:
 
 ```console
 $ mix phx.gen.auth Accounts User users
@@ -28,10 +30,10 @@ Since this generator installed additional dependencies in `mix.exs`, let's fetch
 $ mix deps.get
 ```
 
-Now we need to verify the database connection details for the development and test environments in `config/` so the migrator and tests can run properly. Then run the following to create the database:
+Now run the pending repository migrations:
 
 ```console
-$ mix ecto.setup
+$ mix ecto.migrate
 ```
 
 Let's run the tests to make sure our new authentication system works as expected.
@@ -40,7 +42,7 @@ Let's run the tests to make sure our new authentication system works as expected
 $ mix test
 ```
 
-And finally, let's start our Phoenix server and try it out.
+And finally, let's start our Phoenix server and try it out (note the new `Register` and `Log in` links at the top right of the default page).
 
 ```console
 $ mix phx.server


### PR DESCRIPTION
After running `mix phx.gen.auth` you are prompted to run `mix deps.get` followed by `mix ecto.migrate`.

The docs reference `mix ecto.setup` however, which seems to be deprecated in favor of `mix ecto.create`, neither of which are correct in this context, assuming a basic Phoenix app is up and running prior to adding auth.

This PR corrects the docs, replacing `mix ecto.setup` with `mix ecto.migrate` along with an appropriate description of the step.

It also adds the assumption that the reader has gone through the introductory guides and has a running Phoenix app, as well as calling out the addition of the `Register` and `Log in` links added to the default page. 

I also took the liberty to remove some extraneous language about umbrella app root locations, which seemed unnecessary in the context of learning auth basics.