### PR TITLE
Use `bash` for syntax highlighting of windows commands

### DIFF
--- a/guides/data_modelling/contexts.md
+++ b/guides/data_modelling/contexts.md
@@ -22,8 +22,8 @@ $ curl https://new.phoenixframework.org/hello | sh
 
 For Windows PowerShell:
 
-```cmd
-> curl.exe -fsSO https://new.phoenixframework.org/hello.bat; .\hello.bat
+```bash
+curl.exe -fsSO https://new.phoenixframework.org/hello.bat; .\hello.bat
 ```
 
 If those commands do not work, see the [Installation Guide](installation.html) and then run `mix phx.new`:

--- a/guides/introduction/up_and_running.md
+++ b/guides/introduction/up_and_running.md
@@ -14,8 +14,8 @@ $ curl https://new.phoenixframework.org/myapp | sh
 
 For Windows PowerShell:
 
-```cmd
-> curl.exe -fsSO https://new.phoenixframework.org/myapp.bat; .\myapp.bat
+```bash
+curl.exe -fsSO https://new.phoenixframework.org/myapp.bat; .\myapp.bat
 ```
 
 The above will install Erlang, Elixir, and Phoenix, and generate a fresh Phoenix application. It will also automatically pick one of PostgreSQL or MySQL as the database, and fallback to SQLite if none of them are available. Once the command above completes, it will open up a Phoenix application, with the steps necessary to complete your installation. Note your Phoenix application name is taken from the path.


### PR DESCRIPTION
This allows the commands to be copied correctly. The leading `>` has been removed so that it isn't included in the copied output.

This fixes #6281