### PR TITLE
Refresh auth tokens periodically in phx.gen.auth code.

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -142,7 +142,7 @@ defmodule <%= inspect auth_module %> do
       conn = fetch_cookies(conn, signed: [@remember_me_cookie])
 
       if token = conn.cookies[@remember_me_cookie] do
-        {token, put_token_in_session(conn, token)}
+        {token, conn |> put_token_in_session(token) |> put_session(:<%= schema.singular %>_remember_me, true)}
       else
         {nil, conn}
       end

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -325,7 +325,7 @@ defmodule <%= inspect auth_module %> do
 
   <%= if live? do %>@doc "Returns the path to redirect to after log in."
   # the <%= schema.singular %> was already logged in, redirect to settings
-  def signed_in_path(%Plug.Conn{assigns: %{current_scope: %<%= inspect scope_config.scope.alias %>{user: %<%= inspect context.alias %>.<%= inspect schema.alias %>{}}}}) do
+  def signed_in_path(%Plug.Conn{assigns: %{current_scope: %<%= inspect scope_config.scope.alias %>{<%= schema.singular %>: %<%= inspect context.alias %>.<%= inspect schema.alias %>{}}}}) do
     ~p"<%= schema.route_prefix %>/settings"
   end
 

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -144,8 +144,8 @@ defmodule <%= inspect auth_module %>Test do
         |> <%= inspect schema.alias %>Auth.fetch_current_scope_for_<%= schema.singular %>([])
 
       assert conn.assigns.current_scope.<%= schema.singular %>.id == <%= schema.singular %>.id
-      assert get_session(conn, :<%= schema.singular %>_token) == <%= schema.singular %>_token<%= if live? do %>
-      assert get_session(conn, :<%= schema.singular %>_remember_me)
+      assert get_session(conn, :<%= schema.singular %>_token) == <%= schema.singular %>_token
+      assert get_session(conn, :<%= schema.singular %>_remember_me)<%= if live? do %>
 
       assert get_session(conn, :live_socket_id) ==
                "<%= schema.plural %>_sessions:#{Base.url_encode64(<%= schema.singular %>_token)}"<% end %>

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -165,7 +165,7 @@ defmodule <%= inspect auth_module %>Test do
 
     defp offset_<%= schema.singular %>_token(token, amount_to_add, unit) do
       dt = DateTime.add(DateTime.utc_now(), amount_to_add, unit)
-      query = from ut in <%= inspect schema.alias %>Token, where: ut.token == ^token
+      query = from(ut in <%= inspect schema.alias %>Token, where: ut.token == ^token)
       {1, nil} = Repo.update_all(query, set: [inserted_at: dt, refreshed_at: dt])
       {<%= schema.singular %>_token, _} = <%= inspect context.alias %>.get_<%= schema.singular %>_auth_by_session_token(token)
       <%= schema.singular %>_token

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -145,6 +145,7 @@ defmodule <%= inspect auth_module %>Test do
 
       assert conn.assigns.current_scope.<%= schema.singular %>.id == <%= schema.singular %>.id
       assert get_session(conn, :<%= schema.singular %>_token) == <%= schema.singular %>_token<%= if live? do %>
+      assert get_session(conn, :<%= schema.singular %>_remember_me)
 
       assert get_session(conn, :live_socket_id) ==
                "<%= schema.plural %>_sessions:#{Base.url_encode64(<%= schema.singular %>_token)}"<% end %>

--- a/priv/templates/phx.gen.auth/migration.ex
+++ b/priv/templates/phx.gen.auth/migration.ex
@@ -21,6 +21,7 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.
       <%= migration.column_definitions[:token] %>
       add :context, :string, null: false
       add :sent_to, :string
+      add :refreshed_at, :utc_datetime
 
       timestamps(<%= if schema.timestamp_type != :naive_datetime, do: "type: #{inspect schema.timestamp_type}, " %>updated_at: false)
     end

--- a/priv/templates/phx.gen.auth/scope.ex
+++ b/priv/templates/phx.gen.auth/scope.ex
@@ -18,12 +18,12 @@ defmodule <%= inspect scope_config.scope.module %> do
 
   alias <%= inspect schema.module %>
 
-  defstruct user: nil
+  defstruct <%= schema.singular %>: nil
 
   @doc """
   Creates a scope for the given <%= schema.singular %>.
 
-  Returns nil if no user is given.
+  Returns nil if no <%= schema.singular %> is given.
   """
   def for_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do
     %__MODULE__{<%= schema.singular %>: <%= schema.singular %>}


### PR DESCRIPTION
The auth code currently generated by `mix phx.gen.auth` has two small issues that I've encountered:

1. After logging in, a user who maintains their session (either by never closing their browser or
due to things like Session Restore in Firefox) will be forced to reauthenticate after the session
token expires, which defaults to 60 days.

2. Even if the user selects the "remember me" option and the remember me cookie is created, the cookie and
token will only last for 60 days from the time that the authentication first happened.

A user could be happily working seconds before the token is set to expire, and then on the next request be forced to log in again. And no matter what, the user is forced to reauthenticate at least every 60 days.

