### PR TITLE
Make Liveview's root divs transparent for layout purposes.

### DIFF
--- a/installer/templates/phx_assets/app.css
+++ b/installer/templates/phx_assets/app.css
@@ -2,4 +2,12 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+/*
+ * Make LiveView wrapper divs transparent for layout.
+ * This makes it possible to use LiveViews as flex children for example.
+ */
+
+
+[data-phx-root-id] { display: contents }
+
 /* This file is for your main application CSS */


### PR DESCRIPTION
I suspect this PR might be a slightly hard sell, but I will do my best to motivate my reasons for proposing its inclusion.

LiveView generates non-optional wrapper divs. This presents challenges for using LiveViews in certain layouts. For example, if you want your LiveView to be a flex child, then your best course of action is to add `container: {:div, style: "display: contents"}` when rendering the LiveView. `display: contents` makes the element invisible for layout purposes, so the child of the wrapper div effectively replaces the wrapper div in the layout.

Another option is to make this the global default for your wrapper divs. This can be done in CSS with the following line:

```css
[data-phx-root-id] { display: contents }
```

Adding this to an existing project might be tricky, because it can negate the impact of the `:container` option. But adding it at the beginning of a project seems without risk. And it is nice to have this in place from the beginning, because when you need it you will probably pull your hair out for a day before you figure out how to make the layout work that you want.

I think including this PR would be a nice developer experience improvement.

(h/t to @LostKobrakai and @tmjoen for helping me find this solution in Slack)