### PR TITLE
Fix phx.new crash when parent directory contains a colon

### DIFF
--- a/installer/lib/phx_new/project.ex
+++ b/installer/lib/phx_new/project.ex
@@ -72,10 +72,9 @@ defmodule Phx.New.Project do
 
   def join_path(%Project{} = project, location, path)
       when location in [:project, :app, :web] do
-    project
-    |> Map.fetch!(:"#{location}_path")
-    |> Path.join(path)
-    |> expand_path_with_bindings(project)
+    base = Map.fetch!(project, :"#{location}_path")
+    expanded = expand_path_with_bindings(path, project)
+    Path.join(base, expanded)
   end
 
   defp expand_path_with_bindings(path, %Project{} = project) do

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -804,6 +804,17 @@ defmodule Mix.Tasks.Phx.NewTest do
     end
   end
 
+  test "new with colon in parent directory path" do
+    in_tmp("new with colon in path", fn ->
+      colon_dir = Path.join(File.cwd!(), "0:0")
+      File.mkdir_p!(colon_dir)
+      project_path = Path.join(colon_dir, "myapp")
+      Mix.Tasks.Phx.New.run([project_path, "--no-install"])
+
+      assert_file(Path.join(project_path, "mix.exs"), "app: :myapp")
+    end)
+  end
+
   test "new without args" do
     in_tmp("new without args", fn ->
       assert capture_io(fn -> Mix.Tasks.Phx.New.run([]) end) =~


### PR DESCRIPTION
`mix phx.new` crashes with a `KeyError` when the parent directory
contains a colon (e.g., `/mnt/usb-Seagate:0/code/myapp`).

The regex in `Project.expand_path_with_bindings/2` matches
`:[a-zA-Z0-9_]+` against the full absolute path, so a directory
like `0:0` causes `:0` to be interpreted as a template binding.

The fix applies the binding expansion only to the relative template
path before joining it with the base path.

### To reproduce (before fix)

```console
mkdir 0:0 && cd 0:0
mix phx.new myapp
# => ** (KeyError) key :"0" not found in: %Phx.New.Project{...}
```

### After fix

```console
mkdir 0:0 && cd 0:0
mix phx.new myapp
# => works correctly
```

Closes #6585