### PR TITLE
Remove redundant validate_attr case.

### DIFF
--- a/lib/mix/phoenix/schema.ex
+++ b/lib/mix/phoenix/schema.ex
@@ -425,7 +425,7 @@ defmodule Mix.Phoenix.Schema do
       mix phx.gen.schema Comment comments body:text status:enum:published:unpublished
   """
 
-  defp validate_attr!({name, :datetime}), do: validate_attr!({name, :naive_datetime})
+  defp validate_attr!({name, :datetime}), do: {name, :naive_datetime}
 
   defp validate_attr!({name, :array}) do
     Mix.raise("""
@@ -438,7 +438,6 @@ defmodule Mix.Phoenix.Schema do
 
   defp validate_attr!({_name, :enum}), do: Mix.raise(@enum_missing_value_error)
   defp validate_attr!({_name, type} = attr) when type in @valid_types, do: attr
-  defp validate_attr!({_name, {:enum, _vals}} = attr), do: attr
   defp validate_attr!({_name, {type, _}} = attr) when type in @valid_types, do: attr
 
   defp validate_attr!({_, type}) do


### PR DESCRIPTION
- After change from [this PR](https://github.com/phoenixframework/phoenix/pull/4601/files#diff-4307581434ae66da4750cde438c2b192c4a11c8b71ba32dbf78aea36daa0ee3eR368), `:enum` valid case becomes redundant. Next line has general check that includes valid enum case.
- Also removed redundant passing throw for `:datetime` case. Instead, return already prepared result right away.