### PR TITLE
Add docs for :layout option to Endpoint's :render_errors config

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -212,6 +212,11 @@ defmodule Phoenix.Endpoint do
 
           [formats: [html: MyApp.ErrorHTML], layout: false, log: :debug]
 
+      To specify a layout, provide a tuple specifying the function that provides
+      the layout:
+
+          [formats: [html: MyApp.ErrorHTML], layout: {MyAppWeb.Layouts, :root}, log: :debug]
+
     * `:log_access_url` - log the access url once the server boots
 
   Note that you can also store your own configurations in the Phoenix.Endpoint.

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -210,12 +210,12 @@ defmodule Phoenix.Endpoint do
       A `:formats` list can be provided to specify a module per format to handle
       error rendering. Example:
 
-          [formats: [html: MyApp.ErrorHTML], layout: false, log: :debug]
+          [formats: [html: MyAppWeb.ErrorHTML], layout: false, log: :debug]
 
       To specify a layout, provide a tuple specifying the function that provides
       the layout:
 
-          [formats: [html: MyApp.ErrorHTML], layout: {MyAppWeb.Layouts, :root}, log: :debug]
+          [formats: [html: MyAppWeb.ErrorHTML], layout: {MyAppWeb.Layouts, :root}, log: :debug]
 
     * `:log_access_url` - log the access url once the server boots
 


### PR DESCRIPTION
When setting up an error view, I noticed that the `:layout` option to `:render_errors` was undocumented, and spent quite a while figuring out how to set it. This PR adds an example to the [docs](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#module-runtime-configuration).

I'm not sure what the `:log` option is for either, but left it there.

<img width="818" alt="image" src="https://github.com/user-attachments/assets/b1eeb807-b894-41db-86e6-487c2c80d270" />
