### PR TITLE
Generate session token function improved naming

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -47,7 +47,7 @@ defmodule <%= inspect auth_module %> do
   """
   def log_out_<%= schema.singular %>(conn) do
     <%= schema.singular %>_token = get_session(conn, :<%= schema.singular %>_token)
-    <%= schema.singular %>_token && <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token!(<%= schema.singular %>_token)
+    <%= schema.singular %>_token && <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token(<%= schema.singular %>_token)
 
     if live_socket_id = get_session(conn, :live_socket_id) do
       <%= inspect(endpoint_module) %>.broadcast(live_socket_id, "disconnect", %{})
@@ -69,7 +69,7 @@ defmodule <%= inspect auth_module %> do
          {<%= schema.singular %>, token_inserted_at} <- <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token) do
       conn
       |> assign(:<%= scope_config.scope.assign_key %>, <%= inspect scope_config.scope.alias %>.for_<%= schema.singular %>(<%= schema.singular %>))
-      |> maybe_reissue_<%= schema.singular %>_session_token!(<%= schema.singular %>, token_inserted_at)
+      |> maybe_reissue_<%= schema.singular %>_session_token(<%= schema.singular %>, token_inserted_at)
     else
       nil -> assign(conn, :<%= scope_config.scope.assign_key %>, <%= inspect scope_config.scope.alias %>.for_<%= schema.singular %>(nil))
     end
@@ -90,7 +90,7 @@ defmodule <%= inspect auth_module %> do
   end
 
   # Reissue the session token if it is older than the configured reissue age.
-  defp maybe_reissue_<%= schema.singular %>_session_token!(conn, <%= schema.singular %>, token_inserted_at) do
+  defp maybe_reissue_<%= schema.singular %>_session_token(conn, <%= schema.singular %>, token_inserted_at) do
     token_age = <%= inspect datetime_module %>.diff(<%= datetime_now %>, token_inserted_at, :day)
 
     if token_age >= @session_reissue_age_in_days do

--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -47,7 +47,7 @@ defmodule <%= inspect auth_module %> do
   """
   def log_out_<%= schema.singular %>(conn) do
     <%= schema.singular %>_token = get_session(conn, :<%= schema.singular %>_token)
-    <%= schema.singular %>_token && <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token(<%= schema.singular %>_token)
+    <%= schema.singular %>_token && <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token!(<%= schema.singular %>_token)
 
     if live_socket_id = get_session(conn, :live_socket_id) do
       <%= inspect(endpoint_module) %>.broadcast(live_socket_id, "disconnect", %{})
@@ -69,7 +69,7 @@ defmodule <%= inspect auth_module %> do
          {<%= schema.singular %>, token_inserted_at} <- <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token) do
       conn
       |> assign(:<%= scope_config.scope.assign_key %>, <%= inspect scope_config.scope.alias %>.for_<%= schema.singular %>(<%= schema.singular %>))
-      |> maybe_reissue_<%= schema.singular %>_session_token(<%= schema.singular %>, token_inserted_at)
+      |> maybe_reissue_<%= schema.singular %>_session_token!(<%= schema.singular %>, token_inserted_at)
     else
       nil -> assign(conn, :<%= scope_config.scope.assign_key %>, <%= inspect scope_config.scope.alias %>.for_<%= schema.singular %>(nil))
     end
@@ -90,7 +90,7 @@ defmodule <%= inspect auth_module %> do
   end
 
   # Reissue the session token if it is older than the configured reissue age.
-  defp maybe_reissue_<%= schema.singular %>_session_token(conn, <%= schema.singular %>, token_inserted_at) do
+  defp maybe_reissue_<%= schema.singular %>_session_token!(conn, <%= schema.singular %>, token_inserted_at) do
     token_age = <%= inspect datetime_module %>.diff(<%= datetime_now %>, token_inserted_at, :day)
 
     if token_age >= @session_reissue_age_in_days do
@@ -109,7 +109,7 @@ defmodule <%= inspect auth_module %> do
   # function will clear the session to avoid fixation attacks. See the
   # renew_session function to customize this behaviour.
   defp create_or_extend_session(conn, <%= schema.singular %>, params) do
