### PR TITLE
Update data modelling guide and ecto guide

### DIFF
--- a/guides/data_modelling/cross_context_boundaries.md
+++ b/guides/data_modelling/cross_context_boundaries.md
@@ -544,7 +544,7 @@ Head back over to your shopping cart context in `lib/hello/shopping_cart.ex` and
     |> Ecto.Multi.delete_all(:discarded_items, fn %{cart: cart} ->
       from(i in CartItem, where: i.cart_id == ^cart.id and i.quantity == 0)
     end)
-    |> Repo.transaction()
+    |> Repo.transact()
     |> case do
       {:ok, %{cart: cart}} ->
         broadcast(scope, {:updated, cart})
@@ -558,6 +558,6 @@ Head back over to your shopping cart context in `lib/hello/shopping_cart.ex` and
 
 We started much like how our out-of-the-box code started – we take the cart struct and cast the user input to a cart changeset, except this time we use `Ecto.Changeset.cast_assoc/3` to cast the nested item data into `CartItem` changesets. Remember the [`<.inputs_for />`](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#inputs_for/1) call in our cart form template? That hidden ID data is what allows Ecto's `cast_assoc` to map item data back to existing item associations in the cart. Next we use `Ecto.Multi.new/0`, which you may not have seen before. Ecto's `Multi` is a feature that allows lazily defining a chain of named operations to eventually execute inside a database transaction. Each operation in the multi chain receives the values from the previous steps and executes until a failed step is encountered. When an operation fails, the transaction is rolled back and an error is returned, otherwise the transaction is committed.
 
-For our multi operations, we start by issuing an update of our cart, which we named `:cart`. After the cart update is issued, we perform a multi `delete_all` operation, which takes the updated cart and applies our zero-quantity logic. We prune any items in the cart with zero quantity by returning an ecto query that finds all cart items for this cart with an empty quantity. Calling `Repo.transaction/1` with our multi will execute the operations in a new transaction and we return the success or failure result to the caller just like the original function.
+For our multi operations, we start by issuing an update of our cart, which we named `:cart`. After the cart update is issued, we perform a multi `delete_all` operation, which takes the updated cart and applies our zero-quantity logic. We prune any items in the cart with zero quantity by returning an ecto query that finds all cart items for this cart with an empty quantity. Calling `Repo.transact/2` with our multi will execute the operations in a new transaction and we return the success or failure result to the caller just like the original function.
 
 Let's head back to the browser and try it out. Add a few products to your cart, update the quantities, and watch the values changes along with the price calculations. Setting any quantity to 0 will also remove the item. You can also try logging out and registering a new user to see how the carts are scoped to the current user. Pretty neat!

--- a/guides/data_modelling/cross_context_boundaries.md
+++ b/guides/data_modelling/cross_context_boundaries.md
@@ -126,7 +126,7 @@ We generated a new resource inside our `ShoppingCart` named `CartItem`. This sch
 -     add :product_id, references(:products, on_delete: :nothing)
 +     add :product_id, references(:products, on_delete: :delete_all)
 
-      timestamps()
+      timestamps(type: :utc_datetime)
     end
 
 -   create index(:cart_items, [:cart_id])
@@ -172,7 +172,7 @@ Now that we know where our data dependencies exist, let's add our schema associa
 +   belongs_to :user, Hello.Accounts.User
 +   has_many :items, Hello.ShoppingCart.CartItem
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 ```
 
@@ -188,7 +188,7 @@ Now that our cart is associated to the items we place in it, let's set up the ca
 +   belongs_to :cart, Hello.ShoppingCart.Cart
 +   belongs_to :product, Hello.Catalog.Product
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @doc false
@@ -558,6 +558,6 @@ Head back over to your shopping cart context in `lib/hello/shopping_cart.ex` and
 
 We started much like how our out-of-the-box code started – we take the cart struct and cast the user input to a cart changeset, except this time we use `Ecto.Changeset.cast_assoc/3` to cast the nested item data into `CartItem` changesets. Remember the [`<.inputs_for />`](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#inputs_for/1) call in our cart form template? That hidden ID data is what allows Ecto's `cast_assoc` to map item data back to existing item associations in the cart. Next we use `Ecto.Multi.new/0`, which you may not have seen before. Ecto's `Multi` is a feature that allows lazily defining a chain of named operations to eventually execute inside a database transaction. Each operation in the multi chain receives the values from the previous steps and executes until a failed step is encountered. When an operation fails, the transaction is rolled back and an error is returned, otherwise the transaction is committed.
 
-For our multi operations, we start by issuing an update of our cart, which we named `:cart`. After the cart update is issued, we perform a multi `delete_all` operation, which takes the updated cart and applies our zero-quantity logic. We prune any items in the cart with zero quantity by returning an ecto query that finds all cart items for this cart with an empty quantity. Calling `Repo.transact/2` with our multi will execute the operations in a new transaction and we return the success or failure result to the caller just like the original function.
+For our multi operations, we start by issuing an update of our cart, which we named `:cart`. After the cart update is issued, we perform a multi `delete_all` operation, which takes the updated cart and applies our zero-quantity logic. We prune any items in the cart with zero quantity by returning an ecto query that finds all cart items for this cart with an empty quantity. Calling `Repo.transact/1` with our multi will execute the operations in a new transaction and we return the success or failure result to the caller just like the original function.
 
 Let's head back to the browser and try it out. Add a few products to your cart, update the quantities, and watch the values changes along with the price calculations. Setting any quantity to 0 will also remove the item. You can also try logging out and registering a new user to see how the carts are scoped to the current user. Pretty neat!

--- a/guides/data_modelling/in_context_relationships.md
+++ b/guides/data_modelling/in_context_relationships.md
@@ -114,7 +114,7 @@ Perfect. Before we integrate categories in the web layer, we need to let our con
 
 +   many_to_many :categories, Category, join_through: "product_categories", on_replace: :delete
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
 ```
@@ -128,7 +128,9 @@ With our schema associations set up, we can implement the selection of categorie
 
 - def get_product!(id), do: Repo.get!(Product, id)
 + def get_product!(id) do
-+   Product |> Repo.get!(id) |> Repo.preload(:categories)
++   Product
++   |> Repo.get!(id)
++   |> Repo.preload(:categories)
 + end
 
   def create_product(attrs) do

--- a/guides/data_modelling/more_examples.md
+++ b/guides/data_modelling/more_examples.md
@@ -222,7 +222,7 @@ From our requirements alone, we can start to see why a generic `create_order` fu
     |> Ecto.Multi.run(:prune_cart, fn _repo, _changes ->
       ShoppingCart.prune_cart_items(scope, cart)
     end)
-    |> Repo.transaction()
+    |> Repo.transact()
     |> case do
       {:ok, %{order: order}} ->
         broadcast(scope, {:created, order})

--- a/guides/data_modelling/more_examples.md
+++ b/guides/data_modelling/more_examples.md
@@ -34,7 +34,7 @@ We generated an `Orders` context. The order is automatically scoped to the curre
 +     add :total_price, :decimal, precision: 15, scale: 6, null: false
       add :user_id, references(:users, type: :id, on_delete: :delete_all)
 
-      timestamps()
+      timestamps(type: :utc_datetime)
     end
   end
 ```
@@ -73,7 +73,7 @@ We used the `phx.gen.context` command to generate the `LineItem` Ecto schema and
       add :order_id, references(:orders, on_delete: :nothing)
       add :product_id, references(:products, on_delete: :nothing)
 
-      timestamps()
+      timestamps(type: :utc_datetime)
     end
 
     create index(:order_line_items, [:order_id])
@@ -92,7 +92,7 @@ With our migration in place, let's wire up our orders and line items association
 +   has_many :line_items, Hello.Orders.LineItem
 +   has_many :products, through: [:line_items, :product]
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 ```
 
@@ -108,7 +108,7 @@ We used `has_many :line_items` to associate orders and line items, just like we'
 +   belongs_to :order, Hello.Orders.Order
 +   belongs_to :product, Hello.Catalog.Product
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 ```
 

--- a/guides/data_modelling/your_first_context.md
+++ b/guides/data_modelling/your_first_context.md
@@ -65,7 +65,7 @@ With the new route in place, Phoenix reminds us to update our repo by running `m
 -     add :views, :integer
 +     add :views, :integer, default: 0, null: false
 
-      timestamps()
+      timestamps(type: :utc_datetime)
     end
 ```
 
@@ -216,7 +216,7 @@ defmodule Hello.Catalog.Product do
     field :title, :string
     field :views, :integer
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @doc false

--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -85,7 +85,7 @@ defmodule Hello.Repo.Migrations.CreateUsers do
       add :bio, :string
       add :number_of_pets, :integer
 
-      timestamps()
+      timestamps(type: :utc_datetime)
     end
   end
 end
@@ -97,15 +97,15 @@ And here's what that translates to in the actual `users` table.
 $ psql
 hello_dev=# \d users
 Table "public.users"
-Column         |            Type             | Modifiers
----------------+-----------------------------+----------------------------------------------------
-id             | bigint                      | not null default nextval('users_id_seq'::regclass)
-name           | character varying(255)      |
-email          | character varying(255)      |
-bio            | character varying(255)      |
-number_of_pets | integer                     |
-inserted_at    | timestamp without time zone | not null
-updated_at     | timestamp without time zone | not null
+Column         |            Type                | Modifiers
+---------------+--------------------------------+----------------------------------------------------
+id             | bigint                         | not null default nextval('users_id_seq'::regclass)
+name           | character varying(255)         |
+email          | character varying(255)         |
+bio            | character varying(255)         |
+number_of_pets | integer                        |
+inserted_at    | timestamp(0) without time zone | not null 
+updated_at     | timestamp(0) without time zone | not null 
 Indexes:
 "users_pkey" PRIMARY KEY, btree (id)
 ```
@@ -162,7 +162,7 @@ defmodule Hello.User do
     field :name, :string
     field :number_of_pets, :integer
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
   @doc false
@@ -403,32 +403,32 @@ iex> alias Hello.{Repo, User}
 
 iex> Repo.insert(%User{email: "user1@example.com"})
 [debug] QUERY OK db=6.5ms queue=0.5ms idle=1358.3ms
-INSERT INTO "users" ("email","inserted_at","updated_at") VALUES ($1,$2,$3) RETURNING "id" ["user1@example.com", ~N[2021-02-25 01:58:55], ~N[2021-02-25 01:58:55]]
+INSERT INTO "users" ("email","inserted_at","updated_at") VALUES ($1,$2,$3) RETURNING "id" ["user1@example.com", ~U[2021-02-25 01:58:55Z], ~U[2021-02-25 01:58:55Z]]
 {:ok,
  %Hello.User{
    __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
    bio: nil,
    email: "user1@example.com",
    id: 1,
-   inserted_at: ~N[2021-02-25 01:58:55],
+   inserted_at: ~U[2021-02-25 01:58:55Z],
    name: nil,
    number_of_pets: nil,
-   updated_at: ~N[2021-02-25 01:58:55]
+   updated_at: ~U[2021-02-25 01:58:55Z]
  }}
 
 iex> Repo.insert(%User{email: "user2@example.com"})
 [debug] QUERY OK db=1.3ms idle=1402.7ms
-INSERT INTO "users" ("email","inserted_at","updated_at") VALUES ($1,$2,$3) RETURNING "id" ["user2@example.com", ~N[2021-02-25 02:03:28], ~N[2021-02-25 02:03:28]]
+INSERT INTO "users" ("email","inserted_at","updated_at") VALUES ($1,$2,$3) RETURNING "id" ["user2@example.com", ~U[2021-02-25 02:03:28Z], ~U[2021-02-25 02:03:28Z]]
 {:ok,
  %Hello.User{
    __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
    bio: nil,
    email: "user2@example.com",
    id: 2,
-   inserted_at: ~N[2021-02-25 02:03:28],
+   inserted_at: ~U[2021-02-25 02:03:28Z],
    name: nil,
    number_of_pets: nil,
-   updated_at: ~N[2021-02-25 02:03:28]
+   updated_at: ~U[2021-02-25 02:03:28Z]
  }}
 ```
 
@@ -448,20 +448,20 @@ SELECT u0."id", u0."bio", u0."email", u0."name", u0."number_of_pets", u0."insert
     bio: nil,
     email: "user1@example.com",
     id: 1,
-    inserted_at: ~N[2021-02-25 01:58:55],
+    inserted_at: ~U[2021-02-25 01:58:55Z],
     name: nil,
     number_of_pets: nil,
-    updated_at: ~N[2021-02-25 01:58:55]
+    updated_at: ~U[2021-02-25 01:58:55Z]
   },
   %Hello.User{
     __meta__: #Ecto.Schema.Metadata<:loaded, "users">,
     bio: nil,
     email: "user2@example.com",
     id: 2,
-    inserted_at: ~N[2021-02-25 02:03:28],
+    inserted_at: ~U[2021-02-25 02:03:28Z],
     name: nil,
     number_of_pets: nil,
-    updated_at: ~N[2021-02-25 02:03:28]
+    updated_at: ~U[2021-02-25 02:03:28Z]
   }
 ]
 ```
@@ -624,7 +624,8 @@ def change do
   create table(:comments) do
     add :body, :string
     add :word_count, :integer
-    timestamps()
+
+    timestamps(type: :utc_datetime)
   end
 end
 ...

--- a/guides/security.md
+++ b/guides/security.md
@@ -247,7 +247,7 @@ Related to the above concept, the design of Ecto in Phoenix takes the risk of ma
     field :confirmed_at, :naive_datetime
     field :is_admin, :boolean 
 
-    timestamps()
+    timestamps(type: :utc_datetime)
   end
 
 


### PR DESCRIPTION
This PR updates the data modeling guide to align with the current Phoenix generator default and replaces deprecated usage of `Repo.transaction/2`.

- replace `Repo.transaction/2` with `Repo.transact/2`
- update `timestamps()` to `timestamps(type: :utc_datetime)`