### PR TITLE
Add `check_csrf` option to socket transport options

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -859,8 +859,8 @@ defmodule Phoenix.Endpoint do
       The MFA is invoked with the request `%URI{}` as the first argument,
       followed by arguments in the MFA list, and must return a boolean.
 
-    * `:check_csrf` - if the transport should perform CSRF check. If `origin` check is disabled as
-    well as CSRF check, your app is vulnerable to Cross-Site WebSocket Hijacking (CSWSH) attacks.
+    * `:check_csrf` - if the transport should perform CSRF check. Note that disabling
+    both CSRF and origin checks at the same time is not allowed and will raise.
     Defaults to `true`
 
     * `:code_reloader` - enable or disable the code reloader. Defaults to your

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -860,8 +860,8 @@ defmodule Phoenix.Endpoint do
       followed by arguments in the MFA list, and must return a boolean.
 
     * `:check_csrf` - if the transport should perform CSRF check. Note that disabling
-    both CSRF and origin checks at the same time is not allowed and will raise.
-    Defaults to `true`
+      both CSRF and origin checks at the same time is not allowed and will raise.
+      Defaults to `true`
 
     * `:code_reloader` - enable or disable the code reloader. Defaults to your
       endpoint configuration

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -859,9 +859,12 @@ defmodule Phoenix.Endpoint do
       The MFA is invoked with the request `%URI{}` as the first argument,
       followed by arguments in the MFA list, and must return a boolean.
 
-    * `:check_csrf` - if the transport should perform CSRF check. Note that disabling
-      both CSRF and origin checks at the same time is not allowed and will raise.
-      Defaults to `true`
+    * `:check_csrf` - if the transport should perform CSRF check. To avoid
+      "Cross-Site WebSocket Hijacking", you must have at least one of
+      `check_origin` and `check_csrf` enabled. If you set both to `false`,
+      Phoenix will raise, but it is still possible to disable both by passing
+      a custom MFA to `check_origin`. In such cases, it is your responsibility
+      to ensure at least one of them is enabled. Defaults to `true`
 
     * `:code_reloader` - enable or disable the code reloader. Defaults to your
       endpoint configuration

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -859,6 +859,10 @@ defmodule Phoenix.Endpoint do
       The MFA is invoked with the request `%URI{}` as the first argument,
       followed by arguments in the MFA list, and must return a boolean.
 
+    * `:check_csrf` - if the transport should perform CSRF check. If `origin` check is disabled as
+    well as CSRF check, your app is vulnerable to Cross-Site WebSocket Hijacking (CSWSH) attacks.
+    Defaults to `true`
+
     * `:code_reloader` - enable or disable the code reloader. Defaults to your
       endpoint configuration
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -136,9 +136,10 @@ defmodule Phoenix.Endpoint.Supervisor do
   end
 
   defp check_origin_or_csrf_checked!(endpoint_conf, socket_opts) do
+    check_origin = endpoint_conf[:check_origin]
+
     for {transport, transport_opts} <- socket_opts, is_list(transport_opts) do
-      check_origin =
-        Keyword.get(transport_opts, :check_origin, endpoint_conf[:check_origin])
+      check_origin = Keyword.get(transport_opts, :check_origin, check_origin)
 
       check_csrf = transport_opts[:check_csrf]
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -142,11 +142,7 @@ defmodule Phoenix.Endpoint.Supervisor do
 
     for {transport, transport_opts} <- socket_opts do
       check_origin =
-        if is_boolean(transport_opts[:check_origin]) do
-          transport_opts[:check_origin]
-        else
-          endpoint_check_origin
-        end
+        Keyword.get(transport_opts, :check_origin, endpoint_check_origin)
 
       check_csrf = transport_opts[:check_csrf]
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -152,7 +152,7 @@ defmodule Phoenix.Endpoint.Supervisor do
 
       if check_origin == false and check_csrf == false do
         raise ArgumentError,
-              "One of :check_origin and :check_csrf must be set to non-false value for " <>
+              "one of :check_origin and :check_csrf must be set to non-false value for " <>
                 "transport #{inspect(transport)}"
       end
     end

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -332,8 +332,13 @@ defmodule Phoenix.Socket.Transport do
     import Plug.Conn
     origin = conn |> get_req_header("origin") |> List.first()
     check_origin = check_origin_config(handler, endpoint, opts)
+    check_csrf = opts[:check_csrf]
 
     cond do
