### PR TITLE
Raise on list value in query string parameter encoding

### DIFF
--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -899,7 +899,7 @@ defmodule Phoenix.VerifiedRoutes do
   end
 
   def __encode_query__(dict, sort?) when is_list(dict) do
-    if Keyword.keyword?(dict) do
+    if dict == [] or match?([{_, _} | _], dict) do
       case Plug.Conn.Query.encode(dict, &to_param/1) do
         "" -> ""
         query_str -> maybe_sort_query(query_str, sort?)

--- a/test/phoenix/verified_routes_test.exs
+++ b/test/phoenix/verified_routes_test.exs
@@ -420,11 +420,11 @@ defmodule Phoenix.VerifiedRoutesTest do
 
   test "list value as query string parameter raises" do
     assert_raise ArgumentError, ~r/expected a keyword list or map/, fn ->
-      Phoenix.VerifiedRoutes.__encode_query__(["abc-123"])
+      ~p"/posts/top?#{["abc-123"]}"
     end
 
     assert_raise ArgumentError, ~r/expected a keyword list or map/, fn ->
-      Phoenix.VerifiedRoutes.__encode_query__([1, 2, 3])
+      ~p"/posts/top?#{[1, 2, 3]}"
     end
   end
 


### PR DESCRIPTION
When a plain list is interpolated as a query string value in `~p`,
such as `~p"/path?key=#{[value]}"`, the list was silently treated as a
dict by `Plug.Conn.Query.encode`, producing incorrect output like
`key=[]=value`.

This raises an `ArgumentError` with a helpful message pointing to the
correct syntax:

```
expected a keyword list or map for query string encoding, got: ["abc-123"].
Use the full query string syntax instead, such as ~p"/path?#{[key: ["abc-123"]]}"
```

As suggested by @josevalim in #6582, raising is the clearest option
since list encoding in query strings is not standardized.

Closes #6582