### PR TITLE
Fix comments in installer config

### DIFF
--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -13,7 +13,7 @@ config :<%= @app_name %><%= if @namespaced? do %>,
   ecto_repos: [<%= @app_module %>.Repo]<% end %><%= if @generators do %>,
   generators: <%= inspect @generators %><% end %><% end %>
 
-# Configures the endpoint
+# Configure the endpoint
 config :<%= @app_name %>, <%= @endpoint_module %>,
   url: [host: "localhost"],
   adapter: <%= inspect @web_adapter_module %>,
@@ -24,7 +24,7 @@ config :<%= @app_name %>, <%= @endpoint_module %>,
   pubsub_server: <%= @app_module %>.PubSub,
   live_view: [signing_salt: "<%= @lv_signing_salt %>"]<%= if @mailer do %>
 
-# Configures the mailer
+# Configure the mailer
 #
 # By default it uses the "Local" adapter which stores the emails
 # locally. You can see the emails in your browser, at "/dev/mailbox".
@@ -54,7 +54,7 @@ config :tailwind,
     cd: Path.expand("..<%= if @in_umbrella, do: "/apps/#{@app_name}" %>", __DIR__),
   ]<% end %>
 
-# Configures Elixir's Logger
+# Configure Elixir's Logger
 config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]

--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -8,7 +8,7 @@ import Config
 # before starting your production server.
 config :<%= @web_app_name %>, <%= @endpoint_module %>, cache_static_manifest: "priv/static/cache_manifest.json"<% end %><%= if @mailer do %>
 
-# Configures Swoosh API Client
+# Configure Swoosh API Client
 config :swoosh, api_client: Swoosh.ApiClient.Req
 
 # Disable Swoosh Local Memory Storage

--- a/installer/templates/phx_umbrella/apps/app_name/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name/config/config.exs
@@ -6,7 +6,7 @@ config :<%= @app_name %><%= if @namespaced? do %>,
   namespace: <%= @app_module %><% end %><%= if @ecto do %>,
   ecto_repos: [<%= @app_module %>.Repo]<% end %><% end %><%= if @mailer do %>
 
-# Configures the mailer
+# Configure the mailer
 #
 # By default it uses the "Local" adapter which stores the emails
 # locally. You can see the emails in your browser, at "/dev/mailbox".

--- a/installer/templates/phx_umbrella/config/extra_config.exs
+++ b/installer/templates/phx_umbrella/config/extra_config.exs
@@ -1,6 +1,6 @@
 import Config
 
-# Configures Elixir's Logger
+# Configure Elixir's Logger
 config :logger, :default_formatter,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id]

--- a/installer/templates/phx_umbrella/config/prod.exs
+++ b/installer/templates/phx_umbrella/config/prod.exs
@@ -1,7 +1,7 @@
 import Config
 
 <%= if @mailer do %>
-# Configures Swoosh API Client
+# Configure Swoosh API Client
 config :swoosh, :api_client, Swoosh.ApiClient.Req
 
 # Disable Swoosh Local Memory Storage


### PR DESCRIPTION
The installer creates config files that mostly use the imperative mood but are oddly inconsistent:
`installer/templates/phx_single/config/config.exs`:
> \# **Configures** the mailer
> \# Configure esbuild (the version is required)
> \# Configure tailwind (the version is required)
> \# **Configures** Elixir's Logger

`installer/templates/phx_single/config/prod.exs`:
> \# **Configures** Swoosh API Client
> \# Disable Swoosh Local Memory Storage
> \# Do not print debug messages in production

`installer/templates/phx_single/config/dev.exs`:
> \# Watch static and templates
> \# Enable dev routes
> \# Do not include metadata
> \# Set a higher stacktrace
> \# Initialize plugs at runtime
> \# Disable swoosh api client

I suggest sticking to imperative mood for consistency