### PR TITLE
Fix non-closing flash when using --no-assets

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -54,8 +54,9 @@ defmodule <%= @web_namespace %>.CoreComponents do
     <div
       :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
       id={@id}
-      phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
-      role="alert"
+      <%= if @javascript do %>phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
+      <% else %>onclick="this.hidden = true"
+      <% end %>role="alert"
       class="toast toast-top toast-end z-50"
       {@rest}
     >

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -532,6 +532,11 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file("phx_blog/config/prod.exs", fn file ->
         refute file =~ "config :phx_blog, PhxBlogWeb.Endpoint, cache_static_manifest:"
       end)
+
+      assert_file("phx_blog/lib/phx_blog_web/components/core_components.ex", fn file ->
+        assert file =~ ~S|onclick="this.hidden = true"|
+        refute file =~ ~S|JS.push("lv:clear-flash"|
+      end)
     end)
   end
 


### PR DESCRIPTION
Hi folks!

Currently the flash cannot be closed when the project is generated with `--no-assets`, but it seems to be fixable with some plain Javascript.

Not sure if this is the best way to address it, but since I had to figure this out and it worked for me, I thought maybe it could be upstreamed. Otherwise feel free to close this 🙂