### PR TITLE
Include more information on AlreadySentError errors

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -541,7 +541,16 @@ defmodule Phoenix.Controller do
     put_private_view(conn, :phoenix_view, :replace, formats)
   end
 
-  def put_view(%Plug.Conn{}, _module), do: raise(AlreadySentError)
+  def put_view(%Plug.Conn{} = conn, module) do
+    raise(AlreadySentError, """
+      The response was already sent.
+
+          Status code: `#{conn.status}`
+          Request path: `#{conn.request_path}`
+          Method: `#{conn.method}`
+          View module: `#{inspect(module)}`
+      """)
+  end
 
   defp put_private_view(conn, priv_key, kind, formats) when is_list(formats) do
     formats = Enum.into(formats, %{}, fn {format, value} -> {to_string(format), value} end)
@@ -578,7 +587,16 @@ defmodule Phoenix.Controller do
     put_private_view(conn, :phoenix_view, :new, formats)
   end
 
-  def put_new_view(%Plug.Conn{}, _module), do: raise(AlreadySentError)
+  def put_new_view(%Plug.Conn{} = conn, module) do
+    raise(AlreadySentError, """
+      The response was already sent.
+
+          Status code: `#{conn.status}`
+          Request path: `#{conn.request_path}`
+          Method: `#{conn.method}`
+          View module: `#{inspect(module)}`
+      """)
+  end
 
   @doc """
   Retrieves the current view for the given format.
@@ -642,7 +660,14 @@ defmodule Phoenix.Controller do
     if state in @unsent do
       put_private_layout(conn, :phoenix_layout, :replace, layout)
     else
-      raise AlreadySentError
+      raise AlreadySentError, """
+      The response was already sent.
+
+          Status code: `#{conn.status}`
+          Request path: `#{conn.request_path}`
+          Method: `#{conn.method}`
+          Layout: `#{inspect(layout)}`
+      """
     end
   end
 
@@ -718,7 +743,16 @@ defmodule Phoenix.Controller do
   @spec put_new_layout(Plug.Conn.t(), [{format :: atom, layout}] | layout) :: Plug.Conn.t()
   def put_new_layout(%Plug.Conn{state: state} = conn, layout)
       when (is_tuple(layout) and tuple_size(layout) == 2) or is_list(layout) or layout == false do
-    unless state in @unsent, do: raise(AlreadySentError)
+    unless state in @unsent do
+      raise(AlreadySentError, """
+      The response was already sent.
+
+          Status code: `#{conn.status}`
+          Request path: `#{conn.request_path}`
+          Method: `#{conn.method}`
+          Layout: `#{inspect(layout)}`
+      """)
+    end
     put_private_layout(conn, :phoenix_layout, :new, layout)
   end
 
@@ -759,7 +793,14 @@ defmodule Phoenix.Controller do
     if state in @unsent do
       put_private_layout(conn, :phoenix_root_layout, :replace, layout)
     else
-      raise AlreadySentError
+      raise AlreadySentError, """
+      The response was already sent.
+
+          Status code: `#{conn.status}`
+          Request path: `#{conn.request_path}`
+          Method: `#{conn.method}`
+          Layout: `#{inspect(layout)}`
+      """
     end
   end
 
@@ -784,7 +825,15 @@ defmodule Phoenix.Controller do
     put_private(conn, :phoenix_layout_formats, formats)
   end
 
-  def put_layout_formats(%Plug.Conn{}, _formats), do: raise(AlreadySentError)
+  def put_layout_formats(%Plug.Conn{} = conn, _formats) do
+    raise(AlreadySentError, """
+      The response was already sent.
+
+          Status code: `#{conn.status}`
+          Request path: `#{conn.request_path}`
+          Method: `#{conn.method}`
+      """)
+  end
 
   @doc """
   Retrieves current layout formats.

--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -543,12 +543,12 @@ defmodule Phoenix.Controller do
 
   def put_view(%Plug.Conn{} = conn, module) do
     raise(AlreadySentError, """
-      The response was already sent.
+      the response was already sent.
 
-          Status code: `#{conn.status}`
-          Request path: `#{conn.request_path}`
-          Method: `#{conn.method}`
-          View module: `#{inspect(module)}`
+          Status code: #{conn.status}
+          Request path: #{conn.request_path}
+          Method: #{conn.method}
+          View module: #{inspect(module)}
       """)
   end
 
