### PR TITLE
Add fetch() support to LongPoll when XMLHTTPRequest is not available

### DIFF
--- a/assets/js/phoenix/ajax.js
+++ b/assets/js/phoenix/ajax.js
@@ -9,10 +9,41 @@ export default class Ajax {
     if(global.XDomainRequest){
       let req = new global.XDomainRequest() // IE8, IE9
       return this.xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback)
-    } else {
+    } else if(global.XMLHttpRequest){
       let req = new global.XMLHttpRequest() // IE7+, Firefox, Chrome, Opera, Safari
       return this.xhrRequest(req, method, endPoint, headers, body, timeout, ontimeout, callback)
+    } else if(global.fetch && global.AbortController){
+      // Fetch with AbortController for modern browsers
+      return this.fetchRequest(method, endPoint, headers, body, timeout, ontimeout, callback);
+    } else {
+      throw new Error("No suitable XMLHttpRequest implementation found");
     }
+  }
+
+  static fetchRequest(method, endPoint, headers, body, timeout, ontimeout, callback){
+    let options = {
+      method,
+      headers,
+      body,
+    };
+    let controller = null;
+    if(timeout){
+      controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
+      options.signal = controller.signal;
+    }
+    global.fetch(endPoint, options)
+      .then(response => response.text())
+      .then(data => this.parseJSON(data))
+      .then(data => callback && callback(data))
+      .catch(err => {
+        if(err.name === "AbortError" && ontimeout){
+          ontimeout();
+        } else {
+          callback && callback(null);
+        }
+      });
+    return controller;
   }
 
   static xdomainRequest(req, method, endPoint, body, timeout, ontimeout, callback){


### PR DESCRIPTION
Hi, we noticed that when opening a socket in a ServiceWorker and using `LongPoll`, the socket fails because neither `XMLHTTPRequest` or `XDomainRequest` are available in the ServiceWorker scope.

I realise this is a bit of an edge case, as if you have ServiceWorker support, you probably already have native `WebSocket` support. In our instance, we sometimes fall back to LongPoll when network conditions block connections.

To work around this, I've added support for using `fetch`, which is in the global scope of a ServiceWorker. To ensure we don't break any existing setups, `LongPoll` requests still prefer `XDomainRequest` and `XMLHTTPRequest` in the same ordering as before; this only acts as a fallback when neither are available.