### PR TITLE
Include cookie options when deleting remember me cookie

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex
+++ b/priv/templates/phx.gen.auth/auth.ex
@@ -55,7 +55,7 @@ defmodule <%= inspect auth_module %> do
 
     conn
     |> renew_session(nil)
-    |> delete_resp_cookie(@remember_me_cookie)
+    |> delete_resp_cookie(@remember_me_cookie, @remember_me_options)
     |> redirect(to: ~p"/")
   end
 


### PR DESCRIPTION
If you add a domain to `@remember_me_options` then it won’t remove the remember me cookie unless the options are also passed to `delete_resp_cookie/3`
From the [docs](https://hexdocs.pm/plug/1.19.1/Plug.Conn.html#delete_resp_cookie/3):
"Deleting a cookie requires the same options as to when the cookie was put."