### PR TITLE
Fix missing verified route ~p sigil in generated test

### DIFF
--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -80,7 +80,7 @@ defmodule <%= inspect auth_module %>Test do
         |> assign(:<%= scope_config.scope.assign_key %>, <%= inspect scope_config.scope.alias %>.for_<%= schema.singular %>(<%= schema.singular %>))
         |> <%= inspect schema.alias %>Auth.log_in_<%= schema.singular %>(<%= schema.singular %>)
 
-      assert redirected_to(conn) == "<%= schema.route_prefix %>/settings"
+      assert redirected_to(conn) == ~p"<%= schema.route_prefix %>/settings"
     end<% end %>
 
     test "writes a cookie if remember_me was set in previous session", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do


### PR DESCRIPTION
Found while working with `phx.gen.auth` generated code. I looked for the pattern `"([^/]+)?/[^/]+"` in the templates and found no other occurrences. Hopefully this was the only one.