### PR TITLE
PR: Split the Generator Command from Output for Clarity Fixes #6441

### DIFF
--- a/guides/data_modelling/your_first_context.md
+++ b/guides/data_modelling/your_first_context.md
@@ -15,7 +15,10 @@ To jump-start our catalog context, we'll use `mix phx.gen.html` which creates a 
 ```console
 $ mix phx.gen.html Catalog Product products title:string \
 description:string price:decimal views:integer
+```
+After executing the command, you should expect to see output similar to the following:
 
+```console
 * creating lib/hello_web/controllers/product_controller.ex
 * creating lib/hello_web/controllers/product_html/edit.html.heex
 * creating lib/hello_web/controllers/product_html/index.html.heex


### PR DESCRIPTION
This PR splits the command from it's output in the docs to fix #6441 

Feel free to ignore if you prefer to keep it the way it is ... 👌 
I'm sure people can figure it out for themselves, just feels like a unpleasant experience IMO. 🙃 
