### PR TITLE
discard price user input in cross-context boundaries guide

### DIFF
--- a/guides/data_modelling/cross_context_boundaries.md
+++ b/guides/data_modelling/cross_context_boundaries.md
@@ -194,13 +194,15 @@ Now that our cart is associated to the items we place in it, let's set up the ca
   @doc false
   def changeset(cart_item, attrs) do
     cart_item
-    |> cast(attrs, [:price_when_carted, :quantity])
-    |> validate_required([:price_when_carted, :quantity])
+-   |> cast(attrs, [:price_when_carted, :quantity])
++   |> cast(attrs, [:quantity])
+-   |> validate_required([:price_when_carted, :quantity])
++   |> validate_required([:quantity])
 +   |> validate_number(:quantity, greater_than_or_equal_to: 0, less_than: 100)
   end
 ```
 
-First, we replaced the `cart_id` field with a standard `belongs_to` pointing at our `ShoppingCart.Cart` schema. Next, we replaced our `product_id` field by adding our first cross-context data dependency with a `belongs_to` for the `Catalog.Product` schema. Here, we intentionally coupled the data boundaries because it provides exactly what we need: an isolated context API with the bare minimum knowledge necessary to reference a product in our system. Next, we added a new validation to our changeset. With `validate_number/3`, we ensure any quantity provided by user input is between 0 and 100.
+First, we replaced the `cart_id` field with a standard `belongs_to` pointing at our `ShoppingCart.Cart` schema. Next, we replaced our `product_id` field by adding our first cross-context data dependency with a `belongs_to` for the `Catalog.Product` schema. Here, we intentionally coupled the data boundaries because it provides exactly what we need: an isolated context API with the bare minimum knowledge necessary to reference a product in our system. Second, we remove `price_when_carted` from the list of permitted attributes to ensure any price provided by user input is discarded. Finally, we added a new validation to our changeset. With `validate_number/3`, we ensure any quantity provided by user input is between 0 and 100.
 
 With our schemas in place, we can start integrating the new data structures and `ShoppingCart` context APIs into our web-facing features.
 


### PR DESCRIPTION
Updates the cross-context boundaries guide to improve the handling of attributes in the `cart_item` changeset and clarifies the rationale behind these changes in the documentation.

Closes #6217.