### PR TITLE
add test for new verified routes behavior for mix phx.routes

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -1308,12 +1308,13 @@ defmodule Phoenix.Router do
         route.plug_opts
         |> route.plug.formatted_routes()
         |> Enum.map(fn nested_route ->
-          %{
+          route = %{
             route
             | path: Path.join(route.path, nested_route.path),
-              verb: nested_route.verb,
-              plug_opts: nested_route.plug_opts
+              verb: nested_route.verb
           }
+
+          Map.put(route, :label, nested_route.label)
         end)
       else
         plug =

--- a/test/mix/tasks/phx.routes_test.exs
+++ b/test/mix/tasks/phx.routes_test.exs
@@ -48,7 +48,7 @@ defmodule PhoenixTestWeb.PlugRouterWithVerifiedRoutes do
 
   @impl Phoenix.VerifiedRoutes
   def verified_route?(_plug_opts, path) do
-    path == "/foo"
+    path == ["foo"]
   end
 end
 

--- a/test/mix/tasks/phx.routes_test.exs
+++ b/test/mix/tasks/phx.routes_test.exs
@@ -24,6 +24,34 @@ defmodule PhoenixTestLiveWeb.Router do
   get "/", PageController, :index, metadata: %{mfa: {PageController.Live, :init, 1}}
 end
 
+defmodule PhoenixTestWeb.ForwardedRouter do
+  use Phoenix.Router
+
+  forward "/", PhoenixTestWeb.PlugRouterWithVerifiedRoutes
+end
+
+defmodule PhoenixTestWeb.PlugRouterWithVerifiedRoutes do
+  use Plug.Router
+
+  @behaviour Phoenix.VerifiedRoutes
+
+  get "/foo" do
+    send_resp(conn, 200, "ok")
+  end
+
+  @impl Phoenix.VerifiedRoutes
+  def formatted_routes(_plug_opts) do
+    [
+      %{verb: "GET", path: "/foo", label: "Hello"}
+    ]
+  end
+
+  @impl Phoenix.VerifiedRoutes
+  def verified_route?(_plug_opts, path) do
+    path == "/foo"
+  end
+end
+
 defmodule Mix.Tasks.Phx.RoutesTest do
   use ExUnit.Case, async: true
 
@@ -31,6 +59,12 @@ defmodule Mix.Tasks.Phx.RoutesTest do
     Mix.Tasks.Phx.Routes.run(["PhoenixTestWeb.Router", "--no-compile"])
     assert_received {:mix_shell, :info, [routes]}
     assert routes =~ "page_path  GET  /  PageController :index"
+  end
+
+  test "format routes for forwarded router that implements verified routes" do
+    Mix.Tasks.Phx.Routes.run(["PhoenixTestWeb.ForwardedRouter", "--no-compile"])
+    assert_received {:mix_shell, :info, [routes]}
+    assert routes =~ "GET  /foo  Hello"
   end
 
   test "prints error when explicit router cannot be found" do


### PR DESCRIPTION
@zachdaniel I needed to make a little adjustment. While the type for formatted_route defines verb, path and label

```elixir
@type formatted_route :: %{
          required(:verb) => String.t(),
          required(:path) => String.t(),
          required(:label) => String.t()
        }
```

The code expected plug_opts instead and didn't handle the label. I believe this was just an oversight, but please double check.