### PR TITLE
fix: autocomplete with email instead of username in email fields

### DIFF
--- a/priv/templates/phx.gen.auth/login_live.ex
+++ b/priv/templates/phx.gen.auth/login_live.ex
@@ -47,7 +47,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
             field={f[:email]}
             type="email"
             label="Email"
-            autocomplete="username"
+            autocomplete="email"
             required
             phx-mounted={JS.focus()}
           />
@@ -71,7 +71,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
             field={f[:email]}
             type="email"
             label="Email"
-            autocomplete="username"
+            autocomplete="email"
             required
           />
           <.input

--- a/priv/templates/phx.gen.auth/registration_new.html.heex
+++ b/priv/templates/phx.gen.auth/registration_new.html.heex
@@ -18,7 +18,7 @@
         field={f[:email]}
         type="email"
         label="Email"
-        autocomplete="username"
+        autocomplete="email"
         required
         phx-mounted={JS.focus()}
       />

--- a/priv/templates/phx.gen.auth/session_new.html.heex
+++ b/priv/templates/phx.gen.auth/session_new.html.heex
@@ -33,7 +33,7 @@
         field={f[:email]}
         type="email"
         label="Email"
-        autocomplete="username"
+        autocomplete="email"
         required
         phx-mounted={JS.focus()}
       />
@@ -50,7 +50,7 @@
         field={f[:email]}
         type="email"
         label="Email"
-        autocomplete="username"
+        autocomplete="email"
         required
       />
       <.input

--- a/priv/templates/phx.gen.auth/settings_edit.html.heex
+++ b/priv/templates/phx.gen.auth/settings_edit.html.heex
@@ -9,7 +9,7 @@
   <.form :let={f} for={@email_changeset} action={~p"<%= schema.route_prefix %>/settings"} id="update_email">
     <input type="hidden" name="action" value="update_email" />
 
-    <.input field={f[:email]} type="email" label="Email" autocomplete="username" required />
+    <.input field={f[:email]} type="email" label="Email" autocomplete="email" required />
 
     <.button variant="primary" phx-disable-with="Changing...">Change Email</.button>
   </.form>


### PR DESCRIPTION
Hi

When starting a new project and running `mix phx.gen.auth`, all the email fields in the forms from the generated code contain `autocomplete="username"` instead of `autocomplete="email"`.

This is just a small annoyance in the UI side rather than a bug. The functionality is not affected at all but the users are shown possible usernames instead of the expected emails when filling the forms.