### PR TITLE
Correct wording of layouts without modules deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This release introduces deprecation warnings for several features that have been
 
   * `use Phoenix.Controller` must now specify the `:formats` option, which may be set to an empty list if the formats are not known upfront
   * The `:namespace` and `:put_default_views` options on `use Phoenix.Controller` are deprecated and emit a warning on use
-  * Specifying layouts with modules, such as `put_layout(conn, :print)` or `put_layout(conn, html: :print)` is deprecated
+  * Specifying layouts without modules, such as `put_layout(conn, :print)` or `put_layout(conn, html: :print)` is deprecated
   * The `:trailing_slash` option in `Phoenix.Router` has been deprecated in favor of using `Phoenix.VerifiedRoutes`. The overall usage of helpers will be deprecated in the future
 
 ## v1.7


### PR DESCRIPTION
Specifying layouts without module is now deprecated (See #6132). However the changelog incorrectly states that layouts with modules are deprecated.