### PR TITLE
Document the Long-Poll Transport Limitations

### DIFF
--- a/guides/deployment/deployment.md
+++ b/guides/deployment/deployment.md
@@ -33,7 +33,13 @@ let liveSocket = new LiveSocket("/live", Socket, {
 })
 ```
 
-This automatic fallback comes with an important caveat: if you want Long-Polling to work properly, your application must either utilize the BEAM's clustering capabilities, your `Phoenix.PubSub` server must use an adapter that can communicate across nodes (such as `Phoenix.PubSub.Redis`), or your deployment option must implement sticky sessions - ensuring that all requests for a specific session go to the same machine.
+This automatic fallback comes with an important caveat. If you want Long-Polling to work properly, your application must either:
+
+1. Utilize the Erlang VM's clustering capabilities, so the default `Phoenix.PubSub` adapter can broadcast messages across nodes
+
+2. Choose a different `Phoenix.PubSub` adapter (such as `Phoenix.PubSub.Redis`)
+
+3. Or your deployment option must implement sticky sessions - ensuring that all requests for a specific session go to the same machine
 
 The reason for this is simple. While a WebSocket is a long-lived open connection to the same machine, long-polling works by opening a request to the server, waiting for a timeout or until the open request is fulfilled, and repeating this process. In order to preserve the state of the user's connected socket and to preserve the behaviour of a socket being long-lived, the user's process is kept alive, and each long-poll request attempts to find the user's stateful process. If the stateful process is not reachable, every request will create a new process and a new state, thereby breaking the fact that the socket is long-lived and stateful.
 

--- a/guides/deployment/deployment.md
+++ b/guides/deployment/deployment.md
@@ -14,35 +14,6 @@ As an example of deploying to other infrastructures, we also discuss four differ
 
 Let's explore those steps above one by one.
 
-#### Stickiness, Clustering, and the Long-Polling Transport {: .warning}
-
-Phoenix supports two types of transports for its Socket implementation: WebSocket, and Long-Polling. When generating a Phoenix project, you can see the default configuration set in the generated `endpoint.ex` file:
-
-```elixir
-socket "/live", Phoenix.LiveView.Socket,
-  websocket: [connect_info: [session: @session_options]],
-  longpoll: [connect_info: [session: @session_options]]
-```
-
-This configuration tells Phoenix that both the WebSocket and the Long-Polling options are available, and based on the client's network conditions, Phoenix will first attempt to connect to the WebSocket, falling back to the Long-Poll option after the configured timeout found in the generated `app.js` file:
-
-```javascript
-let liveSocket = new LiveSocket("/live", Socket, {
-  longPollFallbackMs: 2500,
-  params: {_csrf_token: csrfToken}
-})
-```
-
-This automatic fallback comes with an important caveat. If you want Long-Polling to work properly, your application must either:
-
-1. Utilize the Erlang VM's clustering capabilities, so the default `Phoenix.PubSub` adapter can broadcast messages across nodes
-
-2. Choose a different `Phoenix.PubSub` adapter (such as `Phoenix.PubSub.Redis`)
-
-3. Or your deployment option must implement sticky sessions - ensuring that all requests for a specific session go to the same machine
-
-The reason for this is simple. While a WebSocket is a long-lived open connection to the same machine, long-polling works by opening a request to the server, waiting for a timeout or until the open request is fulfilled, and repeating this process. In order to preserve the state of the user's connected socket and to preserve the behaviour of a socket being long-lived, the user's process is kept alive, and each long-poll request attempts to find the user's stateful process. If the stateful process is not reachable, every request will create a new process and a new state, thereby breaking the fact that the socket is long-lived and stateful.
-
 ## Handling of your application secrets
 
 All Phoenix applications have data that must be kept secure, for example, the username and password for your production database, and the secret Phoenix uses to sign and encrypt important information. The general recommendation is to keep those in environment variables and load them into your application. This is done in `config/runtime.exs` (formerly `config/prod.secret.exs` or `config/releases.exs`), which is responsible for loading secrets and configuration from environment variables.
@@ -143,6 +114,35 @@ And that's it. Next, you can use one of our official guides to deploy:
   * [to Gigalixir](gigalixir.html), an Elixir-centric Platform as a Service (PaaS)
   * [to Fly.io](fly.html), a PaaS that deploys your servers close to your users with built-in distribution support
   * and [to Heroku](heroku.html), one of the most popular PaaS.
+
+## Clustering and Long-Polling Transports
+
+Phoenix supports two types of transports for its Socket implementation: WebSocket, and Long-Polling. When generating a Phoenix project, you can see the default configuration set in the generated `endpoint.ex` file:
+
+```elixir
+socket "/live", Phoenix.LiveView.Socket,
+  websocket: [connect_info: [session: @session_options]],
+  longpoll: [connect_info: [session: @session_options]]
+```
+
+This configuration tells Phoenix that both the WebSocket and the Long-Polling options are available, and based on the client's network conditions, Phoenix will first attempt to connect to the WebSocket, falling back to the Long-Poll option after the configured timeout found in the generated `app.js` file:
+
+```javascript
+let liveSocket = new LiveSocket("/live", Socket, {
+  longPollFallbackMs: 2500,
+  params: {_csrf_token: csrfToken}
+})
+```
+
+If you are running more than one machine in production, which is the recommended approach in most cases, this automatic fallback comes with an important caveat. If you want Long-Polling to work properly, your application must either:
+
+1. Utilize the Erlang VM's clustering capabilities, so the default `Phoenix.PubSub` adapter can broadcast messages across nodes
+
+2. Choose a different `Phoenix.PubSub` adapter (such as `Phoenix.PubSub.Redis`)
+
+3. Or your deployment option must implement sticky sessions - ensuring that all requests for a specific session go to the same machine
+
+The reason for this is simple. While a WebSocket is a long-lived open connection to the same machine, long-polling works by opening a request to the server, waiting for a timeout or until the open request is fulfilled, and repeating this process. In order to preserve the state of the user's connected socket and to preserve the behaviour of a socket being long-lived, the user's process is kept alive, and each long-poll request attempts to find the user's stateful process. If the stateful process is not reachable, every request will create a new process and a new state, thereby breaking the fact that the socket is long-lived and stateful.
 
 ## Community Deployment Guides
 


### PR DESCRIPTION
Currently, Phoenix will automatically enable a long-poll Socket implementation and LiveView will fallback to long-polling automatically, in order to avoid issues with network conditions not allowing WebSockets. This comes with a major undocumented footgun - Long-Polling requires that either all requests go to the same machine (stickiness), or that nodes in a cluster can communicate.

This documents the footgun and warns the user, along with explaining why this happens.