### PR TITLE
Secure phx.gen.auth forms against PII leakage

### DIFF
--- a/priv/templates/phx.gen.auth/login_live.ex
+++ b/priv/templates/phx.gen.auth/login_live.ex
@@ -79,6 +79,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
             type="password"
             label="Password"
             autocomplete="current-password"
+            spellcheck="false"
           />
           <.button class="btn btn-primary w-full" name={@form[:remember_me].name} value="true">
             Log in and stay logged in <span aria-hidden="true">→</span>

--- a/priv/templates/phx.gen.auth/login_live.ex
+++ b/priv/templates/phx.gen.auth/login_live.ex
@@ -48,6 +48,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
             type="email"
             label="Email"
             autocomplete="email"
+            spellcheck="false"
             required
             phx-mounted={JS.focus()}
           />
@@ -72,6 +73,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
             type="email"
             label="Email"
             autocomplete="email"
+            spellcheck="false"
             required
           />
           <.input

--- a/priv/templates/phx.gen.auth/registration_live.ex
+++ b/priv/templates/phx.gen.auth/registration_live.ex
@@ -28,6 +28,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
             type="email"
             label="Email"
             autocomplete="username"
+            spellcheck="false"
             required
             phx-mounted={JS.focus()}
           />

--- a/priv/templates/phx.gen.auth/registration_new.html.heex
+++ b/priv/templates/phx.gen.auth/registration_new.html.heex
@@ -19,6 +19,7 @@
         type="email"
         label="Email"
         autocomplete="email"
+        spellcheck="false"
         required
         phx-mounted={JS.focus()}
       />

--- a/priv/templates/phx.gen.auth/session_new.html.heex
+++ b/priv/templates/phx.gen.auth/session_new.html.heex
@@ -34,6 +34,7 @@
         type="email"
         label="Email"
         autocomplete="email"
+        spellcheck="false"
         required
         phx-mounted={JS.focus()}
       />
@@ -51,6 +52,7 @@
         type="email"
         label="Email"
         autocomplete="email"
+        spellcheck="false"
         required
       />
       <.input

--- a/priv/templates/phx.gen.auth/session_new.html.heex
+++ b/priv/templates/phx.gen.auth/session_new.html.heex
@@ -58,6 +58,7 @@
         type="password"
         label="Password"
         autocomplete="current-password"
+        spellcheck="false"
       />
       <.button class="btn btn-primary w-full" name={@form[:remember_me].name} value="true">
         Log in and stay logged in <span aria-hidden="true">→</span>

--- a/priv/templates/phx.gen.auth/settings_edit.html.heex
+++ b/priv/templates/phx.gen.auth/settings_edit.html.heex
@@ -24,6 +24,7 @@
       type="password"
       label="New password"
       autocomplete="new-password"
+      spellcheck="false"
       required
     />
     <.input
@@ -31,6 +32,7 @@
       type="password"
       label="Confirm new password"
       autocomplete="new-password"
+      spellcheck="false"
       required
     />
     <.button variant="primary" phx-disable-with="Changing...">

--- a/priv/templates/phx.gen.auth/settings_edit.html.heex
+++ b/priv/templates/phx.gen.auth/settings_edit.html.heex
@@ -9,7 +9,14 @@
   <.form :let={f} for={@email_changeset} action={~p"<%= schema.route_prefix %>/settings"} id="update_email">
     <input type="hidden" name="action" value="update_email" />
 
-    <.input field={f[:email]} type="email" label="Email" autocomplete="email" required />
+    <.input
+      field={f[:email]}
+      type="email"
+      label="Email"
+      autocomplete="email"
+      spellcheck="false"
+      required
+    />
 
     <.button variant="primary" phx-disable-with="Changing...">Change Email</.button>
   </.form>

--- a/priv/templates/phx.gen.auth/settings_live.ex
+++ b/priv/templates/phx.gen.auth/settings_live.ex
@@ -22,6 +22,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           type="email"
           label="Email"
           autocomplete="username"
+          spellcheck="false"
           required
         />
         <.button variant="primary" phx-disable-with="Changing...">Change Email</.button>
@@ -42,6 +43,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           name={@password_form[:email].name}
           type="hidden"
           id="hidden_<%= schema.singular %>_email"
+          spellcheck="false"
           value={@current_email}
         />
         <.input

--- a/priv/templates/phx.gen.auth/settings_live.ex
+++ b/priv/templates/phx.gen.auth/settings_live.ex
@@ -49,6 +49,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           type="password"
           label="New password"
           autocomplete="new-password"
+          spellcheck="false"
           required
         />
         <.input
@@ -56,6 +57,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
           type="password"
           label="Confirm new password"
           autocomplete="new-password"
+          spellcheck="false"
         />
         <.button variant="primary" phx-disable-with="Saving...">
           Save Password


### PR DESCRIPTION
References:

- Article on "Spell-jacking" from 2022: https://www.bleepingcomputer.com/news/security/google-microsoft-can-get-your-passwords-via-web-browsers-spellcheck/

  > Extended spellcheck features in Google Chrome and Microsoft Edge web browsers transmit form data, including personally identifiable information (PII) and in some cases, passwords, to Google and Microsoft respectively.
  >
  > Both Chrome and Edge ship with basic spellcheckers enabled. But, features like Chrome's Enhanced Spellcheck or Microsoft Editor when manually enabled by the user, exhibit this potential privacy risk.
  > ...
  > "Furthermore, if you click on 'show password,' the enhanced spellcheck even sends your password, essentially Spell-Jacking your data," explains otto-js in a blog post.
  >
  > Reacting to otto-js' report, both AWS and LastPass mitigated the issue. In LastPass' case, the remedy was reached by adding a simple HTML attribute spellcheck="false" to the password field

- MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/spellcheck#security_and_privacy_concerns

Some sites implementing `spellcheck="false"`:

- The AWS Console login page sets `spellcheck="false"` on all input fields: https://aws.amazon.com/console/
- Same for LastPass: https://app.lastpass.com/login/
- 1password: https://my.1password.com/signin
- Google: https://accounts.google.com/
- Apple: https://account.apple.com/

Some that don't:
- Microsoft: https://account.microsoft.com/account