### PR TITLE
Revert "fix: autocomplete with email instead of username in email fields"

### DIFF
--- a/priv/templates/phx.gen.auth/login_live.ex
+++ b/priv/templates/phx.gen.auth/login_live.ex
@@ -47,7 +47,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
             field={f[:email]}
             type="email"
             label="Email"
-            autocomplete="email"
+            autocomplete="username"
             spellcheck="false"
             required
             phx-mounted={JS.focus()}
@@ -72,7 +72,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
             field={f[:email]}
             type="email"
             label="Email"
-            autocomplete="email"
+            autocomplete="username"
             spellcheck="false"
             required
           />

--- a/priv/templates/phx.gen.auth/registration_new.html.heex
+++ b/priv/templates/phx.gen.auth/registration_new.html.heex
@@ -18,7 +18,7 @@
         field={f[:email]}
         type="email"
         label="Email"
-        autocomplete="email"
+        autocomplete="username"
         spellcheck="false"
         required
         phx-mounted={JS.focus()}

--- a/priv/templates/phx.gen.auth/session_new.html.heex
+++ b/priv/templates/phx.gen.auth/session_new.html.heex
@@ -33,7 +33,7 @@
         field={f[:email]}
         type="email"
         label="Email"
-        autocomplete="email"
+        autocomplete="username"
         spellcheck="false"
         required
         phx-mounted={JS.focus()}
@@ -51,7 +51,7 @@
         field={f[:email]}
         type="email"
         label="Email"
-        autocomplete="email"
+        autocomplete="username"
         spellcheck="false"
         required
       />

--- a/priv/templates/phx.gen.auth/settings_edit.html.heex
+++ b/priv/templates/phx.gen.auth/settings_edit.html.heex
@@ -13,7 +13,7 @@
       field={f[:email]}
       type="email"
       label="Email"
-      autocomplete="email"
+      autocomplete="username"
       spellcheck="false"
       required
     />


### PR DESCRIPTION
Reverts phoenixframework/phoenix#6502

The choice of `username` over `email` has actually been discussed in the PR that introduced the `autocomplete` attribute: https://github.com/phoenixframework/phoenix/pull/5143#discussion_r1100920085.

That conversation links to https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands/, which in turn links to https://web.dev/articles/sign-in-form-best-practices, quoted below:

> For email inputs use autocomplete="username", since username is recognized by password managers in modern browsers

If not reverting that PR, and rather deciding for `autocomplete="email"`, then we should update leftover `autocomplete="username"` occurrences in `phx.gen.auth` template forms.

<details>

```console
$ git grep -n 'autocomplete=' | grep username
priv/templates/phx.gen.auth/registration_live.ex:30:            autocomplete="username"
priv/templates/phx.gen.auth/settings_live.ex:24:          autocomplete="username"
```

</details>