### PR TITLE
Correct query result in doc to verify_change_email_token_query.

### DIFF
--- a/priv/templates/phx.gen.auth/schema_token.ex
+++ b/priv/templates/phx.gen.auth/schema_token.ex
@@ -134,7 +134,7 @@ defmodule <%= inspect schema.module %>Token do
   @doc """
   Checks if the token is valid and returns its underlying lookup query.
 
-  The query returns the <%= schema.singular %> found by the token, if any.
+  The query returns the <%= schema.singular %>_token found by the token, if any.
 
   This is used to validate requests to change the <%= schema.singular %>
   email. It is different from `verify_email_token_query/2` precisely because


### PR DESCRIPTION
Simple typo in doc.
Query build in method `verify_change_email_token_query` differs from `verify_email_token_query`. It returns `user_token` instead of `user`.
For quick presentation of proof, here is reference to invocation code:
```elixir
    with {:ok, query} <- UserToken.verify_change_email_token_query(token, context),
         %UserToken{sent_to: email} <- Repo.one(query),
```