### PR TITLE
feat: Separate heart beat interval and timeout

### DIFF
--- a/assets/js/phoenix/socket.js
+++ b/assets/js/phoenix/socket.js
@@ -53,6 +53,7 @@ import Timer from "./timer"
  *
  * Defaults `DEFAULT_TIMEOUT`
  * @param {number} [opts.heartbeatIntervalMs] - The millisec interval to send a heartbeat message
+ * @param {number} [opts.heartbeatTimeoutMs] - The default timeout in milliseconds to trigger heartbeat timeouts
  * @param {Function} [opts.reconnectAfterMs] - The optional function that returns the
  * socket reconnect interval, in milliseconds.
  *
@@ -148,6 +149,7 @@ export default class Socket {
       })
     }
     this.heartbeatIntervalMs = opts.heartbeatIntervalMs || 30000
+    this.heartbeatTimeoutMs = opts.heartbeatTimeoutMs || this.heartbeatIntervalMs
     this.rejoinAfterMs = (tries) => {
       if(opts.rejoinAfterMs){
         return opts.rejoinAfterMs(tries)
@@ -600,11 +602,14 @@ export default class Socket {
     return this.ref.toString()
   }
 
+  /**
+   * Send heat beat message. If the response timeout, Attempting to re-establish connection
+   */
   sendHeartbeat(){
     if(this.pendingHeartbeatRef && !this.isConnected()){ return }
     this.pendingHeartbeatRef = this.makeRef()
     this.push({topic: "phoenix", event: "heartbeat", payload: {}, ref: this.pendingHeartbeatRef})
-    this.heartbeatTimeoutTimer = setTimeout(() => this.heartbeatTimeout(), this.heartbeatIntervalMs)
+    this.heartbeatTimeoutTimer = setTimeout(() => this.heartbeatTimeout(), this.heartbeatTimeoutMs)
   }
 
   flushSendBuffer(){


### PR DESCRIPTION
## Motivation for this changes
In my environment (macOS, Chrome) when I switch WiFi, the websocket disconnect event does not occur, it is reconnected by heartbeat.
At this time, since an online event is generated, I wanted to send a heartbeat triggered by this event to perform disconnect detection with a timeout period shorter than the time of the heartbeat interval.

It is intended to be used as follows. This is expected to reduce the time it takes for the connection to be restored.
```ts
const socket = new Socket("endpoint", { heartbeatTimeoutMs: 5000 })
socket.connect()
window.addEventListener('online', ()=> socket.sendHeartbeat())
```

