### PR TITLE
Add `antialiased` class to <body> in default root layout

### DIFF
--- a/installer/templates/phx_web/components/layouts/root.html.heex
+++ b/installer/templates/phx_web/components/layouts/root.html.heex
@@ -28,7 +28,7 @@
       })();
     </script><% end %>
   </head>
-  <body>
+  <body class="antialiased">
     {@inner_content}
   </body>
 </html>


### PR DESCRIPTION
This PR adds the antialiased class from Tailwind CSS to the <body> element in the default `root.html.heex` layout used by newly generated Phoenix projects.

This improves font rendering—especially on macOS and iOS—by enabling subpixel antialiasing, and aligns with best practices in Tailwind CSS projects.

Closes #6182 