### PR TITLE
[docs] add code example on how to render functional component in controller

### DIFF
--- a/guides/components.md
+++ b/guides/components.md
@@ -62,24 +62,7 @@ Next we need to update `show.html.heex`:
 </section>
 ```
 
-You can also directly render the functional component in the controller, skipping the `show.html.heex` template:
-
-```elixir
-def HelloWeb.HelloController do
-  use HelloWeb, :controller
-
-  def show(conn, %{"messenger" => messenger}) do
-    # render the HelloWeb.HelloHTML.greet component
-    render(conn, :greet, messenger: messenger)
-  end
-end
-```
-
-When we reload `http://localhost:4000/hello/Frank`, we should see the same content as before.
-
-Since templates are embedded inside the `HelloHTML` module, we were able to invoke the view function simply as `<.greet messenger="..." />`.
-
-If the component was defined elsewhere, we can also type `<HelloWeb.HelloHTML.greet messenger="..." />`.
+When we reload `http://localhost:4000/hello/Frank`, we should see the same content as before. Since the `show.html.heex` template is embedded within the `HelloHTML` module, we were able to invoke the function component directly as `<.greet messenger="..." />`. If the component was defined elsewhere, we would need to give its full name: `<HelloWeb.HelloHTML.greet messenger="..." />`.
 
 By declaring attributes as required, Phoenix will warn at compile time if we call the `<.greet />` component without passing attributes. If an attribute is optional, you can specify the `:default` option with a value:
 
@@ -87,19 +70,22 @@ By declaring attributes as required, Phoenix will warn at compile time if we cal
 attr :messenger, :string, default: nil
 ```
 
-Although this is a quick example, it shows the different roles function components play in Phoenix:
+Overall, function components are the essential building block of Phoenix rendering stack. The majority of the times, they are functions that receive a single argument called `assigns` and call the `~H` sigil, as we did in `greet/1`. They can also be invoked from templates, with compile-time validation of its attributes declared via `attr`.
 
-* Function components can be defined as functions that receive `assigns` as argument and call the `~H` sigil, as we did in `greet/1`
+In fact, every template embedded into `HelloHTML` is a function component in itself. `show.html.heex` simply becomes a function component named `show`. This also means you can directly render function components directly from the controller, skipping the `show.html.heex` template:
 
-* Function components can be embedded from template files, that's how we load `show.html.heex` into `HelloWeb.HelloHTML`
+```elixir
+def HelloWeb.HelloController do
+  use HelloWeb, :controller
 
-* Function components can declare which attributes are expected, which are validated at compilation time
+  def show(conn, %{"messenger" => messenger}) do
+    # Render the HelloWeb.HelloHTML.greet/1 component
+    render(conn, :greet, messenger: messenger)
+  end
+end
+```
 
-* Function components can be directly rendered from controllers
-
-* Function components can be directly rendered from other function components, as we called `<.greet messenger={@messenger} />` from `show.html.heex`
-
-And there's more. Before we go deeper, let's fully understand the expressive power behind the HEEx template language.
+Next, let's fully understand the expressive power behind the HEEx template language.
 
 ## HEEx
 

--- a/guides/components.md
+++ b/guides/components.md
@@ -62,6 +62,19 @@ Next we need to update `show.html.heex`:
 </section>
 ```
 
+You can also directly render the functional component in the controller, skipping the `show.html.heex` template:
+
+```elixir
+def HelloWeb.HelloController do
+  use HelloWeb, :controller
+
+  def show(conn, %{"messenger" => messenger}) do
+    # render the HelloWeb.HelloHTML.greet component
+    render(conn, :greet, messenger: messenger)
+  end
+end
+```
+
 When we reload `http://localhost:4000/hello/Frank`, we should see the same content as before.
 
 Since templates are embedded inside the `HelloHTML` module, we were able to invoke the view function simply as `<.greet messenger="..." />`.


### PR DESCRIPTION
I didn't see many (any?) code examples in docs of how to render a functional component directly in controller. This PR adds that.