### PR TITLE
Phoenix.Controller: warn when guards refer to unknown actions

### DIFF
--- a/lib/phoenix/controller/pipeline.ex
+++ b/lib/phoenix/controller/pipeline.ex
@@ -11,6 +11,7 @@ defmodule Phoenix.Controller.Pipeline do
 
       Module.register_attribute(__MODULE__, :plugs, accumulate: true)
       @before_compile Phoenix.Controller.Pipeline
+      @after_compile Phoenix.Controller.Pipeline
       @phoenix_fallback :unregistered
 
       @doc false
@@ -38,6 +39,7 @@ defmodule Phoenix.Controller.Pipeline do
   @doc false
   def __action_fallback__(plug, caller) do
     plug = Macro.expand(plug, %{caller | function: {:init, 1}})
+
     quote bind_quoted: [plug: plug] do
       @phoenix_fallback Phoenix.Controller.Pipeline.validate_fallback(
                           plug,
@@ -154,6 +156,48 @@ defmodule Phoenix.Controller.Pipeline do
 
   def __catch__(%Plug.Conn{} = conn, reason, _controller, _action, stack) do
     Plug.Conn.WrapperError.reraise(conn, :error, reason, stack)
+  end
+
+  @doc false
+  defmacro __after_compile__(env, _bytecode) do
+    guards =
+      for {_plug, _opts, guard} <- Module.get_attribute(env.module, :plugs),
+          guard != true,
+          do: guard
+
+    actions =
+      guards
+      |> Macro.prewalk([], fn node, acc ->
+        acc =
+          case node do
+            {:in, _, [{:action, _, _}, actions]} when is_list(actions) ->
+              actions |> Enum.filter(&is_atom/1) |> Enum.concat(acc)
+
+            {:==, _, [{:action, _, _}, action]} when is_atom(action) ->
+              [action | acc]
+
+            {:!=, _, [{:action, _, _}, action]} when is_atom(action) ->
+              [action | acc]
+
+            _ ->
+              acc
+          end
+
+        {node, acc}
+      end)
+      |> elem(1)
+      |> Enum.uniq()
+
+    unknown = actions -- (:functions |> env.module.__info__() |> Keyword.keys())
+
+    if unknown != [] do
+      IO.warn(
+        "Unknown action(s) referenced in #{inspect(env.module)} plug guards: #{inspect(unknown)}",
+        env
+      )
+    end
+
+    :ok
   end
 
   @doc """

--- a/test/phoenix/controller/pipeline_test.exs
+++ b/test/phoenix/controller/pipeline_test.exs
@@ -232,6 +232,38 @@ defmodule Phoenix.Controller.PipelineTest do
     end
   end
 
+  describe "unknown actions in plug guards" do
+    test "warns when unknown actions are found" do
+      warning =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          defmodule UnknownActionsController do
+            use Phoenix.Controller, formats: []
+
+            @module_attribute [:unknown3]
+
+            plug :identity when action == :unknown0
+            plug :identity when action in [:index, :unknown1, :unknown2]
+            plug :identity when action in @module_attribute
+            plug :identity when action != :unknown4
+            plug :identity when action not in [:unknown5]
+
+            defp identity(conn, _), do: conn
+
+            def index(conn, _), do: conn
+          end
+        end)
+
+      assert warning =~
+               "Unknown action(s) referenced in Phoenix.Controller.PipelineTest.UnknownActionsController plug guards: ["
+
+      for n <- 0..5 do
+        assert warning =~ ":unknown#{n}"
+      end
+
+      refute warning =~ ":index"
+    end
+  end
+
   defp stack_conn() do
     conn(:get, "/")
     |> fetch_query_params()


### PR DESCRIPTION
I built this to detect dead code in a private codebase, but thought it might be useful higher up. It's possible there's a reason this won't work for all use cases, but I haven't thought of it myself yet =)

This adds a post-compilation step to the Phoenix.Controller.Pipeline that warns when user `plug` guards include actions that the controller doesn't define. The warning isn't pretty at this time. 


```elixir
defmodule MyAppWeb.MyController do
  use Phoenix.Controller, formats: []

  plug :my_plug when action in [:index, :create]
  plug :other_plug when action == :hello
  plug :last_plug when action not in [:another_missing_action]

  def index(conn, _), do: conn
end
```

Would produce a warning like:

```
     warning: Unknown action(s) referenced in MyAppWeb.MyController plug guards: [:hello, :create, :another_missing_action]
     │
 239 │           defmodule MyAppWeb.MyController do
     │           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     │
     └─ file/path:1: MyAppWeb.MyController (module)
```
Far from pretty, and not immediately intuitive what the user should do, but just thought I'd open this for discussion before homing in on UX if it is wanted.

I've done no benchmarking to see what impact this has on a codebase, but it's walking only a small set of AST in each controller