### PR TITLE
Bundle app.js as ESM module for new projects

### DIFF
--- a/guides/asset_management.md
+++ b/guides/asset_management.md
@@ -84,8 +84,16 @@ error: Could not resolve "/images/bg.png" (mark it as external to exclude it fro
 Given the images are already managed by Phoenix, you need to mark all resources from `/images` (and also `/fonts`) as external, as the error message says. This is what Phoenix does by default for new apps since v1.6.1+. In your `config/config.exs`, you will find:
 
 ```elixir
-    args:
-      ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
+    args: ~w(
+      js/app.js
+      --bundle
+      --format=esm
+      --target=es2022
+      --outdir=../priv/static/assets/js
+      --external:/fonts/*
+      --external:/images/*
+      --alias:@=.
+    ),
 ```
 
 If you need to reference other directories, you need to update the arguments above accordingly. Note running `mix phx.digest` will create digested files for all of the assets in `priv/static`, so your images and fonts are still cache-busted.
@@ -95,9 +103,20 @@ If you need to reference other directories, you need to update the arguments abo
 If you import a Node package that depends on additional fonts or images, you might find them to fail to load. This is because they are referenced in the JS or CSS but by default Esbuild will not touch or process referenced files. You can add arguments to esbuild in `config/config.exs` to ensure that the referenced resources are copied to the output folder. The following example would copy all referenced font files to the output folder:
 
 ```elixir
-    args:
-      ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.
-      --loader:.woff=copy --loader:.ttf=copy --loader:.eot=copy --loader:.woff2=copy),
+    args: ~w(
+      js/app.js
+      --bundle
+      --format=esm
+      --target=es2022
+      --outdir=../priv/static/assets/js
+      --external:/fonts/*
+      --external:/images/*
+      --alias:@=.
+      --loader:.woff=copy
+      --loader:.ttf=copy
+      --loader:.eot=copy
+      --loader:.woff2=copy
+    ),
 ```
 For more information, see [the esbuild documentation](https://esbuild.github.io/content-types/#copy).
 

--- a/guides/howto/custom_error_pages.md
+++ b/guides/howto/custom_error_pages.md
@@ -90,7 +90,7 @@ Phoenix generates an `ErrorHTML` for us, but it doesn't give us a `lib/hello_web
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>Welcome to Phoenix!</title>
     <link rel="stylesheet" href="/assets/css/app.css"/>
-    <script defer type="text/javascript" src="/assets/js/app.js"></script>
+    <script type="module" src="/assets/js/app.js"></script>
   </head>
   <body>
     <header>

--- a/guides/real_time/channels.md
+++ b/guides/real_time/channels.md
@@ -437,7 +437,7 @@ Next, we need to pass this token to JavaScript. We can do so inside a script tag
 
 ```heex
 <script>window.userToken = "<%= assigns[:user_token] %>";</script>
-<script src={~p"/assets/js/app.js"}></script>
+<script type="module" src={~p"/assets/js/app.js"}></script>
 ```
 
 ### Step 4 - Pass the Token to the Socket Constructor and Verify

--- a/installer/templates/phx_single/config/config.exs.eex
+++ b/installer/templates/phx_single/config/config.exs.eex
@@ -42,8 +42,16 @@ config :<%= @app_name %>, <%= @app_module %>.Mailer, adapter: Swoosh.Adapters.Lo
 config :esbuild,
   version: "0.25.4",
   <%= @app_name %>: [
-    args:
-      ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
+    args: ~w(
+      js/app.js
+      --bundle
+      --format=esm
+      --target=es2022
+      --outdir=../priv/static/assets/js
+      --external:/fonts/*
+      --external:/images/*
+      --alias:@=.
+    ),
     cd: Path.expand("..<%= if @in_umbrella, do: "/apps/#{@app_name}" %>/assets", __DIR__),
     env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
   ]<% end %><%= if @css do %>

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs.eex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs.eex
@@ -21,8 +21,16 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
 config :esbuild,
   version: "0.25.4",
   <%= @web_app_name %>: [
-    args:
-      ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
+    args: ~w(
+      js/app.js
+      --bundle
+      --format=esm
+      --target=es2022
+      --outdir=../priv/static/assets/js
+      --external:/fonts/*
+      --external:/images/*
+      --alias:@=.
+    ),
     cd: Path.expand("../apps/<%= @web_app_name %>/assets", __DIR__),
     env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
   ]<% end %><%= if @css do %>

--- a/installer/templates/phx_web/components/layouts/root.html.heex.eex
+++ b/installer/templates/phx_web/components/layouts/root.html.heex.eex
@@ -7,7 +7,7 @@
     <.live_title default="<%= @app_module %>" suffix=" · Phoenix Framework" phx-no-format>{assigns[:page_title]}</.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} /><%= if not @css do %>
     <link phx-track-static rel="stylesheet" href={~p"/assets/default.css"} /><% end %>
-    <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>
+    <script phx-track-static type="module" src={~p"/assets/js/app.js"}>
     </script><%= if @css do %>
     <script>
       (() => {

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -165,8 +165,9 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert File.exists?("phx_blog/assets/vendor")
 
       assert_file("phx_blog/config/config.exs", fn file ->
-        assert file =~ "cd: Path.expand(\"../assets\", __DIR__)"
         assert file =~ "config :esbuild"
+        assert file =~ "--format=esm"
+        assert file =~ "cd: Path.expand(\"../assets\", __DIR__)"
       end)
 
       # Ecto

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -60,7 +60,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       end)
 
       assert_file(root_path(@app, "config/config.exs"), fn file ->
-        assert file =~ ~r/config :esbuild/
+        assert file =~ "config :esbuild"
+        assert file =~ "--format=esm"
         assert file =~ "cd: Path.expand(\"../apps/phx_umb_web/assets\", __DIR__)"
         assert file =~ ~S[import_config "#{config_env()}.exs"]
         assert file =~ "config :phoenix, :json_library, Jason"


### PR DESCRIPTION
_Related to https://github.com/phoenixframework/phoenix_live_view/pull/4062#issuecomment-3586535854._

Update the `mix phx.new` installer to configure `esbuild` to output ESM modules by default in new Phoenix projects.

ESM modules enable tree shaking, code splitting, and enforce JavaScript strict mode, which can be beneficial for reducing bundle sizes, and catching common coding errors earlier.

In the JavaScript ecosystem, modern bundlers like Vite output ESM modules by default.

If a developer discovers later that they strictly need to support a non-module environment (like a third-party embed), it is trivial to go back to an IIFE output target.