+      check_origin == false and check_csrf == false ->
+        raise ArgumentError,
+              "One of :check_origin and :check_csrf must be set"
+
       is_nil(origin) or check_origin == false ->
         conn
 

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -465,7 +465,7 @@ defmodule Phoenix.Socket.Transport do
 
   The CSRF check can be disabled with the `:check_csrf` option.
   """
-  def connect_info(conn, endpoint, keys, opts \\ [check_csrf: true]) do
+  def connect_info(conn, endpoint, keys, opts \\ []) do
     for key <- keys, into: %{} do
       case key do
         :peer_data ->

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -496,7 +496,7 @@ defmodule Phoenix.Socket.Transport do
     with cookie when is_binary(cookie) <- conn.cookies[key],
          conn = put_in(conn.secret_key_base, endpoint.config(:secret_key_base)),
          {_, session} <- store.get(conn, cookie, init),
-         true <- not check_csrf || csrf_token_valid?(conn, session, csrf_token_key) do
+         true <- not check_csrf or csrf_token_valid?(conn, session, csrf_token_key) do
       session
     else
       _ -> nil

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -332,13 +332,8 @@ defmodule Phoenix.Socket.Transport do
     import Plug.Conn
     origin = conn |> get_req_header("origin") |> List.first()
     check_origin = check_origin_config(handler, endpoint, opts)
-    check_csrf = opts[:check_csrf]
 
     cond do
-      check_origin == false and check_csrf == false ->
-        raise ArgumentError,
-              "One of :check_origin and :check_csrf must be set"
-
       is_nil(origin) or check_origin == false ->
         conn
 

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -463,7 +463,7 @@ defmodule Phoenix.Socket.Transport do
 
     * `:user_agent` - the value of the "user-agent" request header
 
-  The CSRF check can be disabled with the `:check_csrf` option.
+  The CSRF check can be disabled by setting the `:check_csrf` option to `false`.
   """
   def connect_info(conn, endpoint, keys, opts \\ []) do
     for key <- keys, into: %{} do

--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -463,9 +463,7 @@ defmodule Phoenix.Socket.Transport do
 
     * `:user_agent` - the value of the "user-agent" request header
 
