### PR TITLE
Update Routing Cheatsheet/Guide focused on Verified Routes

### DIFF
--- a/guides/cheatsheets/router.cheatmd
+++ b/guides/cheatsheets/router.cheatmd
@@ -14,9 +14,9 @@ get "/users", UserController, :index
 patch "/users/:id", UserController, :update
 ```
 ```elixir
-# generated routes
+# Verified Routes
 ~p"/users"
-~p"/users/9" # user_id is 9
+~p"/users/#{@user}"
 ```
 Also accepts `put`, `patch`, `options`, `delete` and `head`.
 
@@ -34,7 +34,6 @@ Generates `:index`, `:edit`, `:new`, `:show`, `:create`, `:update` and `:delete`
 ```elixir
 resources "/users", UserController, only: [:show]
 resources "/users", UserController, except: [:create, :delete]
-resources "/users", UserController, as: :person # ~p"/person"
 ```
 
 #### Nested
@@ -45,9 +44,15 @@ resources "/users", UserController do
 end
 ```
 ```elixir
-# generated routes
-~p"/users/3/posts" # user_id is 3
-~p"/users/3/posts/17" # user_id is 3 and post_id = 17
+# Verified Routes
+~p"/users"
+~p"/users/new"
+~p"/users/#{@user}"
+~p"/users/#{@user}/edit"
+~p"/users/#{@user}/posts"
+~p"/users/#{@user}/posts/new"
+~p"/users/#{@user}/posts/#{@post}"
+~p"/users/#{@user}/posts/#{@post}/edit"
 ```
 For more info check the [resources docs.](routing.html#resources)
 
@@ -58,26 +63,32 @@ For more info check the [resources docs.](routing.html#resources)
 scope "/admin", HelloWeb.Admin do
   pipe_through :browser
 
-  resources "/users",   UserController
+  resources "/users", UserController
 end
 ```
 ```elixir
-# generated path helpers
+# Verified Routes
 ~p"/admin/users"
+~p"/admin/users/new"
+~p"/admin/users/#{@user}"
+~p"/admin/users/#{@user}/edit"
 ```
 
 #### Nested
 ```elixir
-scope "/api", HelloWeb.Api, as: :api do
+scope "/api", HelloWeb.Api do
   pipe_through :api
 
-  scope "/v1", V1, as: :v1 do
+  scope "/v1", V1 do
     resources "/users", UserController
   end
 end
 ```
 ```elixir
-# generated path helpers
+# Verified Routes
 ~p"/api/v1/users"
+~p"/api/v1/users/new"
+~p"/api/v1/users/#{@user}"
+~p"/api/v1/users/#{@user}/edit"
 ```
 For more info check the [scoped routes](routing.md#scoped-routes) docs.

--- a/guides/routing.md
+++ b/guides/routing.md
@@ -401,10 +401,10 @@ This is great, exactly what we want. Note how every route and controller is prop
 Scopes can also be arbitrarily nested, but you should do it carefully as nesting can sometimes make our code confusing and less clear. With that said, suppose that we had a versioned API with resources defined for images, reviews, and users. Then technically, we could set up routes for the versioned API like this:
 
 ```elixir
-scope "/api", HelloWeb.Api, as: :api do
+scope "/api", HelloWeb.Api do
   pipe_through :api
 
-  scope "/v1", V1, as: :v1 do
+  scope "/v1", V1 do
     resources "/images",  ImageController
     resources "/reviews", ReviewController
     resources "/users",   UserController


### PR DESCRIPTION
When the Cheatsheet was created, it got feedback from the Phoenix team to focus on Verified Routes instead of Router Helpers (https://github.com/phoenixframework/phoenix/pull/5605#issuecomment-1779497054).

This takes the guide one step further by removing the usage of `as: :some_name` from the `scope` and `resources` macros, which was previously used to generate router helpers.

It also updates the examples to showcase how Verified Routes are typically used, by interpolating variables/assigns directly into the path.

Finally, it removes the `as: :some_name` option from the nested `scope` calls in the Routing guide, as it was also not relevant in that context, because the guide is focused on Verified Routes usage.