-    token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+    token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
     remember_me = get_session(conn, :<%= schema.singular %>_remember_me)
 
     conn

--- a/priv/templates/phx.gen.auth/auth_test.exs
+++ b/priv/templates/phx.gen.auth/auth_test.exs
@@ -108,7 +108,7 @@ defmodule <%= inspect auth_module %>Test do
 
   describe "logout_<%= schema.singular %>/1" do
     test "erases session and cookies", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
 
       conn =
         conn
@@ -145,7 +145,7 @@ defmodule <%= inspect auth_module %>Test do
 
   describe "fetch_<%= scope_config.scope.assign_key %>_for_<%= schema.singular %>/2" do
     test "authenticates <%= schema.singular %> from session", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
 
       conn =
         conn |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token) |> <%= inspect schema.alias %>Auth.fetch_<%= scope_config.scope.assign_key %>_for_<%= schema.singular %>([])
@@ -177,7 +177,7 @@ defmodule <%= inspect auth_module %>Test do
     end
 
     test "does not authenticate if data is missing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      _ = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      _ = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
       conn = <%= inspect schema.alias %>Auth.fetch_<%= scope_config.scope.assign_key %>_for_<%= schema.singular %>(conn, [])
       refute get_session(conn, :<%= schema.singular %>_token)
       refute conn.assigns.<%= scope_config.scope.assign_key %>
@@ -216,7 +216,7 @@ defmodule <%= inspect auth_module %>Test do
     end
 
     test "assigns <%= scope_config.scope.assign_key %> based on a valid <%= schema.singular %>_token", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
       session = conn |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token) |> get_session()
 
       {:cont, updated_socket} =
@@ -247,7 +247,7 @@ defmodule <%= inspect auth_module %>Test do
 
   describe "on_mount :require_authenticated" do
     test "authenticates <%= scope_config.scope.assign_key %> based on a valid <%= schema.singular %>_token", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
       session = conn |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token) |> get_session()
 
       {:cont, updated_socket} =
@@ -284,7 +284,7 @@ defmodule <%= inspect auth_module %>Test do
 
   describe "on_mount :require_sudo_mode" do
     test "allows <%= schema.plural %> that have authenticated in the last 10 minutes", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
