### PR TITLE
Update live reload patterns

### DIFF
--- a/installer/templates/phx_single/config/dev.exs
+++ b/installer/templates/phx_single/config/dev.exs
@@ -46,14 +46,18 @@ config :<%= @app_name %>, <%= @endpoint_module %>,<%= if @inside_docker_env? do 
 # configured to run both http and https servers on
 # different ports.<%= if @html do %>
 
-# Watch static and templates for browser reloading.
+# Reload browser tabs when matching files change.
 config :<%= @app_name %>, <%= @endpoint_module %>,
   live_reload: [
     web_console_logger: true,
     patterns: [
-      ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
-      ~r"priv/gettext/.*(po)$",<% end %>
-      ~r"lib/<%= @lib_web_name %>/(?:controllers|live|components|router)/?.*\.(ex|heex)$"
+      # Static assets, except user uploads
+      ~r"priv/static/(?!uploads/).*\.(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
+      # Gettext translations
+      ~r"priv/gettext/.*\.po$",<% end %>
+      # Router, Controllers, LiveViews and LiveComponents
+      ~r"lib/<%= @lib_web_name %>/router\.ex$",
+      ~r"lib/<%= @lib_web_name %>/(controllers|live|components)/.*\.(ex|heex)$"
     ]
   ]<% end %>
 

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs
@@ -46,14 +46,18 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,<%= if @inside_docker_env?
 # configured to run both http and https servers on
 # different ports.<%= if @html do %>
 
-# Watch static and templates for browser reloading.
+# Reload browser tabs when matching files change.
 config :<%= @web_app_name %>, <%= @endpoint_module %>,
   live_reload: [
     web_console_logger: true,
     patterns: [
-      ~r"priv/static/(?!uploads/).*(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
-      ~r"priv/gettext/.*(po)$",<% end %>
-      ~r"lib/<%= @web_app_name %>/(?:controllers|live|components|router)/?.*\.(ex|heex)$"
+      # Static assets, except user uploads
+      ~r"priv/static/(?!uploads/).*\.(js|css|png|jpeg|jpg|gif|svg)$",<%= if @gettext do %>
+      # Gettext translations
+      ~r"priv/gettext/.*\.po$",<% end %>
+      # Router, Controllers, LiveViews and LiveComponents
+      ~r"lib/<%= @web_app_name %>/router\.ex$",
+      ~r"lib/<%= @web_app_name %>/(controllers|live|components)/.*\.(ex|heex)$"
     ]
   ]<% end %>
 

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -31,6 +31,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       Mix.Tasks.Phx.New.run([@app_name])
 
       assert_file("phx_blog/README.md")
+
       assert_file("phx_blog/AGENTS.md", fn file ->
         assert file =~ "### UI/UX & design guidelines"
       end)
@@ -144,7 +145,8 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file("phx_blog/config/dev.exs", fn file ->
         assert file =~ "esbuild: {Esbuild,"
-        assert file =~ "lib/phx_blog_web/(?:controllers|live|components|router)/?.*\\.(ex|heex)$"
+        assert file =~ "lib/phx_blog_web/router\\.ex$"
+        assert file =~ "lib/phx_blog_web/(controllers|live|components)/.*\\.(ex|heex)$"
         assert file =~ "http: [ip: {127, 0, 0, 1}"
       end)
 

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -72,7 +72,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file(root_path(@app, "config/dev.exs"), fn file ->
         assert file =~ ~r[esbuild: {Esbuild]
-        assert file =~ "lib/#{@app}_web/(?:controllers|live|components|router)/?.*\\.(ex|heex)$"
+        assert file =~ "lib/#{@app}_web/router\\.ex$"
+        assert file =~ "lib/#{@app}_web/(controllers|live|components)/.*\\.(ex|heex)$"
         assert file =~ "config :#{@app}_web, dev_routes: true"
       end)
 
@@ -734,7 +735,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
   test "umbrella with --no-agents-md" do
     in_tmp("umbrella with no agents md", fn ->
       Mix.Tasks.Phx.New.run([@app, "--umbrella", "--no-agents-md"])
-      
+
       refute_file(root_path(@app, "AGENTS.md"))
     end)
   end


### PR DESCRIPTION
- For consistency, update regex patterns to match expected file extensions.
- Match on `router.ex`, but not `router/foo.ex`, nor `live.ex` etc.
- Inspired by changes introduced in https://github.com/phoenixframework/phoenix/commit/6910ef85033be666ab2f17aa801b8d88062a60f0 (Phoenix v1.8.0-rc.2).