### PR TITLE
Class attribute type

### DIFF
--- a/guides/asset_management.md
+++ b/guides/asset_management.md
@@ -325,7 +325,7 @@ setting width, height, and background color classes.
     <.icon name="ri-github" class="ml-1 w-3 h-3 animate-spin" />
 """
 attr :name, :string, required: true
-attr :class, :string, default: "size-5"
+attr :class, :any, default: "size-5"
 
 def icon(%{name: "ri-" <> _} = assigns) do
   ~H"""

--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -90,7 +90,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <.button navigate={~p"/"}>Home</.button>
   """
   attr :rest, :global, include: ~w(href navigate patch method download name value disabled)
-  attr :class, :string
+  attr :class, :any
   attr :variant, :string, values: ~w(primary)
   slot :inner_block, required: true
 
@@ -161,8 +161,8 @@ defmodule <%= @web_namespace %>.CoreComponents do
   attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
-  attr :class, :string, default: nil, doc: "the input class to use over defaults"
-  attr :error_class, :string, default: nil, doc: "the input error class to use over defaults"
+  attr :class, :any, default: nil, doc: "the input class to use over defaults"
+  attr :error_class, :any, default: nil, doc: "the input error class to use over defaults"
 
   attr :rest, :global,
     include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
@@ -412,7 +412,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
       <.icon name="hero-arrow-path" class="ml-1 size-3 motion-safe:animate-spin" />
   """
   attr :name, :string, required: true
-  attr :class, :string, default: "size-4"
+  attr :class, :any, default: "size-4"
 
   def icon(%{name: "hero-" <> _} = assigns) do
     ~H"""


### PR DESCRIPTION
This pull request broadens the accepted type for the class attribute to better reflect its actual usage and improve component flexibility.

Currently, the type is too restrictive, which leads to unnecessary warnings for perfectly valid cases like:

```elixir
<.icon name="hero-x-mark" class={[@condition && "foo", "bar"]} />
```

The tag engine supports class values as:
- strings
- lists of strings, false, or nil
- nested lists of these values

By widening the type, we align the type spec with real behavior, eliminate false warnings, and allow more flexible component usage.