### PR TITLE
Proposal: Handle map attribute in generated view

### DIFF
--- a/lib/mix/tasks/phx.gen.live.ex
+++ b/lib/mix/tasks/phx.gen.live.ex
@@ -344,7 +344,6 @@ defmodule Mix.Tasks.Phx.Gen.Live do
   @doc false
   def inputs(%Schema{} = schema) do
     schema.attrs
-    |> Enum.reject(fn {_key, type} -> type == :map end)
     |> Enum.map(fn
       {_, {:references, _}} ->
         nil
@@ -362,6 +361,9 @@ defmodule Mix.Tasks.Phx.Gen.Live do
         ~s(<.input field={@form[#{inspect(key)}]} type="checkbox" label="#{label(key)}" />)
 
       {key, :text} ->
+        ~s(<.input field={@form[#{inspect(key)}]} type="textarea" label="#{label(key)}" />)
+
+      {key, :map} ->
         ~s(<.input field={@form[#{inspect(key)}]} type="textarea" label="#{label(key)}" />)
 
       {key, :date} ->

--- a/priv/templates/phx.gen.live/index.ex
+++ b/priv/templates/phx.gen.live/index.ex
@@ -20,8 +20,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         id="<%= schema.plural %>"
         rows={@streams.<%= schema.collection %>}
         row_click={fn {_id, <%= schema.singular %>} -> JS.navigate(~p"<%= scope_assign_route_prefix %><%= schema.route_prefix %>/#{<%= schema.singular %>}") end}
-      ><%= for {k, _} <- schema.attrs do %>
-        <:col :let={{_id, <%= schema.singular %>}} label="<%= Phoenix.Naming.humanize(Atom.to_string(k)) %>">{<%= schema.singular %>.<%= k %>}</:col><% end %>
+      ><%= for {k, t} <- schema.attrs do %>
+        <:col :let={{_id, <%= schema.singular %>}} label="<%= Phoenix.Naming.humanize(Atom.to_string(k)) %>"><%= if t == :map do %>{Jason.encode!(@<%= schema.singular %>.<%= k %>, pretty: true)}<% else %>{@<%= schema.singular %>.<%= k %>}<% end %></:col><% end %>
         <:action :let={{_id, <%= schema.singular %>}}>
           <div class="sr-only">
             <.link navigate={~p"<%= scope_assign_route_prefix %><%= schema.route_prefix %>/#{<%= schema.singular %>}"}>Show</.link>

--- a/priv/templates/phx.gen.live/show.ex
+++ b/priv/templates/phx.gen.live/show.ex
@@ -20,8 +20,8 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
         </:actions>
       </.header>
 
-      <.list><%= for {k, _} <- schema.attrs do %>
-        <:item title="<%= Phoenix.Naming.humanize(Atom.to_string(k)) %>">{@<%= schema.singular %>.<%= k %>}</:item><% end %>
+      <.list><%= for {k, t} <- schema.attrs do %>
+        <:item title="<%= Phoenix.Naming.humanize(Atom.to_string(k)) %>"><%= if t in [:map] do %>{Jason.encode!(@<%= schema.singular %>.<%= k %>, pretty: true)}<% else %>{@<%= schema.singular %>.<%= k %>}<% end %></:item><% end %>
       </.list>
     </Layouts.app>
     """


### PR DESCRIPTION
Currently phx.gen.live takes map attributes but generated views are broken

- Index/Show: crashed , as map cannot be rendered as HTML
- Form: input element is missing

This PR is to add textarea input with JSON encode/decoding in the form module, not in the changeset module - so that phx.gen.live works for map attrs out-of-box.

Right now only added phx.gen.live - if it sounds good I can work on phx.gen.html as well