-      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
       session = conn |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token) |> get_session()
 
       socket = %LiveView.Socket{
@@ -299,7 +299,7 @@ defmodule <%= inspect auth_module %>Test do
     test "redirects when authentication is too old", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       eleven_minutes_ago = <%= datetime_now %> |> <%= inspect datetime_module %>.add(-11, :minute)
       <%= schema.singular %> = %{<%= schema.singular %> | authenticated_at: eleven_minutes_ago}
-      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>!(<%= schema.singular %>)
       {<%= schema.singular %>, token_inserted_at} = <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(<%= schema.singular %>_token)
       assert <%= inspect datetime_module %>.compare(token_inserted_at, <%= schema.singular %>.authenticated_at) == :gt
       session = conn |> put_session(:<%= schema.singular %>_token, <%= schema.singular %>_token) |> get_session()
@@ -327,7 +327,7 @@ defmodule <%= inspect auth_module %>Test do
     test "redirects when authentication is too old", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
       eleven_minutes_ago = <%= datetime_now %> |> <%= inspect datetime_module %>.add(-11, :minute)
       <%= schema.singular %> = %{<%= schema.singular %> | authenticated_at: eleven_minutes_ago}
-      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      <%= schema.singular %>_token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
       {<%= schema.singular %>, token_inserted_at} = <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(<%= schema.singular %>_token)
       assert <%= inspect datetime_module %>.compare(token_inserted_at, <%= schema.singular %>.authenticated_at) == :gt
 

--- a/priv/templates/phx.gen.auth/conn_case.exs
+++ b/priv/templates/phx.gen.auth/conn_case.exs
@@ -25,7 +25,7 @@
   It returns an updated `conn`.
   """
   def log_in_<%= schema.singular %>(conn, <%= schema.singular %>, opts \\ []) do
-    token = <%= inspect context.module %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+    token = <%= inspect context.module %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
 
     maybe_set_token_authenticated_at(token, opts[:token_authenticated_at])
 

--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -164,7 +164,7 @@
   @doc """
   Generates a session token.
   """
-  def generate_<%= schema.singular %>_session_token(<%= schema.singular %>) do
+  def generate_<%= schema.singular %>_session_token!(<%= schema.singular %>) do
     {token, <%= schema.singular %>_token} = <%= inspect schema.alias %>Token.build_session_token(<%= schema.singular %>)
     Repo.insert!(<%= schema.singular %>_token)
     token

--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -268,7 +268,7 @@
   @doc """
   Deletes the signed token with the given context.
   """
-  def delete_<%= schema.singular %>_session_token(token) do
+  def delete_<%= schema.singular %>_session_token!(token) do
     Repo.delete_all(from(<%= inspect schema.alias %>Token, where: [token: ^token, context: "session"]))
     :ok
   end

--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -268,7 +268,7 @@
   @doc """
   Deletes the signed token with the given context.
   """
-  def delete_<%= schema.singular %>_session_token!(token) do
+  def delete_<%= schema.singular %>_session_token(token) do
     Repo.delete_all(from(<%= inspect schema.alias %>Token, where: [token: ^token, context: "session"]))
     :ok
   end

--- a/priv/templates/phx.gen.auth/test_cases.exs
+++ b/priv/templates/phx.gen.auth/test_cases.exs
@@ -360,7 +360,7 @@
     test "deletes the token" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
       token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
-      assert <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token!(token) == :ok
+      assert <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token(token) == :ok
       refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token)
     end
   end

--- a/priv/templates/phx.gen.auth/test_cases.exs
+++ b/priv/templates/phx.gen.auth/test_cases.exs
@@ -236,7 +236,7 @@
     end
 
     test "deletes all tokens for the given <%= schema.singular %>", %{<%= schema.singular %>: <%= schema.singular %>} do
-      _ = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      _ = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
 
       {:ok, {_, _}} =
         <%= inspect context.alias %>.update_<%= schema.singular %>_password(<%= schema.singular %>, %{
@@ -247,13 +247,13 @@
     end
   end
 
-  describe "generate_<%= schema.singular %>_session_token/1" do
+  describe "generate_<%= schema.singular %>_session_token!/1" do
     setup do
       %{<%= schema.singular %>: <%= schema.singular %>_fixture()}
     end
 
     test "generates a token", %{<%= schema.singular %>: <%= schema.singular %>} do
-      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
       assert <%= schema.singular %>_token = Repo.get_by(<%= inspect schema.alias %>Token, token: token)
       assert <%= schema.singular %>_token.context == "session"
       assert <%= schema.singular %>_token.authenticated_at != nil
@@ -270,7 +270,7 @@
 
     test "duplicates the authenticated_at of given <%= schema.singular %> in new token", %{<%= schema.singular %>: <%= schema.singular %>} do
       <%= schema.singular %> = %{<%= schema.singular %> | authenticated_at: <%= inspect datetime_module %>.add(<%= datetime_now %>, -3600)}
-      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
       assert <%= schema.singular %>_token = Repo.get_by(<%= inspect schema.alias %>Token, token: token)
       assert <%= schema.singular %>_token.authenticated_at == <%= schema.singular %>.authenticated_at
       assert <%= inspect datetime_module %>.compare(<%= schema.singular %>_token.inserted_at, <%= schema.singular %>.authenticated_at) == :gt
@@ -280,7 +280,7 @@
   describe "get_<%= schema.singular %>_by_session_token/1" do
     setup do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
-      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
+      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
       %{<%= schema.singular %>: <%= schema.singular %>, token: token}
     end
 
@@ -359,8 +359,8 @@
   describe "delete_<%= schema.singular %>_session_token/1" do
     test "deletes the token" do
       <%= schema.singular %> = <%= schema.singular %>_fixture()
-      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token(<%= schema.singular %>)
-      assert <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token(token) == :ok
+      token = <%= inspect context.alias %>.generate_<%= schema.singular %>_session_token!(<%= schema.singular %>)
+      assert <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token!(token) == :ok
       refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token)
     end
   end


### PR DESCRIPTION
This is my first PR, I didn't see any issue related to this.

I realized this function uses `Repo.insert!` which will raise an error if it fails. I changed the function naming adding a `!` to prevent developers about the possible raising.