### PR TITLE
don't include node_modules in tsconfig path mapping

### DIFF
--- a/installer/templates/phx_assets/tsconfig.json
+++ b/installer/templates/phx_assets/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "*": ["node_modules/*", "../deps/*"]
+      "*": ["../deps/*"]
     },
     "allowJs": true,
     "noEmit": true


### PR DESCRIPTION
Closes https://github.com/phoenixframework/phoenix/issues/6391.