### PR TITLE
add button_classes to CoreComponents

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -178,6 +178,41 @@ defmodule <%= @web_namespace %>.CoreComponents do
   end
 
   @doc """
+  Renders a link styled as a button.
+
+  ## Examples
+
+      <.link_button href={~p"/items/new"}>
+        New Item
+      </.link_button>
+  """
+  attr :class, :string, default: nil
+
+  attr :rest, :global,
+    include:
+      ~w(patch navigate href replace method csrf_token download hreflang referrerpolicy rel target type),
+    doc: """
+    Additional HTML attributes added to the `a` tag.
+    """
+
+  slot :inner_block, required: true
+
+  def link_button(assigns) do
+    ~H"""
+    <.link
+      class={[
+        "inline-block phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
+        "text-sm font-semibold leading-6 text-white active:text-white/80",
+        @class
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </.link>
+    """
+  end
+
+  @doc """
   Renders an input with label and error messages.
 
   A `Phoenix.HTML.FormField` may be passed as argument,

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -163,53 +163,23 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def button(assigns) do
     ~H"""
-    <button
-      type={@type}
-      class={[
-        "phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
-        "text-sm font-semibold leading-6 text-white active:text-white/80",
-        @class
-      ]}
-      {@rest}
-    >
+    <button type={@type} class={[button_classes(), @class]} {@rest}>
       {render_slot(@inner_block)}
     </button>
     """
   end
 
   @doc """
-  Renders a link styled as a button.
+  Returns the default button classes.
 
   ## Examples
 
-      <.link_button href={~p"/items/new"}>
+      <.link class={button_classes()} href={~p"/items/new"}>
         New Item
