### PR TITLE
phx.gen.auth: Replace `utc_now/0 + truncate/1` with `utc_now/1`

### DIFF
--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -115,7 +115,7 @@ defmodule <%= inspect schema.module %> do
     <%= case schema.timestamp_type do %>
     <% :naive_datetime -> %>now = NaiveDateTime.utc_now(:second)
     <% :utc_datetime -> %>now = DateTime.utc_now(:second)
-    <% :utc_datetime_usec -> %>now = DateTime.utc_now(:second)
+    <% :utc_datetime_usec -> %>now = DateTime.utc_now(:microsecond)
     <% end %>change(<%= schema.singular %>, confirmed_at: now)
   end
 

--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -113,9 +113,9 @@ defmodule <%= inspect schema.module %> do
   """
   def confirm_changeset(<%= schema.singular %>) do
     <%= case schema.timestamp_type do %>
-    <% :naive_datetime -> %>now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-    <% :utc_datetime -> %>now = DateTime.utc_now() |> DateTime.truncate(:second)
-    <% :utc_datetime_usec -> %>now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    <% :naive_datetime -> %>now = NaiveDateTime.utc_now(:second)
+    <% :utc_datetime -> %>now = DateTime.utc_now(:second)
+    <% :utc_datetime_usec -> %>now = DateTime.utc_now(:second)
     <% end %>change(<%= schema.singular %>, confirmed_at: now)
   end
 

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -822,7 +822,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         assert_file("lib/my_app/accounts/user.ex", fn file ->
           assert file =~ "field :confirmed_at, :utc_datetime"
           assert file =~ "timestamps(type: :utc_datetime)"
-          assert file =~ "now = DateTime.utc_now() |> DateTime.truncate(:second)"
+          assert file =~ "now = DateTime.utc_now(:second)"
         end)
 
         assert_file("lib/my_app/accounts/user_token.ex", fn file ->


### PR DESCRIPTION
We can do that because new apps require Elixir 1.15+.
