### PR TITLE
Fix Elixir 1.20 compilation warnings

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.20.0-rc.6
+erlang 27.3.3

--- a/lib/phoenix/naming.ex
+++ b/lib/phoenix/naming.ex
@@ -43,7 +43,7 @@ defmodule Phoenix.Naming do
     suffix_size = byte_size(suffix)
     prefix_size = byte_size(string) - suffix_size
     case string do
-      <<prefix::binary-size(^prefix_size), ^suffix::binary>> -> prefix
+      <<prefix::binary-^size(prefix_size), ^suffix::binary>> -> prefix
       _ -> string
     end
   end


### PR DESCRIPTION
Resolve compilation warnings in Elixir 1.20 by updating bitstring binary-size to binary-^size syntax.