### PR TITLE
Enable Tailwind `dark:` with data-theme attribute

### DIFF
--- a/installer/templates/phx_assets/app.css
+++ b/installer/templates/phx_assets/app.css
@@ -96,7 +96,7 @@
 @custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);
 @custom-variant phx-change-loading (.phx-change-loading&, .phx-change-loading &);
 
-/* Use the data attribute for Dark Mode  */
+/* Use the data attribute for dark mode  */
 @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
 /* Make LiveView wrapper divs transparent for layout */

--- a/installer/templates/phx_assets/app.css
+++ b/installer/templates/phx_assets/app.css
@@ -96,6 +96,9 @@
 @custom-variant phx-submit-loading (.phx-submit-loading&, .phx-submit-loading &);
 @custom-variant phx-change-loading (.phx-change-loading&, .phx-change-loading &);
 
+/* Use the data attribute for Dark Mode  */
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+
 /* Make LiveView wrapper divs transparent for layout */
 [data-phx-session], [data-phx-teleported-src] { display: contents }
 


### PR DESCRIPTION
 The Theme Switcher [root.html.heex](https://github.com/phoenixframework/phoenix/blob/main/installer/templates/phx_web/components/layouts/root.html.heex) uses the `data-theme` attribute to toggle between light/dark themes. 
Tailwind's `dark:` variant expects per default a `class="dark"` though.

This custom variant makes Tailwind's `dark:` work with `data-theme="dark"`.

`@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));`

Without this, the `dark:` utility will not work, even DaisyUI themes switch correctly.

👉 Reference: https://tailwindcss.com/docs/dark-mode#using-a-data-attribute
