### PR TITLE
Enable `:force_ssl` in `:prod` environment by default

### DIFF
--- a/installer/templates/phx_single/config/prod.exs
+++ b/installer/templates/phx_single/config/prod.exs
@@ -10,7 +10,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>, cache_static_manifest: "p
 
 <% end %># Force using SSL in production. This also sets the "strict-security-transport" header,
 # also known as HSTS. `:force_ssl` is required to be set at compile-time.
-config :<%= @web_app_name %>, <%= @endpoint_module %>, force_ssl: [rewrite_on: [:x_forwarded_proto], host: nil]<%= if @mailer do %>
+config :<%= @web_app_name %>, <%= @endpoint_module %>, force_ssl: [rewrite_on: [:x_forwarded_proto]]<%= if @mailer do %>
 
 # Configures Swoosh API Client
 config :swoosh, api_client: Swoosh.ApiClient.Req

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/prod.exs
@@ -11,4 +11,4 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 
 # Force using SSL in production. This also sets the "strict-security-transport" header,
 # also known as HSTS. `:force_ssl` is required to be set at compile-time.
-config :<%= @web_app_name %>, <%= @endpoint_module %>, force_ssl: [rewrite_on: [:x_forwarded_proto], host: nil]
+config :<%= @web_app_name %>, <%= @endpoint_module %>, force_ssl: [rewrite_on: [:x_forwarded_proto]]


### PR DESCRIPTION
This is a proposal to enable the `:force_ssl` option and HSTS by default on new installations.

HSTS is a standard nowadays, recommend for most, if not all, websites or webapps. However,
for I feel like it can be easy to miss if you are not really into web security - just like
CSP, so thanks for making it a default now ❤️

The given option may not be the best suited for a default installation. I basically
copy-pasted the "Using SSL" part of the documentation, making it as generic as possible.
