### PR TITLE
Add w-fit to logo to limit is clickable area

### DIFF
--- a/installer/templates/phx_web/components/layouts.ex
+++ b/installer/templates/phx_web/components/layouts.ex
@@ -15,7 +15,7 @@ defmodule <%= @web_namespace %>.Layouts do
     ~H"""
     <header class="navbar px-4 sm:px-6 lg:px-8">
       <div class="flex-1">
-        <a href="/" class="flex-1 flex items-center gap-2">
+        <a href="/" class="flex-1 flex w-fit items-center gap-2">
           <img src={~p"/images/logo.svg"} width="36" />
           <span class="text-sm font-semibold">v{Application.spec(:phoenix, :vsn)}</span>
         </a>


### PR DESCRIPTION
Add w-fit to logo to limit is clickable area

Currently, the logo’s anchor tag in the header spans the full width, resulting in an invisible but clickable area. This could lead to unexpected behavior and poor UX. By restricting the anchor tag’s size using w-fit, it now only spans its actual content.

Before:
Entire header area is clickable (even outside the logo)
![grafik](https://github.com/user-attachments/assets/8a77b0c6-e47f-484c-a17b-5435b4bc943b)
with red background for demonstation
![grafik](https://github.com/user-attachments/assets/f18960a5-1842-445d-a921-ac22dc8cee3f)

After:
Only the logo itself is clickable (no excess clickable area, no pointer cursor outside the logo)
![grafik](https://github.com/user-attachments/assets/9f11766d-36ec-423e-a3ff-b9849c00c924)
(with red background for demonstation)
![grafik](https://github.com/user-attachments/assets/67e7eb2a-e8d4-4bf4-9042-8a827ce99d1c)
