### PR TITLE
Add documentation on how to read request data

### DIFF
--- a/guides/json_and_apis.md
+++ b/guides/json_and_apis.md
@@ -177,7 +177,7 @@ If you explore the remaining controller, you will learn the `show` action is sim
 
 ## Reading request data
 
-As we've seen in [Request life-cycle](request_lifecycle.html), all controller actions take two arguments, `conn` and `params`. Phoenix automatically parses path parameters, query parameters and the request body into the `params` argument.
+As we've seen in [Request life-cycle](request_lifecycle.html), all controller actions take two arguments, `conn` and `params`. Plug automatically parses path parameters, query parameters and the request body into the `params` argument.
 
 ### Minimal example
 
@@ -198,6 +198,7 @@ defmodule HelloWeb.Router do
     get "/:name", HelloController, :show
     post "/", HelloController, :show
   end
+end
 ```
 
 A controller with a single action (`lib/hello_web/controllers/hello_controller.ex`):
@@ -238,7 +239,7 @@ In the exact same way: `Hello world!`
 
 ### Request data is merged
 
-Since all data is merged under a single map, providing more than one source of data (such as both a path parameter and a JSON body, or a query parameter and a form), will result in **fields with the same name overriding eachother.**
+Since all data is merged under a single map, providing more than one source of data (such as both a path parameter and a JSON body, or a query parameter and a form), will result in **fields with the same name overriding each other.**
 
 The priority is as follows: `Path Parameters > Body (any kind) > Query Parameters`
 


### PR DESCRIPTION
Didn't find any information on this topic in the entire Phoenix documentation, most StackOverflow questions related to this topic are from either [11 years ago](https://stackoverflow.com/questions/24104180/how-do-i-get-request-body-in-phoenix) and refer to Plug's `read_body` function or are referring to [reading raw request data](https://stackoverflow.com/questions/36201806/getting-raw-http-request-body-in-phoenix), which isn't my case.

This PR documents:

- How to access the request's body, path parameters and query parameters.
- Plug's "data merging" behavior
- The `mix phx.new` command with all `--no-*` flags for creating a bare bones JSON API.

As a new user of the framework, this sort of stuff is absolutely critical to get us through the door, especially for those of us coming from an "Express/Nest" style background and looking for better alternatives to do backend work.

I can't speak for all backend JS developers, but I feel like features such as LiveView and HEEx Templates, while flagship functionalities and core to the "Phoenix experience", are not the biggest priority in the adoption cycle for most of us. We're more interested in getting a simple backend service up and running before exploring other possibilities.

Feedback is more than welcome :)

[2025-12-30] EDIT: Just to be sure I didn't miss anything, I went over Plug's documentation once again and actually found [some information on this](https://hexdocs.pm/plug/Plug.Conn.html#module-fetchable-fields). It's still a bit confusing as a newcomer, and I'd have to understand how Plug and Phoenix interact just to read some data, which is not ideal. I still think the change is worth considering.