### PR TITLE
Add rule to fix DateTime quirk

### DIFF
--- a/usage-rules/elixir.md
+++ b/usage-rules/elixir.md
@@ -31,6 +31,7 @@
 - **Never** nest multiple modules in the same file as it can cause cyclic dependencies and compilation errors
 - **Never** use map access syntax (`changeset[:field]`) on structs as they do not implement the Access behaviour by default. For regular structs, you **must** access the fields directly, such as `my_struct.field` or use higher level APIs that are available on the struct if they exist, `Ecto.Changeset.get_field/2` for changesets
 - Elixir's standard library has everything necessary for date and time manipulation. Familiarize yourself with the common `Time`, `Date`, `DateTime`, and `Calendar` interfaces by accessing their documentation as necessary. **Never** install additional dependencies unless asked or for date/time parsing (which you can use the `date_time_parser` package)
+- **Never** use `DateTime.utc_now() |> DateTime.truncate(:second)`. **Always** use `DateTime.utc_now(:second)` instead
 - Don't use `String.to_atom/1` on user input (memory leak risk)
 - Predicate function names should not start with `is_` and should end in a question mark. Names like `is_thing` should be reserved for guards
 - Elixir's builtin OTP primitives like `DynamicSupervisor` and `Registry`, require names in the child spec, such as `{DynamicSupervisor, name: MyApp.MyDynamicSup}`, then you can use `DynamicSupervisor.start_child(MyApp.MyDynamicSup, child_spec)`


### PR DESCRIPTION
I'm not sure about other coding assistants, but codex has this quirk where it would always use `DateTime.utc_now() |> DateTime.truncate(:second)`instead of `DateTime.utc_now(:second)`. 