### PR TITLE
Allow skipping migration when generating context with `--no-migration`

### DIFF
--- a/lib/mix/tasks/phx.gen.context.ex
+++ b/lib/mix/tasks/phx.gen.context.ex
@@ -28,6 +28,8 @@ defmodule Mix.Tasks.Phx.Gen.Context do
   A migration file for the repository and test files for the context
   will also be generated.
 
+  The generated migration can be skipped with `--no-migration`.
+
   ## Generating without a schema
 
   In some cases, you may wish to bootstrap the context module and
@@ -90,7 +92,8 @@ defmodule Mix.Tasks.Phx.Gen.Context do
     prefix: :string,
     live: :boolean,
     compile: :boolean,
-    primary_key: :string
+    primary_key: :string,
+    migration: :boolean
   ]
 
   @default_opts [schema: true, context: true]

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -367,6 +367,14 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
     end)
   end
 
+  test "generates schema with no migration option", config do
+    in_tmp_project(config.test, fn ->
+      Gen.Context.run(~w(Blog Post posts title:string --no-migration))
+
+      assert Path.wildcard("priv/repo/migrations/*") == []
+    end)
+  end
+
   test "generates context with no schema and repo option", config do
     in_tmp_project(config.test, fn ->
       Gen.Context.run(~w(Blog Post posts title:string --no-schema --repo=Foo.RepoX))


### PR DESCRIPTION
fixes #6080 

first time contributing to Phoenix, so I hope I got it right ^^ 