### PR TITLE
Fix controller.ex documentation typo

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -937,7 +937,7 @@ defmodule Phoenix.Controller do
         def show(conn, _params) do
           conn
           |> put_view(html: MyAppWeb.UserHTML)
-          render(conn, "show.html", message: "Hello")
+          |> render("show.html", message: "Hello")
         end
       end
 


### PR DESCRIPTION
The changes fix the documentation example. The example doesn't pipe the updated `conn` to the `render` function.