### PR TITLE
Fix missing newline in phx.gen.auth template

### DIFF
--- a/priv/templates/phx.gen.auth/schema.ex
+++ b/priv/templates/phx.gen.auth/schema.ex
@@ -1,7 +1,8 @@
 defmodule <%= inspect schema.module %> do
   use Ecto.Schema
   import Ecto.Changeset
-<%= if schema.binary_id do %>  @primary_key {:id, :binary_id, autogenerate: true}
+<%= if schema.binary_id do %>
+  @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id<% end %>
   schema <%= inspect schema.table %> do
     field :email, :string


### PR DESCRIPTION
When the `--binary-id` option is used with `phx.gen.auth`, the generated schema file was missing a blank line between the `import Ecto.Changeset` and the `@primary_key` declaration.

The new placing of the `<%= if ... do %>...<% end %>` construct matches how it is done in the `schema_token.ex` template file.