### PR TITLE
Update checkbox input

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -188,7 +188,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
     ~H"""
     <div class="fieldset mb-2">
       <label>
-        <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} />
+        <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} form={@rest[:form]} />
         <span class="label">
           <input
             type="checkbox"


### PR DESCRIPTION
The use case is to support checkboxes outside the <.form /> element. One needs the `form` attribute on the shadow input. Otherwise, you end up with inconsistent behavior.

```elixir
<.input type="checkbox" form={@form.id} field={@form[:active]} />
<.form for={@form} id={@form.id}></.form>
```

We've been using this in production for a few months without issue. I'm happy to make adjustments if there are concerns about passing all of `rest` to that input.

