### PR TITLE
Fix live_title having line breaks

### DIFF
--- a/installer/templates/phx_web/components/layouts/root.html.heex.eex
+++ b/installer/templates/phx_web/components/layouts/root.html.heex.eex
@@ -4,9 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title default="<%= @app_module %>" suffix=" · Phoenix Framework">
-      {assigns[:page_title]}
-    </.live_title>
+    <.live_title default="<%= @app_module %>" suffix=" · Phoenix Framework" phx-no-format>{assigns[:page_title]}</.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/css/app.css"} /><%= if not @css do %>
     <link phx-track-static rel="stylesheet" href={~p"/assets/default.css"} /><% end %>
     <script defer phx-track-static type="text/javascript" src={~p"/assets/js/app.js"}>


### PR DESCRIPTION
Related to https://github.com/phoenixframework/phoenix/issues/6666

Can confirm it works after installing locally

```
~/workspace
❯ mix phx.new testfix --database sqlite3
warning! Erlang/OTP 28.0 detected.
Regexes will be re-compiled from source at runtime, which will cause degraded performance.
This can be fixed by using Erlang OTP 28.1+ or 27-.
* creating ...
* initializing git repository

Fetch and install dependencies? [Yn]
* running mix deps.get
* running mix assets.setup
* running mix deps.compile

We are almost there! The following steps are missing:

    $ cd testfix

Then configure your database in config/dev.exs and run:

    $ mix ecto.create

Start your Phoenix app with:

    $ mix phx.server

You can also run your app inside IEx (Interactive Elixir) as:

    $ iex -S mix phx.server


~/workspace took 18s
❯ cat testfix/lib/testfix_web/components/layouts/root.html.heex | grep live_title
    <.live_title default="Testfix" suffix=" · Phoenix Framework" phx-no-format>{assigns[:page_title]}</.live_title>

~/workspace
❯ http get http://localhost:4000 | grep "title"
    <!-- @caller lib/testfix_web/components/layouts/root.html.heex:7 (testfix) --><!-- <Phoenix.Component.live_title> lib/phoenix_component.ex:2248 (phoenix_live_view) --><title data-phx-loc="2249" data-default="Testfix" data-suffix=" · Phoenix Framework">Testfix · Phoenix Framework</title><!-- </Phoenix.Component.live_title> -->
    
~/workspace
❯ cd testfix

testfix on  main [?] is 📦 v0.1.0 via 💧 v1.19.3 (OTP 28)
❯ mix format
warning! Erlang/OTP 28.0 detected.
Regexes will be re-compiled from source at runtime, which will cause degraded performance.
This can be fixed by using Erlang OTP 28.1+ or 27-.

testfix on  main [?] is 📦 v0.1.0 via 💧 v1.19.3 (OTP 28)
❯ cat lib/testfix_web/components/layouts/root.html.heex | grep live_title
    <.live_title default="Testfix" suffix=" · Phoenix Framework" phx-no-format>{assigns[:page_title]}</.live_title>
```