### PR TITLE
Update contrib guide on how to generate docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To create projects outside of the `installer/` directory, add the latest archive
 To build the documentation:
 
 ```bash
-npm install --prefix assets
+npm install
 MIX_ENV=docs mix docs
 ```
 


### PR DESCRIPTION
The `assets/package.json` has been removed in https://github.com/phoenixframework/phoenix/commit/484245cbaba8eeb83197af4b6696d1b752f8a8b2 (https://github.com/phoenixframework/phoenix/pull/6044) in favor of a single `package.json` in the project root.

I noticed this while trying to understand the changes between v1.7.21 and v1.8.1, in particular investigating why https://github.com/phoenixframework/phoenix/pull/6321 was needed.