### PR TITLE
validate options passed to socket longpoll / websocket options

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -690,8 +690,43 @@ defmodule Phoenix.Endpoint do
 
   defp socket_paths(endpoint, path, socket, opts) do
     paths = []
-    websocket = Keyword.get(opts, :websocket, true)
-    longpoll = Keyword.get(opts, :longpoll, false)
+
+    common_config = [
+      :path,
+      :serializer,
+      :transport_log,
+      :check_origin,
+      :check_csrf,
+      :code_reloader,
+      :connect_info
+    ]
+
+    websocket =
+      opts
+      |> Keyword.get(:websocket, true)
+      |> maybe_validate_keys(
+        common_config ++
+          [
+            :timeout,
+            :max_frame_size,
+            :fullsweep_after,
+            :compress,
+            :subprotocols,
+            :error_handler
+          ]
+      )
+
+    longpoll =
+      opts
+      |> Keyword.get(:longpoll, true)
+      |> maybe_validate_keys(
+        common_config ++
+          [
+            :window_ms,
+            :pubsub_timeout_ms,
+            :crypto
+          ]
+      )
 
     paths =
       if websocket do
@@ -744,6 +779,9 @@ defmodule Phoenix.Endpoint do
 
     {conn_ast, path}
   end
+
+  defp maybe_validate_keys(true, _), do: true
+  defp maybe_validate_keys(opts, keys) when is_list(opts), do: Keyword.validate!(opts, keys)
 
   ## API
 

--- a/test/phoenix/endpoint/endpoint_test.exs
+++ b/test/phoenix/endpoint/endpoint_test.exs
@@ -370,4 +370,22 @@ defmodule Phoenix.Endpoint.EndpointTest do
       Endpoint.static_integrity("//invalid_path")
     end
   end
+
+  test "validates websocket and longpoll socket options" do
+    assert_raise ArgumentError, ~r/unknown keys \[:invalid\]/, fn ->
+      defmodule MyInvalidSocketEndpoint1 do
+        use Phoenix.Endpoint, otp_app: :phoenix
+
+        socket "/ws", UserSocket, websocket: [path: "/ws", check_origin: false, invalid: true]
+      end
+    end
+
+    assert_raise ArgumentError, ~r/unknown keys \[:drainer\]/, fn ->
+      defmodule MyInvalidSocketEndpoint2 do
+        use Phoenix.Endpoint, otp_app: :phoenix
+
+        socket "/ws", UserSocket, longpoll: [path: "/ws", check_origin: false, drainer: []]
+      end
+    end
+  end
 end

--- a/test/phoenix/integration/long_poll_socket_test.exs
+++ b/test/phoenix/integration/long_poll_socket_test.exs
@@ -67,7 +67,7 @@ defmodule Phoenix.Integration.LongPollSocketTest do
       custom: :value
 
     socket "/custom/:socket_var", UserSocket,
-      longpoll: [path: ":path_var/path", check_origin: ["//example.com"], timeout: 200],
+      longpoll: [path: ":path_var/path", check_origin: ["//example.com"], pubsub_timeout_ms: 200],
       custom: :value
   end
 


### PR DESCRIPTION
We cannot validate options other than websocket / longpoll, because they might be used by custom sockets. See https://github.com/phoenixframework/phoenix/commit/ab2ff9ede9f20720412f7e26f9789c86fbe7ec3d#diff-5ab73ffaee87d2c9de2a1455f11157d5d3c0dd01157ee019d58d37b19dafd68eR29.

@josevalim please double check if validating the websocket / longpoll keys is actually fine.