### PR TITLE
Include maps in the verified routes section of the routing guide

### DIFF
--- a/guides/routing.md
+++ b/guides/routing.md
@@ -198,13 +198,16 @@ Using `~p` for route paths ensures our application paths and URLs stay up to dat
 
 ### More on verified routes
 
-What about paths with query strings? You can either add query string key values directly, or provide a dictionary of key-value pairs, for example:
+What about paths with query strings? You can add query string key values directly, as a keyword list or map of values, for example:
 
 ```elixir
 ~p"/users/17?admin=true&active=false"
 "/users/17?admin=true&active=false"
 
 ~p"/users/17?#{[admin: true]}"
+"/users/17?admin=true"
+
+~p"/users/17?#{%{admin: true}}"
 "/users/17?admin=true"
 ```
 


### PR DESCRIPTION
The [verified routes](https://hexdocs.pm/phoenix/Phoenix.VerifiedRoutes.html) documentation contains "Or as a keyword list or map of values:" whereas the [routing](https://hexdocs.pm/phoenix/routing.html#more-on-verified-routes) documentation only specifies either a query string or "dictionary of key-value pairs".

The intent of this PR is to clarify what is acceptable as a query parameter and reflect what is documented in the verified routes guide.