### PR TITLE
Remove autocomplete attribute from hidden field

### DIFF
--- a/priv/templates/phx.gen.auth/settings_live.ex
+++ b/priv/templates/phx.gen.auth/settings_live.ex
@@ -42,7 +42,6 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           name={@password_form[:email].name}
           type="hidden"
           id="hidden_<%= schema.singular %>_email"
-          autocomplete="username"
           value={@current_email}
         />
         <.input


### PR DESCRIPTION
Introduced in #5143 ([exact line](https://github.com/phoenixframework/phoenix/pull/5143/files#diff-134c438d4061025dd7ca9d1e4d9937e4684d6069c9cc30e2abf1286be8e2628eR57)), probably as an accident when adding `autocomplete` to many form fields.