### PR TITLE
Fix outdated flash component example in docs

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex.eex
+++ b/installer/templates/phx_web/components/core_components.ex.eex
@@ -37,7 +37,14 @@ defmodule <%= @web_namespace %>.CoreComponents do
   ## Examples
 
       <.flash kind={:info} flash={@flash} />
-      <.flash kind={:info} phx-mounted={show("#flash")}>Welcome Back!</.flash>
+      <.flash
+        id="welcome-back"
+        kind={:info}
+        phx-mounted={show("#welcome-back") |> JS.remove_attribute("hidden")}
+        hidden
+      >
+        Welcome Back!
+      </.flash>
   """
   attr :id, :string, doc: "the optional id of flash container"
   attr :flash, :map, default: %{}, doc: "the map of flash messages to display"


### PR DESCRIPTION
The flash component `@doc` example used `show("#flash")` which had two issues:

1. The id `#flash` does not match the default generated id (`flash-#{kind}`)
2. The flash was missing the `hidden` attribute, so `phx-mounted` had no visible effect

Updated the example to follow the same pattern used by the `client-error` and
`server-error` flashes in the generated layouts: explicit `id`, `hidden` attribute,
and `show("#id") |> JS.remove_attribute("hidden")`.

Closes #6624