### PR TITLE
Do not specify layout: false in PageController examples

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -15,7 +15,7 @@ defmodule HelloWeb.PageController do
   use HelloWeb, :controller
 
   def home(conn, _params) do
-    render(conn, :home, layout: false)
+    render(conn, :home)
   end
 end
 ```
@@ -171,7 +171,7 @@ As an example, let's take `PageController`'s `home` action from a newly generate
 
 ```elixir
 def home(conn, _params) do
-  render(conn, :home, layout: false)
+  render(conn, :home)
 end
 ```
 
@@ -282,7 +282,7 @@ Let's change the status in our `PageController` `home` action.
 def home(conn, _params) do
   conn
   |> put_status(202)
-  |> render(:home, layout: false)
+  |> render(:home)
 end
 ```
 
@@ -328,7 +328,7 @@ Finally, let's define in the same file the action we redirect to, which simply r
 
 ```elixir
 def redirect_test(conn, _params) do
-  render(conn, :home, layout: false)
+  render(conn, :home)
 end
 ```
 
@@ -358,7 +358,7 @@ defmodule HelloWeb.PageController do
   def home(conn, _params) do
     conn
     |> put_flash(:error, "Let's pretend we have an error.")
-    |> render(:home, layout: false)
+    |> render(:home)
   end
 end
 ```

--- a/installer/templates/phx_web/controllers/page_controller.ex
+++ b/installer/templates/phx_web/controllers/page_controller.ex
@@ -2,8 +2,6 @@ defmodule <%= @web_namespace %>.PageController do
   use <%= @web_namespace %>, :controller
 
   def home(conn, _params) do
-    # The home page is often custom made,
-    # so skip the default app layout.
-    render(conn, :home, layout: false)
+    render(conn, :home)
   end
 end


### PR DESCRIPTION
Since the generators are no longer defining dynamic layouts with put_layout or in use Phoenix.Controller (since https://github.com/phoenixframework/phoenix/pull/6136/files ), I think there's no need for explicitly disabling the layout in the PageController in the installer or guides