### PR TITLE
add `:log` to `common_config`

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -709,7 +709,8 @@ defmodule Phoenix.Endpoint do
       :check_csrf,
       :code_reloader,
       :connect_info,
-      :auth_token
+      :auth_token,
+      :log
     ]
 
     websocket =


### PR DESCRIPTION
Disable logging as described here https://github.com/phoenixframework/phoenix_live_view/issues/617 no longer works on 1.8 rc.

```
== Compilation error in file lib/myapp_web/endpoint.ex ==
** (ArgumentError) unknown keys [:log] in [connect_info: [session: [store: :cookie, key: "_myapp_key", signing_salt: "zuUbpEkB", same_site: "Lax"]], log: false], the allowed keys are: [:path, :serializer, :transport_log, :check_origin, :check_csrf, :code_reloader, :connect_info, :auth_token, :timeout, :max_frame_size, :fullsweep_after, :compress, :subprotocols, :error_handler]
    (elixir 1.18.3) lib/keyword.ex:362: Keyword.validate!/2
    (phoenix 1.8.0-rc.3) lib/phoenix/endpoint.ex:718: Phoenix.Endpoint.socket_paths/4
    (phoenix 1.8.0-rc.3) lib/phoenix/endpoint.ex:648: anonymous fn/3 in Phoenix.Endpoint."MACRO-__before_compile__"/2
    (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (phoenix 1.8.0-rc.3) expanding macro: Phoenix.Endpoint.__before_compile__/1
    lib/myapp_web/endpoint.ex:1: myappWeb.Endpoint (module)
:error
```