### PR TITLE
fix: Fix Tailwind custom variants for loading classes

### DIFF
--- a/installer/templates/phx_assets/app.css
+++ b/installer/templates/phx_assets/app.css
@@ -92,9 +92,9 @@
 }
 
 /* Add variants based on LiveView classes */
-@custom-variant phx-click-loading ([".phx-click-loading&", ".phx-click-loading &"]);
-@custom-variant phx-submit-loading ([".phx-submit-loading&", ".phx-submit-loading &"]);
-@custom-variant phx-change-loading ([".phx-change-loading&", ".phx-change-loading &"]);
+@custom-variant phx-click-loading (.phx-click-loading&, .phx-click-loading &);
+@custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);
+@custom-variant phx-change-loading (.phx-change-loading&, .phx-change-loading &);
 
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-root-id] { display: contents }


### PR DESCRIPTION
Based on documentation from:

* https://tailwindcss.com/docs/adding-custom-styles#adding-custom-variants
* https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually

And a comment at:

* https://github.com/phoenixframework/phoenix/pull/6109#discussion_r1984001238