### PR TITLE
Clarify Swoosh mailer config instructions in templates

### DIFF
--- a/installer/templates/phx_single/config/runtime.exs
+++ b/installer/templates/phx_single/config/runtime.exs
@@ -85,18 +85,18 @@ if config_env() == :prod do
   # ## Configuring the mailer
   #
   # In production you need to configure the mailer to use a different adapter.
-  # Also, you may need to configure the Swoosh API client of your choice if you
-  # are not using SMTP. Here is an example of the configuration:
+  # Here is an example configuration for Mailgun:
   #
   #     config :<%= @app_name %>, <%= @app_module %>.Mailer,
   #       adapter: Swoosh.Adapters.Mailgun,
   #       api_key: System.get_env("MAILGUN_API_KEY"),
   #       domain: System.get_env("MAILGUN_DOMAIN")
   #
-  # For this example you need include a HTTP client required by Swoosh API client.
-  # Swoosh supports Hackney, Req and Finch out of the box:
+  # Most non-SMTP adapters require an API client. Swoosh supports Req, Hackney,
+  # and Finch out-of-the-box. This configuration is typically done at
+  # compile-time in your config/prod.exs:
   #
-  #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
+  #     config :swoosh, :api_client, Swoosh.ApiClient.Req
   #
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.<% end %>
 end

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/runtime.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/runtime.exs
@@ -64,17 +64,17 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 # ## Configuring the mailer
 #
 # In production you need to configure the mailer to use a different adapter.
-# Also, you may need to configure the Swoosh API client of your choice if you
-# are not using SMTP. Here is an example of the configuration:
+# Here is an example configuration for Mailgun:
 #
 #     config :<%= @app_name %>, <%= @app_module %>.Mailer,
 #       adapter: Swoosh.Adapters.Mailgun,
 #       api_key: System.get_env("MAILGUN_API_KEY"),
 #       domain: System.get_env("MAILGUN_DOMAIN")
 #
-# For this example you need include a HTTP client required by Swoosh API client.
-# Swoosh supports Hackney, Req and Finch out of the box:
+# Most non-SMTP adapters require an API client. Swoosh supports Req, Hackney,
+# and Finch out-of-the-box. This configuration is typically done at
+# compile-time in your config/prod.exs:
 #
-#     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
+#     config :swoosh, :api_client, Swoosh.ApiClient.Req
 #
 # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.<% end %>


### PR DESCRIPTION
- Reword to avoid talking about "Swoosh API client" both before and after the example
- Indicate API client is configured at compile-time in config/prod.exs
- Use Req in the example, aligned with what is configured by default