### PR TITLE
Add LiveViewTest.assert_* macros to locals_without_parens config

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -76,7 +76,17 @@ locals_without_parens = [
   on_mount: 1,
   slot: 1,
   slot: 2,
-  slot: 3
+  slot: 3,
+
+  # Phoenix.LiveViewTest
+  assert_patch: 2,
+  assert_patch: 3,
+  assert_patched: :2,
+  assert_push_event: 4,
+  assert_redirect: 2,
+  assert_redirect: 3,
+  assert_redirected: 2,
+  assert_reply: 3
 ]
 
 [

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -79,14 +79,21 @@ locals_without_parens = [
   slot: 3,
 
   # Phoenix.LiveViewTest
+  assert_patch: 1,
   assert_patch: 2,
   assert_patch: 3,
-  assert_patched: :2,
+  assert_patched: 2,
+  assert_push_event: 3,
   assert_push_event: 4,
+  assert_redirect: 1,
   assert_redirect: 2,
   assert_redirect: 3,
   assert_redirected: 2,
-  assert_reply: 3
+  assert_reply: 2,
+  assert_reply: 3,
+  refute_redirected: 2,
+  refute_push_event: 3,
+  refute_push_event: 4
 ]
 
 [


### PR DESCRIPTION
So one can simply add `:phoenix` to their `:plugins` option in `.formatter.exs` and it will not automatically include parens to those functions when `mix format`ing

Original PR https://github.com/phoenixframework/phoenix_live_view/pull/3535