### PR TITLE
sort query params in verified routes during tests

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,8 @@ config :logger, :console,
 config :phoenix,
   json_library: Jason,
   stacktrace_depth: 20,
-  trim_on_html_eex_engine: false
+  trim_on_html_eex_engine: false,
+  sort_verified_routes_query_params: true
 
 if Mix.env() == :dev do
   esbuild = fn args ->

--- a/installer/templates/phx_single/config/test.exs
+++ b/installer/templates/phx_single/config/test.exs
@@ -23,3 +23,7 @@ config :phoenix, :plug_init_mode, :runtime<%= if @html do %>
 # Enable helpful, but potentially expensive runtime checks
 config :phoenix_live_view,
   enable_expensive_runtime_checks: true<% end %>
+
+# Sort query params output of verified routes for robust url comparisons
+config :phoenix,
+  sort_verified_routes_query_params: true

--- a/installer/templates/phx_umbrella/config/test.exs
+++ b/installer/templates/phx_umbrella/config/test.exs
@@ -16,3 +16,7 @@ config :phoenix, :plug_init_mode, :runtime<%= if @html do %>
 # Enable helpful, but potentially expensive runtime checks
 config :phoenix_live_view,
   enable_expensive_runtime_checks: true<% end %>
+  
+# Sort query params output of verified routes for robust url comparisons
+config :phoenix,
+  sort_verified_routes_query_params: true

--- a/test/phoenix/verified_routes_test.exs
+++ b/test/phoenix/verified_routes_test.exs
@@ -371,6 +371,14 @@ defmodule Phoenix.VerifiedRoutesTest do
 
     assert ~p"/posts/5?#{[foo: %{__struct__: Foo, id: 5}]}" ==
              "/posts/5?foo=5"
+
+    # {key, value} params pairs are sorted
+    assert ~p"/posts/5?#{[b: 2, a: 1, c: 3]}" == "/posts/5?a=1&b=2&c=3"
+    assert ~p"/posts/5?#{%{b: 2, a: 1, c: 3}}" == "/posts/5?a=1&b=2&c=3"
+    # array values are sorted
+    assert ~p"/posts/5?#{[foo: ~w(b a)]}" == "/posts/5?foo[]=a&foo[]=b"
+    # ampersands are escaped and won't mess with splitting query at '&'
+    assert ~p"/posts/5?#{[foo: "bar", "a&b": "e&f"]}" == "/posts/5?a%26b=e%26f&foo=bar"
   end
 
   test "~p mixed query string interpolation" do


### PR DESCRIPTION
By having the query parameters being serialized in order (during tests only) when using VerifiedRoutes, we can make some test assertions (like e.g. `assert_redirect/3` from Phoenix.Liveview) less brittle when the query params are constructed dynamically in the backend and it's not easy to predict / maintain exact query param orders in tested urls.

---

Note 1: Originally [this PR](https://github.com/phoenixframework/phoenix_live_view/pull/4047) was attempted to address the issue directly in Liveview tests but it was suggested to make the change to `sigil_p` instead

Note 2: I thought it best to be consistent and sort all query strings - static or dynamic, and that's why I made the changes to `rewrite_path/4` which is the last function called in the verified routes pipeline. If we should only sort query params for dynamic params, we should just change `VerifiedRoutes.__encode_query__/1`

Note 3: I'm not quite sure that the approach taken here for figuring out if we're in test mode or not is the best. I think it won't negatively affect performance since the `if` expressions should be evaluated at compile time, but there could be better, more elegant ways to express the same - please let me know and I'll be happy to make the change