### PR TITLE
Remove reference to OTP version affected by CVE-2025-32433

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -170,11 +170,11 @@ If you call `mix phx.gen.release --docker` you'll see a new file with these cont
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
 #   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20230612-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.15.8-erlang-25.3.2.15-debian-bookworm-20241016-slim
+#   - Ex: hexpm/elixir:1.15.8-erlang-25.3.2.21-debian-bookworm-20250428-slim
 #
 ARG ELIXIR_VERSION=1.15.8
-ARG OTP_VERSION=25.3.2.15
-ARG DEBIAN_VERSION=bookworm-20241016-slim
+ARG OTP_VERSION=25.3.2.21
+ARG DEBIAN_VERSION=bookworm-20250428-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
The example Dockerfile in the "Deploying with Releases" guide references OTP version 25.3.2.15, which is affected by
[CVE-2025-32433](https://github.com/erlang/otp/security/advisories/GHSA-37cp-fgq5-7wc2).

This is lower than the minimum recommended version of OTP-25.3.2.20.

This pull request changes the values in the example Docker to the use a newer patched version of the same major version of OTP, which references an existing image on Docker Hub.