### PR TITLE
Fix immediate fallback to long poll when websocket connection is lost

### DIFF
--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -12,7 +12,7 @@ describe("with transports", function (){
     const mockSend = jest.fn()
     const mockAbort = jest.fn()
     const mockSetRequestHeader = jest.fn()
-    
+
     global.XMLHttpRequest = jest.fn(() => ({
       open: mockOpen,
       send: mockSend,
@@ -92,10 +92,16 @@ describe("with transports", function (){
         mockServer.stop(() => {
           expect(socket.transport).toBe(WebSocket)
           socket.onError((_reason) => {
-            setTimeout(() => {
-              expect(replaceSpy).toHaveBeenCalledWith(LongPoll)
-              done()
-            }, 100)
+            let startTime = Date.now()
+            const interval = setInterval(() => {
+              if (socket.transport === LongPoll) {
+                expect(replaceSpy).toHaveBeenCalledWith(LongPoll)
+                const elapsed = Date.now() - startTime
+                clearInterval(interval)
+                expect(elapsed).toBeGreaterThan(19)
+                done()
+              }
+            }, 5)
           })
           socket.connect()
         })


### PR DESCRIPTION
When a browser client loses its web socket connection to the server, I noticed that it immediately falls back to long poll without respecting the `longPollFallbackMs` delay. 

This causes all connected browser clients to fall back to long poll when restarting an Elixir server, instead of attempting to reconnect to a new web socket as expected. 

I have added a failing test and a potential fix. 

I am not sure that the implementation of the fix is the best so I would appreciate some insight on the issue before diving deeper into a better solution.

In this image you can see that I set the `longPollFallbackMs` to 5500 ms
![image](https://github.com/user-attachments/assets/baf17384-d1be-4deb-b6d2-7744fd97fcec)

This image shows the client immediately falling back to long poll instead of waiting the 5500ms for a web socket connection.
![image](https://github.com/user-attachments/assets/398cff52-cffe-40cd-b909-453411905f64)

Thanks for your consideration!