### PR TITLE
Refer to `MIX_TARGET` not `MIX_BUILD` in docs around separate build directories

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -74,7 +74,7 @@ defmodule Phoenix.Endpoint do
       instances of the same app at the same time with code reloading in
       development, as they will race each other and only one will effectively
       recompile the files. In such cases, tweak your config files so code
-      reloading is enabled in only one of the apps or set the MIX_BUILD
+      reloading is enabled in only one of the apps or set the MIX_TARGET
       environment variable to give them distinct build directories
 
     * `:debug_errors` - when `true`, uses `Plug.Debugger` functionality for

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -74,7 +74,7 @@ defmodule Phoenix.Endpoint do
       instances of the same app at the same time with code reloading in
       development, as they will race each other and only one will effectively
       recompile the files. In such cases, tweak your config files so code
-      reloading is enabled in only one of the apps or set the MIX_TARGET
+      reloading is enabled in only one of the apps or set the `MIX_BUILD_PATH`
       environment variable to give them distinct build directories
 
     * `:debug_errors` - when `true`, uses `Plug.Debugger` functionality for


### PR DESCRIPTION
I couldn't find reference to `MIX_BUILD` in the Mix docs, but I think `MIX_TARGET` is what's meant to be referred to here.

See https://hexdocs.pm/mix/Mix.html#module-environment-variables and https://hexdocs.pm/mix/Mix.html#module-targets for more info.