### PR TITLE
invert copy_core_component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ erl_crash.dump
 phoenix-*.ez
 
 .DS_Store
+
+/priv/templates/phx.gen.live/core_components.ex

--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -1,1 +1,0 @@
-templates/phx_web/components/core_components.ex

--- a/installer/mix.exs
+++ b/installer/mix.exs
@@ -35,11 +35,10 @@ defmodule Phx.New.MixProject do
         ],
         licenses: ["MIT"],
         links: %{"GitHub" => @scm_url},
-        files: ~w(lib templates mix.exs README.md templates/phx_web/components/core_components.ex)
+        files: ~w(lib templates mix.exs README.md)
       ],
       source_url: @scm_url,
       docs: docs(),
-      aliases: aliases(),
       homepage_url: "https://www.phoenixframework.org",
       description: """
       Phoenix framework project generator.
@@ -66,22 +65,9 @@ defmodule Phx.New.MixProject do
     ]
   end
 
-  defp aliases do
-    [
-      "hex.publish": [&copy_core_components/1, "hex.publish"]
-    ]
-  end
-
   defp docs do
     [
       source_url_pattern: "#{@scm_url}/blob/v#{@version}/installer/%{path}#L%{line}"
     ]
-  end
-
-  defp copy_core_components(_) do
-    source = Path.join([__DIR__, "..", "priv", "templates", "phx.gen.live", "core_components.ex"])
-    destination_dir = Path.join([__DIR__, "templates", "phx_web", "components"])
-    destination = Path.join(destination_dir, "core_components.ex")
-    File.cp!(source, destination)
   end
 end

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -64,15 +64,15 @@ defmodule <%= @web_namespace %>.CoreComponents do
         @kind == :info && "alert-info",
         @kind == :error && "alert-error"
       ]}>
-        <.icon :if={@kind == :info} name="hero-information-circle-mini" class="size-5 shrink-0" />
-        <.icon :if={@kind == :error} name="hero-exclamation-circle-mini" class="size-5 shrink-0" />
+        <.icon :if={@kind == :info} name="hero-information-circle-mini" class="h-5 w-5 shrink-0" />
+        <.icon :if={@kind == :error} name="hero-exclamation-circle-mini" class="h-5 w-5 shrink-0" />
         <div>
           <p :if={@title} class="font-semibold">{@title}</p>
           <p>{msg}</p>
         </div>
         <div class="flex-1" />
         <button type="button" class="group self-start cursor-pointer" aria-label=<%= maybe_heex_attr_gettext.("close", @gettext) %>>
-          <.icon name="hero-x-mark-solid" class="size-5 opacity-40 group-hover:opacity-70" />
+          <.icon name="hero-x-mark-solid" class="h-5 w-5 opacity-40 group-hover:opacity-70" />
         </button>
       </div>
     </div>
@@ -80,35 +80,23 @@ defmodule <%= @web_namespace %>.CoreComponents do
   end
 
   @doc """
-  Renders a button with navigation support.
+  Renders a button.
 
   ## Examples
 
       <.button>Send!</.button>
-      <.button phx-click="go" variant="primary">Send!</.button>
-      <.button navigate={~p"/"}>Home</.button>
+      <.button phx-click="go" class="ml-2">Send!</.button>
   """
-  attr :rest, :global, include: ~w(href navigate patch)
-  attr :variant, :string, values: ~w(primary)
+  attr :class, :string, default: nil
+  attr :rest, :global
   slot :inner_block, required: true
 
-  def button(%{rest: rest} = assigns) do
-    variants = %{"primary" => "btn-primary", nil => "btn-primary btn-soft"}
-    assigns = assign(assigns, :class, Map.fetch!(variants, assigns[:variant]))
-
-    if rest[:href] || rest[:navigate] || rest[:patch] do
-      ~H"""
-      <.link class={["btn", @class]} {@rest}>
-        {render_slot(@inner_block)}
-      </.link>
-      """
-    else
-      ~H"""
-      <button class={["btn", @class]} {@rest}>
-        {render_slot(@inner_block)}
-      </button>
-      """
-    end
+  def button(assigns) do
+    ~H"""
+    <button class={["btn", @class]} {@rest}>
+      {render_slot(@inner_block)}
+    </button>
+    """
   end
 
   @doc """
