### PR TITLE
Add `Phoenix.VerifiedRoutes` behaviour for custom routers

### DIFF
--- a/lib/phoenix/router/console_formatter.ex
+++ b/lib/phoenix/router/console_formatter.ex
@@ -10,7 +10,8 @@ defmodule Phoenix.Router.ConsoleFormatter do
   @longpoll_verbs ["GET", "POST"]
 
   def format(router, endpoint \\ nil) do
-    routes = Phoenix.Router.routes(router)
+    routes = router.formatted_routes([])
+
     column_widths = calculate_column_widths(router, routes, endpoint)
 
     IO.iodata_to_binary([
@@ -19,7 +20,7 @@ defmodule Phoenix.Router.ConsoleFormatter do
     ])
   end
 
-  defp format_endpoint(nil, _), do: ""
+  defp format_endpoint(nil, _router), do: ""
 
   defp format_endpoint(endpoint, widths) do
     case endpoint.__sockets__() do
@@ -104,21 +105,12 @@ defmodule Phoenix.Router.ConsoleFormatter do
     %{
       verb: verb,
       path: path,
-      plug: plug,
-      metadata: metadata,
-      plug_opts: plug_opts,
-      helper: helper
+      label: label
     } = route
 
     verb = verb_name(verb)
-    route_name = route_name(router, helper)
+    route_name = route_name(router, Map.get(route, :helper))
     {verb_len, path_len, route_name_len} = column_widths
-
-    log_module =
-      case metadata[:mfa] do
-        {mod, _fun, _arity} -> mod
-        _ -> plug
-      end
 
     String.pad_leading(route_name, route_name_len) <>
       "  " <>
@@ -126,7 +118,7 @@ defmodule Phoenix.Router.ConsoleFormatter do
       "  " <>
       String.pad_trailing(path, path_len) <>
       "  " <>
-      "#{inspect(log_module)} #{inspect(plug_opts)}\n"
+      label <> "\n"
   end
 
   defp route_name(_router, nil), do: ""


### PR DESCRIPTION
This comes with two parts:

- These routes are expanded when printing routes using `mix phx.routes`. I've added an additional `label` metadata which is extremely useful for things like `AshJsonApi` to display the resource & action being routed to
- verified routes logic has been modified to match these expanded routes as well. 

I've tested manually and it works well, but I will of course add tests for this logic if this kind of thing seems like a good idea to the team.

Original ElixirForum discussion: https://elixirforum.com/t/allow-forwarded-to-plugs-to-have-a-callback-that-returns-additional-routes/65365/2

I had to use `Code.ensure_compiled/1` on the nested plug, which I couldn't find a good way around but I'm open to ideas on (open to ideas on the whole implementation).

One note is that part of the reason for a lot of these forwarded-to plugs to exist is to do dynamic routing that can't be done at compile time, so it would negate most of the benefit if we expanded these routes at compile time directly into the router (verified routes being different because it happens in after_verify).

Thoughts?
