### PR TITLE
Fix endpoint binding comment location in installer templates

### DIFF
--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -10,7 +10,8 @@ config :<%= @app_name %>, <%= @endpoint_module %>,<%= if @inside_docker_env? do 
   # Bind to 0.0.0.0 to expose the server to the docker host machine.
   # This makes make the service accessible from any network interface.
   # Change to `ip: {127, 0, 0, 1}` to allow access only from the server machine.
-  http: [ip: {0, 0, 0, 0}, port: 4000],<% else %># Binding to loopback ipv4 address prevents access from other machines.
+  http: [ip: {0, 0, 0, 0}, port: 4000],<% else %>
+  # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
   http: [ip: {127, 0, 0, 1}, port: 4000],<% end %>
   check_origin: false,

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -10,7 +10,8 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,<%= if @inside_docker_env?
   # Bind to 0.0.0.0 to expose the server to the docker host machine.
   # This makes make the service accessible from any network interface.
   # Change to `ip: {127, 0, 0, 1}` to allow access only from the server machine.
-  http: [ip: {0, 0, 0, 0}, port: 4000],<% else %># Binding to loopback ipv4 address prevents access from other machines.
+  http: [ip: {0, 0, 0, 0}, port: 4000],<% else %>
+  # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
   http: [ip: {127, 0, 0, 1}, port: 4000],<% end %>
   check_origin: false,


### PR DESCRIPTION
When not in the docker container, the current code produces

```elixir
config :foo, FooWeb.Endpoint,# Binding to loopback ipv4 address prevents access from other machines.
  # This makes make the service accessible from any network interface.
```

which turns to the following.

```elixir
# Binding to loopback ipv4 address prevents access from other machines.
config :foo, FooWeb.Endpoint,
  # This makes make the service accessible from any network interface.
```

To keep the comment on the next line, add new line after else.