### PR TITLE
Update CoreComponents, add explicit label association

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex
+++ b/installer/templates/phx_web/components/core_components.ex
@@ -207,7 +207,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
     ~H"""
     <div class="fieldset mb-2">
-      <label>
+      <label for={@id}>
         <input
           type="hidden"
           name={@name}
@@ -235,7 +235,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div class="fieldset mb-2">
-      <label>
+      <label for={@id}>
         <span :if={@label} class="label mb-1">{@label}</span>
         <select
           id={@id}
@@ -256,7 +256,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(%{type: "textarea"} = assigns) do
     ~H"""
     <div class="fieldset mb-2">
-      <label>
+      <label for={@id}>
         <span :if={@label} class="label mb-1">{@label}</span>
         <textarea
           id={@id}
@@ -277,7 +277,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
   def input(assigns) do
     ~H"""
     <div class="fieldset mb-2">
-      <label>
+      <label for={@id}>
         <span :if={@label} class="label mb-1">{@label}</span>
         <input
           type={@type}


### PR DESCRIPTION
## Description

Currently, the `input`s generated in `CoreComponents` uses nesting to implicitly associate the `label` with the `input`. 
This works fine in most cases but there are a couple drawbacks 

-  Some assistive technologies have limitations or issues when labels are only implicitly associated.  The [WAI](https://www.w3.org/WAI/) recommends always using explicit association when possible. 
-  Someone tweaking their core components might move the `input` to be a sibling of the `label`, breaking the implicit association and unintentionally cause accessibility problems. If they are using [PhoenixTest](https://hexdocs.pm/phoenix_test/PhoenixTest.html), this would also break any tests that fill in these inputs, since the majority of the functions rely on a working label.           

For more info, see 
- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/label  
- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/for
- https://www.w3.org/WAI/tutorials/forms/labels/#associating-labels-explicitly


## Changes

Update `CoreComponents` templates for `input`s. Add `for={@id}` to explicitly associate a `label` element with its `input` element. 

Diff of the generated `CoreComponents` with these changes:  

```diff
     ~H"""
     <div class="fieldset mb-2">
-      <label>
+      <label for={@id}>
         <input
           type="hidden"
           name={@name}
@@ -234,7 +234,7 @@ defmodule SomeTestProjectWeb.CoreComponents do
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div class="fieldset mb-2">
-      <label>
+      <label for={@id}>
         <span :if={@label} class="label mb-1">{@label}</span>
         <select
           id={@id}
@@ -255,7 +255,7 @@ defmodule SomeTestProjectWeb.CoreComponents do
   def input(%{type: "textarea"} = assigns) do
     ~H"""
     <div class="fieldset mb-2">
-      <label>
+      <label for={@id}>
         <span :if={@label} class="label mb-1">{@label}</span>
         <textarea
           id={@id}
@@ -276,7 +276,7 @@ defmodule SomeTestProjectWeb.CoreComponents do
   def input(assigns) do
     ~H"""
     <div class="fieldset mb-2">
-      <label>
+      <label for={@id}>
         <span :if={@label} class="label mb-1">{@label}</span>
         <input
           type={@type}
```