### PR TITLE
Fix typos in documentation and unit test

### DIFF
--- a/assets/test/longpoll_test.js
+++ b/assets/test/longpoll_test.js
@@ -260,7 +260,7 @@ describe("Ajax.request", () => {
     expect(global.XMLHttpRequest).toHaveBeenCalled()
   })
 
-  it("should use fetch when XMLHttpRequest is not availble", () => {
+  it("should use fetch when XMLHttpRequest is not available", () => {
     global.XMLHttpRequest = undefined // Simulate it being unavailable
     Ajax.request("GET", "/test-endpoint", {}, null, 0, null, (response) => {
       expect(response).toEqual({success: true})

--- a/guides/components.md
+++ b/guides/components.md
@@ -79,7 +79,7 @@ Next we need to update `show.html.heex`:
 </Layouts.app>
 ```
 
-When we reload `http://localhost:4000/hello/Frank`, we should see the same content as before! The `show.html.heex` is now invoking two different funcion components:
+When we reload `http://localhost:4000/hello/Frank`, we should see the same content as before! The `show.html.heex` is now invoking two different function components:
 
   * `<Layouts.app` - the syntax for invoking function componente defined in a separate module and it follows the same rules as calling any other function in Elixir
 

--- a/usage-rules/ecto.md
+++ b/usage-rules/ecto.md
@@ -5,5 +5,5 @@
 - `Ecto.Schema` fields always use the `:string` type, even for `:text`, columns, ie: `field :name, :string`
 - `Ecto.Changeset.validate_number/2` **DOES NOT SUPPORT the `:allow_nil` option**. By default, Ecto validations only run if a change for the given field exists and the change value is not nil, so such as option is never needed
 - You **must** use `Ecto.Changeset.get_field(changeset, :field)` to access changeset fields
-- Fields which are set programatically, such as `user_id`, must not be listed in `cast` calls or similar for security purposes. Instead they must be explicitly set when creating the struct
+- Fields which are set programmatically, such as `user_id`, must not be listed in `cast` calls or similar for security purposes. Instead they must be explicitly set when creating the struct
 - **Always** invoke `mix ecto.gen.migration migration_name_using_underscores` when generating migration files, so the correct timestamp and conventions are applied


### PR DESCRIPTION
This PR fixes minor spelling mistakes in the documentation and in a unit test.

No functional changes.
