### PR TITLE
Allow download attr on `<.button>`

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -88,7 +88,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <.button phx-click="go" variant="primary">Send!</.button>
       <.button navigate={~p"/"}>Home</.button>
   """
-  attr :rest, :global, include: ~w(href navigate patch method)
+  attr :rest, :global, include: ~w(href navigate patch method download)
   attr :variant, :string, values: ~w(primary)
   slot :inner_block, required: true
 


### PR DESCRIPTION
This is quite a useful attribute for linking controllers from LVs without disrupting the LVs javascript livecycle