### PR TITLE
Update Tailwind to version 4.1.12 to prevent some unpredictable behaviors in utility classes.

### DIFF
--- a/installer/templates/phx_single/config/config.exs
+++ b/installer/templates/phx_single/config/config.exs
@@ -45,7 +45,7 @@ config :esbuild,
 
 # Configure tailwind (the version is required)
 config :tailwind,
-  version: "4.1.7",
+  version: "4.1.12",
   <%= @app_name %>: [
     args: ~w(
       --input=assets/css/app.css

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs
@@ -29,7 +29,7 @@ config :esbuild,
 
 # Configure tailwind (the version is required)
 config :tailwind,
-  version: "4.1.7",
+  version: "4.1.12",
   <%= @web_app_name %>: [
     args: ~w(
       --input=assets/css/app.css

--- a/integration_test/config/config.exs
+++ b/integration_test/config/config.exs
@@ -4,6 +4,6 @@ config :phoenix, :json_library, Jason
 
 config :swoosh, api_client: false
 
-config :tailwind, :version, "4.1.7"
+config :tailwind, :version, "4.1.12"
 
 config :phoenix_live_view, enable_expensive_runtime_checks: true


### PR DESCRIPTION
In Tailwind 4.1.7 when you use some class like `space-y-10` , you can see in your browser it is created like

```css
.space-y-10 {}
```

![photo_2025-09-01 12 55 20](https://github.com/user-attachments/assets/c3aecd84-9eb2-4be4-9ac6-46f41da74d08)


After updating to last version it is fixed!

> I tested it in Phoenix 1.8.1 with `mix phx.new ...` in the last version of windows and mac os; I should be noted I did not test the Phoenix source directly