### PR TITLE
Guides: Removes default arg for context create functions

### DIFF
--- a/guides/data_modelling/cross_context_boundaries.md
+++ b/guides/data_modelling/cross_context_boundaries.md
@@ -338,7 +338,7 @@ Let's implement the new interface for the `ShoppingCart` context API in `lib/hel
 +    )
 +  end
 
-   def create_cart(%Scope{} = scope, attrs \\ %{}) do
+   def create_cart(%Scope{} = scope, attrs) do
      with {:ok, cart = %Cart{}} <-
             %Cart{}
             |> Cart.changeset(attrs, scope)

--- a/guides/data_modelling/in_context_relationships.md
+++ b/guides/data_modelling/in_context_relationships.md
@@ -131,7 +131,7 @@ With our schema associations set up, we can implement the selection of categorie
 +   Product |> Repo.get!(id) |> Repo.preload(:categories)
 + end
 
-  def create_product(attrs \\ %{}) do
+  def create_product(attrs) do
     %Product{}
 -   |> Product.changeset(attrs)
 +   |> change_product(attrs)

--- a/guides/data_modelling/your_first_context.md
+++ b/guides/data_modelling/your_first_context.md
@@ -192,7 +192,7 @@ Now we know how data is fetched, but how are products persisted? Let's take a lo
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_product(attrs \\ %{}) do
+  def create_product(attrs) do
     %Product{}
     |> Product.changeset(attrs)
     |> Repo.insert()


### PR DESCRIPTION
I went through the context guides again in `rc4` to check on my changes in `rc3`. A minor cause of confusion I missed last time was the current context generators not having a default `attrs` for the create function.

This change removes the default `attrs` from snippets that show the default create function of a context.