### PR TITLE
Remove an old and unused PubSub subscribe option

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -509,7 +509,7 @@ defmodule Phoenix.Socket do
   defp result({:error, _}), do: :error
 
   def __init__({state, %{id: id, endpoint: endpoint} = socket}) do
-    _ = id && endpoint.subscribe(id, link: true)
+    _ = id && endpoint.subscribe(id)
     {:ok, {state, %{socket | transport_pid: self()}}}
   end
 

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -226,7 +226,7 @@ defmodule Phoenix.Transports.LongPoll do
   defp client_ref(pid) when is_pid(pid), do: self()
 
   defp subscribe(endpoint, topic) when is_binary(topic),
-    do: Phoenix.PubSub.subscribe(endpoint.config(:pubsub_server), topic, link: true)
+    do: Phoenix.PubSub.subscribe(endpoint.config(:pubsub_server), topic)
 
   defp subscribe(_endpoint, pid) when is_pid(pid),
     do: :ok

--- a/lib/phoenix/transports/long_poll_server.ex
+++ b/lib/phoenix/transports/long_poll_server.ex
@@ -33,7 +33,7 @@ defmodule Phoenix.Transports.LongPoll.Server do
           client_ref: nil
         }
 
-        :ok = PubSub.subscribe(state.pubsub_server, priv_topic, link: true)
+        :ok = PubSub.subscribe(state.pubsub_server, priv_topic)
         schedule_inactive_shutdown(state.window_ms)
         {:ok, state}
 


### PR DESCRIPTION
The `link: true` option was supported with versions of `phoenix_pubsub` earlier than 2.0.0, and was removed in this commit https://github.com/phoenixframework/phoenix_pubsub/commit/c05d47f6411d81f3cd94d53607848b5195239c4f

As Phoenix requires `phoenix_pubsub` `~> 2.1`, I believe removing these options is safe.