### PR TITLE
Fix @stream typo in usage-rules liveview streams example

### DIFF
--- a/usage-rules/liveview.md
+++ b/usage-rules/liveview.md
@@ -37,7 +37,7 @@
 
       <div id="tasks" phx-update="stream">
         <div class="hidden only:block">No tasks yet</div>
-        <div :for={{id, task} <- @stream.tasks} id={id}>
+        <div :for={{id, task} <- @streams.tasks} id={id}>
           {task.name}
         </div>
       </div>


### PR DESCRIPTION
The empty-state example in `usage-rules/liveview.md` uses `@stream.tasks` (singular) but it should be `@streams.tasks` (plural).

The stream assign is initialized as `:streams` in [`phoenix_live_view.ex#L1979`](https://github.com/phoenixframework/phoenix_live_view/blob/a304c175dd662cd989baa15307134b00e2d5ac28/lib/phoenix_live_view.ex#L1979) and every other example in this file correctly uses the plural form.