### PR TITLE
demonstration of usage rules in installer

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -293,6 +293,8 @@ defmodule Mix.Tasks.Phx.New do
 
         cmd(project, "mix deps.compile")
 
+        cmd(project, "mix usage_rules.sync AGENTS.md phoenix --yes")
+
         Task.await_many(tasks, :infinity)
       end
 

--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -63,6 +63,8 @@ defmodule <%= @app_module %>.MixProject do
       {:gettext, "~> 0.26"},<% end %>
       {:jason, "~> 1.2"},
       {:dns_cluster, "~> 0.2.0"},
+      {:usage_rules, "~> 0.1", only: :dev},
+      {:igniter, "~> 0.6", only: [:dev, :test]},
       {<%= inspect @web_adapter_app %>, "<%= @web_adapter_vsn %>"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -122,7 +122,7 @@ defmodule Phoenix.MixProject do
       links: %{"GitHub" => @scm_url},
       files: ~w(
           assets/js lib priv CHANGELOG.md LICENSE.md mix.exs package.json README.md .formatter.exs
-          installer/templates/phx_web/components/core_components.ex
+          installer/templates/phx_web/components/core_components.ex usage-rules.md
         )
     ]
   end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -1,0 +1,11 @@
+# How to use Phoenix
+
+this file would describe high level rules for using Phoenix.
+It should have:
+- prevention against common footguns that the agent makes
+- Core guidelines that set agents on the correct path
+- breadcrumbs, but not full context. Link to docs for more etc.
+
+It should not have:
+- Ecto usage guidelines
+- other dependency usage rules, those live in those dependencies


### PR DESCRIPTION
This shows what using https://hexdocs.pm/usage_rules could look like. There are a lot of benefits, and one easily mitigatable drawback.

## The pattern

By shipping usage-rules.md files instead of AGENTS.md files, packages can manage their individual rules easily, and change them over time. We provide a mix task to then combine the rules files of the packages you use into a single `AGENTS.md`. There are a bunch of options around how you do this, but the most common is

```
mix usage_rules.sync AGENTS.md --all
```

to just transplant the file contents into an `AGENTS.md` file. Each package's usage rules are separated by comments that allow us to replace them. So if you update Phoenix, you can simply `mix usage_rules.sync AGENTS.md phoenix` to get the latest.

Not shown in this demo is an alternative mode where all we do is create bread crumbs for the agent:

```
mix usage_rules.sync AGENTS.md --all --link-to-folder deps
```

Which results in a markdown file that just describes the package and links to the deps. This makes usage rules *always up to date as deps change*. It just happens to require some more nudges to the agent to actually use those usage rules. Despite that, this approach has been performing better in general for me.

You can choose whichever strategy you want.

## The benefits

- Users of Phoenix who have not generated new apps can easily run a mix task to get these new usage rules. This helps existing users benefit easily.
- The rules can be split up across each relevant package and maintained separately instead of phoenix core having knowledge/opinions about how each package works. This helps with maintenance burden.
- The usage rules can easily be updated. Imagine a scenario where a breaking change to Ecto, or some other non-phoenix-core library now means that the Phoenix `AGENTS.md` is out of date and giving bad advice. Users update their deps and just "have a worse experience". How would you distribute that fix?
- Despite the standardization around AGENTS.md, it is not the only context file that people need to manage. This allows those patterns to grow separately from our rules declaration. It is future proofing the ecosystem by not adopting any specific company's standard. Even without the mix task we provide, the actual benefit of usage rules is that we now have a place to look for "the critical context that library authors believe that agents should have to work with a given tool". 

## The con

Right now, I've designed it in this PR to actually set up igniter & usage rules as that is what you need to run this task going forward. This naturally adds two more dev dependencies to Phoenix. You could, instead, simply generate `AGENTS.md` with the required markdown comments that make it usage_rules compatible. This would let users keep it up to date however they want. I'd ensure that changes to usage rules don't affect that compatibility.

---

Long story short: usage rules offers some standardization, and various benefits over just providing an AGENTS.md file.

Given the usage-rules.md file in this PR, you would get the following `AGENTS.md` file.

https://gist.github.com/zachdaniel/26fb60986fa5a9e47e37ff3f88e64e64

If you instead used `--link-to-folder deps`, you'd get this one:

https://gist.github.com/zachdaniel/5b5c20a5b41c98b8348b1e12d46f10e4


One small note: we put the package description into the usage rules, which isn't very useful for Phoenix since its just "peace of mind from...". I think it's fine because agents probably know what Phoenix is 😆. But we could add some mechanism to extract a better description.

https://github.com/user-attachments/assets/adebff38-da8d-41b8-84b8-106fbd41e898

