### PR TITLE
Generate passing live tests when schema and table names are equal

### DIFF
--- a/priv/templates/phx.gen.live/index.ex
+++ b/priv/templates/phx.gen.live/index.ex
@@ -50,7 +50,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     {:ok,
      socket
      |> assign(:page_title, "Listing <%= schema.human_plural %>")<%= if primary_key != :id do %>
-     |> stream_configure(:<%= schema.collection %>, dom_id: &"<%= schema.table %>-#{&1.<%= primary_key %>}")<% end %>
+     |> stream_configure(:<%= schema.collection %>, dom_id: &"<%= schema.collection %>-#{&1.<%= primary_key %>}")<% end %>
      |> stream(:<%= schema.collection %>, list_<%= schema.plural %>(<%= socket_scope %>))}
   end
 

--- a/priv/templates/phx.gen.live/live_test.exs
+++ b/priv/templates/phx.gen.live/live_test.exs
@@ -60,7 +60,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
 
       assert {:ok, form_live, _html} =
                index_live
-               |> element("#<%= schema.plural %>-#{<%= schema.singular %>.<%= primary_key %>} a", "Edit")
+               |> element("#<%= schema.collection %>-#{<%= schema.singular %>.<%= primary_key %>} a", "Edit")
                |> render_click()
                |> follow_redirect(conn, ~p"<%= scope_param_route_prefix %><%= schema.route_prefix %>/#{<%= schema.singular %>}/edit")
 
@@ -84,7 +84,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
     test "deletes <%= schema.singular %> in listing", %{conn: conn, <%= schema.singular %>: <%= schema.singular %><%= test_context_scope %>} do
       {:ok, index_live, _html} = live(conn, ~p"<%= scope_param_route_prefix %><%= schema.route_prefix %>")
 
-      assert index_live |> element("#<%= schema.plural %>-#{<%= schema.singular %>.<%= primary_key %>} a", "Delete") |> render_click()
+      assert index_live |> element("#<%= schema.collection %>-#{<%= schema.singular %>.<%= primary_key %>} a", "Delete") |> render_click()
       refute has_element?(index_live, "#<%= schema.plural %>-#{<%= schema.singular %>.<%= primary_key %>}")
     end
   end


### PR DESCRIPTION
Generate passing live tests when schema and table names are equal

When the live generator is used with a schema name that is the same as
the table name, the generated tests should not fail.

This change makes sure that the generated tests correctly target the
collection item elements by using `schema.collection` instead of
`schema.table`.

The following generator calling variations should therefore work as
intended:

- same names, default pk name: `mix phx.gen.live Books Series series name:string`
- different names, default pk name: `mix phx.gen.live Books Author authors name:string`
- same names, custom pk name: `mix phx.gen.live Books Covers covers --primary-key covers_id front:text back:text`
- different names, custom pk name: `mix phx.gen.live Books Reviewer reviewers --primary-key reviewer_id name:string`

For context, before this change, calling the generator with the same
word for schema name and table name (e.g. `mix phx.gen.live Books Series
series name:string`) resulted in failing tests with errors like:

```
  1) test Index updates series in listing (ExampleWeb.SeriesLiveTest)
     test/example_web/live/series_live_test.exs:52
     ** (ArgumentError) selector "#series_collection-c9129c62-f6b4-4749-854d-6d56f6a3b4b2 a" did not return any element within:

     <div id="phx-GGSpIya1xsOZigmM" data-phx-main="" data-phx-session="SFMyNTY.g2gDaAJhBnQAAAAIdwJpZG0AAAAUcGh4LUdHU3BJeWExeHNPWmlnbU13B3Nlc3Npb250AAAAAHcKcGFyZW50X3BpZHcDbmlsdwZ...
  ...
```

Reason being, that the stream used to generate the listing was named
after the `schema.collection` which was in this case suffixed with
`_collection` while the tests used the `schema.plural` value.

For reference see:
- <https://github.com/phoenixframework/phoenix/blob/v1.8.1/lib/mix/phoenix/schema.ex#L102>
- <https://github.com/phoenixframework/phoenix/blob/v1.8.1/priv/templates/phx.gen.live/index.ex#L54>
