### PR TITLE
use single source of truth for socket token authn docs

### DIFF
--- a/guides/real_time/channels.md
+++ b/guides/real_time/channels.md
@@ -107,7 +107,8 @@ In your Phoenix app's `Endpoint` module, a `socket` declaration specifies which 
 ```elixir
 socket "/socket", HelloWeb.UserSocket,
   websocket: true,
-  longpoll: false
+  longpoll: false,
+  auth_token: true
 ```
 
 Phoenix comes with two default transports: websocket and longpoll. You can configure them directly via the `socket` declaration.

--- a/guides/real_time/channels.md
+++ b/guides/real_time/channels.md
@@ -117,7 +117,7 @@ Phoenix comes with two default transports: websocket and longpoll. You can confi
 On the client side, you will establish a socket connection to the route above:
 
 ```javascript
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+let socket = new Socket("/socket", {authToken: window.userToken})
 ```
 
 On the server, Phoenix will invoke `HelloWeb.UserSocket.connect/2`, passing your parameters and the initial socket state. Within the socket, you can authenticate and identify a socket connection and set default socket assigns. The socket is also where you define your channel routes.

--- a/guides/real_time/presence.md
+++ b/guides/real_time/presence.md
@@ -93,7 +93,7 @@ We can see presence working by adding the following to `assets/js/app.js`:
 ```javascript
 import {Socket, Presence} from "phoenix"
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+let socket = new Socket("/socket", {authToken: window.userToken})
 let channel = socket.channel("room:lobby", {name: window.location.search.split("=")[1]})
 let presence = new Presence(channel)
 

--- a/priv/templates/phx.gen.socket/socket.js
+++ b/priv/templates/phx.gen.socket/socket.js
@@ -5,52 +5,11 @@
 import {Socket} from "phoenix"
 
 // And connect to the path in "<%= web_prefix %>/endpoint.ex". We pass the
-// token for authentication. Read below how it should be used.
-let socket = new Socket("/socket", {params: {token: window.userToken}})
-
-// When you connect, you'll often need to authenticate the client.
-// For example, imagine you have an authentication plug, `MyAuth`,
-// which authenticates the session and assigns a `:current_user`.
-// If the current user exists you can assign the user's token in
-// the connection for use in the layout.
+// token for authentication.
 //
-// In your "<%= web_prefix %>/router.ex":
-//
-//     pipeline :browser do
-//       ...
-//       plug MyAuth
-//       plug :put_user_token
-//     end
-//
-//     defp put_user_token(conn, _) do
-//       if current_user = conn.assigns[:current_user] do
-//         token = Phoenix.Token.sign(conn, "user socket", current_user.id)
-//         assign(conn, :user_token, token)
-//       else
-//         conn
-//       end
-//     end
-//
-// Now you need to pass this token to JavaScript. You can do so
-// inside a script tag in "<%= web_prefix %>/components/layouts/root.html.heex":
-//
-//     <script>window.userToken = "<%%= assigns[:user_token] %>";</script>
-//
-// You will need to verify the user token in the "connect/3" function
-// in "<%= web_prefix %>/channels/user_socket.ex":
-//
-//     def connect(%{"token" => token}, socket, _connect_info) do
-//       # max_age: 1209600 is equivalent to two weeks in seconds
-//       case Phoenix.Token.verify(socket, "user socket", token, max_age: 1_209_600) do
-//         {:ok, user_id} ->
-//           {:ok, assign(socket, :user, user_id)}
-//
-//         {:error, reason} ->
-//           :error
-//       end
-//     end
-//
-// Finally, connect to the socket:
+// Read the [`Using Token Authentication`](https://hexdocs.pm/phoenix/channels.html#using-token-authentication)
+// section to see how the token should be used.
+let socket = new Socket("/socket", {authToken: window.userToken})
 socket.connect()
 
 // Now that you are connected, you can join channels with a topic.

--- a/test/mix/tasks/phx.gen.socket_test.exs
+++ b/test/mix/tasks/phx.gen.socket_test.exs
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
         assert file =~ ~S|// you uncomment its entry in "assets/js/app.js".|
 
         assert file =~ ~S|// And connect to the path in "lib/phoenix_web/endpoint.ex".|
-        assert file =~ ~S|let socket = new Socket("/socket", {params: {token: window.userToken}})|
+        assert file =~ ~S|let socket = new Socket("/socket", {authToken: window.userToken})|
 
         assert file =~ ~S|let channel = socket.channel("room:42", {})|
         assert file =~ ~S|channel.join()|
@@ -74,7 +74,9 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
         assert file =~ ~S|import {Socket} from "phoenix"|
 
         assert file =~ ~S|// And connect to the path in "lib/phoenix/endpoint.ex".|
-        assert file =~ ~S|In your "lib/phoenix/router.ex":|
+
+        assert file =~
+                 ~S|Read the [`Using Token Authentication`](https://hexdocs.pm/phoenix/channels.html#using-token-authentication)|
 
         assert file =~ ~S|let channel = socket.channel("room:42", {})|
         assert file =~ ~S|channel.join()|
@@ -101,9 +103,10 @@ defmodule Mix.Tasks.Phx.Gen.SocketTest do
         assert file =~ ~S|import {Socket} from "phoenix"|
 
         assert file =~ ~S|// And connect to the path in "lib/phoenix_web/endpoint.ex".|
-        assert file =~ ~S|let socket = new Socket("/socket", {params: {token: window.userToken}})|
+        assert file =~ ~S|let socket = new Socket("/socket", {authToken: window.userToken})|
 
-        assert file =~ ~S|In your "lib/phoenix_web/router.ex":|
+        assert file =~
+                 ~S|Read the [`Using Token Authentication`](https://hexdocs.pm/phoenix/channels.html#using-token-authentication)|
 
         assert file =~ ~S|let channel = socket.channel("room:42", {})|
         assert file =~ ~S|channel.join()|


### PR DESCRIPTION
Removes outdated token authentication documentation from the generated `socket.js` file from `phx.gen.socket`. Instead, it reduces the maintenance of the generator by providing a link to the token authentication section in the guides.

Also, redacts the rest of the docs to reference the new method for authenticating.

Closes #6241.