### PR TITLE
Fix crash when an open :show page gets a PubSub broadcast for other items

### DIFF
--- a/priv/templates/phx.gen.live/show.ex
+++ b/priv/templates/phx.gen.live/show.ex
@@ -53,5 +53,10 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
      socket
      |> put_flash(:error, "The current <%= schema.singular %> was deleted.")
      |> push_navigate(to: ~p"<%= scope_socket_route_prefix %><%= schema.route_prefix %>")}
+  end
+
+  def handle_info({type, %<%= inspect schema.module %>{}}, socket)
+      when type in [:created, :updated, :deleted] do
+    {:noreply, socket}
   end<% end %>
 end


### PR DESCRIPTION
In the code generated with `mix phx.gen.live`, in the `show.ex` file, there are 2 `handle_info/2` callbacks that are tightly bound to only match when the messages broadcast from the context are for the item they are currently showing. If the user has another tab open on a show page, and does anything from another tab, such as adding, deleting or updating a different item, the show LV will crash with a "no function claus matching" exception.

This simply adds a fallback `handle_info/2` handler that tightly matches all other expected messages due to the `Context.subscribe_items/1` call in the generated `mount/3`, so that LV won't crash when it gets an unexpected message. However, if it gets a different message that is from something else that the user adds, then it will still crash so they know they need to handle that message shape.