### PR TITLE
Fix inconsistent form field access in phx.gen.auth login template

### DIFF
--- a/priv/templates/phx.gen.auth/login_live.ex
+++ b/priv/templates/phx.gen.auth/login_live.ex
@@ -75,7 +75,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
             required
           />
           <.input
-            field={@form[:password]}
+            field={f[:password]}
             type="password"
             label="Password"
             autocomplete="current-password"


### PR DESCRIPTION
The password input uses `@form[:password]` while other inputs in the same form use `f[:email]` via the `:let={f}` binding. This changes it to `f[:password]` for consistency.