### PR TITLE
 Open default Phoenix app documentation links in a new tab

### DIFF
--- a/installer/templates/phx_web/controllers/page_html/home.html.heex
+++ b/installer/templates/phx_web/controllers/page_html/home.html.heex
@@ -65,6 +65,7 @@
           <a
             href="https://hexdocs.pm/phoenix/overview.html"
             class="group relative rounded-2xl px-6 py-4 text-sm font-semibold leading-6 text-zinc-900 sm:py-6"
+            target="_blank"
           >
             <span class="absolute inset-0 rounded-2xl bg-zinc-50 transition group-hover:bg-zinc-100 sm:group-hover:scale-105">
             </span>
@@ -85,6 +86,7 @@
           <a
             href="https://github.com/phoenixframework/phoenix"
             class="group relative rounded-2xl px-6 py-4 text-sm font-semibold leading-6 text-zinc-900 sm:py-6"
+            target="_blank"
           >
             <span class="absolute inset-0 rounded-2xl bg-zinc-50 transition group-hover:bg-zinc-100 sm:group-hover:scale-105">
             </span>
@@ -103,6 +105,7 @@
           <a
             href={"https://github.com/phoenixframework/phoenix/blob/v#{Application.spec(:phoenix, :vsn)}/CHANGELOG.md"}
             class="group relative rounded-2xl px-6 py-4 text-sm font-semibold leading-6 text-zinc-900 sm:py-6"
+            target="_blank"
           >
             <span class="absolute inset-0 rounded-2xl bg-zinc-50 transition group-hover:bg-zinc-100 sm:group-hover:scale-105">
             </span>
@@ -136,6 +139,7 @@
             <a
               href="https://twitter.com/elixirphoenix"
               class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-zinc-900"
+              target="_blank"
             >
               <svg
                 viewBox="0 0 16 16"
@@ -151,6 +155,7 @@
             <a
               href="https://elixirforum.com"
               class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-zinc-900"
+              target="_blank"
             >
               <svg
                 viewBox="0 0 16 16"
@@ -166,6 +171,7 @@
             <a
               href="https://web.libera.chat/#elixir"
               class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-zinc-900"
+              target="_blank"
             >
               <svg
                 viewBox="0 0 16 16"
@@ -190,6 +196,7 @@
             <a
               href="https://discord.gg/elixir"
               class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-zinc-900"
+              target="_blank"
             >
               <svg
                 viewBox="0 0 16 16"
@@ -205,6 +212,7 @@
             <a
               href="https://fly.io/docs/elixir/getting-started/"
               class="group -mx-2 -my-0.5 inline-flex items-center gap-3 rounded-lg px-2 py-0.5 hover:bg-zinc-50 hover:text-zinc-900"
+              target="_blank"
             >
               <svg
                 viewBox="0 0 20 20"


### PR DESCRIPTION
Usually you want these links to open in a new tab, so that you dont navigate away from localhost when starting up the project.

So I added `target="_blank"` to all ankers on the starting page.