### PR TITLE
Add `padding: false` to `Base.encode64/2` in New generator

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -449,7 +449,7 @@ defmodule Phx.New.Generator do
   defp phoenix_js_path(path), do: "../../#{path}/"
 
   defp random_string(length),
-    do: :crypto.strong_rand_bytes(length) |> Base.encode64() |> binary_part(0, length)
+    do: :crypto.strong_rand_bytes(length) |> Base.encode64(padding: false) |> binary_part(0, length)
 
   # In the context of a HEEx attribute value, transforms a given message into a
   # dynamic `gettext` call or a fixed-value string attribute, depending on the


### PR DESCRIPTION
To keep the same pattern used in the `gen.secret` task. See https://github.com/phoenixframework/phoenix/commit/2c9fc8512065ae36a83b3479fba9ef9ca4c479b1