### PR TITLE
Update controllers documentation

### DIFF
--- a/guides/controllers.md
+++ b/guides/controllers.md
@@ -262,11 +262,14 @@ If we wanted to render an XML version of our `home` action, we might implement t
 def home(conn, _params) do
   conn
   |> put_resp_content_type("text/xml")
+  |> put_format(:xml)
   |> render(:home, content: some_xml_content)
 end
 ```
 
-We would then need to provide an `home.xml.eex` template which created valid XML, and we would be done.
+Then we would need to provide a `home.xml.eex` template that creates XML and a `PageXML` view that embeds the template, and that would be it.
+
+Note: The `home.xml.eex` template uses the `.eex` extension. `.eex` templates are rendered by [`EEx`](https://hexdocs.pm/eex/main/EEx.html).
 
 For a list of valid content mime-types, please see the `MIME` library.
 


### PR DESCRIPTION
The changes update the [Setting the Content Type](https://hexdocs.pm/phoenix/1.8.0/controllers.html#setting-the-content-type) section with the up-to-date way of setting the content type from within controllers

Additionally to `put_resp_content_type`, the changes add `put_format`. According to [`Phoenix.Controller.render`](https://github.com/phoenixframework/phoenix/blob/008d5ff9e61daddf5a8620b1c4ad22470d6137f8/lib/phoenix/controller.ex#L949) implementation, `put_format` is the only way to set the corresponding view from within controllers

The changes mention that aside from adding a template file, one should also add a `PageXML` view to embed the template

Also, the note at the bottom double-checks that one should use `.eex` instead of `heex` to render XML. Otherwise, the connection pipeline crashes with a rather cryptic error while trying to fit `Phoenix.LiveView.Rendered` in the `Plug.Conn.resp` which expects a binary

---

Please note that my changes might not align with the intended way of setting the content type from within Phoenix controllers. It might not be as easy as adding the `put_format` call. They just make the documentation example work, but in a possibly perverted way 😅
