### PR TITLE
Component tests poc

### DIFF
--- a/integration_test/mix.exs
+++ b/integration_test/mix.exs
@@ -13,7 +13,10 @@ defmodule Phoenix.Integration.MixProject do
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      test_ignore_filters: [
+        &String.starts_with?(&1, "test/fixtures")
+      ]
     ]
   end
 

--- a/integration_test/test/code_generation/app_with_defaults_test.exs
+++ b/integration_test/test/code_generation/app_with_defaults_test.exs
@@ -20,6 +20,23 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithDefaultsTest do
         assert_tests_pass(app_root_path)
       end)
     end
+
+    test "has functioning core_components" do
+      with_installer_tmp("app_with_defaults", fn tmp_dir ->
+        {app_root_path, _} = generate_phoenix_app(tmp_dir, "default_app")
+
+        dest = Path.join(app_root_path, "test/default_app_web/components")
+
+        File.mkdir_p!(dest)
+        File.cp!(
+          Path.expand("../fixtures/core_components.exs", __DIR__),
+          Path.join(dest, "core_components_test.exs")
+        )
+
+        drop_test_database(app_root_path)
+        assert_tests_pass(app_root_path)
+      end)
+    end
   end
 
   describe "phx.gen.html" do

--- a/integration_test/test/fixtures/core_components.exs
+++ b/integration_test/test/fixtures/core_components.exs
@@ -1,0 +1,19 @@
+defmodule DefaultAppWeb.CoreComponentsTest do
+  import Phoenix.LiveViewTest
+  import DefaultAppWeb.CoreComponents
+
+  use Phoenix.Component
+  use DefaultAppWeb.ConnCase
+
+  describe "label component" do
+    test "generates a label" do
+      assigns = %{}
+
+      html = rendered_to_string(~H"""
+        <.input type="checkbox" name="example" label="Click here"/>
+      """)
+
+      assert html =~ "Click here"
+    end
+  end
+end


### PR DESCRIPTION
I'd like to make contributions to the core_components set and I suspect others might want to do the same, rather than jumping immediately to their own or third party replacements.

Given that there are for instance missing input types, and a few bugs still being found in the existing components, I think it would be good if there were some pinning tests, and a pattern to add more tests, so that new features or bug fixes are less likely to introduce regressions in existing functionality. 

This also might be a good way to make sure that --no-tailwind or other --no flags don't create a bunch of issues. 

This is basically a placeholder test because I know testing but my knowledge of phoenix LV is still a bit spotty. 

It was suggested (Chris?) that these should be integration tests and I think I understand why.