### PR TITLE
Update inconsistent core_component select input class

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -267,7 +267,11 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <select
         id={@id}
         name={@name}
-        class="mt-2 block w-full rounded-md border border-zinc-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
+        class={[
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          @errors == [] && "border-zinc-300 focus:border-zinc-400",
+          @errors != [] && "border-rose-400 focus:border-rose-400"
+        ]}
         multiple={@multiple}
         {@rest}
       >

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -267,7 +267,11 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <select
         id={@id}
         name={@name}
-        class="mt-2 block w-full rounded-md border border-zinc-300 bg-white shadow-sm focus:border-zinc-400 focus:ring-0 sm:text-sm"
+        class={[
+          "mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6",
+          @errors == [] && "border-zinc-300 focus:border-zinc-400",
+          @errors != [] && "border-rose-400 focus:border-rose-400"
+        ]}
         multiple={@multiple}
         {@rest}
       >


### PR DESCRIPTION
Other core component input has class `sm:leading-6` and error handling cause select input has different height and error feedback:

Before:
![Screenshot 2025-01-12 at 12 52 27](https://github.com/user-attachments/assets/043e0549-8e06-455c-bec2-668647942dd0)
![Screenshot 2025-01-12 at 12 55 01](https://github.com/user-attachments/assets/5b6905b0-48d5-45d3-ba96-1f9d5a865aa4)


After:
![Screenshot 2025-01-12 at 12 52 35](https://github.com/user-attachments/assets/5a0e8ca0-5855-4ce9-ae95-207894d99623)
![Screenshot 2025-01-12 at 12 55 26](https://github.com/user-attachments/assets/46366221-16e7-46a4-b33a-8f9224657caf)


