### PR TITLE
Fix typo in components guide

### DIFF
--- a/guides/components.md
+++ b/guides/components.md
@@ -81,7 +81,7 @@ Next we need to update `show.html.heex`:
 
 When we reload `http://localhost:4000/hello/Frank`, we should see the same content as before! The `show.html.heex` is now invoking two different function components:
 
-  * `<Layouts.app` - the syntax for invoking function componente defined in a separate module and it follows the same rules as calling any other function in Elixir
+  * `<Layouts.app` - the syntax for invoking function components defined in a separate module and it follows the same rules as calling any other function in Elixir
 
   * `<.greet` - when the function component is defined in the same module as the template, we can skip the module name, and invoke the component using its name prefixed with a dot
 


### PR DESCRIPTION
First of all, thank you for building such an amazing framework! 🎉
Phoenix has made my day-to-day work genuinely enjoyable, and I'm deeply grateful to everyone involved in the project. 🙏💜

While reading through the guides, I spotted a small typo in
`guides/components.md` and figured I'd send a fix. Hope it helps! 🔧

- `componente` → `components`