### PR TITLE
docs: fix grammar in router and schema generator docs

### DIFF
--- a/lib/mix/tasks/phx.gen.schema.ex
+++ b/lib/mix/tasks/phx.gen.schema.ex
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Phx.Gen.Schema do
   ## primary_key
 
   By default, the primary key in the table is called `id`. This option
-  allows to change the name of the primary key column. For example:
+  allows changing the name of the primary key column. For example:
 
       $ mix phx.gen.schema Blog.post posts --primary-key post_id
 

--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -117,7 +117,7 @@ defmodule Phoenix.Router do
   >   which is heavily optimized by the Erlang VM
   >
   > * For each route you define, we also define metadata to implement `Phoenix.VerifiedRoutes`.
-  >   As we will soon learn, verified routes allows to us to reference any route
+  >   As we will soon learn, verified routes allow us to reference any route
   >   as if it is a plain looking string, except it is verified by the compiler
   >   to be valid (making it much harder to ship broken links, forms, mails, etc
   >   to production)


### PR DESCRIPTION

**Repo:** phoenixframework/phoenix (⭐ 21000)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Fixes two minor grammatical errors in public module documentation. In `lib/phoenix/router.ex`, the phrase "verified routes allows to us to reference any route" is corrected to "verified routes allow us to reference any route". In `lib/mix/tasks/phx.gen.schema.ex`, the non-idiomatic "allows to change the name of the primary key column" is corrected to "allows changing the name of the primary key column".

## Why
Both strings are rendered on hexdocs.pm as part of Phoenix's published API documentation, so grammar slips are visible to every Phoenix user reading the Router guide or the `mix phx.gen.schema` task reference. The fixes are purely textual and do not change any behavior, examples, or code paths.

## Testing
No runtime code is touched, so the existing test suite is unaffected. A reviewer can verify by reading the before/after lines in `lib/phoenix/router.ex:120` and `lib/mix/tasks/phx.gen.schema.ex:92`.

## Risk
Low — documentation-only wording change, no code paths affected.
