### PR TITLE
Make socket auto disconnect on page hide optional

### DIFF
--- a/assets/js/phoenix/socket.js
+++ b/assets/js/phoenix/socket.js
@@ -108,6 +108,10 @@ import Timer from "./timer"
  *       removeItem(keyName) { delete this.storage[keyName] }
  *       setItem(keyName, keyValue) { this.storage[keyName] = keyValue }
  *     }
+ * 
+ * @param {boolean} [opts.disableAutoDisconnectOnPageHide] - Boolean that determines if the socket should auto disconnect on page hide
+ *
+ * Defaults to false.
  *
 */
 export default class Socket {
@@ -139,7 +143,8 @@ export default class Socket {
       this.decode = this.defaultDecoder
     }
     let awaitingConnectionOnPageShow = null
-    if(phxWindow && phxWindow.addEventListener){
+    this.disableAutoDisconnectOnPageHide = opts.disableAutoDisconnectOnPageHide || false
+    if(!this.disableAutoDisconnectOnPageHide && phxWindow && phxWindow.addEventListener){
       phxWindow.addEventListener("pagehide", _e => {
         if(this.conn){
           this.disconnect()

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -39,6 +39,7 @@ describe("with transports", function (){
       expect(socket.longpollerTimeout).toBe(20000)
       expect(socket.heartbeatIntervalMs).toBe(30000)
       expect(socket.logger).toBeNull()
+      expect(socket.disableAutoDisconnectOnPageHide).toBe(false)
       expect(socket.binaryType).toBe("arraybuffer")
       expect(typeof socket.reconnectAfterMs).toBe("function")
     })
@@ -64,6 +65,7 @@ describe("with transports", function (){
         logger: customLogger,
         reconnectAfterMs: customReconnect,
         params: {one: "two"},
+        disableAutoDisconnectOnPageHide: true
       })
 
       expect(socket.timeout).toBe(40000)
@@ -72,6 +74,7 @@ describe("with transports", function (){
       expect(socket.transport).toBe(customTransport)
       expect(socket.logger).toBe(customLogger)
       expect(socket.params()).toEqual({one: "two"})
+      expect(socket.disableAutoDisconnectOnPageHide).toBe(true)
     })
 
     describe("with Websocket", function (){


### PR DESCRIPTION
The block below is useful for handling autoconnection/disconnection when users leave or enter the tab
```js
if (phxWindow && phxWindow.addEventListener) {
      phxWindow.addEventListener("pagehide", (_e) => {
        if (this.conn) {
          this.disconnect();
          awaitingConnectionOnPageShow = this.connectClock;
        }
      });
      phxWindow.addEventListener("pageshow", (_e) => {
        if (awaitingConnectionOnPageShow === this.connectClock) {
          awaitingConnectionOnPageShow = null;
          this.connect();
        }
      });
    }
```

But in our case, It clashes with our own listener that does this among other things. That's why we're introducing `disableWindowEventListeners` to make this optional