### PR TITLE
treat 410 as error if we already have a token

### DIFF
--- a/assets/js/phoenix/longpoll.js
+++ b/assets/js/phoenix/longpoll.js
@@ -76,6 +76,7 @@ export default class LongPoll {
           // is gone. We fail so that the client rejoins its channels.
           this.onerror(410)
           this.closeAndRetry(3410, "session_gone", false)
+          return
         }
         this.token = token
       } else {


### PR DESCRIPTION
Relates to: https://elixirforum.com/t/handling-channels-liveview-longpoll-fallback-unmatched-topic/72378

On mobile Safari (e.g. iOS) the following could happen when using LongPoll:

1. user connects to a channel
2. device goes to sleep
3. Phoenix shuts down long poll server
4. client connects again, server responds with 410
5. LongPoll continues as usual, but channels are not joined any more
6. client sends messages for previous channel
7. channel errors with "unmatched topic" but does not rejoin

We handle this by checking if we already have a LongPoll token when receiving a 410 code and instead trigger an error which will cause a proper rejoin.