### PR TITLE
Scrub `payload["value"]` for LiveView form submit events

### DIFF
--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -179,7 +179,7 @@ defmodule Phoenix.Logger do
         is_binary(v) and String.contains?(v, params) ->
           new_value =
             Enum.reduce(params, v, fn param, v ->
-              String.replace(v, ~r/#{Regex.escape(param)}=([^&]*)&/, "#{param}=[FILTERED]&")
+              Regex.replace(~r/#{Regex.escape(param)}=([^&]*)(&?)/, v, "#{param}=[FILTERED]\\2")
             end)
 
           {k, new_value}
@@ -358,12 +358,7 @@ defmodule Phoenix.Logger do
   @doc false
   def phoenix_socket_drain(_, _, %{log: false}, _), do: :ok
 
-  def phoenix_socket_drain(
-        _,
-        %{count: count, total: total, index: index, rounds: rounds},
-        %{log: level} = meta,
-        _
-      ) do
+  def phoenix_socket_drain(_, %{count: count, total: total, index: index, rounds: rounds}, %{log: level} = meta, _) do
     Logger.log(level, fn ->
       %{socket: socket, interval: interval} = meta
 

--- a/lib/phoenix/socket/message.ex
+++ b/lib/phoenix/socket/message.ex
@@ -43,17 +43,11 @@ defmodule Phoenix.Socket.Message do
     end
 
     defp process_message(
-           %{event: "event", payload: %{"event" => "submit", "type" => "form", "value" => value}} =
+           %{payload: payload} =
              msg
          )
-         when is_binary(value) do
-      processed_value =
-        value
-        |> Plug.Conn.Query.decode()
-        |> Phoenix.Logger.filter_values()
-        |> Plug.Conn.Query.encode()
-
-      put_in(msg.payload["value"], processed_value)
+         when is_map(payload) do
+      %{msg | payload: Phoenix.Logger.filter_values(payload)}
     end
 
     defp process_message(msg), do: msg

--- a/lib/phoenix/socket/message.ex
+++ b/lib/phoenix/socket/message.ex
@@ -42,11 +42,7 @@ defmodule Phoenix.Socket.Message do
       Inspect.Any.inspect(processed_msg, opts)
     end
 
-    defp process_message(
-           %{payload: payload} =
-             msg
-         )
-         when is_map(payload) do
+    defp process_message(%{payload: payload} = msg) when is_map(payload) do
       %{msg | payload: Phoenix.Logger.filter_values(payload)}
     end
 

--- a/test/phoenix/socket/message_test.exs
+++ b/test/phoenix/socket/message_test.exs
@@ -25,6 +25,25 @@ defmodule Phoenix.Socket.MessageTest do
       assert inspected =~ "email=john@example.com"
     end
 
+    test "filters sensitive values at the end of form submit events" do
+      message = %Message{
+        topic: "lv:1",
+        event: "event",
+        payload: %{
+          "event" => "submit",
+          "type" => "form",
+          "value" => "username=john&password=secret123"
+        },
+        ref: "1",
+        join_ref: "1"
+      }
+
+      inspected = inspect(message)
+
+      assert inspected =~ "username=john"
+      assert inspected =~ "password=[FILTERED]\""
+    end
+
     test "handles malformed query strings gracefully" do
       message = %Message{
         topic: "lv:1",

--- a/test/phoenix/socket/message_test.exs
+++ b/test/phoenix/socket/message_test.exs
@@ -1,0 +1,45 @@
+defmodule Phoenix.Socket.MessageTest do
+  use ExUnit.Case, async: true
+  doctest Phoenix.Socket.Message
+
+  alias Phoenix.Socket.Message
+
+  describe "inspect/2 custom implementation" do
+    test "filters sensitive values in form submit events" do
+      message = %Message{
+        topic: "lv:1",
+        event: "event",
+        payload: %{
+          "event" => "submit",
+          "type" => "form",
+          "value" => "username=john&password=secret123&email=john@example.com"
+        },
+        ref: "1",
+        join_ref: "1"
+      }
+
+      inspected = inspect(message)
+
+      assert inspected =~ "password=%5BFILTERED%5D"
+      assert inspected =~ "username=john"
+      assert inspected =~ "email=john%40example.com"
+    end
+
+    test "handles malformed query strings gracefully" do
+      message = %Message{
+        topic: "lv:1",
+        event: "event",
+        payload: %{
+          "event" => "submit",
+          "type" => "form",
+          "value" => "invalid=query=string&password=secret"
+        },
+        ref: "1",
+        join_ref: "1"
+      }
+
+      inspected = inspect(message)
+      assert is_binary(inspected)
+    end
+  end
+end

--- a/test/phoenix/socket/message_test.exs
+++ b/test/phoenix/socket/message_test.exs
@@ -20,9 +20,9 @@ defmodule Phoenix.Socket.MessageTest do
 
       inspected = inspect(message)
 
-      assert inspected =~ "password=%5BFILTERED%5D"
+      assert inspected =~ "password=[FILTERED]"
       assert inspected =~ "username=john"
-      assert inspected =~ "email=john%40example.com"
+      assert inspected =~ "email=john@example.com"
     end
 
     test "handles malformed query strings gracefully" do


### PR DESCRIPTION
Its very possible we don't want to do this way, but I think sharing the implementation of a possible fix is valuable.

## The Problem

The `Last Message` on a GenServer crash can display the values from a form submit, which will not have Phoenix's parameter filtering logic applied to the `"value"` string. This was reported by a user of mine when submitting a form that takes a password.

![image](https://github.com/user-attachments/assets/110c5afd-fc03-485a-a5aa-1741bf6cf325)

## The solution

What I've done here is just a very naive match on this specific pattern of socket message to scrub values in the inspect protocol. The issue with this is that we're lifting a LV concern to a Phoenix concern potentially. Since all we are doing is scrubbing values that are configured for scrubbing, this seems safe enough to me to make a PR.

I'm happy if this is just a discussion starter and maybe we figure some other way out to do this 😄 