### PR TITLE
Stop reconnecting when close was clean

### DIFF
--- a/assets/js/phoenix/socket.js
+++ b/assets/js/phoenix/socket.js
@@ -158,7 +158,7 @@ export default class Socket {
         } else {
           this.pageHidden = false
           // reconnect immediately
-          if(!this.isConnected()){
+          if(!this.isConnected() && !this.closeWasClean){
             this.teardown(() => this.connect())
           }
         }


### PR DESCRIPTION
If the connection was closed gracefully then skip the reconnect in the "visibilitychange" event.