### PR TITLE
Changed context_app used in scope_config_string to use web app when running phx.gen.auth inside an umbrella project.

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -325,17 +325,20 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
         "#{context.basename}_#{context.schema.singular}"
 
       # my_app_accounts_user
-      is_new_scope?(existing_scopes, "#{context.context_app}_#{context.basename}_#{context.schema.singular}") ->
+      is_new_scope?(
+        existing_scopes,
+        "#{context.context_app}_#{context.basename}_#{context.schema.singular}"
+      ) ->
         "#{context.context_app}_#{context.basename}_#{context.schema.singular}"
 
       true ->
-        Mix.raise """
+        Mix.raise("""
         Could not generate a scope name for #{context.schema.singular}! These scopes already exist:
 
             * #{Enum.map(existing_scopes, fn {name, _scope} -> name end) |> Enum.join("\n    * ")}
 
         You can customize the scope name by passing the --scope option.
-        """
+        """)
     end
   end
 
@@ -363,8 +366,12 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
   end
 
   defp scope_config_string(context, key, default_scope) do
+    context_app =
+      (Mix.Phoenix.in_umbrella?(File.cwd!()) && String.to_atom("#{context.context_app}_web")) ||
+        context.context_app
+
     """
-    config :#{context.context_app}, :scopes,
+    config :#{context_app}, :scopes,
       #{key}: [
         default: #{if default_scope, do: false, else: true},
         module: #{inspect(context.module)}.Scope,

--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -367,7 +367,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
   defp scope_config_string(context, key, default_scope) do
     context_app =
-      (Mix.Phoenix.in_umbrella?(File.cwd!()) && String.to_atom("#{context.context_app}_web")) ||
+      (Mix.Phoenix.in_umbrella?(File.cwd!()) && Application.get_application(context.web_module)) ||
         context.context_app
 
     """


### PR DESCRIPTION
**Fix: Use web app as `context_app` in `scope_config_string/3` when in umbrella projects**

Updated `scope_config_string/3` to correctly use the web app (`*_web`) as the `context_app` when running `phx.gen.auth` inside an umbrella project. This ensures scope config is written to the appropriate application when running generators inside the my_app/apps/my_app_web directory.

```elixir
  defp scope_config_string(context, key, default_scope) do
    context_app =
      (Mix.Phoenix.in_umbrella?(File.cwd!()) && String.to_atom("#{context.context_app}_web")) ||
        context.context_app

    """
    config :#{context_app}, :scopes,
      #{key}: [
        default: #{if default_scope, do: false, else: true},
        module: #{inspect(context.module)}.Scope,
        assign_key: :current_scope,
        access_path: [:#{context.schema.singular}, :#{context.schema.opts[:primary_key] || :id}],
        schema_key: :#{context.schema.singular}_#{context.schema.opts[:primary_key] || :id},
        schema_type: :#{if(context.schema.binary_id, do: :binary_id, else: :id)},
        schema_table: :#{context.schema.table},
        test_data_fixture: #{inspect(context.module)}Fixtures,
        test_login_helper: :register_and_log_in_#{context.schema.singular}
      ]\
    """
  end
```