### PR TITLE
Fix action rename example in controllers guides

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -47,7 +47,7 @@ defmodule HelloWeb.PageController do
   ...
 
   def index(conn, _params) do
-    render(conn, :index)
+    render(conn, :home)
   end
 end
 ```


### PR DESCRIPTION
Only action name should be changed to match route renaming.
Change of passing template's name leads to bug, as the template is not renamed.
And description above clearly talks only about action.