This is due to the validity of the token being based on when it was inserted into the database, by the `inserted_at` column.

This PR seeks to remedy this by automatically refreshing the generated tokens in the database, with a new column, `refreshed_at`, that is added to the `users_tokens` table. It will also refresh the remember me cookie with the browser so that its `expires` and `max_age` is extended.

You can easily see the differences of the generated code in [this project](https://github.com/nshafer/myapp18/compare/auth_live_orig..auth_live_new) which was generated with
`phx.gen.auth Accounts User users`.
Note: This PR applies the same changes to both live and no-live versions of the auth.
- [`phx.gen.auth --live Accounts User users`](https://github.com/nshafer/myapp18/compare/auth_live_orig..auth_live_new)
- [`phx.gen.auth --no-live Accounts User users`](https://github.com/nshafer/myapp18/compare/auth_nolive_orig..auth_nolive_new)

I've attempted to limit any kind of performance impact of this PR. I've set it to only refresh once every 24 hours by default to limit potentially costly `UPDATE`s to the database to once a day per token by default. The current code already does a join between `users` and `users_tokens`, returning just the fields of `users` and this modifies it only so that all fields of both `users` and `users_tokens` are returned on every request. This is so that the `fetch_current_scope_for_user/2` function can check how long its been since the token was refreshed, and refresh the token and cookie if needed. With the default columns of `users_tokens` this increase is minimal, but we can reduce it by selecting only the `refreshed_at` column if we want.

I also make all changes happen in the main `fetch_current_scope_for_user/2` function, so tokens will not be checked or refreshed on live view connected mounts or live navigations. The first reason is that we wouldn't be able to refresh the cookie from a websocket. The other reason is that it's unnecessary for most situations where a normal request is made before the connected mount anyways. The only scenario I can think of is like a kiosk display that has a live view mounted 24/7, which never does a normal request, just websocket connects. But at least now a dev has the option to cause that kiosk to do a full refresh at least once every 60 days to maintain their auth, instead of it logging out every 2 months regardless.

Security wise, the only impact I can think of is where a users cookies are exfiltrated or intercepted. Instead of the stolen cookie only working for up to 60 days, it would work indefinitely as long as the attacker made a request with it periodically to refresh it. To me this doesn't seem like an escalation of risk or reduction in security, since the channel of attack already implies a much more serious problem. An attacker can have up to 60 days to wreak havoc or steal data with the old cookies anyways. The new "sudo" mechanism is not affected by this change, since `is_sudo?` is based on when the token was created. So an attacker in this scenario would not be able to do anything that requires "sudo", such as change email address or password. The current mechanism where all tokens are deleted when the user changes their email or password still applies. I also left a comment near the module attribute, `@session_refresh_age_in_hours`, that if it's increased to a value greater than the session age, then refreshing is effectively disabled, in case a dev wants to only support short-lived authentication sessions.

I tested that this works with all the other recent changes, such as sudo mode, which is still based on the `inserted_at` of the token. I did fix a small bug where a user session that was restored from the remember me cookie would not persist that preference if the user was required to re-auth for a sudo required page. I also added to the tests to make sure `authenticated_at` is set properly in the `User`.

I attempted to limit the changes to the bare-minimum so that devs could more easily upgrade existing generated code. The main exception is that I took the opportunity to retire `verify_session_token_query/1` from the generated context which always returned {:ok, query} and never an error. My guess is that it was a hold-over from an old version of the function that could return an error. I rewrote this function to `valid_session_token_query/1` which just returns the query. The other change is that I unified the units between the related module attributes settings in `user_token.ex` and `user_auth.ex`. It used to be `@session_validity_in_days 60` in the former, and `@max_age 60 * 60 * 24 * 60` in the latter. I changed it to `@max_session_age_in_days 60` in `user_auth.ex` so that changes in one file can be easily copied to the other. If a dev were inclined to update their already-generated code, then they would just need to create a db migration that adds the `add :refreshed_at, :utc_datetime` column, and then sets it to the current value of `inserted_at`. From there the sessions will start refreshing.

Finally, I added a `prune_user_tokens/0` function in the generated context that will properly remove old and expired tokens from the database. I felt this was very valuable for us to provide so that the deletions happen properly with the different token types without having to understand all of the auth code. This function is not called anywhere by default, but it can be easily hooked up to some kind of periodic background task to keep the database size from ballooning with old useless tokens.

I explored other options for the refresh, such as storing the refresh time in the session and remember me cookies instead of the database. I felt this didn't really result in any kind of improvement, as it would bloat the session and cookies for all requests, instead of just the data returned from the db, and make the code more complicated.

Oh I also fixed a couple things related to scopes that was causing test failures with non-"user" like settings, such as `mix phx.gen.auth Company Person people`. (Speaking of, should the `is_sudo?` stuff be in scopes? Seems like that's a good example of how requests can be scoped, with a `recently_authenticated` check or something.)

Let me know if there's something I'm not aware of with this change, such as for performance impact or security.

Thanks!
Nathan Shafer
