### PR TITLE
Enable raise_on_missing_only in development

### DIFF
--- a/installer/templates/phx_web/endpoint.ex
+++ b/installer/templates/phx_web/endpoint.ex
@@ -24,7 +24,8 @@ defmodule <%= @endpoint_module %> do
     at: "/",
     from: :<%= @web_app_name %>,
     gzip: not code_reloading?,
-    only: <%= @web_namespace %>.static_paths()
+    only: <%= @web_namespace %>.static_paths(),
+    raise_on_missing_only: code_reloading?
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.


### PR DESCRIPTION
Configure Plug.Static with raise_on_missing_only: code_reloading?() to help developers catch missing entries in static_paths() during development. This prevents the common trap where files like favicon.svg return 404 because they aren't properly declared in the :only list (often because they digested paths).

Part of the fix for: https://github.com/phoenixframework/phoenix/issues/6203

Requires: https://github.com/elixir-plug/plug/pull/1286