@@ -260,7 +248,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   defp error(assigns) do
     ~H"""
     <p class="mt-1.5 flex gap-2 items-center text-sm text-error">
-      <.icon name="hero-exclamation-circle-mini" class="size-5" />
+      <.icon name="hero-exclamation-circle-mini" class="h-5 w-5" />
       {render_slot(@inner_block)}
     </p>
     """
@@ -277,7 +265,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def header(assigns) do
     ~H"""
-    <header class={[@actions != [] && "flex items-center justify-between gap-6", "pb-4", @class]}>
+    <header class={[@actions != [] && "flex items-center justify-between gap-6", "pb-8", @class]}>
       <div>
         <h1 class="text-lg font-semibold leading-8">
           {render_slot(@inner_block)}
@@ -382,6 +370,27 @@ defmodule <%= @web_namespace %>.CoreComponents do
   end
 
   @doc """
+  Renders a back navigation link.
+
+  ## Examples
+
+      <.back navigate={~p"/posts"}>Back to posts</.back>
+  """
+  attr :navigate, :any, required: true
+  slot :inner_block, required: true
+
+  def back(assigns) do
+    ~H"""
+    <div class="pt-8">
+      <.link navigate={@navigate} class="text-sm inline-flex gap-2 items-center">
+        <.icon name="hero-arrow-left-solid" class="h-3 w-3" />
+        {render_slot(@inner_block)}
+      </.link>
+    </div>
+    """
+  end
+
+  @doc """
   Renders a [Heroicon](https://heroicons.com).
 
   Heroicons come in three styles – outline, solid, and mini.
@@ -392,15 +401,15 @@ defmodule <%= @web_namespace %>.CoreComponents do
   width, height, and background color classes.
 
   Icons are extracted from the `deps/heroicons` directory and bundled within
-  your compiled app.css by the plugin in `assets/vendor/heroicons.js`.
+  your compiled main.css by the plugin in `assets/vendor/heroicons.js`.
 
   ## Examples
 
       <.icon name="hero-x-mark-solid" />
-      <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
+      <.icon name="hero-arrow-path" class="ml-1 w-3 h-3 motion-safe:animate-spin" />
   """
   attr :name, :string, required: true
-  attr :class, :string, default: "size-4"
+  attr :class, :string, default: nil
 
   def icon(%{name: "hero-" <> _} = assigns) do
     ~H"""

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -64,15 +64,15 @@ defmodule <%= @web_namespace %>.CoreComponents do
         @kind == :info && "alert-info",
         @kind == :error && "alert-error"
       ]}>
-        <.icon :if={@kind == :info} name="hero-information-circle-mini" class="h-5 w-5 shrink-0" />
-        <.icon :if={@kind == :error} name="hero-exclamation-circle-mini" class="h-5 w-5 shrink-0" />
+        <.icon :if={@kind == :info} name="hero-information-circle-mini" class="size-5 shrink-0" />
+        <.icon :if={@kind == :error} name="hero-exclamation-circle-mini" class="size-5 shrink-0" />
         <div>
           <p :if={@title} class="font-semibold">{@title}</p>
           <p>{msg}</p>
         </div>
         <div class="flex-1" />
         <button type="button" class="group self-start cursor-pointer" aria-label=<%= maybe_heex_attr_gettext.("close", @gettext) %>>
-          <.icon name="hero-x-mark-solid" class="h-5 w-5 opacity-40 group-hover:opacity-70" />
+          <.icon name="hero-x-mark-solid" class="size-5 opacity-40 group-hover:opacity-70" />
         </button>
       </div>
     </div>
