### PR TITLE
Auth links consistency on email confirmation pages.

### DIFF
--- a/priv/templates/phx.gen.auth/confirmation_edit.html.heex
+++ b/priv/templates/phx.gen.auth/confirmation_edit.html.heex
@@ -7,7 +7,7 @@
     </:actions>
   </.simple_form>
 
-  <p class="text-center mt-4">
+  <p :if={!@current_<%= schema.singular %>} class="text-center mt-4">
     <.link href={~p"<%= schema.route_prefix %>/register"}>Register</.link>
     | <.link href={~p"<%= schema.route_prefix %>/log_in"}>Log in</.link>
   </p>

--- a/priv/templates/phx.gen.auth/confirmation_instructions_live.ex
+++ b/priv/templates/phx.gen.auth/confirmation_instructions_live.ex
@@ -20,7 +20,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         </:actions>
       </.simple_form>
 
-      <p class="text-center mt-4">
+      <p :if={!@current_<%= schema.singular %>} class="text-center mt-4">
         <.link href={~p"<%= schema.route_prefix %>/register"}>Register</.link>
         | <.link href={~p"<%= schema.route_prefix %>/log_in"}>Log in</.link>
       </p>

--- a/priv/templates/phx.gen.auth/confirmation_live.ex
+++ b/priv/templates/phx.gen.auth/confirmation_live.ex
@@ -15,7 +15,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         </:actions>
       </.simple_form>
 
-      <p class="text-center mt-4">
+      <p :if={!@current_<%= schema.singular %>} class="text-center mt-4">
         <.link href={~p"<%= schema.route_prefix %>/register"}>Register</.link>
         | <.link href={~p"<%= schema.route_prefix %>/log_in"}>Log in</.link>
       </p>

--- a/priv/templates/phx.gen.auth/confirmation_new.html.heex
+++ b/priv/templates/phx.gen.auth/confirmation_new.html.heex
@@ -13,7 +13,7 @@
     </:actions>
   </.simple_form>
 
-  <p class="text-center mt-4">
+  <p :if={!@current_<%= schema.singular %>} class="text-center mt-4">
     <.link href={~p"<%= schema.route_prefix %>/register"}>Register</.link>
     | <.link href={~p"<%= schema.route_prefix %>/log_in"}>Log in</.link>
   </p>


### PR DESCRIPTION
Email confirmation pages can be open by logged in user. In such case we have following inconsistency.
- Below confirmation form we have "Register" and "Log in" links.
- While at the top menu we have "Settings" and "Log out".

This change fixing inconsistency by presenting links below confirmation form only if user is not logged in.
Note: I used `if !condition` because `unless` is going to be deprecated.