### PR TITLE
[phx gen.auth] test on page content not page nav content

### DIFF
--- a/priv/templates/phx.gen.auth/confirmation_live_test.exs
+++ b/priv/templates/phx.gen.auth/confirmation_live_test.exs
@@ -32,6 +32,19 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       assert html =~ "Keep me logged in on this device"
     end
 
+    test "renders login page for already logged in <%= schema.singular %>", %{conn: conn, confirmed_<%= schema.singular %>: <%= schema.singular %>} do
+      conn = log_in_<%= schema.singular %>(conn, <%= schema.singular %>)
+
+      token =
+        extract_<%= schema.singular %>_token(fn url ->
+          <%= inspect context.alias %>.deliver_login_instructions(<%= schema.singular %>, url)
+        end)
+
+      {:ok, _lv, html} = live(conn, ~p"<%= schema.route_prefix %>/log-in/#{token}")
+      refute html =~ "Confirm my account"
+      assert html =~ "Log in"
+    end
+
     test "confirms the given token once", %{conn: conn, unconfirmed_<%= schema.singular %>: <%= schema.singular %>} do
       token =
         extract_<%= schema.singular %>_token(fn url ->


### PR DESCRIPTION
This test currently asserts on the "Log in" text rendered in the root layout's default navigation.

IMHO this should assert on actual page content instead of nav bar content.

Maybe it was meant to assert on this "Log in":
https://github.com/phoenixframework/phoenix/blob/db21e45e558f5bb8774e552f9afcae147cae680b/priv/templates/phx.gen.auth/confirmation_live.ex#L50

But that would require the user to be already logged in, not just to be confirmed and would require a different test that I tried to implement.
However the problem with that test is that the assertion is also satisfied by the nav bar content.