@@ -80,23 +80,35 @@ defmodule <%= @web_namespace %>.CoreComponents do
   end
 
   @doc """
-  Renders a button.
+  Renders a button with navigation support.
 
   ## Examples
 
       <.button>Send!</.button>
-      <.button phx-click="go" class="ml-2">Send!</.button>
+      <.button phx-click="go" variant="primary">Send!</.button>
+      <.button navigate={~p"/"}>Home</.button>
   """
-  attr :class, :string, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(href navigate patch)
+  attr :variant, :string, values: ~w(primary)
   slot :inner_block, required: true
 
-  def button(assigns) do
-    ~H"""
-    <button class={["btn", @class]} {@rest}>
-      {render_slot(@inner_block)}
-    </button>
-    """
+  def button(%{rest: rest} = assigns) do
+    variants = %{"primary" => "btn-primary", nil => "btn-primary btn-soft"}
+    assigns = assign(assigns, :class, Map.fetch!(variants, assigns[:variant]))
+
+    if rest[:href] || rest[:navigate] || rest[:patch] do
+      ~H"""
+      <.link class={["btn", @class]} {@rest}>
+        {render_slot(@inner_block)}
+      </.link>
+      """
+    else
+      ~H"""
+      <button class={["btn", @class]} {@rest}>
+        {render_slot(@inner_block)}
+      </button>
+      """
+    end
   end
 
   @doc """
@@ -248,7 +260,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   defp error(assigns) do
     ~H"""
     <p class="mt-1.5 flex gap-2 items-center text-sm text-error">
-      <.icon name="hero-exclamation-circle-mini" class="h-5 w-5" />
+      <.icon name="hero-exclamation-circle-mini" class="size-5" />
       {render_slot(@inner_block)}
     </p>
     """
@@ -265,7 +277,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   def header(assigns) do
     ~H"""
-    <header class={[@actions != [] && "flex items-center justify-between gap-6", "pb-8", @class]}>
+    <header class={[@actions != [] && "flex items-center justify-between gap-6", "pb-4", @class]}>
       <div>
         <h1 class="text-lg font-semibold leading-8">
           {render_slot(@inner_block)}
@@ -370,27 +382,6 @@ defmodule <%= @web_namespace %>.CoreComponents do
   end
 
   @doc """
-  Renders a back navigation link.
-
-  ## Examples
-
-      <.back navigate={~p"/posts"}>Back to posts</.back>
-  """
-  attr :navigate, :any, required: true
-  slot :inner_block, required: true
-
-  def back(assigns) do
-    ~H"""
-    <div class="pt-8">
-      <.link navigate={@navigate} class="text-sm inline-flex gap-2 items-center">
-        <.icon name="hero-arrow-left-solid" class="h-3 w-3" />
-        {render_slot(@inner_block)}
-      </.link>
-    </div>
-    """
-  end
-
-  @doc """
   Renders a [Heroicon](https://heroicons.com).
 
   Heroicons come in three styles – outline, solid, and mini.
@@ -401,15 +392,15 @@ defmodule <%= @web_namespace %>.CoreComponents do
   width, height, and background color classes.
 
   Icons are extracted from the `deps/heroicons` directory and bundled within
-  your compiled main.css by the plugin in `assets/vendor/heroicons.js`.
+  your compiled app.css by the plugin in `assets/vendor/heroicons.js`.
 
   ## Examples
 
       <.icon name="hero-x-mark-solid" />
-      <.icon name="hero-arrow-path" class="ml-1 w-3 h-3 motion-safe:animate-spin" />
+      <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
   """
   attr :name, :string, required: true
