### PR TITLE
Use better styling for errors on light theme

### DIFF
--- a/installer/templates/phx_assets/app.css
+++ b/installer/templates/phx_assets/app.css
@@ -79,8 +79,8 @@
   --color-success-content: oklch(98% 0.014 180.72);
   --color-warning: oklch(66% 0.179 58.318);
   --color-warning-content: oklch(98% 0.022 95.277);
-  --color-error: oklch(65% 0.241 354.308);
-  --color-error-content: oklch(97% 0.014 343.198);
+  --color-error: oklch(58% 0.253 17.585);
+  --color-error-content: oklch(96% 0.015 12.422);
   --radius-selector: 0.25rem;
   --radius-field: 0.25rem;
   --radius-box: 0.5rem;

--- a/installer/templates/phx_static/default.css
+++ b/installer/templates/phx_static/default.css
@@ -2460,8 +2460,8 @@
     --color-success-content: oklch(98% 0.014 180.72);
     --color-warning: oklch(66% 0.179 58.318);
     --color-warning-content: oklch(98% 0.022 95.277);
-    --color-error: oklch(65% 0.241 354.308);
-    --color-error-content: oklch(97% 0.014 343.198);
+    --color-error: oklch(58% 0.253 17.585);
+    --color-error-content: oklch(96% 0.015 12.422);
     --radius-selector: 0.25rem;
     --radius-field: 0.25rem;
     --radius-box: 0.5rem;


### PR DESCRIPTION
Before:

![IMG_0881](https://github.com/user-attachments/assets/597212b7-da8f-417c-b2f1-291c2c4a58ee)

After:

![image](https://github.com/user-attachments/assets/c5684aa8-2eea-4462-99e7-4c5a5ed93cfe)
