### PR TITLE
Improve `Phoenix.Presence.get_by_key/2` documentation, return value, and typespec.

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -189,8 +189,8 @@ defmodule Phoenix.Presence do
 
   """
 
-  @type presences :: %{String.t() => %{metas: [map()]}}
-  @type presence :: %{key: String.t(), meta: map()}
+  @type presence :: %{metas: [map()]}
+  @type presences :: %{String.t() => presence}
   @type topic :: String.t()
 
   @doc """
@@ -297,12 +297,16 @@ defmodule Phoenix.Presence do
   devices, could return:
 
       iex> MyPresence.get_by_key("room:1", "user1")
-      [%{name: "User 1", metas: [%{device: "Desktop"}, %{device: "Mobile"}]}]
+      %{
+        name: "User 1",
+        additional_info: %{},
+        metas: [%{device: "Desktop"}, %{device: "Mobile"}]
+      }
 
   Like `c:list/1`, the presence metadata is passed to the `fetch`
   callback of your presence module to fetch any additional information.
   """
-  @callback get_by_key(Phoenix.Socket.t() | topic, key :: String.t()) :: [presence]
+  @callback get_by_key(socket_or_topic :: Phoenix.Socket.t() | topic, key :: String.t()) :: presence | nil
 
   @doc """
   Extend presence information with additional data.
@@ -540,8 +544,7 @@ defmodule Phoenix.Presence do
     string_key = to_string(key)
 
     case Phoenix.Tracker.get_by_key(module, topic, key) do
-      [] ->
-        []
+      [] -> nil
 
       [_ | _] = pid_metas ->
         metas = Enum.map(pid_metas, fn {_pid, meta} -> meta end)

--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -303,6 +303,9 @@ defmodule Phoenix.Presence do
         metas: [%{device: "Desktop"}, %{device: "Mobile"}]
       }
 
+      iex> MyPresence.get_by_key("room:1", "untracked_user")
+      nil
+
   Like `c:list/1`, the presence metadata is passed to the `fetch`
   callback of your presence module to fetch any additional information.
   """

--- a/test/phoenix/presence_test.exs
+++ b/test/phoenix/presence_test.exs
@@ -98,7 +98,7 @@ defmodule Phoenix.PresenceTest do
   test "get_by_key/2 returns metadata for key", config do
     pid2 = spawn(fn -> :timer.sleep(:infinity) end)
     pid3 = spawn(fn -> :timer.sleep(:infinity) end)
-    assert MyPresence.get_by_key(config.topic, 1) == []
+    assert is_nil(MyPresence.get_by_key(config.topic, 1))
     assert {:ok, _} = MyPresence.track(self(), config.topic, 1, %{name: "u1"})
     assert {:ok, _} = MyPresence.track(pid2, config.topic, 1, %{name: "u1.2"})
     assert {:ok, _} = MyPresence.track(pid3, config.topic, 2, %{name: "u1.2"})
@@ -106,8 +106,8 @@ defmodule Phoenix.PresenceTest do
     assert %{extra: "extra", metas: [%{name: "u1", phx_ref: _}, %{name: "u1.2", phx_ref: _}]} =
              MyPresence.get_by_key(config.topic, 1)
 
-    assert MyPresence.get_by_key(config.topic, "another_key") == []
-    assert MyPresence.get_by_key("another_topic", 2) == []
+    assert is_nil(MyPresence.get_by_key(config.topic, "another_key"))
+    assert is_nil(MyPresence.get_by_key("another_topic", 2))
   end
 
   test "handle_diff broadcasts events with default fetched data",


### PR DESCRIPTION
## Issue
#5759 states that issue #4514 wasn't addressed properly. Checking the [docs for `Phoenix.Presence.get_by_key/2`](https://hexdocs.pm/phoenix/Phoenix.Presence.html#c:get_by_key/2), it does have inconsistencies between its return value and the typespec it's being referred to.

## Improvements and Changes
Going by the given problem and proposed solution from #4514, I have made the changes:

- Improve and fix the `presence` typespec that returns a map with the `:metas`.
- If no `presence` found under the supplied `key` in `socket_or_topic` scope, return `nil`. Pros of having a `nil` return value instead of `[]` is that it's easier to evaluate not being a truthy value.
- Change the documented return value of `Phoenix.Presence.get_by_key/2` to return a map instead of a list that contains the `metas` information, along with some additional info that might be returned on the `Phoenix.Presence.fetch/2` callback.
- Change test specs on `test/phoenix/presence_test.exs` to check with `is_nil` instead of `[]` if the returned value on untracked `key` is empty.