### PR TITLE
Fix: only process vsn parameter when it is a binary

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -595,7 +595,7 @@ defmodule Phoenix.Socket do
     :ok
   end
 
-  defp negotiate_serializer(serializers, vsn) when is_list(serializers) do
+  defp negotiate_serializer(serializers, vsn) when is_list(serializers) and is_binary(vsn) do
     case Version.parse(vsn) do
       {:ok, vsn} ->
         serializers
@@ -617,6 +617,11 @@ defmodule Phoenix.Socket do
         Logger.warning("Client sent invalid transport version \"#{vsn}\"")
         :error
     end
+  end
+
+  defp negotiate_serializer(_serializer, vsn) do
+    Logger.warning("Client sent invalid transport version \"#{vsn}\"")
+    :error
   end
 
   defp user_connect(handler, endpoint, transport, serializer, params, connect_info) do


### PR DESCRIPTION
Fixes #6661 

Adds a guard to `negotiate_serializer/2` to ensure `vsn` is a binary, otherwise `Version.parse/1` raises an exception.

Returns an `:error` atom otherwise and logs a warning.