### PR TITLE
ensure visibilitychange does not connect if never connected

### DIFF
--- a/assets/js/phoenix/socket.js
+++ b/assets/js/phoenix/socket.js
@@ -126,7 +126,10 @@ export default class Socket {
     this.establishedConnections = 0
     this.defaultEncoder = Serializer.encode.bind(Serializer)
     this.defaultDecoder = Serializer.decode.bind(Serializer)
-    this.closeWasClean = false
+    // We start with closeWasClean true to avoid the visibility change
+    // logic from connecting if the socket was never connected in the first place.
+    // transportConnect sets it to false on open.
+    this.closeWasClean = true
     this.disconnecting = false
     this.binaryType = opts.binaryType || "arraybuffer"
     this.connectClock = 1

--- a/assets/test/socket_test.js
+++ b/assets/test/socket_test.js
@@ -104,6 +104,43 @@ describe("with transports", function (){
     })
   })
 
+  describe("visibilitychange", function (){
+    it("does not connect a socket that was never connected", function (){
+      socket = new Socket("/socket")
+      const teardownSpy = jest.spyOn(socket, "teardown")
+
+      Object.defineProperty(document, "visibilityState", {value: "hidden", writable: true})
+      window.dispatchEvent(new Event("visibilitychange"))
+
+      Object.defineProperty(document, "visibilityState", {value: "visible", writable: true})
+      window.dispatchEvent(new Event("visibilitychange"))
+
+      expect(teardownSpy).not.toHaveBeenCalled()
+    })
+
+    it("reconnects on visibility change after unclean close", function (){
+      socket = new Socket("/socket")
+      socket.closeWasClean = false
+      const teardownSpy = jest.spyOn(socket, "teardown")
+
+      Object.defineProperty(document, "visibilityState", {value: "visible", writable: true})
+      window.dispatchEvent(new Event("visibilitychange"))
+
+      expect(teardownSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not reconnect on visibility change after clean close", function (){
+      socket = new Socket("/socket")
+      socket.closeWasClean = true
+      const teardownSpy = jest.spyOn(socket, "teardown")
+
+      Object.defineProperty(document, "visibilityState", {value: "visible", writable: true})
+      window.dispatchEvent(new Event("visibilitychange"))
+
+      expect(teardownSpy).not.toHaveBeenCalled()
+    })
+  })
+
   describe("protocol", function (){
     beforeEach(function (){
       socket = new Socket("/socket")


### PR DESCRIPTION
The fix from #6579 did not handle the case where the socket was never connected in the first place.

Closes #6620.
Relates to #6578.