### PR TITLE
Add note on compile time config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This release introduces deprecation warnings for several features that have been
 
 ## Potential breaking changes
 
-  * The `config` variable is no longer available in `Phoenix.Endpoint`. In the past, it was possible to read your endpoint configuration at compile-time via an injected variable named `config`, which is no longer supported. Use `Application.compile_env/3` instead, which is tracked by the Elixir compiler and lead to a better developer experience
+  * The `config` variable is no longer available in `Phoenix.Endpoint`. In the past, it was possible to read your endpoint configuration at compile-time via an injected variable named `config`, which is no longer supported. Use `Application.compile_env/3` instead, which is tracked by the Elixir compiler and lead to a better developer experience. This may also lead to errors on application boot if you were previously incorrectly setting compile time config at runtime.
 
 ## 1.8.0 (2025-08-05)
 


### PR DESCRIPTION
:wave: I ran into an issue with the upgrade process to 1.8.0 where an application that previously tried to set (incorrectly) `force_ssl: true` in `config/runtime.exs` would crash on boot, I am assuming this is related to the changes to the config where its now all marked as compile time which is highlighting the mistake, but it would be nice if the changelog tied this reference / warned you of this possibility.

I've suggested an additional sentence but obviously I'm happy for it to be tweaked as desired.