### PR TITLE
use data-phx-session as selector for LV containers

### DIFF
--- a/installer/templates/phx_assets/app.css
+++ b/installer/templates/phx_assets/app.css
@@ -97,6 +97,6 @@
 @custom-variant phx-change-loading ([".phx-change-loading&", ".phx-change-loading &"]);
 
 /* Make LiveView wrapper divs transparent for layout */
-[data-phx-root-id] { display: contents }
+[data-phx-session] { display: contents }
 
 /* This file is for your main application CSS */

--- a/installer/templates/phx_static/default.css
+++ b/installer/templates/phx_static/default.css
@@ -2288,7 +2288,7 @@
     }
   }
 }
-[data-phx-root-id] {
+[data-phx-session] {
   display: contents;
 }
 @layer base {


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix/issues/6188.

`[data-phx-session]` is more appropriate, since the session attribute is already included in the disconnected render.