### PR TITLE
Add host constraints to mix phx.routes output

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -539,7 +539,7 @@ defmodule Phoenix.Router do
         quote line: line, do: _ = &(unquote(module).unquote(function) / unquote(arity))
       end)
 
-    keys = [:verb, :path, :plug, :plug_opts, :helper, :metadata]
+    keys = [:verb, :path, :plug, :plug_opts, :helper, :metadata, :hosts]
     routes = Enum.map(routes, &Map.take(&1, keys))
 
     quote do
@@ -1286,7 +1286,9 @@ defmodule Phoenix.Router do
               verb: nested_route.verb
           }
 
-          Map.put(route, :label, nested_route.label)
+          route
+          |> Map.put(:label, nested_route.label)
+          |> Map.put(:hosts, Map.get(nested_route, :hosts, route.hosts))
         end)
       else
         plug =
@@ -1302,6 +1304,7 @@ defmodule Phoenix.Router do
             helper: route.helper,
             verb: route.verb,
             path: route.path,
+            hosts: route.hosts,
             label: label
           }
         ]

--- a/test/phoenix/router/console_formatter_test.exs
+++ b/test/phoenix/router/console_formatter_test.exs
@@ -93,6 +93,43 @@ defmodule Phoenix.Router.ConsoleFormatterTest do
     end
   end
 
+  defmodule RouterTestHostRoutes do
+    use Phoenix.Router
+
+    scope host: "api.example.com" do
+      get "/users", RouteFormatter.PageController, :index, as: :api_users
+    end
+
+    scope host: "admin.example.com" do
+      get "/users", RouteFormatter.ImageController, :index, as: :admin_users
+    end
+  end
+
+  test "format routes with host constraints" do
+    assert draw(RouterTestHostRoutes) == """
+           [api.example.com]      api_users_path  GET  /users  RouteFormatter.PageController :index
+           [admin.example.com]  admin_users_path  GET  /users  RouteFormatter.ImageController :index
+           """
+  end
+
+  defmodule RouterTestMixedHostRoutes do
+    use Phoenix.Router
+
+    scope host: "api.example.com" do
+      get "/users", RouteFormatter.PageController, :index, as: :api_users
+    end
+
+    get "/health", RouteFormatter.PageController, :index, as: :health
+  end
+
+  test "format routes with mixed host constraints" do
+    expected =
+      "[api.example.com]  api_users_path  GET  /users   RouteFormatter.PageController :index\n" <>
+        "                      health_path  GET  /health  RouteFormatter.PageController :index\n"
+
+    assert draw(RouterTestMixedHostRoutes) == expected
+  end
+
   defmodule HelpersFalseRouter do
     use Phoenix.Router, helpers: false
     resources "/image", RouteFormatter.ImageController


### PR DESCRIPTION
Fixes #6589

This adds host constraints to the `mix phx.routes` output.

Routes defined inside `scope` blocks with a `host:` option are now prefixed
with the corresponding host, making it easier to distinguish routes that share
the same path but differ by host.

Example:

Before:
GET  /users  MyAppWeb.UserController :index
GET  /users  MyAppWeb.AdminUserController :index

After:
[api.example.com]    GET  /users  MyAppWeb.UserController :index
[admin.example.com]  GET  /users  MyAppWeb.AdminUserController :index
