### PR TITLE
Digest async imports in javascript assets

### DIFF
--- a/test/fixtures/digest/priv/static/async_import.js
+++ b/test/fixtures/digest/priv/static/async_import.js
@@ -1,0 +1,32 @@
+async function asyncImport() {
+  const app = await import("./app.js");
+  console.log(app);
+}
+
+async function defaultAsyncImport() {
+  const app = (await import("./app.js")).default;
+  console.log(app);
+}
+
+function promiseImport() {
+  import("./app.js").then((app) => {
+    console.log(app);
+  });
+}
+
+async function noDigestImport() {
+  const thing = await import("https://example.com/thing.js");
+  console.log(thing);
+}
+
+async function notAPathAsyncImport() {
+  const notAsyncPath = {};
+  await import(notAsyncPath);
+}
+
+async function notAPathPromiseImport() {
+  const notPromisePath = {};
+  import(notPromisePath).then(function (thing) {
+    console.log(thing);
+  });
+}


### PR DESCRIPTION
esbuild supports [ES6 async module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import), but they're not currently compatible with the `mix phx.digest` process as the import paths aren't digested.

This PR adds support for digesting any async and promise based imports inside a JS file, so a developer can use these without giving up cache busting, etc. Async imports are great for front end performance as expensive libraries can be loaded on-demand rather than up front.

Before this PR, the following code would load a non-digested `other-module.js`, and so not benefit from cache busting, etc.

```
function onClick() {
  const { usefulFunction } = await import("./other-module.js");
  usefulFunction();
}
```

After this PR `mix phx.digest` will switch the import path for the digested path, e.g.

```
function onClick() {
  const { usefulFunction } = await import("./other-module-2ddf92b4c94e25bd296b2df90848a564.js");
  usefulFunction();
}
```

Note: esbuild in Phoenix doesn't use async imports out of the box, it need to be enabled by changing the args to include following flags: `--chunk-names=js/chunks/[name]-[hash] --splitting --format=esm`. I think there's an argument for changing the default flags to do this, but I understand if that might add more complexity than desired to the default asset pipeline.

I think there is value in supporting this in the digester even if we don't flip the defaults, because it allows users who want to implement their own esbuild config to benefit from chunking/splitting/async import, without having to throw out the Phoenix digesting process entirely. Throwing out the Phoenix digest process is fairly annoying, as it means finding a solution for digesting the non-JS assets, which esbuild doesn't really support.

This PR doesn't digest any chunked imports, eg. `import { foo } from "./chunks/chunk-abcdef.js"`. We could digest these too, but do already have a hash appended, so the benefit would probably just be aesthetic, but it's probably still worth doing.

Anyway, let me know what you think and whether this is something you'd like to add to Phoenix. If there's support for it, I suggest I add some documentation and chunk support too.