### PR TITLE
Only show either #client-error or #server-error, not both

### DIFF
--- a/installer/templates/phx_web/components/layouts.ex.eex
+++ b/installer/templates/phx_web/components/layouts.ex.eex
@@ -92,7 +92,10 @@ defmodule <%= @web_namespace %>.Layouts do
         id="client-error"
         kind={:error}
         title=<%= maybe_heex_attr_gettext.("We can't find the internet", @gettext) %>
-        phx-disconnected={show(".phx-client-error #client-error") |> JS.remove_attribute("hidden")}
+        phx-disconnected={
+          show(".phx-client-error #client-error")
+          |> JS.remove_attribute("hidden", to: ".phx-client-error #client-error")
+        }
         phx-connected={hide("#client-error") |> JS.set_attribute({"hidden", ""})}
         hidden
       >
@@ -104,7 +107,10 @@ defmodule <%= @web_namespace %>.Layouts do
         id="server-error"
         kind={:error}
         title=<%= maybe_heex_attr_gettext.("Something went wrong!", @gettext) %>
-        phx-disconnected={show(".phx-server-error #server-error") |> JS.remove_attribute("hidden")}
+        phx-disconnected={
+          show(".phx-server-error #server-error")
+          |> JS.remove_attribute("hidden", to: ".phx-server-error #server-error")
+        }
         phx-connected={hide("#server-error") |> JS.set_attribute({"hidden", ""})}
         hidden
       >


### PR DESCRIPTION
Can confirm a newly generated Phoenix project works just fine and also I wrote exactly like how `mix format` would have made it. Happy to receive feedback if there's a better approach.

Related: https://github.com/phoenixframework/phoenix/issues/6673