### PR TITLE
Fix security docs text rendering

### DIFF
--- a/guides/security.md
+++ b/guides/security.md
@@ -345,6 +345,7 @@ User input determines the `content-type` of the file. There is no validation o
 
 ```html
 <html><script>alert(1)</script></html>
+```
 
 This will result in JavaScript being executed in the browser of the victim who views the image. Restricting the `put_resp_content_type` argument to only image files would fix this vulnerability. 
 
@@ -387,7 +388,7 @@ Content-Length: 53
 post[title]=My+Title&post[body]=This+is+the+body
 ```
 
-An attacker can embed the following form on attacker.com:
+An attacker can embed the following form on `attacker.com`:
 
 ```html
 <form action="https://example.com/posts" method="post">
@@ -412,6 +413,7 @@ The way most web frameworks, including Phoenix, mitigate this vulnerability is b
 <!-- A typical CSRF token seen in a Phoenix form -->
 <input name="_csrf_token" type="hidden" hidden="" 
   value="WUZXJh07BhAIJ24jP1d-KQEpLwYmMDwQ0-2eYNLH_x8oHoO_qv_HJDqZ">
+```
 
 This changes the previous HTTP request to:
 


### PR DESCRIPTION
Fixes the text rendering errors on https://hexdocs.pm/phoenix/1.8.0-rc.4/security.html

Attached is a screenshot showing the current error.

<img width="1260" height="827" alt="Screenshot 2025-07-15 at 11 40 27 AM" src="https://github.com/user-attachments/assets/1c98a29c-1473-4a5c-89cd-b766d86a72e7" />
