### PR TITLE
align sqlite migration code with comment

### DIFF
--- a/installer/templates/phx_single/lib/app_name/application.ex
+++ b/installer/templates/phx_single/lib/app_name/application.ex
@@ -37,6 +37,6 @@ defmodule <%= @app_module %>.Application do
 
   defp skip_migrations?() do
     # By default, sqlite migrations are run when using a release
-    System.get_env("RELEASE_NAME") != nil
+    System.get_env("RELEASE_NAME") == nil
   end<% end %>
 end

--- a/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
+++ b/installer/templates/phx_umbrella/apps/app_name/lib/app_name/application.ex
@@ -23,6 +23,6 @@ defmodule <%= @app_module %>.Application do
 
   defp skip_migrations?() do
     # By default, sqlite migrations are run when using a release
-    System.get_env("RELEASE_NAME") != nil
+    System.get_env("RELEASE_NAME") == nil
   end<% end %>
 end

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -704,7 +704,7 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~ "skip: skip_migrations?()"
 
         assert file =~ "defp skip_migrations?() do"
-        assert file =~ ~s/System.get_env("RELEASE_NAME") != nil/
+        assert file =~ ~s/System.get_env("RELEASE_NAME") == nil/
       end)
 
       assert_file("custom_path/test/support/conn_case.ex", "DataCase.setup_sandbox(tags)")

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -635,7 +635,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         assert file =~ "skip: skip_migrations?()"
 
         assert file =~ "defp skip_migrations?() do"
-        assert file =~ ~s/System.get_env("RELEASE_NAME") != nil/
+        assert file =~ ~s/System.get_env("RELEASE_NAME") == nil/
       end)
 
       assert_file(root_path(app, "config/dev.exs"), [~r/database: .*_dev.db/])


### PR DESCRIPTION
fixes #5945 

The wording of the code comment implies the opposite of what the function actually does.
I aligned the code with the comment. Can also do it the other way around if needed. 







