### PR TITLE
Use relative path for JS doc link

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -195,7 +195,7 @@ defmodule Phoenix.MixProject do
       "guides/howto/writing_a_channels_client.md",
       "guides/cheatsheets/router.cheatmd",
       "CHANGELOG.md",
-      "JS Documentation": [url: "/js/"]
+      "JS Documentation": [url: "js/index.html"]
     ]
   end
 


### PR DESCRIPTION
Changes JS documentation link in the sidebar from `/js/` to `js/index.html` which works both for online and offline (the file:// protocol) use cases.

**Context**
The link that was added via https://github.com/phoenixframework/phoenix/pull/6247 results in the following href `<a href="/js/">JS Documentation</a>` which when clicked leads to `https://hexdocs.pm/js/` at [hexdocs](https://hexdocs.pm/phoenix/1.8.0-rc.4) and `file:///js/` locally.

**How to test the change**
- Locally, run `mix docs -f html`. Open the docs. Click the "JS documentation" external link and see if it opens the JS documentation page.
- For [Hexdocs](https://hexdocs.pm/phoenix/1.8.0-rc.4/overview.html), open DevTools and manually edit the `href` attribute to be `js/index.html` and then click on it. It should lead to the JS documentation.