### PR TITLE
Add `Phoenix.Controller.assign/2` to match LiveView API

### DIFF
--- a/lib/phoenix/controller.ex
+++ b/lib/phoenix/controller.ex
@@ -1889,6 +1889,20 @@ defmodule Phoenix.Controller do
     Phoenix.VerifiedRoutes.unverified_url(conn, current_path(conn, params))
   end
 
+  @doc """
+  Assigns multiple key-value pairs to the connection.
+
+  This function accepts a map or keyword list of assigns and merges them into
+  the connection's assigns. It is equivalent to calling `Plug.Conn.assign/3`
+  multiple times.
+
+  ## Examples
+
+      assign(conn, name: "Alice", role: :admin)
+      assign(conn, %{name: "Alice", role: :admin})
+  """
+  defdelegate assign(conn, assigns), to: Plug.Conn, as: :merge_assigns
+
   @doc false
   def __plugs__(controller_module, opts) do
     if Keyword.get(opts, :put_default_views, true) do


### PR DESCRIPTION
Adds `assign/2` to Phoenix.Controller for consistency with the LiveView API.
This delegates to `Plug.Conn.merge_assigns/2` and provides a familiar interface
for developers moving between controllers and LiveViews.

Before:

```
conn
|> assign(:name, "Alice")
|> assign(:role, :admin)
```

After:
```
assign(conn, name: "Alice", role: :admin)
```

This mirrors the `assign/2` function available in LiveView, making the assign
API consistent across both controller and LiveView contexts