### PR TITLE
Accept function in `Phoenix.Socket.assign/2`

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -345,13 +345,18 @@ defmodule Phoenix.Socket do
 
   @doc """
   Adds key/value pairs to socket assigns.
+  Accepts a keyword list, a map, or a single-argument function.
 
-  A keyword list or a map of assigns must be given as argument to be merged into existing assigns.
+  When a keyword list or map is provided, it will be merged into the existing assigns.
+
+  If a function is given, it takes the current assigns as an argument and its return
+  value will be merged into the current assigns.
 
   ## Examples
 
       iex> assign(socket, name: "Elixir", logo: "💧")
       iex> assign(socket, %{name: "Elixir"})
+      iex> assign(socket, fn %{name: name, logo: logo} -> %{title: Enum.join([name, logo], " | ")} end)
 
   """
   def assign(%Socket{} = socket, keyword_or_map)
@@ -359,17 +364,8 @@ defmodule Phoenix.Socket do
     %{socket | assigns: Map.merge(socket.assigns, Map.new(keyword_or_map))}
   end
 
-  @doc """
-  Evaluates `fun` and puts the result under `key` in socket assigns.
-
-  The function receives the current assigns.
-
-  ## Examples
-
-      iex> socket |> assign(:name, "Elixir") |> assign_lazy(:label, fn %{name: name} -> "Label: \#{name}" end)
-  """
-  def assign_lazy(%Socket{} = socket, key, fun) when is_function(fun, 1) do
-    assign(socket, [{key, fun.(socket.assigns)}])
+  def assign(%Socket{} = socket, fun) when is_function(fun, 1) do
+    assign(socket, fun.(socket.assigns))
   end
 
   @doc """

--- a/test/phoenix/socket/socket_test.exs
+++ b/test/phoenix/socket/socket_test.exs
@@ -80,16 +80,14 @@ defmodule Phoenix.SocketTest do
       assert socket.assigns[:foo] == :baz
       assert socket.assigns[:abc] == :def
     end
-  end
 
-  describe "assign_lazy/3" do
-    test "assigns to socket" do
+    test "accepts functions" do
       socket = %Phoenix.Socket{}
       assert socket.assigns[:foo] == nil
       socket = assign(socket, :foo, :bar)
       assert socket.assigns[:foo] == :bar
-      socket = assign_lazy(socket, :baz, fn %{foo: :bar} -> :baz end)
-      assert socket.assigns[:baz] == :baz
+      socket = assign(socket, fn %{foo: :bar} -> [baz: :quux] end)
+      assert socket.assigns[:baz] == :quux
     end
   end
 


### PR DESCRIPTION
This PR adds `assign_lazy/3` to `Phoenix.Socket` (if you like the idea, I will add a similar change to the `Phoenix.Component` module in the `phoenix_live_view`).

It is quite often that you need to update the socket based on the value that it is already in `assigns`.
For more complicated things, this could be handled with private functions, but this `assign_lazy/3` is useful when you need something very simple.

It is similar to the `assign_new/3`, but it assigns the value even if the given `key` exists.

```elixir
socket
|> assign_strcut1()
|> assign_struct2()
|> assign_lazy(:title, %{struct1: struct1, struct2: struct2} -> "#{strcut1.name} #{strcut2.name}") end)
```
