### PR TITLE
Change reloader to not remove priv if it is not a copy

### DIFF
--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -35,7 +35,10 @@ defmodule Phoenix.CodeReloader.Server do
   end
 
   def handle_call(:check_symlinks, _from, state) do
-    if state.check_symlinks and Code.ensure_loaded?(Mix.Project) and not Mix.Project.umbrella?() do
+    has_top_level_priv? = File.dir?("priv")
+
+    if state.check_symlinks and Code.ensure_loaded?(Mix.Project) and not Mix.Project.umbrella?() and
+         has_top_level_priv? do
       priv_path = "#{Mix.Project.app_path()}/priv"
 
       case :file.read_link(priv_path) do

--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -35,10 +35,8 @@ defmodule Phoenix.CodeReloader.Server do
   end
 
   def handle_call(:check_symlinks, _from, state) do
-    has_top_level_priv? = File.dir?("priv")
-
     if state.check_symlinks and Code.ensure_loaded?(Mix.Project) and not Mix.Project.umbrella?() and
-         has_top_level_priv? do
+         File.dir?("priv") do
       priv_path = "#{Mix.Project.app_path()}/priv"
 
       case :file.read_link(priv_path) do


### PR DESCRIPTION
When starting, the code reloader checks if _build/dev/myapp/priv is a symlink or hard copy. It may be a hard copy on Windows, if Mix cannot create a symlink. To allow symlinks, it may be necessary to run the terminal as Administrator at least once. So, if it is a hard copy, reloader removes _build/dev/myapp/priv and lets Mix recreate it, possibly creating a symlink. The main reason is that making hard copy on each recompilation is slow on Windows.

The above assumes that there exists priv/ at the top level and is either symlinked or copied. However, it is possible that _build/dev/myapp/priv is created directly. If that's the case, if the reloader removes it (as it does currently), it is just missing altogether. This PR fixes it by checking if the top level priv/ exists before deleting the build one.