### PR TITLE
phx.new - Fix deprecation warning when using Elixir ~> 1.18

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -268,7 +268,7 @@ defmodule Mix.Tasks.Phx.New do
 
   if Version.match?(System.version(), "~> 1.18") do
     defp rebar_available? do
-      Mix.Rebar.rebar_args(:rebar3, [])
+      true
     end
   else
     defp rebar_available? do

--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -266,8 +266,14 @@ defmodule Mix.Tasks.Phx.New do
     Code.ensure_loaded?(Hex)
   end
 
-  defp rebar_available? do
-    Mix.Rebar.rebar_cmd(:rebar3)
+  if Version.match?(System.version(), "~> 1.18") do
+    defp rebar_available? do
+      Mix.Rebar.rebar_args(:rebar3, [])
+    end
+  else
+    defp rebar_available? do
+      Mix.Rebar.rebar_cmd(:rebar3)
+    end
   end
 
   defp print_missing_steps(steps) do


### PR DESCRIPTION
When generating a new application using Elixir 1.18.0-dev, this warning is raised:

> Compiling 1 file (.ex)
>      warning: Mix.Rebar.rebar_cmd/1 is deprecated. Use rebar_args/2 or available?/1 instead
>      │
>  275 │       Mix.Rebar.rebar_cmd(:rebar3)
>      │                 ~
>      │
>      └─ lib/mix/tasks/phx.new.ex:275:17: Mix.Tasks.Phx.New.rebar_available?/0

Not sure if this is a good practice, but that's I come up with. 