### PR TITLE
Prevent multiple emails separated by commas in email field

### DIFF
--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -46,7 +46,9 @@ defmodule <%= inspect schema.module %> do
   defp validate_email(changeset, opts) do
     changeset
     |> validate_required([:email])
-    |> validate_format(:email, ~r/^[^\s]+@[^\s]+$/, message: "must have the @ sign and no spaces")
+    |> validate_format(:email, ~r/^[^@,;\s]+@[^@,;\s]+$/,
+      message: "must have the @ sign and no spaces"
+    )
     |> validate_length(:email, max: 160)
     |> maybe_validate_unique_email(opts)
   end


### PR DESCRIPTION
I know the conventional wisdom is there's no reason to over complicate email validation because it is implicitly validated by  sending a confirmation email.
The current regex accepts multiple emails separated by commas or semicolons. For example: 
- `email1@example.com,email2@example.com`
- `email1@example.com;email2@example.com`

Some email servers accept a comma or semicolon seperated list of emails as valid and would send the content to each recipient. For example, [Mailgun](https://mailgun-docs.redoc.ly/docs/mailgun/api-reference/openapi-final/tag/Messages/). Documentation mentions you can use comma to separate multiple recipients. (I haven't tested it)

That means the implicit validation of the email is not enough. It could allows user with one email to sign up multiple times by using a suffix of random emails or enable abuse by submitting registrations with more than 20 emails at once.