### PR TITLE
Change the socket default for longpoll back to false

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -730,7 +730,7 @@ defmodule Phoenix.Endpoint do
 
     longpoll =
       opts
-      |> Keyword.get(:longpoll, true)
+      |> Keyword.get(:longpoll, false)
       |> maybe_validate_keys(
         common_config ++
           [


### PR DESCRIPTION
The default for `longpoll` was changed to `true` for no apparent reason by this PR https://github.com/phoenixframework/phoenix/pull/6072 about 7 months ago.

This can and has caused issues for us after updating Phoenix as we didn't expect `longpoll` to become enabled. 
The default was `false` before since forever and still is in `Phoenix.Socket`, and is documented as such in the `Phoenix.Endpoint` docs.

The specific issue we ran into was that our sockets websocket was configured with session options while longpoll was not configured at all since it was not enabled previously. Every time the connection would fall back to longpoll it would fail to connect due to missing the session information. This would only happen from time to time so was an elusive issue track down.

```
socket "/live", Phoenix.LiveView.Socket,
    websocket: [connect_info: [session: @session_options]]
```

I would propose changing the default back to `false` as I think that is the expected behavior, unless there is a strong reason not to.