### PR TITLE
Add method to global attributes for generated button core component

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -88,7 +88,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <.button phx-click="go" variant="primary">Send!</.button>
       <.button navigate={~p"/"}>Home</.button>
   """
-  attr :rest, :global, include: ~w(href navigate patch)
+  attr :rest, :global, include: ~w(href navigate patch method)
   attr :variant, :string, values: ~w(primary)
   slot :inner_block, required: true
 


### PR DESCRIPTION
Removes compiler warning when a generated `CoreComponents.button` is wrapping a `Phoenix.Component.link` with a `method` attribute.

Resolves #6172