### PR TITLE
Remove no-op lines from recreate_default_css script

### DIFF
--- a/installer/recreate_default_css.exs
+++ b/installer/recreate_default_css.exs
@@ -22,10 +22,6 @@ File.cd!("installer", fn ->
   shell_in_daisy!.("mix phx.gen.auth Accounts User users --live")
   shell_in_daisy!.("mix deps.get")
   shell_in_daisy!.("mix phx.gen.live Blog Post posts title:string body:text")
-
-  css = File.read!("dayzee/assets/css/app.css")
-  File.write!("dayzee/assets/css/app.css", String.replace(css, "themes: all;", "themes: light --default, dark --prefersdark;"))
-
   shell_in_daisy!.("mix tailwind dayzee")
 
   content = File.read!("dayzee/priv/static/assets/css/app.css")


### PR DESCRIPTION
* There is no more "themes: all;" in the target CSS file, so `String.replace/3` is a no-op. The default theme config was changed in 6da42953c4e7d94e7666fa0584b29fc4e35fc465 (#6147)
* installer/templates/phx_static/default.css is up-to-date, last updated in cc5c7af03507710952c6c73a27f02e7fb6a70d3f