-  The CSRF check can be disabled with the option `:check_csrf`. Beware: if
-  the `origin` header check is disabled as well, then your app is vulnerable
-  to Cross-Site WebSocket Hijacking (CSWSH) attacks.
+  The CSRF check can be disabled with the `:check_csrf` option.
   """
   def connect_info(conn, endpoint, keys, opts \\ [check_csrf: true]) do
     for key <- keys, into: %{} do

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -4,6 +4,7 @@ defmodule Phoenix.Transports.LongPoll do
 
   # 10MB
   @max_base64_size 10_000_000
+  @connect_info_opts [:check_csrf]
 
   import Plug.Conn
   alias Phoenix.Socket.{V1, V2, Transport}
@@ -136,7 +137,10 @@ defmodule Phoenix.Transports.LongPoll do
         (System.system_time(:millisecond) |> Integer.to_string())
 
     keys = Keyword.get(opts, :connect_info, [])
-    connect_info = Transport.connect_info(conn, endpoint, keys)
+
+    connect_info =
+      Transport.connect_info(conn, endpoint, keys, Keyword.take(opts, @connect_info_opts))
+
     arg = {endpoint, handler, opts, conn.params, priv_topic, connect_info}
     spec = {Phoenix.Transports.LongPoll.Server, arg}
 

--- a/lib/phoenix/transports/websocket.ex
+++ b/lib/phoenix/transports/websocket.ex
@@ -15,6 +15,8 @@ defmodule Phoenix.Transports.WebSocket do
   #
   @behaviour Plug
 
+  @connect_info_opts [:check_csrf]
+
   import Plug.Conn
 
   alias Phoenix.Socket.{V1, V2, Transport}
@@ -45,7 +47,9 @@ defmodule Phoenix.Transports.WebSocket do
 
       %{params: params} = conn ->
         keys = Keyword.get(opts, :connect_info, [])
-        connect_info = Transport.connect_info(conn, endpoint, keys)
+
+        connect_info =
+          Transport.connect_info(conn, endpoint, keys, Keyword.take(opts, @connect_info_opts))
 
         config = %{
           endpoint: endpoint,

--- a/test/phoenix/socket/transport_test.exs
+++ b/test/phoenix/socket/transport_test.exs
@@ -276,7 +276,7 @@ defmodule Phoenix.Socket.TransportTest do
     end
   end
 
-  describe "connect_info/3" do
+  describe "connect_info/4" do
     defp load_connect_info(connect_info) do
       [connect_info: connect_info] = Transport.load_config(connect_info: connect_info)
       connect_info
@@ -330,5 +330,31 @@ defmodule Phoenix.Socket.TransportTest do
               |> Transport.connect_info(Endpoint, connect_info)
     end
 
+    test "loads the session when CSRF is disabled despite CSRF token not being provided" do
+      conn = conn(:get, "https://foo.com/") |> Endpoint.call([])
+      session_cookie = conn.cookies["_hello_key"]
+
+      connect_info = load_connect_info(session: {Endpoint, :session_config, []})
+
+      assert %{session: %{"from_session" => "123"}} =
+        conn(:get, "https://foo.com/")
+        |> put_req_cookie("_hello_key", session_cookie)
+        |> fetch_query_params()
+        |> Transport.connect_info(Endpoint, connect_info, check_csrf: false)
+    end
+
+    test "doesn't load session when an invalid CSRF token is provided" do
+      conn = conn(:get, "https://foo.com/") |> Endpoint.call([])
+      invalid_csrf_token = "some invalid CSRF token"
+      session_cookie = conn.cookies["_hello_key"]
+
+      connect_info = load_connect_info(session: {Endpoint, :session_config, []})
+
+      assert %{session: nil} =
+        conn(:get, "https://foo.com/", _csrf_token: invalid_csrf_token)
+        |> put_req_cookie("_hello_key", session_cookie)
+        |> fetch_query_params()
+        |> Transport.connect_info(Endpoint, connect_info)
+    end
   end
 end

--- a/test/phoenix/socket/transport_test.exs
+++ b/test/phoenix/socket/transport_test.exs
@@ -237,6 +237,13 @@ defmodule Phoenix.Socket.TransportTest do
       # an allowed host
       refute check_origin("https://host.com/", check_origin: mfa).halted
     end
+
+    test "raises if both :check_origin and :check_csrf are set to false" do
+      assert_raise ArgumentError, ~r/One of :check_origin and :check_csrf must be set/, fn ->
+        check_origin("https://host.com/", check_origin: false, check_csrf: false)
+      end
+    end
+
   end
 
   ## Check subprotocols

--- a/test/phoenix/socket/transport_test.exs
+++ b/test/phoenix/socket/transport_test.exs
@@ -237,13 +237,6 @@ defmodule Phoenix.Socket.TransportTest do
       # an allowed host
       refute check_origin("https://host.com/", check_origin: mfa).halted
     end
-
-    test "raises if both :check_origin and :check_csrf are set to false" do
-      assert_raise ArgumentError, ~r/One of :check_origin and :check_csrf must be set/, fn ->
-        check_origin("https://host.com/", check_origin: false, check_csrf: false)
-      end
-    end
-
   end
 
   ## Check subprotocols


### PR DESCRIPTION
This PR proposes adding a `check_csrf` option to Phoenix's socket transport, so as to enable caching Liveview's static rendering.

## Context

After releasing [`plug_http_cache`](https://github.com/tanguilp/plug_http_cache), I was asked if we could use it to cache Liveviews.

After a few experiment, I came with the following PR last year: https://github.com/phoenixframework/phoenix/pull/5667. Note that in this PR, I **didn't** follow the proposed approach in the discussion there (prefer being honest here :see_no_evil:).

I took more time to study the different approaches how to implement it this year. I described it in 2 blog posts:
- [Caching Liveviews - Part 1: The road to HTTP-caching Liveviews](https://svground.fr/blog/posts/caching-liveviews-part-1/)
- [Caching Liveviews - Part 2: Publicly caching private Liveviews](https://svground.fr/blog/posts/caching-liveviews-part-2/)

We're talking about caching Liveview's with *session enabled*. When disabled, caching works OOTB.

Key takeaways are:
- there are 2 mechanisms to prevent CSWSH: checking `origin` and checking a CSRF token
- both mechanisms protect against CSWSH. As a consequence using only one is safe
- by default Phoenix uses both for websocket & longpoll transports. `origin` check can be disabled, CSRF check cannot
- we can't cache liveviews because the generated pages contain a CSRF token, which is user-specific
- we propose instead to enable `origin` check, and disable the CSRF check
- the second article also discusses:
  - how to selectively caching some liveviews (opt-in caching)
  - a pattern to avoid accidentally cache private data (`assign_private`, similar to `assign_async`)

I believe this pattern (*Publicly caching private Liveviews*) is actually another use-case for Liveview, separate but not exclusive to server-rendered interactivity. Usually you would make heavy use of javascript, requesting a separate APIs to get the little bits of private user data. The proposed pattern greatly simplifies that, and is compatible with any caching system (`plug_http_cache`, CDN, any shared cache between the Phoenix server and the user browser). But only time will tell :grin: 

![Screenshot from 2024-09-04 16-45-11](https://github.com/user-attachments/assets/bf7c4ac9-5159-4eae-9766-6accb7dc6b5e)

## Implementation

To disable CSRF check, you would do:

```elixir
socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options], check_csrf: false]
```

The `check_csrf` option is transport-specific, contrary to `check_origin` that can be configured at the endpoint level as well. This is because:
- we could have non-web transports for which checking CSRF makes no sense
- this could confuse users, because you still need to check CSRF for Phoenix views' forms for instance

We change the signature of `Phoenix.Socket.Transport.connect_info/4` to add an `opts` parameter that defaults to `[check_csrf: true]`.

When disabling CSRF check for Phoenix socket transports, we no longer need to 1) add a CSRF token in the HTML page 2) send the token as a parameter to the JS `LiveSocket` call.

A test was added to check that when this option is set to `true` (default value), including an invalid CSRF token fails to retrieve session data.

From a security perspective, I think that with the default values (secure by default) and the current warnings, it's hard to make Liveview insecure without noticing it.