### PR TITLE
Update installer README, fix deprecated snippet

### DIFF
--- a/installer/README.md
+++ b/installer/README.md
@@ -14,4 +14,4 @@ ensure any previous archive versions are removed:
 Then run:
 
     $ cd installer
-    $ MIX_ENV=prod mix do archive.build, archive.install
+    $ MIX_ENV=prod mix do archive.build + archive.install


### PR DESCRIPTION
## Description

The installer README uses a deprecated `mix do` feature in the "build and install locally" instructions. 

The existing snippet gives this warning
```
warning: using commas as separators in "mix do" is deprecated, use + between commands instead
  (mix 1.19.3) lib/mix/tasks/do.ex:129: Mix.Tasks.Do.gather_commands/3
  (mix 1.19.3) lib/mix/tasks/do.ex:75: Mix.Tasks.Do.run/1
  (mix 1.19.3) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
  (mix 1.19.3) lib/mix/cli.ex:129: Mix.CLI.run_task/2
  /usr/local/bin/mix:7: (file)
  (elixir 1.19.3) src/elixir_compiler.erl:81: :elixir_compiler.dispatch/4
```

## Changes

Update installer README, fix deprecated snippet. 