-      </.link_button>
+      </.link>
   """
-  attr :class, :string, default: nil
-
-  attr :rest, :global,
-    include:
-      ~w(patch navigate href replace method csrf_token download hreflang referrerpolicy rel target type),
-    doc: """
-    Additional HTML attributes added to the `a` tag.
-    """
-
-  slot :inner_block, required: true
-
-  def link_button(assigns) do
-    ~H"""
-    <.link
-      class={[
-        "inline-block phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
-        "text-sm font-semibold leading-6 text-white active:text-white/80",
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </.link>
-    """
+  def button_classes do
+    "inline-block phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3 text-sm font-semibold leading-6 text-white active:text-white/80"
   end
 
   @doc """

--- a/priv/templates/phx.gen.html/index.html.heex
+++ b/priv/templates/phx.gen.html/index.html.heex
@@ -1,11 +1,9 @@
 <.header>
   Listing <%= schema.human_plural %>
   <:actions>
-    <.button phx-click={JS.dispatch("click", to: {:inner, "a"})}>
-      <.link href={~p"<%= schema.route_prefix %>/new"}>
-        New <%= schema.human_singular %>
-      </.link>
-    </.button>
+    <.link_button href={~p"<%= schema.route_prefix %>/new"}>
+      New <%= schema.human_singular %>
+    </.link_button>
   </:actions>
 </.header>
 

--- a/priv/templates/phx.gen.html/index.html.heex
+++ b/priv/templates/phx.gen.html/index.html.heex
@@ -1,9 +1,9 @@
 <.header>
   Listing <%= schema.human_plural %>
   <:actions>
-    <.link_button href={~p"<%= schema.route_prefix %>/new"}>
+    <.link class={button_classes()} href={~p"<%= schema.route_prefix %>/new"}>
       New <%= schema.human_singular %>
-    </.link_button>
+    </.link>
   </:actions>
 </.header>
 

--- a/priv/templates/phx.gen.html/show.html.heex
+++ b/priv/templates/phx.gen.html/show.html.heex
@@ -2,11 +2,9 @@
   <%= schema.human_singular %> {@<%= schema.singular %>.id}
   <:subtitle>This is a <%= schema.singular %> record from your database.</:subtitle>
   <:actions>
-    <.button phx-click={JS.dispatch("click", to: {:inner, "a"})}>
-      <.link href={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/edit"}>
-        Edit <%= schema.singular %>
-      </.link>
-    </.button>
+    <.link_button href={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/edit"}>
+      Edit <%= schema.singular %>
+    </.link_button>
   </:actions>
 </.header>
 

--- a/priv/templates/phx.gen.html/show.html.heex
+++ b/priv/templates/phx.gen.html/show.html.heex
@@ -2,9 +2,9 @@
   <%= schema.human_singular %> {@<%= schema.singular %>.id}
   <:subtitle>This is a <%= schema.singular %> record from your database.</:subtitle>
   <:actions>
-    <.link_button href={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/edit"}>
+    <.link class={button_classes()} href={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/edit"}>
       Edit <%= schema.singular %>
-    </.link_button>
+    </.link>
   </:actions>
 </.header>
 

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -178,6 +178,41 @@ defmodule <%= @web_namespace %>.CoreComponents do
   end
 
   @doc """
+  Renders a link styled as a button.
+
+  ## Examples
+
+      <.link_button href={~p"/items/new"}>
+        New Item
+      </.link_button>
+  """
+  attr :class, :string, default: nil
+
+  attr :rest, :global,
+    include:
+      ~w(patch navigate href replace method csrf_token download hreflang referrerpolicy rel target type),
+    doc: """
+    Additional HTML attributes added to the `a` tag.
+    """
+
+  slot :inner_block, required: true
+
+  def link_button(assigns) do
+    ~H"""
+    <.link
+      class={[
+        "inline-block phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
+        "text-sm font-semibold leading-6 text-white active:text-white/80",
+        @class
+      ]}
+      {@rest}
+    >
+      {render_slot(@inner_block)}
+    </.link>
+    """
+  end
+
+  @doc """
   Renders an input with label and error messages.
 
   A `Phoenix.HTML.FormField` may be passed as argument,

--- a/priv/templates/phx.gen.live/core_components.ex
+++ b/priv/templates/phx.gen.live/core_components.ex
@@ -163,53 +163,23 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def button(assigns) do
     ~H"""
-    <button
-      type={@type}
-      class={[
-        "phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
-        "text-sm font-semibold leading-6 text-white active:text-white/80",
-        @class
-      ]}
-      {@rest}
-    >
+    <button type={@type} class={[button_classes(), @class]} {@rest}>
       {render_slot(@inner_block)}
     </button>
     """
   end
 
   @doc """
-  Renders a link styled as a button.
+  Returns the default button classes.
 
   ## Examples
 
-      <.link_button href={~p"/items/new"}>
+      <.link class={button_classes()} href={~p"/items/new"}>
         New Item
-      </.link_button>
+      </.link>
   """
-  attr :class, :string, default: nil
-
-  attr :rest, :global,
-    include:
-      ~w(patch navigate href replace method csrf_token download hreflang referrerpolicy rel target type),
-    doc: """
-    Additional HTML attributes added to the `a` tag.
-    """
-
-  slot :inner_block, required: true
-
-  def link_button(assigns) do
-    ~H"""
-    <.link
-      class={[
-        "inline-block phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3",
-        "text-sm font-semibold leading-6 text-white active:text-white/80",
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </.link>
-    """
+  def button_classes do
+    "inline-block phx-submit-loading:opacity-75 rounded-lg bg-zinc-900 hover:bg-zinc-700 py-2 px-3 text-sm font-semibold leading-6 text-white active:text-white/80"
   end
 
   @doc """

--- a/priv/templates/phx.gen.live/index.ex
+++ b/priv/templates/phx.gen.live/index.ex
@@ -9,9 +9,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     <.header>
       Listing <%= schema.human_plural %>
       <:actions>
-        <.link_button navigate={~p"<%= schema.route_prefix %>/new"}>
+        <.link class={button_classes()} navigate={~p"<%= schema.route_prefix %>/new"}>
           New <%= schema.human_singular %>
-        </.link_button>
+        </.link>
       </:actions>
     </.header>
 

--- a/priv/templates/phx.gen.live/index.ex
+++ b/priv/templates/phx.gen.live/index.ex
@@ -9,11 +9,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     <.header>
       Listing <%= schema.human_plural %>
       <:actions>
-        <.button phx-click={JS.dispatch("click", to: {:inner, "a"})}>
-          <.link navigate={~p"<%= schema.route_prefix %>/new"}>
-            New <%= schema.human_singular %>
-          </.link>
-        </.button>
+        <.link_button navigate={~p"<%= schema.route_prefix %>/new"}>
+          New <%= schema.human_singular %>
+        </.link_button>
       </:actions>
     </.header>
 

--- a/priv/templates/phx.gen.live/show.ex
+++ b/priv/templates/phx.gen.live/show.ex
@@ -10,9 +10,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       <%= schema.human_singular %> {@<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>}
       <:subtitle>This is a <%= schema.singular %> record from your database.</:subtitle>
       <:actions>
-        <.link_button navigate={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/edit?return_to=show"}>
+        <.link class={button_classes()} navigate={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/edit?return_to=show"}>
           Edit <%= schema.singular %>
-        </.link_button>
+        </.link>
       </:actions>
     </.header>
 

--- a/priv/templates/phx.gen.live/show.ex
+++ b/priv/templates/phx.gen.live/show.ex
@@ -10,11 +10,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       <%= schema.human_singular %> {@<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>}
       <:subtitle>This is a <%= schema.singular %> record from your database.</:subtitle>
       <:actions>
-        <.button phx-click={JS.dispatch("click", to: {:inner, "a"})}>
-          <.link navigate={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/edit?return_to=show"}>
-            Edit <%= schema.singular %>
-          </.link>
-        </.button>
+        <.link_button navigate={~p"<%= schema.route_prefix %>/#{@<%= schema.singular %>}/edit?return_to=show"}>
+          Edit <%= schema.singular %>
+        </.link_button>
       </:actions>
     </.header>
 


### PR DESCRIPTION
Buttons and Links must not be nested inside each other, otherwise there are accessibility issues. A previous PR did not fix the problem, but just inverted the problem.

Adds a helper function to return button_classes for styling other components, like links.

Fixes #5770.
Relates to: #5820