### PR TITLE
Preserve original name when `as` is not provided to `simple_form`

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -120,7 +120,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       </.simple_form>
   """
   attr :for, :any, required: true, doc: "the data structure for the form"
-  attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
+  attr :as, :any, doc: "the server side parameter to collect all input under"
 
   attr :rest, :global,
     include: ~w(autocomplete name rel action enctype method novalidate target multipart),
@@ -130,8 +130,10 @@ defmodule <%= @web_namespace %>.CoreComponents do
   slot :actions, doc: "the slot for form actions, such as a submit button"
 
   def simple_form(assigns) do
+    assigns = assign(assigns, :as, if(assigns[:as], do: %{as: assigns[:as]}, else: %{}))
+
     ~H"""
-    <.form :let={f} for={@for} as={@as} {@rest}>
+    <.form :let={f} for={@for} {@as} {@rest}>
       <div class="mt-10 space-y-8 bg-white">
         <%%= render_slot(@inner_block, f) %>
         <div :for={action <- @actions} class="mt-2 flex items-center justify-between gap-6">

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -120,7 +120,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       </.simple_form>
   """
   attr :for, :any, required: true, doc: "the data structure for the form"
-  attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
+  attr :as, :any, doc: "the server side parameter to collect all input under"
 
   attr :rest, :global,
     include: ~w(autocomplete name rel action enctype method novalidate target multipart),
@@ -130,8 +130,10 @@ defmodule <%= @web_namespace %>.CoreComponents do
   slot :actions, doc: "the slot for form actions, such as a submit button"
 
   def simple_form(assigns) do
+    assigns = assign(assigns, :as, if(assigns[:as], do: %{as: assigns[:as]}, else: %{}))
+
     ~H"""
-    <.form :let={f} for={@for} as={@as} {@rest}>
+    <.form :let={f} for={@for} {@as} {@rest}>
       <div class="mt-10 space-y-8 bg-white">
         <%%= render_slot(@inner_block, f) %>
         <div :for={action <- @actions} class="mt-2 flex items-center justify-between gap-6">


### PR DESCRIPTION
Remove the default `nil` value for the `as` attribute in the generated `simple_form` core component.

This default interferes with the form name present in the form struct provided through the component's `for` attribute when used with `:let=`.

For example, consider the following code:

```
<.simple_form :let={f} for={@form}>
  <%= inspect(f.name) %>
  <.input field={f[:bar]} label="Bar" />
</.simple_form>
```

When rendered, `f.name` is `nil`, and the `name` attribute of the form field only contains `bar`, missing the proper field name prefix from the form struct:

```
<div class="mt-10 space-y-8 bg-white">
  nil
  <div data-phx-id="m9-phx-GAgAfRg6YU4XV6tC">
    <label for="bar" class="block text-sm font-semibold leading-6 text-zinc-800" data-phx-id="m10-phx-GAgAfRg6YU4XV6tC">
    Bar
    </label>
    <input type="text" name="bar" id="bar" class="mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6 border-zinc-300 focus:border-zinc-400">
  </div>
</div>
```

This issue been reported [over here](https://github.com/phoenixframework/phoenix/issues/5901).

Fixes phoenixframework/phoenix#5901