### PR TITLE
Add warning for `mix phx.server` when `sever: false` in Endpoint

### DIFF
--- a/lib/mix/tasks/phx.server.ex
+++ b/lib/mix/tasks/phx.server.ex
@@ -6,8 +6,11 @@ defmodule Mix.Tasks.Phx.Server do
   @moduledoc """
   Starts the application by configuring all endpoints servers to run.
 
-  Note: to start the endpoint without using this mix task you must set
-  `server: true` in your `Phoenix.Endpoint` configuration.
+  Note:
+  - to start the endpoint without using this mix task you must set `server:
+    true` in your `Phoenix.Endpoint` configuration.
+  - if you have set `server: false` in your `Phoenix.Endpoint` configuration
+    this task will not override that, so the endpoint servers will not run.
 
   ## Command line options
 

--- a/lib/phoenix/endpoint/supervisor.ex
+++ b/lib/phoenix/endpoint/supervisor.ex
@@ -217,9 +217,16 @@ defmodule Phoenix.Endpoint.Supervisor do
   end
 
   defp server?(conf) when is_list(conf) do
-    Keyword.get_lazy(conf, :server, fn ->
-      Application.get_env(:phoenix, :serve_endpoints, false)
-    end)
+    serve_endpoints = Application.get_env(:phoenix, :serve_endpoints, false)
+    server = Keyword.get(conf, :server, serve_endpoints)
+
+    if not server and serve_endpoints,
+      do:
+        Logger.warning(
+          ":server is set to :false in your Phoenix.Endpoint configuration, so the server will not be started"
+        )
+
+    server
   end
 
   defp defaults(otp_app, module) do


### PR DESCRIPTION
Add a warning if you run `mix phx.sever` but have set `sever: false` in Endpoint. Without this change you get no output when running `mix phx.server` is this scenario.

Also document this.