### PR TITLE
Do not show ANSI escape codes on exception pages

### DIFF
--- a/lib/phoenix/code_reloader.ex
+++ b/lib/phoenix/code_reloader.ex
@@ -330,6 +330,11 @@ defmodule Phoenix.CodeReloader do
   defp format_output(output) do
     output
     |> String.trim()
+    |> remove_ansi_escapes()
     |> Plug.HTML.html_escape()
+  end
+
+  defp remove_ansi_escapes(text) do
+    Regex.replace(~r/\e\[[0-9;]*[a-zA-Z]/, text, "")
   end
 end

--- a/test/phoenix/code_reloader_test.exs
+++ b/test/phoenix/code_reloader_test.exs
@@ -8,7 +8,7 @@ defmodule Phoenix.CodeReloaderTest do
   end
 
   def reload(_, _) do
-    {:error, "oops"}
+    {:error, "oops \e[31merror"}
   end
 
   @tag :capture_log
@@ -59,7 +59,7 @@ defmodule Phoenix.CodeReloaderTest do
 
     assert conn.state == :sent
     assert conn.status == 500
-    assert conn.resp_body =~ "oops"
+    assert conn.resp_body =~ "oops error"
     assert conn.resp_body =~ "CompileError"
     assert conn.resp_body =~ "Compilation error"
   end


### PR DESCRIPTION
The code reloader capture the output of mix compile tasks and shows it directly on the exception page. When the output includes ANSI escapes for coloring they are left as is:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2e7616e2-2669-437b-8aee-7bbc01a30df0" />

This adds a simple regex pass to remove them.