### PR TITLE
Fix route.ex typo in scopes.md

### DIFF
--- a/guides/authn_authz/scopes.md
+++ b/guides/authn_authz/scopes.md
@@ -42,7 +42,7 @@ end
 The scope is automatically fetched by the `fetch_current_scope_for_user` plug that is injected into the `:browser` pipeline:
 
 ```elixir
-# route.ex
+# router.ex
 ...
 pipeline :browser do
   ...


### PR DESCRIPTION
Noticed a small typo in the Scopes docs where it refers to route.ex instead of router.ex.