### PR TITLE
Re-add support for hidden inputs

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -151,7 +151,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   attr :type, :string,
     default: "text",
     values: ~w(checkbox color date datetime-local email file month number password
-               search select tel text textarea time url week)
+               search select tel text textarea time url week hidden)
 
   attr :field, Phoenix.HTML.FormField,
     doc: "a form field struct retrieved from the form, for example: @form[:email]"
@@ -177,6 +177,12 @@ defmodule <%= @web_namespace %>.CoreComponents do
     |> assign_new(:name, fn -> if assigns.multiple, do: field.name <> "[]", else: field.name end)
     |> assign_new(:value, fn -> field.value end)
     |> input()
+  end
+
+  def input(%{type: "hidden"} = assigns) do
+    ~H"""
+    <input type="hidden" id={@id} name={@name} value={@value} {@rest} />
+    """
   end
 
   def input(%{type: "checkbox"} = assigns) do


### PR DESCRIPTION
Removed in https://github.com/phoenixframework/phoenix/commit/712ad7ede061b4716d6b17fc3b6bb7e4858d5ebe, but it is useful not having to write `@field[:name].value` etc. and AI also makes mistakes there.

Closes https://github.com/phoenixframework/phoenix/pull/6389.