### PR TITLE
warn when using phx.gen.auth without esbuild

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -272,6 +272,23 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
     if generated_with_no_html?() do
       raise_with_help("mix phx.gen.auth requires phoenix_html", :phx_generator_args)
     end
+
+    if generated_with_no_assets_or_esbuild?() do
+      Mix.shell().yes?("""
+      Warning: did not find phoenix_html in your app.js.
+
+      phx.gen.auth expects the phoenix_html JavaScript to be available in your application for
+      the generated logout link to work.
+      This is not the case for applications generated with `--no-assets` or `--no-esbuild`.
+
+      To make the logout link work, you'll need to manually add the phoenix_html JavaScript to your application.
+      It is available at the "priv/static/phoenix_html" path of the phoenix_html application.
+
+      Alternatively, you can refactor the logout link to submit a `<form>` with method "delete" instead.
+
+      Continue?\
+      """) || System.halt()
+    end
   end
 
   defp generated_with_no_html? do
@@ -283,6 +300,12 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
       _ -> false
     end)
     |> Kernel.not()
+  end
+
+  defp generated_with_no_assets_or_esbuild? do
+    not File.exists?("assets/js/app.js") or
+      File.read!("assets/js/app.js") =~
+        "For Phoenix.HTML support, including form and button helpers"
   end
 
   defp build_hashing_library!(opts) do

--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -303,9 +303,11 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
   end
 
   defp generated_with_no_assets_or_esbuild? do
-    not File.exists?("assets/js/app.js") or
-      File.read!("assets/js/app.js") =~
-        "For Phoenix.HTML support, including form and button helpers"
+    not Code.ensure_loaded?(Phoenix.HTML) or
+      case File.read("assets/js/app.js") do
+        {:ok, content} -> content =~ "priv/static/phoenix_html.js"
+        {:error, _} -> true
+      end
   end
 
   defp build_hashing_library!(opts) do


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix/issues/6249.