### PR TITLE
Fix some grammar in the JSON and APIs guide

### DIFF
--- a/guides/json_and_apis.md
+++ b/guides/json_and_apis.md
@@ -173,7 +173,7 @@ end
 
 This view is very simple. The `index` function receives all URLs, and converts them into a list of maps. Those maps are placed inside the data key at the root, exactly as we saw when interfacing with our application from `cURL`. In other words, our JSON view converts our complex data into simple Elixir data-structures. Once our view layer returns, Phoenix uses the `Jason` library to encode JSON and send the response to the client.
 
-If you explore the remaining the controller, you will learn the `show` action is similar to the `index` one. For `create`, `update`, and `delete` actions, Phoenix uses one other important feature, called "Action fallback".
+If you explore the remaining controller, you will learn the `show` action is similar to the `index` one. For `create`, `update`, and `delete` actions, Phoenix uses one other important feature, called "Action fallback".
 
 ## Action fallback
 


### PR DESCRIPTION
This is a trivial fix to some grammar in `json_and_apis.md` - No worries if this gets rejected/closed as too trivial but just wanted to point it out while reading the guide!