### PR TITLE
fix: ReferenceError: Cannot access 'global' before initialization

### DIFF
--- a/assets/js/phoenix/constants.js
+++ b/assets/js/phoenix/constants.js
@@ -1,6 +1,6 @@
 export const globalSelf = typeof self !== "undefined" ? self : null
 export const phxWindow = typeof window !== "undefined" ? window : null
-export const global = globalSelf || phxWindow || global
+export const global = globalSelf || phxWindow || globalThis
 export const DEFAULT_VSN = "2.0.0"
 export const SOCKET_STATES = {connecting: 0, open: 1, closing: 2, closed: 3}
 export const DEFAULT_TIMEOUT = 10000


### PR DESCRIPTION
Here, global refers to an uninitialized global, so if the error is ignored and executed, it will result in undefined.