### PR TITLE
Fix precommit task to use correct --warnings-as-errors flag

### DIFF
--- a/installer/templates/phx_single/mix.exs
+++ b/installer/templates/phx_single/mix.exs
@@ -90,7 +90,7 @@ defmodule <%= @app_module %>.MixProject do
       "assets.deploy": [
 <%= Enum.map(@asset_builders, &"        \"#{&1} #{@app_name} --minify\",\n") ++ ["        \"phx.digest\""] %>
       ]<% end %>,
-      precommit: ["compile --warning-as-errors", "deps.unlock --unused", "format", "test"]
+      precommit: ["compile --warnings-as-errors", "deps.unlock --unused", "format", "test"]
     ]
   end
 end

--- a/installer/templates/phx_umbrella/mix.exs
+++ b/installer/templates/phx_umbrella/mix.exs
@@ -52,7 +52,7 @@ defmodule <%= @root_app_module %>.MixProject do
     [
       # run `mix setup` in all child apps
       setup: ["cmd mix setup"],
-      precommit: ["compile --warning-as-errors", "deps.unlock --unused", "format", "test"]
+      precommit: ["compile --warnings-as-errors", "deps.unlock --unused", "format", "test"]
     ]
   end
 end


### PR DESCRIPTION
Corrects `mix compile` flag in precommit task from `--warning-as-errors` to `--warnings-as-errors`