### PR TITLE
Experimental WebTransport support for phoenix

### DIFF
--- a/assets/js/phoenix/constants.js
+++ b/assets/js/phoenix/constants.js
@@ -22,6 +22,7 @@ export const CHANNEL_EVENTS = {
 
 export const TRANSPORTS = {
   longpoll: "longpoll",
+  webtransport: "webtransport",
   websocket: "websocket"
 }
 export const XHR_STATES = {

--- a/assets/js/phoenix/index.js
+++ b/assets/js/phoenix/index.js
@@ -197,11 +197,13 @@ import LongPoll from "./longpoll"
 import Presence from "./presence"
 import Serializer from "./serializer"
 import Socket from "./socket"
+import WebTransport from "./webtransport"
 
 export {
   Channel,
   LongPoll,
   Presence,
   Serializer,
-  Socket
+  Socket,
+  WebTransport
 }

--- a/assets/js/phoenix/webtransport.js
+++ b/assets/js/phoenix/webtransport.js
@@ -1,0 +1,251 @@
+import {
+  global,
+  SOCKET_STATES,
+  TRANSPORTS,
+  AUTH_TOKEN_PREFIX
+} from "./constants"
+
+const HEADER_SIZE = 5
+const TEXT_FRAME_TYPE = 0
+const MAX_FRAME_SIZE = 16_777_216
+
+let appendBuffer = (left, right) => {
+  let merged = new Uint8Array(left.byteLength + right.byteLength)
+  merged.set(left, 0)
+  merged.set(right, left.byteLength)
+  return merged
+}
+
+let encodeText = (text) => {
+  if(typeof (TextEncoder) !== "undefined"){
+    return new TextEncoder().encode(text)
+  }
+
+  let encoded = unescape(encodeURIComponent(text))
+  let bytes = new Uint8Array(encoded.length)
+  for(let i = 0; i < encoded.length; i++){ bytes[i] = encoded.charCodeAt(i) }
+  return bytes
+}
+
+let decodeText = (bytes) => {
+  if(typeof (TextDecoder) !== "undefined"){
+    return new TextDecoder().decode(bytes)
+  }
+
+  let encoded = ""
+  for(let i = 0; i < bytes.length; i++){ encoded += String.fromCharCode(bytes[i]) }
+  return decodeURIComponent(escape(encoded))
+}
+
+export default class WebTransport {
+  constructor(endPoint, protocols){
+    if(protocols && protocols.length === 2 && protocols[1].startsWith(AUTH_TOKEN_PREFIX)){
+      this.authToken = atob(protocols[1].slice(AUTH_TOKEN_PREFIX.length))
+    }
+    this.endpoint = this.normalizeEndpoint(endPoint)
+    this.transport = null
+    this.stream = null
+    this.reader = null
+    this.writer = null
+    this.readBuffer = new Uint8Array(0)
+    this.maxFrameSize = MAX_FRAME_SIZE
+    this.bufferedAmount = 0
+    this.timeout = null
+    this.binaryType = "arraybuffer"
+    this.readyState = SOCKET_STATES.connecting
+    this.onopen = function (){ } // noop
+    this.onerror = function (){ } // noop
+    this.onmessage = function (){ } // noop
+    this.onclose = function (){ } // noop
+    this.writeChain = Promise.resolve()
+    this.closeSent = false
+    this.didClose = false
+    setTimeout(() => this.connect(), 0)
+  }
+
+  normalizeEndpoint(endPoint){
+    return (endPoint
+      .replace("ws://", "https://")
+      .replace("wss://", "https://")
+      .replace(new RegExp("(.*)\/" + TRANSPORTS.websocket), "$1/" + TRANSPORTS.webtransport))
+  }
+
+  endpointURL(){
+    let url = this.toURL(this.endpoint)
+    if(this.authToken){
+      url.searchParams.set("auth_token", this.authToken)
+    }
+    return url.toString()
+  }
+
+  toURL(url){
+    try {
+      return new URL(url)
+    } catch (_error){
+      let base = global.location ? `${global.location.protocol}//${global.location.host}` : "https://localhost"
+      return new URL(url, base)
+    }
+  }
+
+  async connect(){
+    if(!global.WebTransport){
+      this.onerror("webtransport unavailable")
+      this.finalizeClose({code: 1006, reason: "webtransport unavailable", wasClean: false})
+      return
+    }
+
+    try {
+      this.transport = new global.WebTransport(this.endpointURL())
+      this.transport.closed
+        .then(({closeCode, reason}) => {
+          this.finalizeClose({code: closeCode || 1000, reason, wasClean: true})
+        })
+        .catch(error => {
+          if(!this.didClose){
+            this.onerror(error)
+            this.finalizeClose({code: 1011, reason: "transport error", wasClean: false})
+          }
+        })
+
+      await this.transport.ready
+      if(this.didClose){ return }
+
+      this.stream = await this.transport.createBidirectionalStream()
+      this.reader = this.stream.readable.getReader()
+      this.writer = this.stream.writable.getWriter()
+      this.readyState = SOCKET_STATES.open
+      this.onopen({})
+      this.readLoop()
+    } catch (error){
+      this.onerror(error)
+      this.finalizeClose({code: 1011, reason: "transport setup failed", wasClean: false})
+    }
+  }
+
+  send(body){
+    if(this.readyState !== SOCKET_STATES.open || this.didClose){ return }
+
+    if(typeof (body) !== "string"){
+      this.onerror("binary frames unsupported")
+      this.close(1003, "binary frames unsupported")
+      return
+    }
+
+    let payload = encodeText(body)
+    if(payload.byteLength > this.maxFrameSize){
+      this.onerror("frame too large")
+      this.close(1009, "frame too large")
+      return
+    }
+
+    let frame = new Uint8Array(HEADER_SIZE + payload.byteLength)
+    let view = new DataView(frame.buffer)
+    view.setUint8(0, TEXT_FRAME_TYPE)
+    view.setUint32(1, payload.byteLength)
+    frame.set(payload, HEADER_SIZE)
+
+    this.bufferedAmount += frame.byteLength
+    this.writeChain = this.writeChain
+      .then(() => this.writer.write(frame))
+      .then(() => {
+        this.bufferedAmount -= frame.byteLength
+      })
+      .catch(error => {
+        this.bufferedAmount = 0
+        this.onerror(error)
+        this.close(1011, "write failed")
+      })
+  }
+
+  close(code, reason){
+    if(this.didClose){ return }
+    this.readyState = SOCKET_STATES.closing
+
+    if(this.transport && !this.closeSent){
+      this.closeSent = true
+
+      try {
+        this.transport.close({closeCode: code || 1000, reason: reason || ""})
+      } catch (error){
+        this.onerror(error)
+        this.finalizeClose({code: code || 1000, reason, wasClean: false})
+      }
+    } else if(!this.transport){
+      this.finalizeClose({code: code || 1000, reason, wasClean: true})
+    }
+  }
+
+  async readLoop(){
+    try {
+      while(this.reader && !this.didClose){
+        let {done, value} = await this.reader.read()
+        if(done){ break }
+        this.readBuffer = appendBuffer(this.readBuffer, value)
+        if(!this.processReadBuffer()){ return }
+      }
+
+      this.finalizeClose({code: 1000, reason: "", wasClean: true})
+    } catch (error){
+      if(!this.didClose){
+        this.onerror(error)
+        this.finalizeClose({code: 1011, reason: "read failed", wasClean: false})
+      }
+    }
+  }
+
+  processReadBuffer(){
+    while(this.readBuffer.byteLength >= HEADER_SIZE){
+      let view = new DataView(this.readBuffer.buffer, this.readBuffer.byteOffset, this.readBuffer.byteLength)
+      let type = view.getUint8(0)
+      let len = view.getUint32(1)
+
+      if(len > this.maxFrameSize){
+        this.onerror("frame too large")
+        this.close(1009, "frame too large")
+        return false
+      }
+
+      if(this.readBuffer.byteLength < HEADER_SIZE + len){ return true }
+
+      let payload = this.readBuffer.slice(HEADER_SIZE, HEADER_SIZE + len)
+      this.readBuffer = this.readBuffer.slice(HEADER_SIZE + len)
+
+      if(type !== TEXT_FRAME_TYPE){
+        this.onerror("binary frames unsupported")
+        this.close(1003, "binary frames unsupported")
+        return false
+      }
+
+      this.onmessage({data: decodeText(payload)})
+    }
+
+    return true
+  }
+
+  finalizeClose(opts){
+    if(this.didClose){ return }
+    this.didClose = true
+    this.readyState = SOCKET_STATES.closed
+    this.bufferedAmount = 0
+
+    if(this.reader){
+      this.reader.cancel().catch(() => {})
+      this.reader.releaseLock()
+      this.reader = null
+    }
+
+    if(this.writer){
+      this.writer.releaseLock()
+      this.writer = null
+    }
+
+    this.stream = null
+
+    let closeOpts = Object.assign({code: 1000, reason: "", wasClean: true}, opts)
+    if(typeof (CloseEvent) !== "undefined"){
+      this.onclose(new CloseEvent("close", closeOpts))
+    } else {
+      this.onclose(closeOpts)
+    }
+  }
+}

--- a/assets/test/webtransport_test.js
+++ b/assets/test/webtransport_test.js
@@ -1,0 +1,133 @@
+import {jest} from "@jest/globals"
+import WebTransport from "../js/phoenix/webtransport"
+import {Socket, LongPoll} from "../js/phoenix"
+import {AUTH_TOKEN_PREFIX, SOCKET_STATES} from "../js/phoenix/constants"
+
+let originalWebTransport
+
+let mockWebTransport = () => {
+  let writer = {
+    write: jest.fn(() => Promise.resolve()),
+    releaseLock: jest.fn()
+  }
+
+  let reader = {
+    read: jest.fn(() => new Promise(() => {})),
+    cancel: jest.fn(() => Promise.resolve()),
+    releaseLock: jest.fn()
+  }
+
+  let stream = {
+    readable: {getReader: () => reader},
+    writable: {getWriter: () => writer}
+  }
+
+  let closeResolve
+  let transport = {
+    ready: Promise.resolve(),
+    closed: new Promise(resolve => {
+      closeResolve = resolve
+    }),
+    createBidirectionalStream: jest.fn(() => Promise.resolve(stream)),
+    close: jest.fn()
+  }
+
+  global.WebTransport = jest.fn(() => transport)
+  return {transport, writer, closeResolve}
+}
+
+describe("WebTransport", () => {
+  beforeEach(() => {
+    originalWebTransport = global.WebTransport
+  })
+
+  afterEach(() => {
+    global.WebTransport = originalWebTransport
+  })
+
+  it("normalizes websocket endpoint and appends auth token query param", () => {
+    mockWebTransport()
+    let authToken = "my-auth-token"
+    let encoded = btoa(authToken).replace(/=/g, "")
+    let protocols = ["phoenix", `${AUTH_TOKEN_PREFIX}${encoded}`]
+
+    let transport = new WebTransport("wss://example.com/socket/websocket?vsn=2.0.0", protocols)
+    expect(transport.endpoint).toBe("https://example.com/socket/webtransport?vsn=2.0.0")
+    expect(transport.endpointURL()).toContain("auth_token=my-auth-token")
+  })
+
+  it("encodes outgoing text messages as tlv frames", async () => {
+    let {writer, closeResolve} = mockWebTransport()
+    let transport = new WebTransport("wss://example.com/socket/websocket?vsn=2.0.0")
+
+    await new Promise(resolve => {
+      transport.onopen = () => resolve()
+    })
+
+    expect(transport.readyState).toBe(SOCKET_STATES.open)
+
+    transport.send("ok")
+    await transport.writeChain
+
+    expect(writer.write).toHaveBeenCalledTimes(1)
+    let frame = writer.write.mock.calls[0][0]
+    let view = new DataView(frame.buffer, frame.byteOffset, frame.byteLength)
+
+    expect(frame[0]).toBe(0)
+    expect(view.getUint32(1)).toBe(2)
+    expect(Array.from(frame.slice(5))).toEqual([111, 107])
+
+    transport.close(1000, "")
+    closeResolve({closeCode: 1000, reason: ""})
+  })
+})
+
+describe("Socket WebTransport fallback", () => {
+  let originalWebSocket
+
+  beforeEach(() => {
+    originalWebSocket = global.WebSocket
+  })
+
+  afterEach(() => {
+    global.WebSocket = originalWebSocket
+  })
+
+  it("uses WebSocket as first fallback when transport is WebTransport", () => {
+    function FakeWebSocket(){}
+    global.WebSocket = FakeWebSocket
+
+    let socket = new Socket("/socket", {
+      transport: WebTransport,
+      longPollFallbackMs: 20
+    })
+
+    let fallbackSpy = jest.spyOn(socket, "connectWithFallback").mockImplementation(() => {})
+
+    socket.connect()
+
+    expect(fallbackSpy).toHaveBeenCalledWith(FakeWebSocket, 20)
+  })
+
+  it("chains fallback to LongPoll after non-LongPoll fallback", () => {
+    jest.useFakeTimers()
+
+    function FakeWebSocket(){}
+
+    let socket = new Socket("/socket", {
+      transport: WebTransport,
+      longPollFallbackMs: 20
+    })
+
+    socket.transportConnect = jest.fn()
+    let fallbackSpy = jest.spyOn(socket, "connectWithFallback")
+
+    socket.connectWithFallback(FakeWebSocket, 20)
+
+    let errorCallback = socket.stateChangeCallbacks.error[socket.stateChangeCallbacks.error.length - 1][1]
+    errorCallback("failed")
+
+    expect(fallbackSpy).toHaveBeenNthCalledWith(2, LongPoll, 20)
+    jest.useRealTimers()
+  })
+})

--- a/lib/phoenix/endpoint/cowboy2_adapter.ex
+++ b/lib/phoenix/endpoint/cowboy2_adapter.ex
@@ -14,6 +14,9 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
       as defined by [`Plug.Cowboy`](https://hexdocs.pm/plug_cowboy/). Defaults
       to `false`
 
+    * `:http3` - the configuration for the HTTP/3 server. It starts a Cowboy
+      QUIC listener with `:cowboy.start_quic/3`. Defaults to `false`
+
     * `:drainer` - a drainer process that triggers when your application is
       shutting down to wait for any on-going request to finish. It accepts all
       options as defined by [`Plug.Cowboy.Drainer`](https://hexdocs.pm/plug_cowboy/Plug.Cowboy.Drainer.html).
@@ -52,7 +55,7 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
   def child_specs(endpoint, config) do
     otp_app = Keyword.fetch!(config, :otp_app)
 
-    refs_and_specs =
+    refs_and_specs_http =
       for {scheme, port} <- [http: 4000, https: 4040], opts = config[scheme] do
         port = :proplists.get_value(:port, opts, port)
 
@@ -66,10 +69,28 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
         child_spec(scheme, endpoint, opts, config[:code_reloader])
       end
 
-    {refs, child_specs} = Enum.unzip(refs_and_specs)
+    refs_and_specs =
+      case config[:http3] do
+        opts when is_list(opts) ->
+          refs_and_specs_http ++ [http3_child_spec(endpoint, opts, config[:code_reloader])]
 
-    if drainer = refs != [] && Keyword.get(config, :drainer, []) do
-      child_specs ++ [{Plug.Cowboy.Drainer, Keyword.put_new(drainer, :refs, refs)}]
+        _ ->
+          refs_and_specs_http
+      end
+
+    {_refs, child_specs} = Enum.unzip(refs_and_specs)
+    refs_for_drainer = Enum.map(refs_and_specs_http, &elem(&1, 0))
+
+    drainer = refs_for_drainer != [] && Keyword.get(config, :drainer, [])
+
+    if config[:http3] && drainer do
+      Logger.warning(
+        "HTTP/3 WebTransport sessions are not drained by Plug.Cowboy.Drainer; only Ranch listeners are drained"
+      )
+    end
+
+    if drainer do
+      child_specs ++ [{Plug.Cowboy.Drainer, Keyword.put_new(drainer, :refs, refs_for_drainer)}]
     else
       child_specs
     end
@@ -91,6 +112,50 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
 
     spec = Plug.Cowboy.child_spec(ref: ref, scheme: scheme, plug: plug, options: config)
     spec = update_in(spec.start, &{__MODULE__, :start_link, [scheme, endpoint, &1]})
+    {ref, spec}
+  end
+
+  defp http3_child_spec(endpoint, config, code_reloader?) do
+    port = Keyword.fetch!(config, :port)
+    ref = make_ref(endpoint, :http3)
+
+    socket_opts =
+      [port: port_to_integer(port)]
+      |> maybe_put_opt(:certfile, config)
+      |> maybe_put_opt(:keyfile, config)
+      |> Kernel.++(Keyword.get(config, :transport_options, []))
+
+    transport_opts = %{socket_opts: socket_opts}
+
+    plug =
+      if code_reloader? do
+        {Phoenix.Endpoint.SyncCodeReloadPlug, {endpoint, []}}
+      else
+        {endpoint, []}
+      end
+
+    dispatch =
+      endpoint
+      |> webtransport_routes()
+      |> Kernel.++([{:_, Plug.Cowboy.Handler, plug}])
+      |> then(fn routes -> :cowboy_router.compile([{:_, routes}]) end)
+
+    proto_opts =
+      config
+      |> Keyword.drop([:port, :certfile, :keyfile, :transport_options])
+      |> Enum.into(%{})
+      |> Map.put_new(:enable_connect_protocol, true)
+      |> Map.put_new(:h3_datagram, true)
+      |> Map.put_new(:enable_webtransport, true)
+      |> Map.put_new(:wt_max_sessions, 1)
+      |> put_dispatch_env(dispatch)
+
+    spec = %{
+      id: ref,
+      start: {__MODULE__, :start_http3, [endpoint, ref, transport_opts, proto_opts]},
+      type: :worker
+    }
+
     {ref, spec}
   end
 
@@ -116,9 +181,76 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
     end
   end
 
+  @doc false
+  def start_http3(endpoint, ref, transport_opts, proto_opts) do
+    with :ok <- ensure_quic_available(endpoint, ref) do
+      try do
+        case :cowboy.start_quic(ref, transport_opts, proto_opts) do
+          {:ok, listener_ref} ->
+            Logger.info(info(:http3, endpoint, ref, transport_opts))
+            start_http3_keeper(listener_ref)
+
+          {:error, {:shutdown, {_, _, {:listen_error, _, :eaddrinuse}}}} = error ->
+            Logger.error([
+              info(:http3, endpoint, ref, transport_opts),
+              " failed, port already in use"
+            ])
+
+            error
+
+          {:error, {:shutdown, {_, _, {{_, {:error, :eaddrinuse}}, _}}}} = error ->
+            Logger.error([
+              info(:http3, endpoint, ref, transport_opts),
+              " failed, port already in use"
+            ])
+
+            error
+
+          {:error, _} = error ->
+            error
+        end
+      catch
+        kind, reason ->
+          Logger.error([
+            info(:http3, endpoint, ref, transport_opts),
+            " failed, QUIC startup prerequisites are not available: ",
+            Exception.format_banner(kind, reason)
+          ])
+
+          {:error, {:shutdown, {kind, reason}}}
+      end
+    else
+      {:error, _} = error ->
+        error
+    end
+  end
+
   defp info(scheme, endpoint, ref) do
     server = "cowboy #{Application.spec(:cowboy)[:vsn]}"
     "Running #{inspect(endpoint)} with #{server} at #{bound_address(scheme, ref)}"
+  end
+
+  defp info(:http3, endpoint, _ref, transport_opts) do
+    server = "cowboy #{Application.spec(:cowboy)[:vsn]}"
+    "Running #{inspect(endpoint)} with #{server} at #{bound_http3_address(transport_opts)}"
+  end
+
+  defp info(scheme, endpoint, ref, _transport_opts), do: info(scheme, endpoint, ref)
+
+  defp start_http3_keeper(listener_ref) do
+    Task.start_link(fn ->
+      Process.flag(:trap_exit, true)
+
+      receive do
+        {:EXIT, _from, _reason} -> :ok
+      end
+
+      if Code.ensure_loaded?(:quicer) and function_exported?(:quicer, :close_listener, 1) do
+        _ = apply(:quicer, :close_listener, [listener_ref])
+      end
+
+      :ok
+    end)
   end
 
   defp bound_address(scheme, ref) do
@@ -138,6 +270,18 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
   defp port_to_integer(port) when is_binary(port), do: String.to_integer(port)
   defp port_to_integer(port) when is_integer(port), do: port
 
+  def server_info(endpoint, :http3) do
+    opts = endpoint.config(:http3, [])
+
+    with {:ok, port} <- Keyword.fetch(opts, :port) do
+      {:ok, {Keyword.get(opts, :ip, {0, 0, 0, 0}), port_to_integer(port)}}
+    else
+      :error -> {:error, :not_found}
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
   def server_info(endpoint, scheme) do
     address =
       endpoint
@@ -151,5 +295,67 @@ defmodule Phoenix.Endpoint.Cowboy2Adapter do
 
   defp make_ref(endpoint, scheme) do
     Module.concat(endpoint, scheme |> Atom.to_string() |> String.upcase())
+  end
+
+  defp webtransport_routes(endpoint) do
+    if function_exported?(endpoint, :__webtransport_routes__, 0) do
+      endpoint.__webtransport_routes__()
+    else
+      []
+    end
+  end
+
+  defp maybe_put_opt(opts, key, config) do
+    case Keyword.fetch(config, key) do
+      {:ok, value} -> Keyword.put(opts, key, value)
+      :error -> opts
+    end
+  end
+
+  defp put_dispatch_env(proto_opts, dispatch) do
+    env =
+      case Map.get(proto_opts, :env) do
+        nil -> %{dispatch: dispatch}
+        env when is_map(env) -> Map.put(env, :dispatch, dispatch)
+        env when is_list(env) -> env |> Enum.into(%{}) |> Map.put(:dispatch, dispatch)
+        _ -> %{dispatch: dispatch}
+      end
+
+    Map.put(proto_opts, :env, env)
+  end
+
+  defp bound_http3_address(transport_opts) do
+    socket_opts = Map.get(transport_opts, :socket_opts, [])
+    port = Keyword.get(socket_opts, :port, :unknown)
+
+    case Keyword.get(socket_opts, :ip, {0, 0, 0, 0}) do
+      {:local, unix_path} ->
+        "#{unix_path} (http3+unix)"
+
+      addr when is_tuple(addr) ->
+        "#{:inet.ntoa(addr)}:#{port} (http3)"
+
+      addr when is_binary(addr) ->
+        "#{addr}:#{port} (http3)"
+
+      _ ->
+        "#{port} (http3)"
+    end
+  end
+
+  defp ensure_quic_available(endpoint, ref) do
+    case Application.ensure_all_started(:quicer) do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} = error ->
+        Logger.error([
+          info(:http3, endpoint, ref),
+          " failed, quicer dependency is unavailable: ",
+          inspect(reason)
+        ])
+
+        error
+    end
   end
 end

--- a/lib/phoenix/transports/webtransport.ex
+++ b/lib/phoenix/transports/webtransport.ex
@@ -1,0 +1,78 @@
+defmodule Phoenix.Transports.WebTransport do
+  @moduledoc false
+
+  alias Phoenix.Socket.V2
+
+  @supported_connect_info_keys [
+    :peer_data,
+    :trace_context_headers,
+    :x_headers,
+    :uri,
+    :user_agent,
+    :auth_token
+  ]
+
+  def default_config() do
+    [
+      path: "/webtransport",
+      serializer: [{V2.JSONSerializer, "~> 2.0.0"}],
+      transport_log: false,
+      check_csrf: false,
+      max_frame_size: 16_777_216,
+      max_pending_bytes: 1_048_576
+    ]
+  end
+
+  def validate_config!(config) do
+    connect_info_keys = Keyword.get(config, :connect_info, [])
+
+    if Keyword.get(config, :path) != "/webtransport" do
+      raise ArgumentError, "custom webtransport :path is not supported in v1"
+    end
+
+    validate_connect_info_keys!(connect_info_keys)
+    validate_check_csrf!(config, connect_info_keys)
+    validate_serializers!(Keyword.fetch!(config, :serializer))
+    config
+  end
+
+  defp validate_serializers!(serializers) when is_list(serializers) do
+    valid? =
+      Enum.all?(serializers, fn
+        {V2.JSONSerializer, _} -> true
+        _ -> false
+      end)
+
+    if valid? do
+      :ok
+    else
+      raise ArgumentError, "webtransport requires V2.JSONSerializer-only configuration in v1"
+    end
+  end
+
+  defp validate_connect_info_keys!(keys) do
+    Enum.each(keys, fn
+      :sec_websocket_headers ->
+        raise ArgumentError,
+              ":sec_websocket_headers connect_info is not supported for webtransport"
+
+      key when key in @supported_connect_info_keys ->
+        :ok
+
+      {_, _} ->
+        :ok
+
+      key ->
+        raise ArgumentError,
+              "unsupported webtransport connect_info key: #{inspect(key)}. Supported keys: #{inspect(@supported_connect_info_keys)}"
+    end)
+  end
+
+  defp validate_check_csrf!(config, connect_info_keys) do
+    if Keyword.get(config, :check_csrf, false) and
+         not Enum.any?(connect_info_keys, &match?({:session, _}, &1)) do
+      raise ArgumentError,
+            "webtransport with check_csrf: true requires connect_info to include {:session, ...}"
+    end
+  end
+end

--- a/lib/phoenix/transports/webtransport/handler.ex
+++ b/lib/phoenix/transports/webtransport/handler.ex
@@ -1,0 +1,332 @@
+defmodule Phoenix.Transports.WebTransport.Handler do
+  @moduledoc false
+  Code.ensure_loaded?(:cowboy_webtransport)
+  @behaviour :cowboy_webtransport
+
+  require Logger
+
+  alias Phoenix.Socket.Transport
+
+  defstruct endpoint: nil,
+            handler: nil,
+            opts: [],
+            socket_state: nil,
+            stream_id: nil,
+            buffer: <<>>,
+            max_frame_size: 16_777_216,
+            max_pending_bytes: 1_048_576,
+            pending_frames: [],
+            pending_bytes: 0,
+            query_params: %{},
+            path_params: %{},
+            params: %{}
+
+  def init(req, {endpoint, handler, opts}) do
+    query_params = query_params(req)
+    path_params = path_params(req)
+    params = Map.merge(query_params, path_params)
+
+    conn =
+      req
+      |> to_conn(params, path_params)
+      |> Transport.code_reload(endpoint, opts)
+      |> Transport.transport_log(opts[:transport_log])
+      |> Transport.check_origin(handler, endpoint, opts, & &1)
+      |> maybe_put_auth_token(params, opts[:auth_token])
+
+    if conn.halted do
+      {:ok, :cowboy_req.reply(conn.status || 403, req), :rejected}
+    else
+      keys = Keyword.get(opts, :connect_info, [])
+      {peer_data?, keys} = split_peer_data_key(keys)
+
+      connect_info =
+        Transport.connect_info(conn, endpoint, keys,
+          check_csrf: Keyword.get(opts, :check_csrf, false)
+        )
+        |> maybe_put_peer_data(req, peer_data?)
+
+      config = %{
+        endpoint: endpoint,
+        transport: :webtransport,
+        options: opts,
+        params: params,
+        connect_info: connect_info
+      }
+
+      case handler.connect(config) do
+        {:ok, socket_state} ->
+          state = %__MODULE__{
+            endpoint: endpoint,
+            handler: handler,
+            opts: opts,
+            socket_state: socket_state,
+            max_frame_size: Keyword.get(opts, :max_frame_size, 16_777_216),
+            max_pending_bytes: Keyword.get(opts, :max_pending_bytes, 1_048_576),
+            query_params: query_params,
+            path_params: path_params,
+            params: params
+          }
+
+          {:cowboy_webtransport, req, state, %{req_filter: &__MODULE__.req_filter/1}}
+
+        :error ->
+          {:ok, :cowboy_req.reply(403, req), :rejected}
+
+        {:error, _reason} ->
+          {:ok, :cowboy_req.reply(403, req), :rejected}
+      end
+    end
+  end
+
+  def webtransport_init(%__MODULE__{handler: handler, socket_state: socket_state} = state) do
+    case handler.init(socket_state) do
+      {:ok, socket_state} ->
+        {[], %{state | socket_state: socket_state}}
+
+      _ ->
+        {[{:close, 0, "socket init failed"}], state}
+    end
+  end
+
+  def webtransport_handle({:stream_open, stream_id, :bidi}, %__MODULE__{stream_id: nil} = state) do
+    commands = flush_pending(stream_id, state.pending_frames)
+    {commands, %{state | stream_id: stream_id, pending_frames: [], pending_bytes: 0}}
+  end
+
+  def webtransport_handle({:stream_open, _stream_id, _type}, state) do
+    {[], state}
+  end
+
+  def webtransport_handle({:opened_stream_id, _open_stream_ref, _stream_id}, state) do
+    {[], state}
+  end
+
+  def webtransport_handle(
+        {:stream_data, stream_id, _is_fin, data},
+        %__MODULE__{stream_id: stream_id} = state
+      ) do
+    with {:ok, frames, buffer} <-
+           parse_frames(<<state.buffer::binary, data::binary>>, state.max_frame_size),
+         {:ok, commands, socket_state} <- process_frames(frames, state) do
+      {commands, %{state | buffer: buffer, socket_state: socket_state}}
+    else
+      {:error, reason} ->
+        {[{:close, 0, reason_to_string(reason)}], state}
+    end
+  end
+
+  def webtransport_handle({:stream_data, _stream_id, _is_fin, _data}, state) do
+    {[{:close, 0, "unexpected stream data"}], state}
+  end
+
+  def webtransport_handle({:datagram, _}, state) do
+    {[{:close, 0, "datagram unsupported"}], state}
+  end
+
+  def webtransport_handle(:close_initiated, state) do
+    {[], state}
+  end
+
+  # Cowboy handles terminal `{closed, _, _}` and `:closed_abruptly` by invoking
+  # terminate directly, so they do not reach webtransport_handle/2.
+  def webtransport_handle(_, state) do
+    {[], state}
+  end
+
+  def webtransport_info(
+        message,
+        %__MODULE__{handler: handler, socket_state: socket_state} = state
+      ) do
+    case handler.handle_info(message, socket_state) do
+      {:ok, socket_state} ->
+        {[], %{state | socket_state: socket_state}}
+
+      {:push, {opcode, payload}, socket_state} ->
+        case encode_frame(opcode, payload) do
+          {:ok, frame} ->
+            if state.stream_id do
+              {[{:send, state.stream_id, frame}], %{state | socket_state: socket_state}}
+            else
+              pending_bytes = state.pending_bytes + IO.iodata_length(frame)
+
+              if pending_bytes > state.max_pending_bytes do
+                {[{:close, 0, "pending frame buffer exceeded"}],
+                 %{state | socket_state: socket_state}}
+              else
+                {[],
+                 %{
+                   state
+                   | socket_state: socket_state,
+                     pending_frames: [frame | state.pending_frames],
+                     pending_bytes: pending_bytes
+                 }}
+              end
+            end
+
+          {:error, :binary_not_supported} ->
+            Logger.warning(
+              "Ignoring binary payload on WebTransport session because v1 WebTransport transport is text-only"
+            )
+
+            {[], %{state | socket_state: socket_state}}
+
+          {:error, reason} ->
+            {[{:close, 0, reason_to_string(reason)}], %{state | socket_state: socket_state}}
+        end
+
+      {:stop, reason, socket_state} ->
+        {[{:close, 0, reason_to_string(reason)}], %{state | socket_state: socket_state}}
+    end
+  end
+
+  def terminate(reason, req, %__MODULE__{handler: handler, socket_state: socket_state}) do
+    _ = req
+    handler.terminate(reason, socket_state)
+  end
+
+  def req_filter(req) do
+    Map.take(req, [:method, :version, :scheme, :host, :port, :path, :qs, :peer, :headers])
+  end
+
+  defp process_frames(frames, state) do
+    Enum.reduce_while(frames, {:ok, [], state.socket_state}, fn {payload, opts},
+                                                                {:ok, commands, socket_state} ->
+      case state.handler.handle_in({payload, opts}, socket_state) do
+        {:ok, socket_state} ->
+          {:cont, {:ok, commands, socket_state}}
+
+        {:reply, _status, {opcode, reply_payload}, socket_state} ->
+          case encode_frame(opcode, reply_payload) do
+            {:ok, frame} ->
+              {:cont, {:ok, [{:send, state.stream_id, frame} | commands], socket_state}}
+
+            {:error, :binary_not_supported} ->
+              Logger.warning(
+                "Ignoring binary reply payload on WebTransport session because v1 WebTransport transport is text-only"
+              )
+
+              {:cont, {:ok, commands, socket_state}}
+
+            {:error, reason} ->
+              {:halt, {:error, reason}}
+          end
+
+        {:stop, reason, socket_state} ->
+          _ = socket_state
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, commands, socket_state} -> {:ok, Enum.reverse(commands), socket_state}
+      error -> error
+    end
+  end
+
+  defp flush_pending(_stream_id, []), do: []
+
+  defp flush_pending(stream_id, frames) do
+    frames
+    |> Enum.reverse()
+    |> Enum.map(&{:send, stream_id, &1})
+  end
+
+  defp encode_frame(:text, payload) do
+    size = IO.iodata_length(payload)
+    {:ok, [<<0, size::32>>, payload]}
+  rescue
+    _ -> {:error, :invalid_payload}
+  end
+
+  defp encode_frame(:binary, _payload), do: {:error, :binary_not_supported}
+  defp encode_frame(_opcode, _payload), do: {:error, :unsupported_opcode}
+
+  defp parse_frames(data, max_frame_size), do: parse_frames(data, max_frame_size, [])
+
+  defp parse_frames(<<>>, _max_frame_size, acc), do: {:ok, Enum.reverse(acc), <<>>}
+
+  defp parse_frames(data, _max_frame_size, acc) when byte_size(data) < 5,
+    do: {:ok, Enum.reverse(acc), data}
+
+  defp parse_frames(<<type, len::32, rest::binary>> = data, max_frame_size, acc) do
+    cond do
+      type != 0 ->
+        {:error, :invalid_type}
+
+      len == 0 or len > max_frame_size ->
+        {:error, :frame_too_large}
+
+      byte_size(rest) < len ->
+        {:ok, Enum.reverse(acc), data}
+
+      true ->
+        <<payload::binary-size(len), tail::binary>> = rest
+        parse_frames(tail, max_frame_size, [{payload, [opcode: :text]} | acc])
+    end
+  end
+
+  defp maybe_put_auth_token(conn, %{"auth_token" => token}, true) when is_binary(token) do
+    Plug.Conn.put_private(conn, :phoenix_transport_auth_token, token)
+  end
+
+  defp maybe_put_auth_token(conn, _params, _auth_token?), do: conn
+
+  defp split_peer_data_key(keys) do
+    has_peer_data? = Enum.any?(keys, &(&1 == :peer_data))
+    {has_peer_data?, Enum.reject(keys, &(&1 == :peer_data))}
+  end
+
+  defp maybe_put_peer_data(connect_info, _req, false), do: connect_info
+
+  defp maybe_put_peer_data(connect_info, req, true) do
+    {address, port} = Map.get(req, :peer, {{127, 0, 0, 1}, 0})
+    Map.put(connect_info, :peer_data, %{address: address, port: port, ssl_cert: nil})
+  end
+
+  defp query_params(req) do
+    req
+    |> :cowboy_req.parse_qs()
+    |> Map.new(fn {key, value} -> {to_string(key), to_string(value)} end)
+    |> Map.put_new("vsn", "2.0.0")
+  end
+
+  defp path_params(req) do
+    req
+    |> :cowboy_req.bindings()
+    |> Enum.reduce(%{}, fn {key, value}, acc ->
+      Map.put(acc, Atom.to_string(key), to_string(value))
+    end)
+  end
+
+  defp to_conn(req, params, path_params) do
+    headers =
+      req |> Map.get(:headers, %{}) |> Enum.map(fn {k, v} -> {to_string(k), to_string(v)} end)
+
+    {remote_ip, _port} = Map.get(req, :peer, {{127, 0, 0, 1}, 0})
+    request_path = req[:path] |> to_string()
+
+    %Plug.Conn{
+      host: req[:host] |> to_string(),
+      method: req[:method] |> to_string(),
+      owner: self(),
+      path_info: String.split(request_path, "/", trim: true),
+      port: req[:port],
+      remote_ip: remote_ip,
+      req_headers: headers,
+      request_path: request_path,
+      scheme: normalize_scheme(req[:scheme]),
+      query_string: req[:qs] |> to_string(),
+      path_params: path_params,
+      params: params
+    }
+  end
+
+  defp normalize_scheme(scheme) when scheme in [:http, :https], do: scheme
+  defp normalize_scheme(<<"https">>), do: :https
+  defp normalize_scheme(<<"http">>), do: :http
+  defp normalize_scheme(scheme) when is_binary(scheme), do: String.to_atom(scheme)
+  defp normalize_scheme(_), do: :https
+
+  defp reason_to_string(reason) when is_binary(reason), do: reason
+  defp reason_to_string(reason), do: inspect(reason)
+end

--- a/test/phoenix/endpoint/cowboy2_adapter_test.exs
+++ b/test/phoenix/endpoint/cowboy2_adapter_test.exs
@@ -1,0 +1,54 @@
+defmodule Phoenix.Endpoint.Cowboy2AdapterTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+
+  defmodule Endpoint do
+    def config(:http3, _default), do: [ip: {127, 0, 0, 1}, port: 4443]
+    def config(_key, default), do: default
+    def init(opts), do: opts
+    def call(conn, _opts), do: conn
+  end
+
+  test "builds HTTP/3 child spec with socket_opts and WebTransport defaults" do
+    [spec] =
+      Phoenix.Endpoint.Cowboy2Adapter.child_specs(Endpoint,
+        otp_app: :phoenix,
+        http3: [port: 4443, certfile: "cert.pem", keyfile: "key.pem"]
+      )
+
+    assert {Phoenix.Endpoint.Cowboy2Adapter, :start_http3,
+            [Endpoint, _ref, transport_opts, proto_opts]} =
+             spec.start
+
+    assert %{socket_opts: socket_opts} = transport_opts
+    assert socket_opts[:port] == 4443
+    assert socket_opts[:certfile] == "cert.pem"
+    assert socket_opts[:keyfile] == "key.pem"
+
+    assert proto_opts.enable_connect_protocol == true
+    assert proto_opts.h3_datagram == true
+    assert proto_opts.enable_webtransport == true
+    assert proto_opts.wt_max_sessions == 1
+    assert is_map(proto_opts.env)
+    assert proto_opts.env[:dispatch]
+  end
+
+  test "server_info/2 returns configured HTTP/3 address" do
+    assert {:ok, {{127, 0, 0, 1}, 4443}} =
+             Phoenix.Endpoint.Cowboy2Adapter.server_info(Endpoint, :http3)
+  end
+
+  test "logs explicit warning when http3 is configured with drainer" do
+    log =
+      capture_log(fn ->
+        Phoenix.Endpoint.Cowboy2Adapter.child_specs(Endpoint,
+          otp_app: :phoenix,
+          http: [port: 4001],
+          http3: [port: 4443, certfile: "cert.pem", keyfile: "key.pem"],
+          drainer: []
+        )
+      end)
+
+    assert log =~ "HTTP/3 WebTransport sessions are not drained by Plug.Cowboy.Drainer"
+  end
+end

--- a/test/phoenix/transports/webtransport/handler_test.exs
+++ b/test/phoenix/transports/webtransport/handler_test.exs
@@ -1,0 +1,104 @@
+defmodule Phoenix.Transports.WebTransport.HandlerTest do
+  use ExUnit.Case, async: false
+
+  alias Phoenix.Transports.WebTransport.Handler
+
+  defmodule TestEndpoint do
+    def config(:code_reloader), do: false
+    def config(:check_origin), do: false
+    def config(:secret_key_base), do: String.duplicate("a", 64)
+    def config(_key), do: nil
+  end
+
+  defmodule CaptureSocket do
+    def connect(config) do
+      send(self(), {:connect_info, config.connect_info})
+      {:ok, %{}}
+    end
+
+    def init(state), do: {:ok, state}
+    def handle_in(_message, state), do: {:ok, state}
+    def handle_info(_message, state), do: {:ok, state}
+    def terminate(_reason, _state), do: :ok
+  end
+
+  defmodule PushSocket do
+    def connect(_config), do: {:ok, %{}}
+    def init(state), do: {:ok, state}
+    def handle_in(_message, state), do: {:ok, state}
+    def handle_info(:push, state), do: {:push, {:text, "hello"}, state}
+    def handle_info(_message, state), do: {:ok, state}
+    def terminate(_reason, _state), do: :ok
+  end
+
+  defmodule BinaryPushSocket do
+    def connect(_config), do: {:ok, %{}}
+    def init(state), do: {:ok, state}
+    def handle_in(_message, state), do: {:ok, state}
+    def handle_info(:push_binary, state), do: {:push, {:binary, <<1, 2, 3>>}, state}
+    def handle_info(_message, state), do: {:ok, state}
+    def terminate(_reason, _state), do: :ok
+  end
+
+  setup do
+    :ets.new(TestEndpoint, [:named_table, :public, :set])
+    :ok
+  end
+
+  test "init includes peer_data in connect_info without crashing" do
+    req = %{
+      method: "CONNECT",
+      version: :"HTTP/3",
+      scheme: :https,
+      host: "example.com",
+      port: 443,
+      path: "/socket/webtransport",
+      qs: "vsn=2.0.0",
+      peer: {{127, 0, 0, 1}, 1234},
+      headers: %{},
+      bindings: %{}
+    }
+
+    assert {:cowboy_webtransport, ^req, _state, _opts} =
+             Handler.init(
+               req,
+               {TestEndpoint, CaptureSocket, [check_origin: false, connect_info: [:peer_data]]}
+             )
+
+    assert_receive {:connect_info,
+                    %{peer_data: %{address: {127, 0, 0, 1}, port: 1234, ssl_cert: nil}}}
+  end
+
+  test "stream_data rejects binary frame type in parser" do
+    state = %Handler{handler: CaptureSocket, socket_state: %{}, stream_id: 1}
+    frame = <<1, 0, 0, 0, 1, 1>>
+
+    assert {[{:close, 0, reason}], _state} =
+             Handler.webtransport_handle({:stream_data, 1, :nofin, frame}, state)
+
+    assert reason =~ "invalid_type"
+  end
+
+  test "webtransport_info closes when pending frame buffer limit is exceeded" do
+    state = %Handler{handler: PushSocket, socket_state: %{}, max_pending_bytes: 4}
+
+    assert {[{:close, 0, "pending frame buffer exceeded"}], _state} =
+             Handler.webtransport_info(:push, state)
+  end
+
+  test "close_initiated does not trigger socket drain path" do
+    state = %Handler{handler: PushSocket, socket_state: %{}}
+    assert {[], ^state} = Handler.webtransport_handle(:close_initiated, state)
+  end
+
+  test "extra stream_open events are ignored" do
+    state = %Handler{handler: PushSocket, socket_state: %{}, stream_id: 1}
+    assert {[], ^state} = Handler.webtransport_handle({:stream_open, 2, :unidi}, state)
+  end
+
+  test "binary pushes are skipped without closing session" do
+    state = %Handler{handler: BinaryPushSocket, socket_state: %{}}
+    assert {[], %Handler{} = next_state} = Handler.webtransport_info(:push_binary, state)
+    assert next_state.socket_state == %{}
+  end
+end


### PR DESCRIPTION
This PR adds experimental [WebTransport](https://www.w3.org/TR/webtransport/) support in phoenix using cowboy backend with native quicer HTTP 3 library

Widespread WebTransport adoption on the browser side is still hindered by Safari (support landing on 26.4) (see https://caniuse.com/webtransport), cowboy HTTP 3 support is still immature and on the infra side QUIC traffic is another story so I don't expect this being a big priority soon

This repo https://github.com/lukaszsamson/phoenix_webtransport_demo has a demo app

<img width="1019" height="807" alt="Screenshot 2026-02-24 at 23 33 10" src="https://github.com/user-attachments/assets/cd0dc642-138b-4338-9eea-807f4d71605c" />
<img width="1475" height="418" alt="Screenshot 2026-02-24 at 23 34 18" src="https://github.com/user-attachments/assets/5d74af11-39f5-4850-8163-6345a400c9ea" />
