### PR TITLE
Fix ex_cldr_routes URL

### DIFF
--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -180,7 +180,7 @@ defmodule Phoenix.VerifiedRoutes do
 
   Finally, for even more complex use cases, where the whole URL needs to localized,
   see projects such as [`routex`](https://hex.pm/packages/routex) and
-  [`ex_cldr_routes`](https://hex.pm/packages/cldr_routes).
+  [`ex_cldr_routes`](https://hex.pm/packages/ex_cldr_routes).
   '''
   @doc false
   defstruct router: nil,


### PR DESCRIPTION
https://hex.pm/packages/cldr_routes is a 404. Should be https://hex.pm/packages/ex_cldr_routes