### PR TITLE
only subscribe if connected

### DIFF
--- a/priv/templates/phx.gen.live/index.ex
+++ b/priv/templates/phx.gen.live/index.ex
@@ -43,7 +43,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   @impl true
   def mount(_params, _session, socket) do<%= if scope do %>
-    <%= inspect context.alias %>.subscribe_<%= schema.plural %>(<%= socket_scope %>)
+    if connected?(socket) do
+      <%= inspect context.alias %>.subscribe_<%= schema.plural %>(<%= socket_scope %>)
+    end
 <% end %>
     {:ok,
      socket

--- a/priv/templates/phx.gen.live/show.ex
+++ b/priv/templates/phx.gen.live/show.ex
@@ -29,7 +29,9 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
   @impl true
   def mount(%{"<%= primary_key %>" => <%= primary_key %>}, _session, socket) do<%= if scope do %>
-    <%= inspect context.alias %>.subscribe_<%= schema.plural %>(<%= socket_scope %>)
+    if connected?(socket) do
+      <%= inspect context.alias %>.subscribe_<%= schema.plural %>(<%= socket_scope %>)
+    end
 <% end %>
     {:ok,
      socket


### PR DESCRIPTION
Originally reported: https://elixirforum.com/t/phoenix-1-8-0-rc-0-released/70256/96

This was an oversight. We don't want to subscribe on the disconnected render, because a webserver like Bandit can reuse processes.