### PR TITLE
Remove deprecated route names from phx.gen.* templates

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -935,7 +935,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
     prefix = Module.concat(context.web_module, schema.web_namespace)
 
     if schema.web_namespace do
-      ~s|"/#{schema.web_path}", #{inspect(prefix)}, as: :#{schema.web_path}|
+      ~s|"/#{schema.web_path}", #{inspect(prefix)}|
     else
       ~s|"/", #{inspect(context.web_module)}|
     end

--- a/lib/mix/tasks/phx.gen.html.ex
+++ b/lib/mix/tasks/phx.gen.html.ex
@@ -213,7 +213,7 @@ defmodule Mix.Tasks.Phx.Gen.Html do
 
       Add the resource to your #{schema.web_namespace} :browser scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
 
-          scope "/#{schema.web_path}", #{inspect(Module.concat(context.web_module, schema.web_namespace))}, as: :#{schema.web_path} do
+          scope "/#{schema.web_path}", #{inspect(Module.concat(context.web_module, schema.web_namespace))} do
             pipe_through :browser
             ...
             resources "#{resource_path}", #{inspect(schema.alias)}Controller#{if schema.opts[:primary_key], do: ~s[, param: "#{schema.opts[:primary_key]}"]}

--- a/lib/mix/tasks/phx.gen.json.ex
+++ b/lib/mix/tasks/phx.gen.json.ex
@@ -203,7 +203,7 @@ defmodule Mix.Tasks.Phx.Gen.Json do
 
       Add the resource to your #{schema.web_namespace} :api scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
 
-          scope "/#{schema.web_path}", #{inspect(Module.concat(context.web_module, schema.web_namespace))}, as: :#{schema.web_path} do
+          scope "/#{schema.web_path}", #{inspect(Module.concat(context.web_module, schema.web_namespace))} do
             pipe_through :api
             ...
             resources "#{resource_path}", #{inspect(schema.alias)}Controller#{if schema.opts[:primary_key], do: ~s[, param: "#{schema.opts[:primary_key]}"]}

--- a/lib/mix/tasks/phx.gen.live.ex
+++ b/lib/mix/tasks/phx.gen.live.ex
@@ -287,7 +287,7 @@ defmodule Mix.Tasks.Phx.Gen.Live do
 
       Add the live routes to your #{schema.web_namespace} :browser scope in #{web_path}/router.ex:
 
-          scope "/#{schema.web_path}", #{inspect(prefix)}, as: :#{schema.web_path} do
+          scope "/#{schema.web_path}", #{inspect(prefix)} do
             pipe_through :browser
             ...
 

--- a/test/mix/tasks/phx.gen.auth_test.exs
+++ b/test/mix/tasks/phx.gen.auth_test.exs
@@ -611,14 +611,14 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
         assert file =~ """
                  ## Authentication routes
 
-                 scope "/warehouse", MyAppWeb.Warehouse, as: :warehouse do
+                 scope "/warehouse", MyAppWeb.Warehouse do
                    pipe_through [:browser, :redirect_if_user_is_authenticated]
 
                    get "/users/register", UserRegistrationController, :new
                    post "/users/register", UserRegistrationController, :create
                  end
 
-                 scope "/warehouse", MyAppWeb.Warehouse, as: :warehouse do
+                 scope "/warehouse", MyAppWeb.Warehouse do
                    pipe_through [:browser, :require_authenticated_user]
 
                    get "/users/settings", UserSettingsController, :edit
@@ -626,7 +626,7 @@ defmodule Mix.Tasks.Phx.Gen.AuthTest do
                    get "/users/settings/confirm-email/:token", UserSettingsController, :confirm_email
                  end
 
-                 scope "/warehouse", MyAppWeb.Warehouse, as: :warehouse do
+                 scope "/warehouse", MyAppWeb.Warehouse do
                    pipe_through [:browser]
 
                    get "/users/log-in", UserSessionController, :new

--- a/test/mix/tasks/phx.gen.html_test.exs
+++ b/test/mix/tasks/phx.gen.html_test.exs
@@ -296,7 +296,7 @@ defmodule Mix.Tasks.Phx.Gen.HtmlTest do
 
                         Add the resource to your Blog :browser scope in lib/phoenix_web/router.ex:
 
-                            scope "/blog", PhoenixWeb.Blog, as: :blog do
+                            scope "/blog", PhoenixWeb.Blog do
                               pipe_through :browser
                               ...
                               resources "/posts", PostController

--- a/test/mix/tasks/phx.gen.json_test.exs
+++ b/test/mix/tasks/phx.gen.json_test.exs
@@ -192,7 +192,7 @@ defmodule Mix.Tasks.Phx.Gen.JsonTest do
 
                         Add the resource to your Blog :api scope in lib/phoenix_web/router.ex:
 
-                            scope "/blog", PhoenixWeb.Blog, as: :blog do
+                            scope "/blog", PhoenixWeb.Blog do
                               pipe_through :api
                               ...
                               resources "/posts", PostController

--- a/test/mix/tasks/phx.gen.live_test.exs
+++ b/test/mix/tasks/phx.gen.live_test.exs
@@ -266,7 +266,7 @@ defmodule Mix.Tasks.Phx.Gen.LiveTest do
 
       Add the live routes to your Blog :browser scope in lib/phoenix_web/router.ex:
 
-          scope "/blog", PhoenixWeb.Blog, as: :blog do
+          scope "/blog", PhoenixWeb.Blog do
             pipe_through :browser
             ...
 


### PR DESCRIPTION
After running `mix phx.gen.auth` and reviewing the generated code, I noticed that it added the `as: :some_name` option to the `scope` macro in the router.

This option is not there on new projects, and `:as` is documented to have no effect when using Verified Routes (which phx.new uses).

Considering the Router Helpers deprecation status, this commit removes the `as: :some_name` option from the generated code.

It does mean someone using the modern generators within a project using Helpers would have to manually add the `as: :some_name` option if they want to have a `some_name_path` function.