### PR TITLE
Raise when a reference conflicts with the scope on schema generation

### DIFF
--- a/lib/mix/phoenix/schema.ex
+++ b/lib/mix/phoenix/schema.ex
@@ -470,7 +470,7 @@ defmodule Mix.Phoenix.Schema do
 
     assocs =
       Enum.map(assocs, fn {key_id, {:references, source}} ->
-        validate_scope_and_reference_conflict!(scope, source)
+        validate_scope_and_reference_conflict!(scope, key_id)
 
         key = String.replace(Atom.to_string(key_id), "_id", "")
         base = schema_module |> Module.split() |> Enum.drop(-1)
@@ -482,11 +482,11 @@ defmodule Mix.Phoenix.Schema do
   end
 
   defp validate_scope_and_reference_conflict!(
-         %Mix.Phoenix.Scope{schema_table: table_name},
-         table_name
+         %Mix.Phoenix.Scope{schema_key: reference_key},
+         reference_key
        ) do
     Mix.raise("""
-    A reference conflicts with the scope, either not pass it or pass it with the --no-scope flag.
+    Reference #{inspect(reference_key)} has the same name as the scope schema key, either skip the reference or pass it with the --no-scope flag.
     """)
   end
 

--- a/lib/mix/phoenix/schema.ex
+++ b/lib/mix/phoenix/schema.ex
@@ -85,7 +85,7 @@ defmodule Mix.Phoenix.Schema do
     table = opts[:table] || schema_plural
     scope = Mix.Phoenix.Scope.scope_from_opts(ctx_app, opts[:scope], opts[:no_scope])
     {cli_attrs, uniques, redacts} = extract_attr_flags(cli_attrs)
-    {assocs, attrs} = partition_attrs_and_assocs(module, attrs(cli_attrs))
+    {assocs, attrs} = partition_attrs_and_assocs(module, attrs(cli_attrs), scope)
     types = types(attrs)
     web_namespace = opts[:web] && Phoenix.Naming.camelize(opts[:web])
     web_path = web_namespace && Phoenix.Naming.underscore(web_namespace)
@@ -450,7 +450,7 @@ defmodule Mix.Phoenix.Schema do
     )
   end
 
-  defp partition_attrs_and_assocs(schema_module, attrs) do
+  defp partition_attrs_and_assocs(schema_module, attrs, scope) do
     {assocs, attrs} =
       Enum.split_with(attrs, fn
         {_, {:references, _}} ->
@@ -470,6 +470,8 @@ defmodule Mix.Phoenix.Schema do
 
     assocs =
       Enum.map(assocs, fn {key_id, {:references, source}} ->
+        validate_scope_and_reference_conflict!(scope, source)
+
         key = String.replace(Atom.to_string(key_id), "_id", "")
         base = schema_module |> Module.split() |> Enum.drop(-1)
         module = Module.concat(base ++ [Phoenix.Naming.camelize(key)])
@@ -478,6 +480,17 @@ defmodule Mix.Phoenix.Schema do
 
     {assocs, attrs}
   end
+
+  defp validate_scope_and_reference_conflict!(
+         %Mix.Phoenix.Scope{schema_table: table_name},
+         table_name
+       ) do
+    Mix.raise("""
+    A reference conflicts with the scope, either not pass it or pass it with the --no-scope flag.
+    """)
+  end
+
+  defp validate_scope_and_reference_conflict!(_scope, _source), do: :ok
 
   defp schema_defaults(attrs) do
     Enum.into(attrs, %{}, fn

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -594,7 +594,7 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
         ],
         fn ->
           assert_raise Mix.Error,
-                       ~r"A reference conflicts with the scope, either not pass it or pass it with the --no-scope flag.",
+                       ~r"Reference :user_id has the same name as the scope schema key, either skip the reference or pass it with the --no-scope flag.",
                        fn ->
                          Gen.Context.run(
                            ~w(Blog Post posts title:string user_id:references:users)

--- a/test/mix/tasks/phx.gen.context_test.exs
+++ b/test/mix/tasks/phx.gen.context_test.exs
@@ -576,4 +576,32 @@ defmodule Mix.Tasks.Phx.Gen.ContextTest do
       )
     end)
   end
+
+  test "raises when a reference conflicts with the scope", config do
+    in_tmp_project(config.test, fn ->
+      with_scope_env(
+        :phoenix,
+        [
+          user: [
+            default: true,
+            module: MyApp.Accounts.Scope,
+            assign_key: :current_scope,
+            access_path: [:user, :id],
+            schema_key: :user_id,
+            schema_type: :binary_id,
+            schema_table: :users
+          ]
+        ],
+        fn ->
+          assert_raise Mix.Error,
+                       ~r"A reference conflicts with the scope, either not pass it or pass it with the --no-scope flag.",
+                       fn ->
+                         Gen.Context.run(
+                           ~w(Blog Post posts title:string user_id:references:users)
+                         )
+                       end
+        end
+      )
+    end)
+  end
 end

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -681,7 +681,7 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
         ],
         fn ->
           assert_raise Mix.Error,
-                       ~r"A reference conflicts with the scope, either not pass it or pass it with the --no-scope flag.",
+                       ~r"Reference :user_id has the same name as the scope schema key, either skip the reference or pass it with the --no-scope flag.",
                        fn ->
                          Gen.Schema.run(
                            ~w(Blog.Post blog_posts title:string user_id:references:users)

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -663,4 +663,32 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
       end
     )
   end
+
+  test "raises when a reference conflicts with the scope", config do
+    in_tmp_project(config.test, fn ->
+      with_scope_env(
+        :phoenix,
+        [
+          user: [
+            default: true,
+            module: MyApp.Accounts.Scope,
+            assign_key: :current_scope,
+            access_path: [:user, :id],
+            schema_key: :user_id,
+            schema_type: :id,
+            schema_table: :users
+          ]
+        ],
+        fn ->
+          assert_raise Mix.Error,
+                       ~r"A reference conflicts with the scope, either not pass it or pass it with the --no-scope flag.",
+                       fn ->
+                         Gen.Schema.run(
+                           ~w(Blog.Post blog_posts title:string user_id:references:users)
+                         )
+                       end
+        end
+      )
+    end)
+  end
 end


### PR DESCRIPTION
This PR resolves #6377 

## Problem

When you have a scope and you try to generate a schema (or context), the field will be duplicated.

```
mix phx.gen.context Blog Post posts title:string user_id:references:users
```

The generated schema will look like:
```
defmodule MyApp.Blog.Post do
  use Ecto.Schema
  import Ecto.Changeset

  @primary_key {:id, :binary_id, autogenerate: true}
  @foreign_key_type :binary_id
  schema "posts" do
    field :title, :string
    field :user_id, :binary_id
    field :user_id, :binary_id

    ...
  end

  ...
end
```

## What this PR does

As @josevalim suggested on the issue #6377, the generation will raise when there's conflict between the scope and the reference.

## Notes

I'm not sure if the error message I'm displaying is meaningful enough. Please let me know if you have suggestions. :)