### PR TITLE
revert code reloader changed file detection

### DIFF
--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -289,7 +289,7 @@ defmodule Phoenix.CodeReloader.Server do
 
   defp mix_compile_unless_stale_config(compilers, compile_args, timestamp, path, purge_fallback?) do
     manifests = Mix.Tasks.Compile.Elixir.manifests()
-    configs = Mix.Project.config_files() |> dbg
+    configs = Mix.Project.config_files()
     config = Mix.Project.config()
 
     case Mix.Utils.extract_stale(configs, manifests) do

--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -289,17 +289,8 @@ defmodule Phoenix.CodeReloader.Server do
 
   defp mix_compile_unless_stale_config(compilers, compile_args, timestamp, path, purge_fallback?) do
     manifests = Mix.Tasks.Compile.Elixir.manifests()
+    configs = Mix.Project.config_files() |> dbg
     config = Mix.Project.config()
-    build_path = Mix.Project.build_path(config)
-
-    # Stop if lock or config files change.
-    # We don't check for mix.exs because changes there that require recompilation
-    # are often related to deps or configs anyway.
-    # We also explicitly remove checks for entries in _build because reporting
-    # them is confusing and they are mostly used for internal Mix book-keeping.
-    configs =
-      [config[:lockfile] | Mix.Project.config_files()]
-      |> Enum.reject(&String.starts_with?(&1, build_path))
 
     case Mix.Utils.extract_stale(configs, manifests) do
       [] ->
@@ -316,7 +307,8 @@ defmodule Phoenix.CodeReloader.Server do
         raise """
         could not compile application: #{Mix.Project.config()[:app]}.
 
-        You must restart your server after changing the following files:
+        You must restart your server after changing configuration files or your dependencies.
+        In particular, the following files changed and must be recomputed on a server restart:
 
           * #{Enum.map_join(files, "\n  * ", &Path.relative_to_cwd/1)}
 


### PR DESCRIPTION
This reverts commit 0f9628a and improves the error message.

@josevalim should we backport?