### PR TITLE
fix(docs): add build path to nodePaths for colocated hooks

### DIFF
--- a/guides/asset_management.md
+++ b/guides/asset_management.md
@@ -143,7 +143,7 @@ let opts = {
   target: "es2022",
   outdir: "../priv/static/assets",
   external: ["*.css", "fonts/*", "images/*"],
-  nodePaths: ["../deps"],
+  nodePaths: ["../deps", `../_build/${process.env.MIX_ENV}`],
   loader: loader,
   plugins: plugins,
 };


### PR DESCRIPTION
Since the introduction of colocated hooks in v1.8 the example for a custom `build.js` file requires the build path to be present as well. If it is not present, the build of the assets will fail with a resolve error `Could not resolve "phoenix-colocated/<app>"`

The default `:esbuild` config already includes the build path by using `Mix.project.build_path()`