### PR TITLE
fix(phx.gen.auth): delete old token when reissuing session

### DIFF
--- a/priv/templates/phx.gen.auth/auth.ex.eex
+++ b/priv/templates/phx.gen.auth/auth.ex.eex
@@ -94,6 +94,8 @@ defmodule <%= inspect auth_module %> do
     token_age = <%= inspect datetime_module %>.diff(<%= datetime_now %>, token_inserted_at, :day)
 
     if token_age >= @session_reissue_age_in_days do
+      old_token = get_session(conn, :<%= schema.singular %>_token)
+      old_token && <%= inspect context.alias %>.delete_<%= schema.singular %>_session_token(old_token)
       create_or_extend_session(conn, <%= schema.singular %>, %{})
     else
       conn

--- a/priv/templates/phx.gen.auth/auth_test.exs.eex
+++ b/priv/templates/phx.gen.auth/auth_test.exs.eex
@@ -200,6 +200,7 @@ defmodule <%= inspect auth_module %>Test do
         |> put_req_cookie(@remember_me_cookie, signed_token)
         |> <%= inspect schema.alias %>Auth.fetch_<%= scope_config.scope.assign_key %>_for_<%= schema.singular %>([])
 
+      refute <%= inspect context.alias %>.get_<%= schema.singular %>_by_session_token(token)
       assert conn.assigns.<%= scope_config.scope.assign_key %>.<%= schema.singular %>.id == <%= schema.singular %>.id
       assert conn.assigns.<%= scope_config.scope.assign_key %>.<%= schema.singular %>.authenticated_at == <%= schema.singular %>.authenticated_at
       assert new_token = get_session(conn, :<%= schema.singular %>_token)


### PR DESCRIPTION
Fixes a bug where reissuing user session token leaves the old token in the database. This bloats the database table and poses a minor security risk as old token will remain valid.

The fix copies the pattern from logout to [clear the token](https://github.com/phoenixframework/phoenix/blob/c88da921ef8009e0aca8643d5334585cd35d5573/priv/templates/phx.gen.auth/auth.ex.eex#L50) 

## Steps to reproduce

1. Run auth scaffold `mix phx.gen.auth Accounts User users`
2. In `user_auth.ex` set `@session_reissue_age_in_days 0`
3. Register a user and log in
4. Check tokens with `SELECT * FROM users_tokens;`
5. Refresh the page
6. Check tokens again (tokens accumulate)