### PR TITLE
Add guide for live_view generator customization

### DIFF
--- a/lib/mix/tasks/phx.gen.ex
+++ b/lib/mix/tasks/phx.gen.ex
@@ -19,7 +19,6 @@ defmodule Mix.Tasks.Phx.Gen do
   | `phx.gen.json`     | x | x | x | x | x |   |
   | `phx.gen.html`     | x | x | x | x | x |   |
 
-
   ## Customizing generators
   
   You can override the default templates used by generators.
@@ -28,6 +27,7 @@ defmodule Mix.Tasks.Phx.Gen do
   A common pattern is to place them under `priv/templates/phx.gen.live/` in your project:
   
   Create the directory for your custom `phx.gen.live` templates:
+
   ```console
   $ mkdir -p priv/templates/phx.gen.live
   ```
@@ -37,14 +37,14 @@ defmodule Mix.Tasks.Phx.Gen do
   ```console
   $ cp -r deps/phoenix/priv/templates/phx.gen.live/* priv/templates/phx.gen.live/
   ```
+
   Phoenix generators will look for templates in your project's `priv/templates` directory first.
-  If a matching template is found, it will be used instead of the built-in default.
+  If a matching template is found, it will be used instead of the default.
 
-  See: `https://fly.io/phoenix-files/customizing-phoenix-generators/` for a more detailed approach.
-
-  `Note: Generator templates may change between minor Phoenix releases,
-  so custom templates may require updates after upgrading.`
-
+  Note generator templates may change between minor or even patch Phoenix releases,
+  so custom templates may require updates after upgrading. Use this mechanism at your
+  own risk.
+```
   """
 
   def run(_args) do

--- a/lib/mix/tasks/phx.gen.ex
+++ b/lib/mix/tasks/phx.gen.ex
@@ -23,16 +23,16 @@ defmodule Mix.Tasks.Phx.Gen do
   
   You can override the default templates used by generators.
   
-  For example, to customize `phx.gen.live`, you can copy and edit the generator templates.
-  A common pattern is to place them under `priv/templates/phx.gen.live/` in your project:
+  For example, to customize `phx.gen.live`, you can copy and edit the generator templates
+  to your own project's priv folder:
   
-  Create the directory for your custom `phx.gen.live` templates:
+  First, create the directory for your custom `phx.gen.live` templates:
 
   ```console
   $ mkdir -p priv/templates/phx.gen.live
   ```
 
-  Copy the default phx.gen.live generator templates into your project so you can customize them:
+  Next, copy the default phx.gen.live generator templates into your project so you can customize them:
 
   ```console
   $ cp -r deps/phoenix/priv/templates/phx.gen.live/* priv/templates/phx.gen.live/

--- a/lib/mix/tasks/phx.gen.ex
+++ b/lib/mix/tasks/phx.gen.ex
@@ -18,6 +18,33 @@ defmodule Mix.Tasks.Phx.Gen do
   | `phx.gen.live`     | x | x | x |   |   | x |
   | `phx.gen.json`     | x | x | x | x | x |   |
   | `phx.gen.html`     | x | x | x | x | x |   |
+
+
+  ## Customizing generators
+  
+  You can override the default templates used by generators.
+  
+  For example, to customize `phx.gen.live`, you can copy and edit the generator templates.
+  A common pattern is to place them under `priv/templates/phx.gen.live/` in your project:
+  
+  Create the directory for your custom `phx.gen.live` templates:
+  ```console
+  $ mkdir -p priv/templates/phx.gen.live
+  ```
+
+  Copy the default phx.gen.live generator templates into your project so you can customize them:
+
+  ```console
+  $ cp -r deps/phoenix/priv/templates/phx.gen.live/* priv/templates/phx.gen.live/
+  ```
+  Phoenix generators will look for templates in your project's `priv/templates` directory first.
+  If a matching template is found, it will be used instead of the built-in default.
+
+  See: `https://fly.io/phoenix-files/customizing-phoenix-generators/` for a more detailed approach.
+
+  `Note: Generator templates may change between minor Phoenix releases,
+  so custom templates may require updates after upgrading.`
+
   """
 
   def run(_args) do

--- a/lib/mix/tasks/phx.gen.ex
+++ b/lib/mix/tasks/phx.gen.ex
@@ -44,7 +44,6 @@ defmodule Mix.Tasks.Phx.Gen do
   Note generator templates may change between minor or even patch Phoenix releases,
   so custom templates may require updates after upgrading. Use this mechanism at your
   own risk.
-```
   """
 
   def run(_args) do


### PR DESCRIPTION
I’ve been maintaining a Phoenix app since version 1.6. When we upgraded to Phoenix 1.7 to adopt LiveView, I often used the phx.gen.live generator. However, I always had to manually edit the generated files to match our internal style and UI structure, which became tedious over time. 

Recently, while exploring Phoenix 1.8 RC-1, I noticed changes in the generators, including the deprecation of the form_component, which I really liked for its more SPA-like behavior in earlier versions. 

While reading through some documentation, I stumbled upon a blog post explaining how to customize Phoenix generators. That was a eureka moment. I realized I could avoid all those repeated edits by overriding the templates once and letting the generator produce code that matches our conventions out of the box. 

This guide is the result of that experience. I thought this could be helpful to others in the community who also maintain apps across versions or follow custom UI patterns. 