### PR TITLE
Allow case-insensitive token type

### DIFF
--- a/guides/authn_authz/api_authentication.md
+++ b/guides/authn_authz/api_authentication.md
@@ -135,10 +135,11 @@ When we ran `mix phx.gen.auth`, it generated a `MyAppWeb.UserAuth` module with s
 
 ```elixir
 def fetch_current_scope_for_api_user(conn, _opts) do
-  with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
-       {:ok, user} <- Accounts.fetch_user_by_api_token(token) do
-    assign(conn, :current_scope, Scope.for_user(user))
-  else
+  with [<<type::binary-7, token::binary>>] when type in ["bearer ", "Bearer "] <-
+           get_req_header(conn, "authorization"),
+         {:ok, user} <- Accounts.fetch_user_by_api_token(token) do
+      assign(conn, :current_user, user)
+    else
     _ ->
       conn
       |> send_resp(:unauthorized, "No access for you")


### PR DESCRIPTION
Improve API, if only by a tiny amount, by removing case sensitivity of the token's "Bearer" prefix. HTTP/1.1 Authentication specifies that [a case-insensitive token be used](https://datatracker.ietf.org/doc/html/rfc7235#section-2.1).

Somewhat related, I think that [OAuth 2.0 RFC using (uppercase) "Bearer" in its example](https://datatracker.ietf.org/doc/html/rfc6750#section-2.1) doesn't necessarily mean that the _implementation_  must also be case sensitive since the example is written in ABNF notation, which [is case insensitive](https://www.rfc-editor.org/rfc/rfc5234#page-5).

Performance of the current vs the proposed version seems to be equivalent:
```
Operating System: macOS
CPU Information: Apple M3 Pro
Number of Available Cores: 11
Available memory: 18 GB
Elixir 1.18.2
Erlang 27.2.3
JIT enabled: true

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 0 ns
reduction time: 0 ns
parallel: 1
inputs: OWASP_min, larger
Estimated total run time: 48 s

Benchmarking case_insensitive with input OWASP_min ...
Benchmarking case_insensitive with input larger ...
Benchmarking case_sensitive with input OWASP_min ...
Benchmarking case_sensitive with input larger ...
Calculating statistics...
Formatting results...

##### With input OWASP_min #####
Name                       ips        average  deviation         median         99th %
case_insensitive        1.72 K      580.49 μs    ±25.30%      562.21 μs      992.99 μs
case_sensitive          1.72 K      582.99 μs    ±23.68%      566.98 μs      883.50 μs

Comparison:
case_insensitive        1.72 K
case_sensitive          1.72 K - 1.00x slower +2.50 μs

##### With input larger #####
Name                       ips        average  deviation         median         99th %
case_sensitive          1.71 K      583.23 μs    ±22.14%      569.13 μs      867.69 μs
case_insensitive        1.70 K      586.77 μs    ±88.17%      565.13 μs      918.21 μs

Comparison:
case_sensitive          1.71 K
case_insensitive        1.70 K - 1.01x slower +3.54 μs
```

Benchee inputs: 
```elixir
inputs: %{
  "OWASP_min" => :crypto.strong_rand_bytes(8) |> Base.encode16(),
  "larger"    => :crypto.strong_rand_bytes(64) |> Base.encode16()
}
```