### PR TITLE
`<.button>` component should allow `disabled` property

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -88,7 +88,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <.button phx-click="go" variant="primary">Send!</.button>
       <.button navigate={~p"/"}>Home</.button>
   """
-  attr :rest, :global, include: ~w(href navigate patch method download name value)
+  attr :rest, :global, include: ~w(href navigate patch method download name value disabled)
   attr :class, :string
   attr :variant, :string, values: ~w(primary)
   slot :inner_block, required: true


### PR DESCRIPTION
`disabled` is a valid property of HTMLButtonElement, and it already works nicely with DaisyUI & Tailwind, but the compiler currently complains about the attribute. This commit fixes that.