### PR TITLE
Update debian/erlang/elixir versions

### DIFF
--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -170,11 +170,10 @@ If you call `mix phx.gen.release --docker` you'll see a new file with these cont
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
 #   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20230612-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.18.4-erlang-27.3.4.2-debian-bookworm-20250811-slim
-#
+#   - Ex: hexpm/elixir:1.18.4-erlang-27.3.4.3-debian-trixie-20250908-slim
 ARG ELIXIR_VERSION=1.18.4
-ARG OTP_VERSION=27.3.4.2
-ARG DEBIAN_VERSION=bookworm-20250811-slim
+ARG OTP_VERSION=27.3.4.3
+ARG DEBIAN_VERSION=trixie-20250908-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"

--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -236,7 +236,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
     |> map_size() > 0
   end
 
-  @debian "bookworm"
+  @debian "trixie"
   defp elixir_and_debian_vsn(elixir_vsn, otp_vsn) do
     url =
       "https://hub.docker.com/v2/namespaces/hexpm/repositories/elixir/tags?name=#{elixir_vsn}-erlang-#{otp_vsn}-debian-#{@debian}-"
@@ -260,7 +260,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
         _ -> System.version()
       end
 
-    otp_vsn =  opts[:otp] || otp_vsn()
+    otp_vsn = opts[:otp] || otp_vsn()
 
     vsns =
       case elixir_and_debian_vsn(wanted_elixir_vsn, otp_vsn) do


### PR DESCRIPTION
Update the [containers](https://hexdocs.pm/phoenix/releases.html#containers) documentation for debian trixie. I chose elixir and erlang versions based on what we set in our Dockerfile at cars.com.

The intent of this PR is to keep documentation up to date.

You can test the generated `url` in the `phx.gen.release.ex` task by going [here](https://hub.docker.com/v2/namespaces/hexpm/repositories/elixir/tags?name=1.18.4-erlang-27.3.4.3-debian-trixie-).