### PR TITLE
Remove not used code

### DIFF
--- a/lib/phoenix/router/route.ex
+++ b/lib/phoenix/router/route.ex
@@ -177,15 +177,9 @@ defmodule Phoenix.Router.Route do
     match_all = match_params ++ match_private ++ match_assigns
     merge_all = merge_params ++ merge_private ++ merge_assigns
 
-    if merge_all != [] do
-      quote do
-        %{unquote_splicing(match_all)} = var!(conn, :conn)
-        %{var!(conn, :conn) | unquote_splicing(merge_all)}
-      end
-    else
-      quote do
-        var!(conn, :conn)
-      end
+    quote do
+      %{unquote_splicing(match_all)} = var!(conn, :conn)
+      %{var!(conn, :conn) | unquote_splicing(merge_all)}
     end
   end
 


### PR DESCRIPTION
Found by 1.19 typesystem. The `build_params()` call returns a non empty list so `merge_all = merge_params ++ merge_private ++ merge_assigns` is non empty as well.

```
     warning: comparison between distinct types found:

         merge_all != []

     given types:

         dynamic(non_empty_list(term(), term())) != empty_list()

     where "merge_all" was given the type:

         # type: dynamic(non_empty_list(term(), term()))
         # from: lib/phoenix/router/route.ex:178:15
         merge_all = merge_params ++ merge_private ++ merge_assigns

     While Elixir can compare across all types, you are comparing across types which are always disjoint, and the result is either always true or always false

     typing violation found at:
     │
 180 │     if merge_all != [] do
     │                  ~
     │
     └─ lib/phoenix/router/route.ex:180:18: Phoenix.Router.Route.build_prepare/1
```