### PR TITLE
Fix phx.auth.gen template

### DIFF
--- a/priv/templates/phx.gen.auth/login_live_test.exs.eex
+++ b/priv/templates/phx.gen.auth/login_live_test.exs.eex
@@ -9,7 +9,7 @@ defmodule <%= inspect context.web_module %>.<%= inspect Module.concat(schema.web
       {:ok, _lv, html} = live(conn, ~p"<%= schema.route_prefix %>/log-in")
 
       assert html =~ "Log in"
-      assert html =~ "Register"
+      assert html =~ "Sign up"
       assert html =~ "Log in with email"
     end
   end


### PR DESCRIPTION
Changes the login_live_test template created by phx.gen.auth to match the text it generates for the corresponding login_live template ("Sign up" instead of "Register").