### PR TITLE
Add interactive mode for phx.new

### DIFF
--- a/installer/lib/mix/tasks/phx.new.ex
+++ b/installer/lib/mix/tasks/phx.new.ex
@@ -147,13 +147,14 @@ defmodule Mix.Tasks.Phx.New do
   any existing files where conflicts exist.
   """
   use Mix.Task
-  alias Phx.New.{Generator, Project, Single, Umbrella, Web, Ecto}
+  alias Phx.New.{Generator, Interactive, Project, Single, Umbrella, Web, Ecto}
 
   @version Mix.Project.config()[:version]
   @shortdoc "Creates a new Phoenix v#{@version} application"
 
   @switches [
     dev: :boolean,
+    interactive: :boolean,
     assets: :boolean,
     esbuild: :boolean,
     tailwind: :boolean,
@@ -199,7 +200,23 @@ defmodule Mix.Tasks.Phx.New do
     result =
       case {opts, argv} do
         {_opts, []} ->
-          Mix.Tasks.Help.run(["phx.new"])
+          if opts[:interactive] do
+            case Interactive.run() do
+              {:ok, base_path, interactive_opts} ->
+                merged_opts = Keyword.merge(opts, interactive_opts)
+
+                if merged_opts[:umbrella] do
+                  generate(base_path, Umbrella, :project_path, merged_opts)
+                else
+                  generate(base_path, Single, :base_path, merged_opts)
+                end
+
+              :abort ->
+                :ok
+            end
+          else
+            Mix.Tasks.Help.run(["phx.new"])
+          end
 
         {opts, [base_path | _]} ->
           if opts[:umbrella] do

--- a/installer/lib/phx_new/interactive.ex
+++ b/installer/lib/phx_new/interactive.ex
@@ -11,10 +11,8 @@ defmodule Phx.New.Interactive do
 
   @web_options [
     {"live", "LiveView"},
-    {"html", "HTML (no LiveView)"},
-    {"live_no_assets", "LiveView (no esbuild, no Tailwind)"},
-    {"html_no_assets", "HTML (no LiveView, no esbuild, no Tailwind)"},
-    {"api", "API (no HTML)"}
+    {"html", "HTML"},
+    {"api", "API-only"}
   ]
 
   def run do
@@ -80,13 +78,13 @@ defmodule Phx.New.Interactive do
 
   defp prompt_web do
     case prompt_choice("Web interface?", @web_options, "live") do
-      "live" -> %{html: true, live: true, assets: true}
-      "html" -> %{html: true, live: false, assets: true}
-      "live_no_assets" -> %{html: true, live: true, assets: false}
-      "html_no_assets" -> %{html: true, live: false, assets: false}
       "api" -> %{html: false, live: false, assets: false}
+      "html" -> %{html: true, live: false, assets: prompt_assets?()}
+      "live" -> %{html: true, live: true, assets: prompt_assets?()}
     end
   end
+
+  defp prompt_assets?, do: yes?("Include Esbuild + Tailwind?")
 
   defp prompt_choice(question, choices, default) do
     info("\n#{question}\n")
@@ -150,10 +148,10 @@ defmodule Phx.New.Interactive do
   defp web_summary(opts) do
     case {opts[:html], opts[:live], opts[:assets]} do
       {true, true, true} -> "LiveView"
-      {true, true, false} -> "LiveView (no esbuild, no Tailwind)"
-      {true, false, true} -> "HTML (no LiveView)"
-      {true, false, false} -> "HTML (no LiveView, no esbuild, no Tailwind)"
-      {false, _, _} -> "API"
+      {true, true, false} -> "LiveView (no Esbuild, no Tailwind)"
+      {true, false, true} -> "HTML"
+      {true, false, false} -> "HTML (no Esbuild, no Tailwind)"
+      {false, _, _} -> "API-only"
     end
   end
 

--- a/installer/lib/phx_new/interactive.ex
+++ b/installer/lib/phx_new/interactive.ex
@@ -26,7 +26,7 @@ defmodule Phx.New.Interactive do
         if is_nil(database) do
           false
         else
-          yes?("Use binary_id as primary key type?")
+          yes?("Use binary_id as primary key type?", false)
         end
 
       %{html: html, live: live, assets: assets} = prompt_web()
@@ -194,16 +194,18 @@ defmodule Phx.New.Interactive do
 
   defp info(msg), do: Mix.shell().info(msg)
 
-  defp yes?(msg) do
-    case prompt("#{msg} [Yn]") |> String.downcase() do
-      "" -> true
+  defp yes?(msg, default \\ true) do
+    hint = if default, do: "[Yn]", else: "[yN]"
+
+    case prompt("#{msg} #{hint}") |> String.downcase() do
+      "" -> default
       "y" -> true
       "yes" -> true
       "n" -> false
       "no" -> false
       _ ->
         info([:red, "Please answer yes or no.\n", :reset])
-        yes?(msg)
+        yes?(msg, default)
     end
   end
 

--- a/installer/lib/phx_new/interactive.ex
+++ b/installer/lib/phx_new/interactive.ex
@@ -217,9 +217,6 @@ defmodule Phx.New.Interactive do
       result when is_binary(result) ->
         result
         |> String.trim()
-        |> normalize_abort_input()
     end
   end
-
-  defp normalize_abort_input(input), do: input
 end

--- a/installer/lib/phx_new/interactive.ex
+++ b/installer/lib/phx_new/interactive.ex
@@ -37,9 +37,9 @@ defmodule Phx.New.Interactive do
         end
 
       %{html: html, live: live, assets: assets} = prompt_web()
-      dashboard = yes?("Include LiveDashboard?")
-      mailer = yes?("Include mailer (Swoosh)?")
-      gettext = yes?("Include gettext (i18n)?")
+      dashboard = yes?("Include LiveDashboard (monitoring)?")
+      mailer = yes?("Include Swoosh (mailer)?")
+      gettext = yes?("Include Gettext (i18n)?")
       adapter = prompt_choice("Which HTTP adapter?", @adapters, "bandit")
       umbrella = yes?("Generate as an umbrella project?")
 

--- a/installer/lib/phx_new/interactive.ex
+++ b/installer/lib/phx_new/interactive.ex
@@ -41,11 +41,9 @@ defmodule Phx.New.Interactive do
       mailer = yes?("Include Swoosh (mailer)?")
       gettext = yes?("Include Gettext (i18n)?")
       adapter = prompt_choice("Which HTTP adapter?", @adapters, "bandit")
-      umbrella = yes?("Generate as an umbrella project?")
 
       opts =
         [
-          umbrella: umbrella,
           ecto: not is_nil(database),
           binary_id: binary_id,
           html: html,
@@ -149,7 +147,6 @@ defmodule Phx.New.Interactive do
     end
 
     info("  Adapter:   #{opts[:adapter]}")
-    info("  Umbrella:  #{opts[:umbrella]}")
     info("")
   end
 
@@ -171,7 +168,6 @@ defmodule Phx.New.Interactive do
   defp print_equivalent_command(path, opts) do
     flags =
       for {condition, flag} <- [
-            {opts[:umbrella], "--umbrella"},
             {!opts[:ecto], "--no-ecto"},
             {opts[:ecto] && opts[:database] != "postgres", "--database #{opts[:database]}"},
             {opts[:binary_id], "--binary-id"},

--- a/installer/lib/phx_new/interactive.ex
+++ b/installer/lib/phx_new/interactive.ex
@@ -17,11 +17,6 @@ defmodule Phx.New.Interactive do
     {"api", "API (no HTML)"}
   ]
 
-  @adapters [
-    {"bandit", "Bandit (bandit)"},
-    {"cowboy", "Cowboy (plug_cowboy)"}
-  ]
-
   def run do
     catch_abort(fn ->
       info([:green, "\nInitialize your Phoenix project (press Ctrl+C to abort)\n", :reset])
@@ -40,7 +35,6 @@ defmodule Phx.New.Interactive do
       dashboard = yes?("Include LiveDashboard (monitoring)?")
       mailer = yes?("Include Swoosh (mailer)?")
       gettext = yes?("Include Gettext (i18n)?")
-      adapter = prompt_choice("Which HTTP adapter?", @adapters, "bandit")
 
       opts =
         [
@@ -51,8 +45,7 @@ defmodule Phx.New.Interactive do
           dashboard: dashboard,
           mailer: mailer,
           gettext: gettext,
-          assets: assets,
-          adapter: adapter
+          assets: assets
         ]
         |> maybe_put_database(database)
 
@@ -146,7 +139,6 @@ defmodule Phx.New.Interactive do
       info("  Includes:  #{Enum.join(includes, ", ")}")
     end
 
-    info("  Adapter:   #{opts[:adapter]}")
     info("")
   end
 
@@ -176,8 +168,7 @@ defmodule Phx.New.Interactive do
             {!opts[:dashboard], "--no-dashboard"},
             {!opts[:mailer], "--no-mailer"},
             {!opts[:gettext], "--no-gettext"},
-            {!opts[:assets], "--no-assets"},
-            {opts[:adapter] != "bandit", "--adapter #{opts[:adapter]}"}
+            {!opts[:assets], "--no-assets"}
           ],
           condition,
           do: flag

--- a/installer/lib/phx_new/interactive.ex
+++ b/installer/lib/phx_new/interactive.ex
@@ -1,0 +1,238 @@
+defmodule Phx.New.Interactive do
+  @moduledoc false
+
+  @databases [
+    {"postgres", "PostgreSQL (postgrex)"},
+    {"mysql", "MySQL (myxql)"},
+    {"mssql", "MSSQL (tds)"},
+    {"sqlite3", "SQLite3 (ecto_sqlite3)"},
+    {"none", "None"}
+  ]
+
+  @web_options [
+    {"live", "LiveView"},
+    {"html", "HTML (no LiveView)"},
+    {"live_no_assets", "LiveView (no esbuild, no Tailwind)"},
+    {"html_no_assets", "HTML (no LiveView, no esbuild, no Tailwind)"},
+    {"api", "API (no HTML)"}
+  ]
+
+  @adapters [
+    {"bandit", "Bandit (bandit)"},
+    {"cowboy", "Cowboy (plug_cowboy)"}
+  ]
+
+  def run do
+    catch_abort(fn ->
+      info([:green, "\nInitialize your Phoenix project (press Ctrl+C to abort)\n", :reset])
+
+      path = prompt_path()
+      database = prompt_database()
+
+      binary_id =
+        if is_nil(database) do
+          false
+        else
+          yes?("Use binary_id as primary key type?")
+        end
+
+      %{html: html, live: live, assets: assets} = prompt_web()
+      dashboard = yes?("Include LiveDashboard?")
+      mailer = yes?("Include mailer (Swoosh)?")
+      gettext = yes?("Include gettext (i18n)?")
+      adapter = prompt_choice("Which HTTP adapter?", @adapters, "bandit")
+      umbrella = yes?("Generate as an umbrella project?")
+
+      opts =
+        [
+          umbrella: umbrella,
+          ecto: not is_nil(database),
+          binary_id: binary_id,
+          html: html,
+          live: live,
+          dashboard: dashboard,
+          mailer: mailer,
+          gettext: gettext,
+          assets: assets,
+          adapter: adapter
+        ]
+        |> maybe_put_database(database)
+
+      print_summary(path, opts)
+      print_equivalent_command(path, opts)
+
+      if yes?("Continue with these settings?") do
+        {:ok, path, opts}
+      else
+        abort()
+      end
+    end)
+  end
+
+  defp prompt_path do
+    case prompt("Project path (e.g., hello_world):") do
+      "" ->
+        info([:red, "Project path cannot be empty. Please try again.\n", :reset])
+        prompt_path()
+
+      input ->
+        input
+    end
+  end
+
+  defp prompt_database do
+    case prompt_choice("What is your database?", @databases, "postgres") do
+      "none" -> nil
+      database -> database
+    end
+  end
+
+  defp prompt_web do
+    case prompt_choice("Web interface?", @web_options, "live") do
+      "live" -> %{html: true, live: true, assets: true}
+      "html" -> %{html: true, live: false, assets: true}
+      "live_no_assets" -> %{html: true, live: true, assets: false}
+      "html_no_assets" -> %{html: true, live: false, assets: false}
+      "api" -> %{html: false, live: false, assets: false}
+    end
+  end
+
+  defp prompt_choice(question, choices, default) do
+    info("\n#{question}\n")
+
+    count = length(choices)
+
+    choices
+    |> Enum.with_index(1)
+    |> Enum.each(fn {{value, label}, index} ->
+      default_marker = if value == default, do: " (default)", else: ""
+      info("  #{index}) #{label}#{default_marker}")
+    end)
+
+    input = prompt("\nChoose [1-#{count}]:")
+
+    case input do
+      "" ->
+        default
+
+      _ ->
+        case Integer.parse(input) do
+          {index, ""} when index >= 1 and index <= count ->
+            {value, _label} = Enum.at(choices, index - 1)
+            value
+
+          {_index, ""} ->
+            info([:red, "Invalid choice. Please try again.\n", :reset])
+            prompt_choice(question, choices, default)
+
+          _ ->
+            info([:red, "Invalid input. Please enter a number.\n", :reset])
+            prompt_choice(question, choices, default)
+        end
+    end
+  end
+
+  defp print_summary(path, opts) do
+    info("\nProject Summary\n")
+
+    info("  Path:      #{path}")
+    info("  Database:  #{database_summary(opts)}")
+    info("  Web:       #{web_summary(opts)}")
+
+    includes =
+      for {key, label} <- [dashboard: "LiveDashboard", mailer: "mailer", gettext: "gettext"],
+          opts[key],
+          do: label
+
+    if Enum.any?(includes) do
+      info("  Includes:  #{Enum.join(includes, ", ")}")
+    end
+
+    info("  Adapter:   #{opts[:adapter]}")
+    info("  Umbrella:  #{opts[:umbrella]}")
+    info("")
+  end
+
+  defp database_summary(opts) do
+    db = opts[:database] || "none"
+    if opts[:binary_id], do: "#{db} (binary_id)", else: db
+  end
+
+  defp web_summary(opts) do
+    case {opts[:html], opts[:live], opts[:assets]} do
+      {true, true, true} -> "LiveView"
+      {true, true, false} -> "LiveView (no esbuild, no Tailwind)"
+      {true, false, true} -> "HTML (no LiveView)"
+      {true, false, false} -> "HTML (no LiveView, no esbuild, no Tailwind)"
+      {false, _, _} -> "API"
+    end
+  end
+
+  defp print_equivalent_command(path, opts) do
+    flags =
+      for {condition, flag} <- [
+            {opts[:umbrella], "--umbrella"},
+            {!opts[:ecto], "--no-ecto"},
+            {opts[:ecto] && opts[:database] != "postgres", "--database #{opts[:database]}"},
+            {opts[:binary_id], "--binary-id"},
+            {!opts[:html], "--no-html"},
+            {opts[:html] && !opts[:live], "--no-live"},
+            {!opts[:dashboard], "--no-dashboard"},
+            {!opts[:mailer], "--no-mailer"},
+            {!opts[:gettext], "--no-gettext"},
+            {!opts[:assets], "--no-assets"},
+            {opts[:adapter] != "bandit", "--adapter #{opts[:adapter]}"}
+          ],
+          condition,
+          do: flag
+
+    cmd = Enum.join(["mix phx.new #{path}" | flags], " ")
+
+    info([:green, "Equivalent command:\n", :reset])
+    info("  $ #{cmd}\n")
+  end
+
+  defp maybe_put_database(opts, nil), do: opts
+  defp maybe_put_database(opts, database), do: Keyword.put(opts, :database, database)
+
+  defp catch_abort(fun) do
+    try do
+      fun.()
+    catch
+      :throw, :abort ->
+        info("\nAborted.\n")
+        :abort
+    end
+  end
+
+  defp abort, do: throw(:abort)
+
+  defp info(msg), do: Mix.shell().info(msg)
+
+  defp yes?(msg) do
+    case prompt("#{msg} [Yn]") |> String.downcase() do
+      "" -> true
+      "y" -> true
+      "yes" -> true
+      "n" -> false
+      "no" -> false
+      _ ->
+        info([:red, "Please answer yes or no.\n", :reset])
+        yes?(msg)
+    end
+  end
+
+  defp prompt(msg) do
+    case Mix.shell().prompt(msg) do
+      :eof ->
+        abort()
+
+      result when is_binary(result) ->
+        result
+        |> String.trim()
+        |> normalize_abort_input()
+    end
+  end
+
+  defp normalize_abort_input(input), do: input
+end

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -821,6 +821,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
 
       Mix.Tasks.Phx.New.run(["--interactive"])
 
@@ -835,7 +836,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       send(self(), {:mix_shell_input, :prompt, "custom_app"})
       send(self(), {:mix_shell_input, :prompt, "4"})
       send(self(), {:mix_shell_input, :prompt, "y"})
-      send(self(), {:mix_shell_input, :prompt, "5"})
+      send(self(), {:mix_shell_input, :prompt, "3"})
       send(self(), {:mix_shell_input, :prompt, "n"})
       send(self(), {:mix_shell_input, :prompt, "n"})
       send(self(), {:mix_shell_input, :prompt, "n"})
@@ -852,6 +853,7 @@ defmodule Mix.Tasks.Phx.NewTest do
   test "new --interactive aborts when user declines" do
     in_tmp("new interactive abort", fn ->
       send(self(), {:mix_shell_input, :prompt, "my_app"})
+      send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -813,69 +813,107 @@ defmodule Mix.Tasks.Phx.NewTest do
 
   test "new --interactive with defaults generates project" do
     in_tmp("new interactive defaults", fn ->
+      # path
       send(self(), {:mix_shell_input, :prompt, "my_app"})
+      # database: postgres (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # binary_id: no (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # web: LiveView (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # assets: yes (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # dashboard: yes (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # mailer: yes (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # gettext: yes (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # confirm: yes (default)
       send(self(), {:mix_shell_input, :prompt, ""})
 
-      Mix.Tasks.Phx.New.run(["--interactive"])
+      assert {:ok, "my_app", opts} = Phx.New.Interactive.run()
 
-      assert_file("my_app/mix.exs", fn file ->
-        assert file =~ "app: :my_app"
-      end)
+      assert %{
+               ecto: true,
+               binary_id: false,
+               html: true,
+               live: true,
+               dashboard: true,
+               mailer: true,
+               gettext: true,
+               assets: true,
+               database: "postgres"
+             } = Map.new(opts)
     end)
   end
 
   test "new --interactive with custom config" do
     in_tmp("new interactive custom", fn ->
+      # path
       send(self(), {:mix_shell_input, :prompt, "custom_app"})
+      # database: sqlite3 (option 4)
       send(self(), {:mix_shell_input, :prompt, "4"})
+      # binary_id: yes
       send(self(), {:mix_shell_input, :prompt, "y"})
+      # web: API-only (option 3, skips assets prompt)
       send(self(), {:mix_shell_input, :prompt, "3"})
+      # dashboard: no
       send(self(), {:mix_shell_input, :prompt, "n"})
+      # mailer: no
       send(self(), {:mix_shell_input, :prompt, "n"})
+      # gettext: no
       send(self(), {:mix_shell_input, :prompt, "n"})
+      # confirm: yes
       send(self(), {:mix_shell_input, :prompt, "y"})
 
-      Mix.Tasks.Phx.New.run(["--interactive"])
+      assert {:ok, "custom_app", opts} = Phx.New.Interactive.run()
 
-      assert_file("custom_app/mix.exs", fn file ->
-        assert file =~ "app: :custom_app"
-      end)
+      assert %{
+               ecto: true,
+               binary_id: true,
+               html: false,
+               live: false,
+               dashboard: false,
+               mailer: false,
+               gettext: false,
+               assets: false,
+               database: "sqlite3"
+             } = Map.new(opts)
     end)
   end
 
   test "new --interactive aborts when user declines" do
     in_tmp("new interactive abort", fn ->
+      # path
       send(self(), {:mix_shell_input, :prompt, "my_app"})
+      # database: postgres (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # binary_id: no (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # web: LiveView (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # assets: yes (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # dashboard: yes (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # mailer: yes (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # gettext: yes (default)
       send(self(), {:mix_shell_input, :prompt, ""})
+      # confirm: no (abort)
       send(self(), {:mix_shell_input, :prompt, "n"})
 
-      Mix.Tasks.Phx.New.run(["--interactive"])
-
-      refute File.exists?("my_app")
+      assert :abort = Phx.New.Interactive.run()
     end)
   end
 
-  # When user presses Ctrl+C or Ctrl+D
   test "new --interactive aborts on eof" do
     in_tmp("new interactive eof", fn ->
+      # User presses Ctrl+C or Ctrl+D
       send(self(), {:mix_shell_input, :prompt, :eof})
 
-      Mix.Tasks.Phx.New.run(["--interactive"])
-
-      refute File.exists?("my_app")
+      assert :abort = Phx.New.Interactive.run()
     end)
   end
 

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -821,7 +821,6 @@ defmodule Mix.Tasks.Phx.NewTest do
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
-      send(self(), {:mix_shell_input, :prompt, ""})
 
       Mix.Tasks.Phx.New.run(["--interactive"])
 
@@ -840,7 +839,6 @@ defmodule Mix.Tasks.Phx.NewTest do
       send(self(), {:mix_shell_input, :prompt, "n"})
       send(self(), {:mix_shell_input, :prompt, "n"})
       send(self(), {:mix_shell_input, :prompt, "n"})
-      send(self(), {:mix_shell_input, :prompt, "2"})
       send(self(), {:mix_shell_input, :prompt, "y"})
 
       Mix.Tasks.Phx.New.run(["--interactive"])
@@ -854,7 +852,6 @@ defmodule Mix.Tasks.Phx.NewTest do
   test "new --interactive aborts when user declines" do
     in_tmp("new interactive abort", fn ->
       send(self(), {:mix_shell_input, :prompt, "my_app"})
-      send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -821,7 +821,6 @@ defmodule Mix.Tasks.Phx.NewTest do
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
-      send(self(), {:mix_shell_input, :prompt, "n"})
       send(self(), {:mix_shell_input, :prompt, ""})
 
       Mix.Tasks.Phx.New.run(["--interactive"])
@@ -842,7 +841,6 @@ defmodule Mix.Tasks.Phx.NewTest do
       send(self(), {:mix_shell_input, :prompt, "n"})
       send(self(), {:mix_shell_input, :prompt, "n"})
       send(self(), {:mix_shell_input, :prompt, "2"})
-      send(self(), {:mix_shell_input, :prompt, "n"})
       send(self(), {:mix_shell_input, :prompt, "y"})
 
       Mix.Tasks.Phx.New.run(["--interactive"])
@@ -863,7 +861,6 @@ defmodule Mix.Tasks.Phx.NewTest do
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
       send(self(), {:mix_shell_input, :prompt, ""})
-      send(self(), {:mix_shell_input, :prompt, "n"})
       send(self(), {:mix_shell_input, :prompt, "n"})
 
       Mix.Tasks.Phx.New.run(["--interactive"])

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -811,6 +811,78 @@ defmodule Mix.Tasks.Phx.NewTest do
     end)
   end
 
+  test "new --interactive with defaults generates project" do
+    in_tmp("new interactive defaults", fn ->
+      send(self(), {:mix_shell_input, :prompt, "my_app"})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, "n"})
+      send(self(), {:mix_shell_input, :prompt, ""})
+
+      Mix.Tasks.Phx.New.run(["--interactive"])
+
+      assert_file("my_app/mix.exs", fn file ->
+        assert file =~ "app: :my_app"
+      end)
+    end)
+  end
+
+  test "new --interactive with custom config" do
+    in_tmp("new interactive custom", fn ->
+      send(self(), {:mix_shell_input, :prompt, "custom_app"})
+      send(self(), {:mix_shell_input, :prompt, "4"})
+      send(self(), {:mix_shell_input, :prompt, "y"})
+      send(self(), {:mix_shell_input, :prompt, "5"})
+      send(self(), {:mix_shell_input, :prompt, "n"})
+      send(self(), {:mix_shell_input, :prompt, "n"})
+      send(self(), {:mix_shell_input, :prompt, "n"})
+      send(self(), {:mix_shell_input, :prompt, "2"})
+      send(self(), {:mix_shell_input, :prompt, "n"})
+      send(self(), {:mix_shell_input, :prompt, "y"})
+
+      Mix.Tasks.Phx.New.run(["--interactive"])
+
+      assert_file("custom_app/mix.exs", fn file ->
+        assert file =~ "app: :custom_app"
+      end)
+    end)
+  end
+
+  test "new --interactive aborts when user declines" do
+    in_tmp("new interactive abort", fn ->
+      send(self(), {:mix_shell_input, :prompt, "my_app"})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, ""})
+      send(self(), {:mix_shell_input, :prompt, "n"})
+      send(self(), {:mix_shell_input, :prompt, "n"})
+
+      Mix.Tasks.Phx.New.run(["--interactive"])
+
+      refute File.exists?("my_app")
+    end)
+  end
+
+  # When user presses Ctrl+C or Ctrl+D
+  test "new --interactive aborts on eof" do
+    in_tmp("new interactive eof", fn ->
+      send(self(), {:mix_shell_input, :prompt, :eof})
+
+      Mix.Tasks.Phx.New.run(["--interactive"])
+
+      refute File.exists?("my_app")
+    end)
+  end
+
   test "new with reserved name" do
     assert_raise Mix.Error, ~r/Application name cannot be "server" as it is reserved/, fn ->
       Mix.Tasks.Phx.New.run(["server"])


### PR DESCRIPTION
Every time I initialize a Phoenix project, I have to triple check the docs to figure out which flags to use. It would be nice if there were an interactive mode.

I made it sort of opinionated and not 1:1 with all the flags. Let me know what you guys think.

https://github.com/user-attachments/assets/9eba74b6-1015-47e4-8710-36282ca1163f

