### PR TITLE
Don't pass type: :id to scope references in generated migrations

### DIFF
--- a/integration_test/test/code_generation/app_with_mysql_adapter_test.exs
+++ b/integration_test/test/code_generation/app_with_mysql_adapter_test.exs
@@ -8,7 +8,10 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMySqlAdapterTest do
         {app_root_path, _} =
           generate_phoenix_app(tmp_dir, "default_mysql_app", ["--database", "mysql"])
 
-        mix_run!(~w(phx.gen.html Blog Post posts title body:string status:enum:unpublished:published:deleted), app_root_path)
+        mix_run!(
+          ~w(phx.gen.html Blog Post posts title body:string status:enum:unpublished:published:deleted),
+          app_root_path
+        )
 
         modify_file(Path.join(app_root_path, "lib/default_mysql_app_web/router.ex"), fn file ->
           inject_before_final_end(file, """
@@ -34,7 +37,10 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMySqlAdapterTest do
         {app_root_path, _} =
           generate_phoenix_app(tmp_dir, "default_mysql_app", ["--database", "mysql"])
 
-        mix_run!(~w(phx.gen.json Blog Post posts title body:string status:enum:unpublished:published:deleted), app_root_path)
+        mix_run!(
+          ~w(phx.gen.json Blog Post posts title body:string status:enum:unpublished:published:deleted),
+          app_root_path
+        )
 
         modify_file(Path.join(app_root_path, "lib/default_mysql_app_web/router.ex"), fn file ->
           inject_before_final_end(file, """
@@ -60,7 +66,10 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMySqlAdapterTest do
         {app_root_path, _} =
           generate_phoenix_app(tmp_dir, "default_mysql_app", ["--database", "mysql", "--live"])
 
-        mix_run!(~w(phx.gen.live Blog Post posts title body:string status:enum:unpublished:published:deleted), app_root_path)
+        mix_run!(
+          ~w(phx.gen.live Blog Post posts title body:string status:enum:unpublished:published:deleted),
+          app_root_path
+        )
 
         modify_file(Path.join(app_root_path, "lib/default_mysql_app_web/router.ex"), fn file ->
           inject_before_final_end(file, """
@@ -82,10 +91,44 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMySqlAdapterTest do
     end
   end
 
+  describe "phx.gen.live with scope" do
+    @tag database: :mysql
+    test "has a passing test suite with scoped references" do
+      with_installer_tmp("mysql_scope_app", fn tmp_dir ->
+        {app_root_path, _} =
+          generate_phoenix_app(tmp_dir, "mysql_scope_app", ["--database", "mysql", "--live"])
+
+        mix_run!(~w(phx.gen.auth Accounts User users --live), app_root_path)
+        # we need to wait, otherwise we'd generate two migrations with the same version...
+        Process.sleep(1500)
+        mix_run!(~w(phx.gen.live Blog Post posts title:string), app_root_path)
+
+        modify_file(Path.join(app_root_path, "lib/mysql_scope_app_web/router.ex"), fn file ->
+          String.replace(
+            file,
+            "live \"/users/settings/confirm-email/:token\", UserLive.Settings, :confirm_email",
+            """
+            live "/users/settings/confirm-email/:token", UserLive.Settings, :confirm_email
+
+                  live "/posts", PostLive.Index, :index
+                  live "/posts/new", PostLive.Form, :new
+                  live "/posts/:id", PostLive.Show, :show
+                  live "/posts/:id/edit", PostLive.Form, :edit
+            """
+          )
+        end)
+
+        drop_test_database(app_root_path)
+        assert_tests_pass(app_root_path)
+      end)
+    end
+  end
+
   describe "phx.gen.auth + argon2" do
     test "has no compilation or formatter warnings (--live)" do
       with_installer_tmp("new with defaults", fn tmp_dir ->
-        {app_root_path, _} = generate_phoenix_app(tmp_dir, "phx_blog", ["--database", "mysql", "--binary-id"])
+        {app_root_path, _} =
+          generate_phoenix_app(tmp_dir, "phx_blog", ["--database", "mysql", "--binary-id"])
 
         mix_run!(~w(phx.gen.auth Accounts User users --hashing-lib argon2 --live), app_root_path)
 
@@ -96,9 +139,13 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMySqlAdapterTest do
 
     test "has no compilation or formatter warnings (--no-live)" do
       with_installer_tmp("new with defaults", fn tmp_dir ->
-        {app_root_path, _} = generate_phoenix_app(tmp_dir, "phx_blog", ["--database", "mysql", "--binary-id"])
+        {app_root_path, _} =
+          generate_phoenix_app(tmp_dir, "phx_blog", ["--database", "mysql", "--binary-id"])
 
-        mix_run!(~w(phx.gen.auth Accounts User users --hashing-lib argon2 --no-live), app_root_path)
+        mix_run!(
+          ~w(phx.gen.auth Accounts User users --hashing-lib argon2 --no-live),
+          app_root_path
+        )
 
         assert_no_compilation_warnings(app_root_path)
         assert_passes_formatter_check(app_root_path)
@@ -108,7 +155,8 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMySqlAdapterTest do
     @tag database: :mysql
     test "has a passing test suite (--live)" do
       with_installer_tmp("app_with_defaults", fn tmp_dir ->
-        {app_root_path, _} = generate_phoenix_app(tmp_dir, "default_app", ["--database", "mysql", "--binary-id"])
+        {app_root_path, _} =
+          generate_phoenix_app(tmp_dir, "default_app", ["--database", "mysql", "--binary-id"])
 
         mix_run!(~w(phx.gen.auth Accounts User users --hashing-lib argon2 --live), app_root_path)
 
@@ -120,9 +168,13 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMySqlAdapterTest do
     @tag database: :mysql
     test "has a passing test suite (--no-live)" do
       with_installer_tmp("app_with_defaults", fn tmp_dir ->
-        {app_root_path, _} = generate_phoenix_app(tmp_dir, "default_app", ["--database", "mysql", "--binary-id"])
+        {app_root_path, _} =
+          generate_phoenix_app(tmp_dir, "default_app", ["--database", "mysql", "--binary-id"])
 
-        mix_run!(~w(phx.gen.auth Accounts User users --hashing-lib argon2 --no-live), app_root_path)
+        mix_run!(
+          ~w(phx.gen.auth Accounts User users --hashing-lib argon2 --no-live),
+          app_root_path
+        )
 
         drop_test_database(app_root_path)
         assert_tests_pass(app_root_path)

--- a/lib/mix/phoenix/scope.ex
+++ b/lib/mix/phoenix/scope.ex
@@ -34,7 +34,8 @@ defmodule Mix.Phoenix.Scope do
       | name: name,
         alias: alias,
         route_access_path: route_access_path,
-        schema_migration_type: scope.schema_migration_type || scope.schema_type
+        schema_migration_type:
+          scope.schema_migration_type || if(scope.schema_type != :id, do: scope.schema_type)
     }
   end
 

--- a/priv/templates/phx.gen.schema/migration.exs.eex
+++ b/priv/templates/phx.gen.schema/migration.exs.eex
@@ -7,7 +7,7 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.
 <% else %><%= if schema.opts[:primary_key] do %>      add :<%= schema.opts[:primary_key] %>, :id, primary_key: true
 <% end %><% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect Mix.Phoenix.Schema.type_for_migration(v) %><%= schema.migration_defaults[k] %>
 <% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= inspect(i) %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)
-<% end %><%= if scope do %>      add :<%= scope.schema_key %>, <%= if scope.schema_table do %>references(:<%= scope.schema_table %>, type: <%= inspect scope.schema_migration_type %>, on_delete: :delete_all)<% else %><%= inspect scope.schema_migration_type %><% end %>
+<% end %><%= if scope do %>      add :<%= scope.schema_key %>, <%= if scope.schema_table do %>references(:<%= scope.schema_table %>, <%= if scope.schema_migration_type != :id do %>type: <%= inspect scope.schema_migration_type %>, <% end %>on_delete: :delete_all)<% else %><%= inspect scope.schema_migration_type %><% end %>
 <% end %>
       timestamps(<%= if schema.timestamp_type != :naive_datetime, do: "type: #{inspect schema.timestamp_type}" %>)
     end<%= if scope do %>

--- a/priv/templates/phx.gen.schema/migration.exs.eex
+++ b/priv/templates/phx.gen.schema/migration.exs.eex
@@ -7,7 +7,7 @@ defmodule <%= inspect schema.repo %>.Migrations.Create<%= Macro.camelize(schema.
 <% else %><%= if schema.opts[:primary_key] do %>      add :<%= schema.opts[:primary_key] %>, :id, primary_key: true
 <% end %><% end %><%= for {k, v} <- schema.attrs do %>      add <%= inspect k %>, <%= inspect Mix.Phoenix.Schema.type_for_migration(v) %><%= schema.migration_defaults[k] %>
 <% end %><%= for {_, i, _, s} <- schema.assocs do %>      add <%= inspect(i) %>, references(<%= inspect(s) %>, on_delete: :nothing<%= if schema.binary_id do %>, type: :binary_id<% end %>)
-<% end %><%= if scope do %>      add :<%= scope.schema_key %>, <%= if scope.schema_table do %>references(:<%= scope.schema_table %>, <%= if scope.schema_migration_type != :id do %>type: <%= inspect scope.schema_migration_type %>, <% end %>on_delete: :delete_all)<% else %><%= inspect scope.schema_migration_type %><% end %>
+<% end %><%= if scope do %>      add :<%= scope.schema_key %>, <%= if scope.schema_table do %>references(:<%= scope.schema_table %>, <%= if scope.schema_migration_type do %>type: <%= inspect scope.schema_migration_type %>, <% end %>on_delete: :delete_all)<% else %><%= inspect(scope.schema_migration_type || scope.schema_type) %><% end %>
 <% end %>
       timestamps(<%= if schema.timestamp_type != :naive_datetime, do: "type: #{inspect schema.timestamp_type}" %>)
     end<%= if scope do %>

--- a/test/mix/tasks/phx.gen.schema_test.exs
+++ b/test/mix/tasks/phx.gen.schema_test.exs
@@ -584,7 +584,7 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
               assert file =~ "add :id, :binary_id, primary_key: true"
 
               assert file =~
-                       "add :org_id, references(:organizations, type: :id, on_delete: :delete_all)"
+                       "add :org_id, references(:organizations, on_delete: :delete_all)"
 
               assert file =~ "create index(:blog_posts, [:org_id])"
             end)
@@ -624,7 +624,42 @@ defmodule Mix.Tasks.Phx.Gen.SchemaTest do
             assert file =~ "add :id, :binary_id, primary_key: true"
 
             assert file =~
-                     "add :org_id, references(:organizations, type: :id, on_delete: :delete_all)"
+                     "add :org_id, references(:organizations, on_delete: :delete_all)"
+
+            assert file =~ "create index(:blog_posts, [:org_id])"
+          end)
+        end
+      )
+    end)
+  end
+
+  test "generates scoped schema with binary_id scope type", config do
+    in_tmp_project(config.test, fn ->
+      with_scope_env(
+        :phoenix,
+        [
+          org: [
+            default: true,
+            module: MyApp.Accounts.Scope,
+            assign_key: :current_scope,
+            access_path: [:user, :org_id],
+            schema_key: :org_id,
+            schema_type: :binary_id,
+            schema_table: :organizations
+          ]
+        ],
+        fn ->
+          Gen.Schema.run(~w(Blog.Post blog_posts title:string --scope org))
+
+          assert_file("lib/phoenix/blog/post.ex", fn file ->
+            assert file =~ "field :org_id, :binary_id"
+          end)
+
+          assert [migration] = Path.wildcard("priv/repo/migrations/*_create_blog_posts.exs")
+
+          assert_file(migration, fn file ->
+            assert file =~
+                     "add :org_id, references(:organizations, type: :binary_id, on_delete: :delete_all)"
 
             assert file =~ "create index(:blog_posts, [:org_id])"
           end)


### PR DESCRIPTION
## Summary

Fixes #6422.

The scope reference in the migration template (`migration.exs.eex`, line 10) was passing `type: :id` explicitly to `references()`. In Ecto's MySQL adapter, `:id` maps to `integer` (signed 32-bit), while the default PK is `bigint unsigned auto_increment`. This type mismatch causes:

```
(MyXQL.Error) (1005) (ER_CANT_CREATE_TABLE) Can't create table (errno: 150 "Foreign key constraint is incorrectly formed")
```

### Ecto type mapping on MySQL

| `references()` option | Ecto type | MySQL SQL | Matches default PK? |
|---|---|---|---|
| *(no type)* | `:bigserial` (default) | `BIGINT UNSIGNED` | Yes |
| `type: :bigserial` | `:bigserial` | `BIGINT UNSIGNED` | Yes |
| `type: :id` | `:id` | `integer` (32-bit) | **No — errno 150** |

### Before (broken on MySQL)

```elixir
add :user_id, references(:users, type: :id, on_delete: :delete_all)
```

### After (works on all adapters)

```elixir
add :user_id, references(:users, on_delete: :delete_all)
```

By omitting `type:` when it's `:id`, Ecto defaults to `:bigserial` which correctly maps to `BIGINT UNSIGNED` on MySQL. Non-`:id` types like `:binary_id` are still passed explicitly.

### Changes

- `priv/templates/phx.gen.schema/migration.exs.eex` — conditionally omit `type:` for scope references when `schema_migration_type == :id`
- Unit tests for both `:id` (omitted) and `:binary_id` (kept) scope types
- MySQL integration test with scoped resources verifying no errno 150