### PR TITLE
fixed index.html.heex path (fixes #6036)

### DIFF
--- a/guides/testing/testing_controllers.md
+++ b/guides/testing/testing_controllers.md
@@ -49,7 +49,7 @@ def index(conn, _params) do
 end
 ```
 
-It gets all posts and renders the "index.html" template. The template can be found in `lib/hello_web/templates/page/index.html.heex`.
+It gets all posts and renders the "index.html" template. The template can be found in `lib/hello_web/controllers/post_html/index.html.heex`.
 
 The test looks like this:
 


### PR DESCRIPTION
correct path for generated `index.html.heex`