### PR TITLE
Fix missing () in error message's suggestion

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -706,7 +706,7 @@ defmodule Phoenix.Channel do
 
         def join(topic, auth_msg, socket) do
           ...
-          send(self, :after_join)
+          send(self(), :after_join)
           {:ok, socket}
         end
 


### PR DESCRIPTION
A minor typo: `send(self, :after_join)` -> `send(self(), :after_join)`