### PR TITLE
amends input guidelines for AI Agents

### DIFF
--- a/installer/templates/phx_single/AGENTS.md
+++ b/installer/templates/phx_single/AGENTS.md
@@ -290,7 +290,8 @@ And **never** do this:
   - **Always** fix the `current_scope` error by moving your routes to the proper `live_session` and ensure you pass `current_scope` as needed
 - Phoenix v1.8 moved the `<.flash_group>` component to the `Layouts` module. You are **forbidden** from calling `<.flash_group>` outside of the `layouts.ex` module
 - Out of the box, `core_components.ex` imports an `<.icon name="hero-x-mark" class="w-5 h-5"/>` component for for hero icons. **Always** use the `<.icon>` component for icons, **never** use `Heroicons` modules or similar
-- **Always** use the imported `<.input>` component for form inputs from `core_components.ex` when available. `<.input>` is imported and using it will will save steps and prevent errors
+- Except for hidden inputs, **Always** use the imported `<.input>` component for form inputs from `core_components.ex` when available. `<.input>` is imported and using it will will save steps and prevent errors.
+Hidden inputs **must** use the standard html `<input>` tag.
 - If you override the default input classes (`<.input class="myclass px-2 py-1 rounded-lg">)`) class with your own values, no default classes are inherited, so your
 custom classes must fully style the input
 


### PR DESCRIPTION
phoenix does not support `<.input type="hidden">`.  as it is currently, in my experience the agents make <.input type="hidden"> which triggers a compiler warning.