### PR TITLE
Fix wrong module name in Scope moduledoc

### DIFF
--- a/priv/templates/phx.gen.auth/scope.ex
+++ b/priv/templates/phx.gen.auth/scope.ex
@@ -2,7 +2,7 @@ defmodule <%= inspect scope_config.scope.module %> do
   @moduledoc """
   Defines the scope of the caller to be used throughout the app.
 
-  The `<%= inspect context.module %>.<%= inspect schema.alias %>Scope` allows public interfaces to receive
+  The `<%= inspect scope_config.scope.module %>` allows public interfaces to receive
   information about the caller, such as if the call is initiated from an
   end-user, and if so, which user. Additionally, such a scope can carry fields
   such as "super user" or other privileges for use as authorization, or to


### PR DESCRIPTION
Truth be told, I'm not entirely sure if it's really a mistake in the docs, or it's a mistake in the module name. Or a mistake in my understanding of scopes. Please do check my understanding - I wrote a rather verbose commit message just to be clear.