### PR TITLE
Add a link to the Flash messages guide from put_flash docs

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1689,6 +1689,8 @@ defmodule Phoenix.Controller do
 
   Returns the updated connection.
 
+  See [Flash messages](controllers.md#flash-messages) in the Controllers guide for more details.
+
   ## Examples
 
       iex> conn = put_flash(conn, :info, "Welcome Back!")


### PR DESCRIPTION
While reading the `put_flash` docs, I was wondering what the valid key values where. This is documented in the guide, so I added a link.

<img width="845" alt="image" src="https://github.com/user-attachments/assets/5dcd2929-fd3b-41cc-add0-5248a8859420" />

Link goes to https://hexdocs.pm/phoenix/controllers.html#flash-messages