@@ -589,12 +589,12 @@ defmodule Phoenix.Controller do
 
   def put_new_view(%Plug.Conn{} = conn, module) do
     raise(AlreadySentError, """
-      The response was already sent.
+      the response was already sent.
 
-          Status code: `#{conn.status}`
-          Request path: `#{conn.request_path}`
-          Method: `#{conn.method}`
-          View module: `#{inspect(module)}`
+          Status code: #{conn.status}
+          Request path: #{conn.request_path}
+          Method: #{conn.method}
+          View module: #{inspect(module)}
       """)
   end
 
@@ -661,12 +661,12 @@ defmodule Phoenix.Controller do
       put_private_layout(conn, :phoenix_layout, :replace, layout)
     else
       raise AlreadySentError, """
-      The response was already sent.
+      the response was already sent.
 
-          Status code: `#{conn.status}`
-          Request path: `#{conn.request_path}`
-          Method: `#{conn.method}`
-          Layout: `#{inspect(layout)}`
+          Status code: #{conn.status}
+          Request path: #{conn.request_path}
+          Method: #{conn.method}
+          Layout: #{inspect(layout)}
       """
     end
   end
@@ -745,12 +745,12 @@ defmodule Phoenix.Controller do
       when (is_tuple(layout) and tuple_size(layout) == 2) or is_list(layout) or layout == false do
     unless state in @unsent do
       raise(AlreadySentError, """
-      The response was already sent.
+      the response was already sent.
 
-          Status code: `#{conn.status}`
-          Request path: `#{conn.request_path}`
-          Method: `#{conn.method}`
-          Layout: `#{inspect(layout)}`
+          Status code: #{conn.status}
+          Request path: #{conn.request_path}
+          Method: #{conn.method}
+          Layout: #{inspect(layout)}
       """)
     end
     put_private_layout(conn, :phoenix_layout, :new, layout)
@@ -794,12 +794,12 @@ defmodule Phoenix.Controller do
       put_private_layout(conn, :phoenix_root_layout, :replace, layout)
     else
       raise AlreadySentError, """
-      The response was already sent.
+      the response was already sent.
 
-          Status code: `#{conn.status}`
-          Request path: `#{conn.request_path}`
-          Method: `#{conn.method}`
-          Layout: `#{inspect(layout)}`
+          Status code: #{conn.status}
+          Request path: #{conn.request_path}
+          Method: #{conn.method}
+          Layout: #{inspect(layout)}
       """
     end
   end
@@ -827,11 +827,11 @@ defmodule Phoenix.Controller do
 
   def put_layout_formats(%Plug.Conn{} = conn, _formats) do
     raise(AlreadySentError, """
-      The response was already sent.
+      the response was already sent.
 
-          Status code: `#{conn.status}`
-          Request path: `#{conn.request_path}`
-          Method: `#{conn.method}`
+          Status code: #{conn.status}
+          Request path: #{conn.request_path}
+          Method: #{conn.method}
       """)
   end
 

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -89,7 +89,16 @@ defmodule Phoenix.Controller.ControllerTest do
     conn = put_format(conn, "print")
     assert layout(conn) == {AppView, :print}
 
-    assert_raise Plug.Conn.AlreadySentError, fn ->
+    message = """
+    The response was already sent.
+
+        Status code: `200`
+        Request path: `/`
+        Method: `GET`
+        Layout: `{AppView, :print}`
+    """
+
+    assert_raise Plug.Conn.AlreadySentError, message, fn ->
       put_layout(sent_conn(), {AppView, :print})
     end
   end

--- a/test/phoenix/controller/controller_test.exs
+++ b/test/phoenix/controller/controller_test.exs
@@ -90,12 +90,12 @@ defmodule Phoenix.Controller.ControllerTest do
     assert layout(conn) == {AppView, :print}
 
     message = """
-    The response was already sent.
+    the response was already sent.
 
-        Status code: `200`
-        Request path: `/`
-        Method: `GET`
-        Layout: `{AppView, :print}`
+        Status code: 200
+        Request path: /
+        Method: GET
+        Layout: {AppView, :print}
     """
 
     assert_raise Plug.Conn.AlreadySentError, message, fn ->


### PR DESCRIPTION
We have an app that is getting a lot of AlreadySentErrors. Likely somewhere we have missed an `halt()`, but tracking that down is tricky. I wonder if we could supply some more information in the various places the error gets raised to help someone debug the issue? I have supplied a small example, but the exact wording and contents can be discussed.

I'm happy to roll this out to more places if we agree it's a good idea.