### PR TITLE
Remove sigil_S from docstrings in templates

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -302,7 +302,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     """
   end
 
-  @doc ~S"""
+  @doc """
   Renders a table with generic styling.
 
   ## Examples

--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -255,7 +255,7 @@
     <%= inspect schema.alias %>Notifier.deliver_update_email_instructions(<%= schema.singular %>, update_email_url_fun.(encoded_token))
   end
 
-  @doc ~S"""
+  @doc """
   Delivers the magic link login instructions to the given <%= schema.singular %>.
   """
   def deliver_login_instructions(%<%= inspect schema.alias %>{} = <%= schema.singular %>, magic_link_url_fun)


### PR DESCRIPTION
When reviewing generated code, I noticed that some docstrings used `~S` unnecessarily.

The case for `@doc ~S"""` is when examples or prose contain backslashes or `#{...}` interpolation, which is not the case here.