### PR TITLE
mix phx.gen.auth: add "Delete Account" button to  generated settings page

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -91,11 +91,15 @@ defmodule <%= @web_namespace %>.CoreComponents do
   """
   attr :rest, :global, include: ~w(href navigate patch method download name value disabled)
   attr :class, :string
-  attr :variant, :string, values: ~w(primary)
+  attr :variant, :string, values: ~w(primary error)
   slot :inner_block, required: true
 
   def button(%{rest: rest} = assigns) do
-    variants = %{"primary" => "btn-primary", nil => "btn-primary btn-soft"}
+    variants = %{
+      "primary" => "btn-primary",
+      "error" => "btn-error",
+      nil => "btn-primary btn-soft"
+    }
 
     assigns =
       assign_new(assigns, :class, fn ->

--- a/priv/templates/phx.gen.auth/context_functions.ex
+++ b/priv/templates/phx.gen.auth/context_functions.ex
@@ -273,6 +273,13 @@
     :ok
   end
 
+  @doc """
+  Deletes a <%= schema.singular %>.
+  """
+  def delete_<%= schema.singular %>(%<%= inspect schema.alias %>{} = <%= schema.singular %>) do
+    Repo.delete(<%= schema.singular %>)
+  end
+
   ## Token helper
 
   defp update_<%= schema.singular %>_and_delete_all_tokens(changeset) do

--- a/priv/templates/phx.gen.auth/settings_live.ex
+++ b/priv/templates/phx.gen.auth/settings_live.ex
@@ -62,6 +62,19 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           Save Password
         </.button>
       </.form>
+
+      <div class="divider" />
+
+      <div class="flex justify-center my-4">
+        <.button
+          phx-click="delete_<%= schema.singular %>"
+          data-confirm="Are you sure you want to delete your account?"
+          variant="error"
+          phx-disable-with="Deleting..."
+        >
+          Delete Account
+        </.button>
+      </div>
     </Layouts.app>
     """
   end
@@ -149,6 +162,24 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     case <%= inspect context.alias %>.change_<%= schema.singular %>_password(<%= schema.singular %>, <%= schema.singular %>_params) do
       %{valid?: true} = changeset ->
         {:noreply, assign(socket, trigger_submit: true, password_form: to_form(changeset))}
+
+      changeset ->
+        {:noreply, assign(socket, password_form: to_form(changeset, action: :insert))}
+    end
+  end
+
+  def handle_event("delete_<%= schema.singular %>", _params, socket) do
+    <%= schema.singular %> = socket.assigns.<%= scope_config.scope.assign_key %>.<%= schema.singular %>
+    true = <%= inspect context.alias %>.sudo_mode?(<%= schema.singular %>)
+
+    case <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>) do
+      {:ok, _<%= schema.singular %>} ->
+        socket =
+          socket
+          |> put_flash(:info, "Account deleted.")
+          |> push_navigate(to: ~p"/")
+
+        {:noreply, socket}
 
       changeset ->
         {:noreply, assign(socket, password_form: to_form(changeset, action: :insert))}

--- a/priv/templates/phx.gen.auth/settings_live_test.exs
+++ b/priv/templates/phx.gen.auth/settings_live_test.exs
@@ -209,4 +209,33 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       assert message == "You must log in to access this page."
     end
   end
+
+  describe "delete <%= schema.singular %>" do
+    setup %{conn: conn} do
+      <%= schema.singular %> = <%= schema.singular %>_fixture()
+      %{conn: log_in_<%= schema.singular %>(conn, <%= schema.singular %>), <%= schema.singular %>: <%= schema.singular %>}
+    end
+
+    test "deletes the <%= schema.singular %>", %{conn: conn, <%= schema.singular %>: <%= schema.singular %>} do
+      {:ok, lv, _html} = live(conn, ~p"<%= schema.route_prefix %>/settings")
+
+      lv
+      |> element("button", "Delete Account")
+      |> render_click()
+
+      assert_raise Ecto.NoResultsError, fn ->
+        <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.id)
+      end
+    end
+
+    test "redirect to root page once deleted", %{conn: conn} do
+      {:ok, lv, _html} = live(conn, ~p"<%= schema.route_prefix %>/settings")
+
+      lv
+      |> element("button", "Delete Account")
+      |> render_click()
+
+      assert_redirected(lv, ~p"/")
+    end
+  end
 end

--- a/priv/templates/phx.gen.auth/test_cases.exs
+++ b/priv/templates/phx.gen.auth/test_cases.exs
@@ -365,6 +365,12 @@
     end
   end
 
+  test "delete_<%= schema.singular %>/1" do
+    <%= schema.singular %> = <%= schema.singular %>_fixture()
+    assert {:ok, %<%= inspect schema.alias %>{}} = <%= inspect context.alias %>.delete_<%= schema.singular %>(<%= schema.singular %>)
+    assert_raise Ecto.NoResultsError, fn -> <%= inspect context.alias %>.get_<%= schema.singular %>!(<%= schema.singular %>.<%= schema.opts[:primary_key] || :id %>) end
+  end
+
   describe "deliver_login_instructions/2" do
     setup do
       %{<%= schema.singular %>: unconfirmed_<%= schema.singular %>_fixture()}


### PR DESCRIPTION
The Settings page generated with `mix phx.gen auth` creates a form to update a user's email and another to set a new password. I've been using the generator with a few new apps and I noticed that I had to implement delete account in each case. It _feels_ like this should come out of the box with the generator. Refer to the red "Delete Account" button in the screenshot below.

👋 Note: I've implemented it for the liveview auth flow. I'd be willing to add it to the static template/controller based flow too if the response to this PR is positive. 

## Screenshots

<img width="825" height="708" alt="Screenshot 2025-08-12 at 9 16 31" src="https://github.com/user-attachments/assets/0f63aef0-b7f9-4828-bfac-0ee6b36d496c" />

## Demo

https://github.com/user-attachments/assets/5fad1fb9-ccec-430e-800d-245d3d5bb703

## Local testing instructions

1. Pull phoenix project somewhere locally
2. create a new phoenix project
3. update the phoenix dependency (mix.exs) to point to the local copy of phoenix: 
```elixir
# relative path to the local copy of phoenix
{:phoenix, path: "../phoenix", override: true},
```
4. Run `mix phx.gen.auth Accounts User users`