### PR TITLE
Clarify channel payloads can be any serializable value

### DIFF
--- a/guides/howto/writing_a_channels_client.md
+++ b/guides/howto/writing_a_channels_client.md
@@ -38,7 +38,7 @@ The general format for messages a client sends to a Phoenix Channel is as follow
 - The `message_reference` is chosen by the client and should be a unique value. The server includes it in its reply so that the client knows which message the reply is for.
 - The `topic_name` must be a known topic for the socket endpoint, and a client must join that topic before sending any messages on it.
 - The `event_name` must match the first argument of a `handle_in` function on the server channel module.
-- The `payload` should be a map and is passed as the second argument to that `handle_in` function.
+- The `payload` should be a serializable value (typically JSON-serializable, depends on the Socket configuration) and is passed as the second argument to that `handle_in` function.
 
 There are three events that are understood by every Phoenix application.
 

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -58,7 +58,7 @@ defmodule Phoenix.Channel do
   `broadcast!/3` or reply directly to a client event for request/response style
   messaging.
 
-  General message payloads are received as maps:
+  General message payloads may have any serializable type, and are often maps:
 
       def handle_in("new_msg", %{"uid" => uid, "body" => body}, socket) do
         ...


### PR DESCRIPTION
Updates documentation to match the implementation.

- https://github.com/phoenixframework/phoenix/blob/e1e7912418dc243faddd71d1136bd743eb84835f/lib/phoenix/channel.ex#L380
- https://github.com/phoenixframework/phoenix/blob/e1e7912418dc243faddd71d1136bd743eb84835f/lib/phoenix/channel.ex#L339

Related to https://github.com/phoenixframework/phoenix_live_view/issues/4221.