### PR TITLE
do not create a new session on sudo mode re-auth

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -55,7 +55,7 @@ defmodule <%= inspect auth_module %> do
     |> put_resp_cookie(@remember_me_cookie, token, @remember_me_options)
   end
 
-  # do not renew session if the <%= schema.singular %> is already logged in (sudo mode reauthentication)
+  # Do not renew session if the <%= schema.singular %> is already logged in (sudo mode reauthentication)
   # to prevent CSRF errors for tabs that are still open
   defp renew_session(conn, <%= schema.singular %>) when conn.assigns.current_scope.<%= schema.singular %>.id == <%= schema.singular %>.id do
     conn

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -35,7 +35,7 @@ defmodule <%= inspect auth_module %> do
     remember_me = get_session(conn, :<%= schema.singular %>_remember_me)
 
     conn
-    |> renew_session(user)
+    |> renew_session(<%= schema.singular %>)
     |> put_token_in_session(token)
     |> maybe_write_remember_me_cookie(token, params, remember_me)
     |> redirect(to: <%= schema.singular %>_return_to || signed_in_path(conn))
@@ -55,13 +55,19 @@ defmodule <%= inspect auth_module %> do
     |> put_resp_cookie(@remember_me_cookie, token, @remember_me_options)
   end
 
+  # do not renew session if the <%= schema.singular %> is already logged in (sudo mode reauthentication)
+  # to prevent CSRF errors for tabs that are still open
+  defp renew_session(conn, <%= schema.singular %>) when conn.assigns.current_scope.<%= schema.singular %>.id == <%= schema.singular %>.id do
+    conn
+  end
+
   # This function renews the session ID and erases the whole
   # session to avoid fixation attacks. If there is any data
   # in the session you may want to preserve after log in/log out,
   # you must explicitly fetch the session data before clearing
   # and then immediately set it after clearing, for example:
   #
-  #     defp renew_session(conn, _user) do
+  #     defp renew_session(conn, _<%= schema.singular %>) do
   #       delete_csrf_token()
   #       preferred_locale = get_session(conn, :preferred_locale)
   #
@@ -71,15 +77,7 @@ defmodule <%= inspect auth_module %> do
   #       |> put_session(:preferred_locale, preferred_locale)
   #     end
   #
-  defp renew_session(conn, <%= schema.singular %> \\ nil)
-
-  # do not renew session if the user is already logged in (sudo mode reauthentication)
-  # to prevent CSRF errors for tabs that are still open
-  defp renew_session(conn, <%= schema.singular %>) when conn.assigns.current_scope.<%= schema.singular %>.id == <%= schema.singular %>.id do
-    conn
-  end
-
-  defp renew_session(conn, _user) do
+  defp renew_session(conn, _<%= schema.singular %>) do
     delete_csrf_token()
 
     conn
@@ -101,7 +99,7 @@ defmodule <%= inspect auth_module %> do
     end
 
     conn
-    |> renew_session()
+    |> renew_session(nil)
     |> delete_resp_cookie(@remember_me_cookie)
     |> redirect(to: ~p"/")
   end

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -33,6 +33,28 @@ defmodule <%= inspect auth_module %>Test do
       refute get_session(conn, :to_be_removed)
     end
 
+    test "keeps session when re-authenticating", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      conn =
+        conn
+        |> assign(:current_scope, <%= inspect scope_config.scope.alias %>.for_<%= schema.singular %>(<%= schema.singular %>))
+        |> put_session(:to_be_removed, "value")
+        |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
+
+      assert get_session(conn, :to_be_removed)
+    end
+
+    test "clears session when <%= schema.singular %> does not match when re-authenticating", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      other_<%= schema.singular %> = <%= schema.singular %>_fixture()
+
+      conn =
+        conn
+        |> assign(:current_scope, <%= inspect scope_config.scope.alias %>.for_<%= schema.singular %>(other_<%= schema.singular %>))
+        |> put_session(:to_be_removed, "value")
+        |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
+
+      refute get_session(conn, :to_be_removed)
+    end
+
     test "redirects to the configured path", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       conn = conn |> put_session(:<%= schema.singular %>_return_to, "/hello") |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
       assert redirected_to(conn) == "/hello"

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -43,7 +43,10 @@ defmodule <%= inspect auth_module %>Test do
       assert get_session(conn, :to_be_removed)
     end
 
-    test "clears session when <%= schema.singular %> does not match when re-authenticating", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+    test "clears session when <%= schema.singular %> does not match when re-authenticating", %{
+      conn: conn,
+      <%= schema.singular %>: <%= schema.singular %>
+    } do
       other_<%= schema.singular %> = <%= schema.singular %>_fixture()
 
       conn =


### PR DESCRIPTION
When re-authenticating to access a sudo-mode protected page, the existing session would be cleared, invalidating the existing CSRF token. This meant that any open tab with in-progress forms would be invalidated. Now, we just put the new token into the session, keeping the same session id + CSRF token.