-  attr :class, :string, default: nil
+  attr :class, :string, default: "size-4"
 
   def icon(%{name: "hero-" <> _} = assigns) do
     ~H"""

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -21,11 +21,6 @@ defmodule Mix.Tasks.Phx.NewTest do
     end
   end
 
-  test "components are in sync with priv" do
-    assert File.read!("../priv/templates/phx.gen.live/core_components.ex") ==
-             File.read!("templates/phx_web/components/core_components.ex")
-  end
-
   test "returns the version" do
     Mix.Tasks.Phx.New.run(["-v"])
     assert_received {:mix_shell, :info, ["Phoenix installer v" <> _]}

--- a/mix.exs
+++ b/mix.exs
@@ -274,14 +274,7 @@ defmodule Phoenix.MixProject do
 
   defp copy_core_components(_) do
     source =
-      Path.join([
-        __DIR__,
-        "installer",
-        "templates",
-        "phx_web",
-        "components",
-        "core_components.ex"
-      ])
+      Path.join(__DIR__, "installer/templates/phx_web/components/core_components.ex")
 
     destination_dir = Path.join([__DIR__, "priv", "templates", "phx.gen.live"])
     destination = Path.join(destination_dir, "core_components.ex")

--- a/mix.exs
+++ b/mix.exs
@@ -120,8 +120,10 @@ defmodule Phoenix.MixProject do
       maintainers: ["Chris McCord", "José Valim", "Gary Rennie", "Jason Stiebs"],
       licenses: ["MIT"],
       links: %{"GitHub" => @scm_url},
-      files:
-        ~w(assets/js lib priv CHANGELOG.md LICENSE.md mix.exs package.json README.md .formatter.exs)
+      files: ~w(
+          assets/js lib priv CHANGELOG.md LICENSE.md mix.exs package.json README.md .formatter.exs
+          installer/templates/phx_web/components/core_components.ex
+        )
     ]
   end
 
@@ -251,7 +253,10 @@ defmodule Phoenix.MixProject do
       docs: ["docs", &generate_js_docs/1],
       "assets.build": ["esbuild module", "esbuild cdn", "esbuild cdn_min", "esbuild main"],
       "assets.watch": "esbuild module --watch",
-      "archive.build": &raise_on_archive_build/1
+      "archive.build": &raise_on_archive_build/1,
+      # copy core_components before compiling / publishing
+      compile: [&copy_core_components/1, "compile"],
+      "hex.publish": [&copy_core_components/1, "hex.publish"]
     ]
   end
 
@@ -265,5 +270,21 @@ defmodule Phoenix.MixProject do
     You are trying to install "phoenix" as an archive, which is not supported. \
     You probably meant to install "phx_new" instead
     """)
+  end
+
+  defp copy_core_components(_) do
+    source =
+      Path.join([
+        __DIR__,
+        "installer",
+        "templates",
+        "phx_web",
+        "components",
+        "core_components.ex"
+      ])
+
+    destination_dir = Path.join([__DIR__, "priv", "templates", "phx.gen.live"])
+    destination = Path.join(destination_dir, "core_components.ex")
+    File.cp!(source, destination)
   end
 end

--- a/test/mix/tasks/phx.gen.live_test.exs
+++ b/test/mix/tasks/phx.gen.live_test.exs
@@ -29,6 +29,11 @@ defmodule Mix.Tasks.Phx.Gen.LiveTest do
     end)
   end
 
+  test "components are in sync with installer" do
+    assert File.read!("priv/templates/phx.gen.live/core_components.ex") ==
+             File.read!("installer/templates/phx_web/components/core_components.ex")
+  end
+
   test "invalid mix arguments", config do
     in_tmp_live_project config.test, fn ->
       assert_raise Mix.Error, ~r/Expected the context, "blog", to be a valid module name/, fn ->


### PR DESCRIPTION
Fixes #6154

It also includes the core_components file in the Phoenix archive, therefore the copy should always succeed. We can also use `cp` instead of `cp!` and not include it in the archive, as it should have already been copied prior to building the archive.