### PR TITLE
feat(core_components): add a flash duration

### DIFF
--- a/installer/templates/phx_web/components/layouts.ex
+++ b/installer/templates/phx_web/components/layouts.ex
@@ -80,17 +80,19 @@ defmodule <%= @web_namespace %>.Layouts do
       <.flash_group flash={@flash} />
   """
   attr :flash, :map, required: true, doc: "the map of flash messages"
-  attr :id, :string, default: "flash-group", doc: "the optional id of flash container"
+  attr :id, :string, default: "flash-group", doc: "the optional id of flash container"<%= if @live and @javascript do %>
+  attr :duration, :integer, default: 5000, doc: "the duration in ms that the flash message stays on screen. set to zero to keep on screen"<% end %>
 
   def flash_group(assigns) do
     ~H"""
     <div id={@id} aria-live="polite">
-      <.flash kind={:info} flash={@flash} />
-      <.flash kind={:error} flash={@flash} /><%= if @live and @javascript do %>
+      <.flash kind={:info} flash={@flash}<%= if @live and @javascript do %> duration={@duration}<% end %> />
+      <.flash kind={:error} flash={@flash}<%= if @live and @javascript do %> duration={@duration}<% end %> /><%= if @live and @javascript do %>
 
       <.flash
         id="client-error"
-        kind={:error}
+        kind={:error}<%= if @live and @javascript do %>
+        duration={0}<% end %>
         title=<%= maybe_heex_attr_gettext.("We can't find the internet", @gettext) %>
         phx-disconnected={show(".phx-client-error #client-error") |> JS.remove_attribute("hidden")}
         phx-connected={hide("#client-error") |> JS.set_attribute({"hidden", ""})}
@@ -102,7 +104,8 @@ defmodule <%= @web_namespace %>.Layouts do
 
       <.flash
         id="server-error"
-        kind={:error}
+        kind={:error}<%= if @live and @javascript do %>
+        duration={0}<% end %>
         title=<%= maybe_heex_attr_gettext.("Something went wrong!", @gettext) %>
         phx-disconnected={show(".phx-server-error #server-error") |> JS.remove_attribute("hidden")}
         phx-connected={hide("#server-error") |> JS.set_attribute({"hidden", ""})}


### PR DESCRIPTION
- Upgraded the flash component to include a duration attribute to allow it to disappear automatically
  - Only applicable to liveviews with javascript
  - Defaults to 5 seconds
  - Allows flash messages to automatically disappear without the user needing to manually close
  - Supports hovering to pause
  - Provides a scaffolded example of a Colocated hook
- Updated the flash_group component to incorporate the duration attribute
  - The client and server error messages do not participate by setting duration to 0 since they already disappear automatically