### PR TITLE
Disallow /live/longpoll in the generated robots.txt

### DIFF
--- a/assets/js/phoenix/socket.js
+++ b/assets/js/phoenix/socket.js
@@ -36,6 +36,11 @@ import Timer from "./timer"
  * @param {number} [opts.longPollFallbackMs] - The millisecond time to attempt the primary transport
  * before falling back to the LongPoll transport. Disabled by default.
  *
+ * Clients without WebSocket support fall back to LongPoll, and this includes search
+ * engine crawlers, whose renderers do not open WebSockets. They then repeatedly request
+ * the LongPoll endpoint (e.g. `/live/longpoll` for LiveView), which serves no indexable
+ * content. Disallow that path in `robots.txt` to avoid spending crawl budget on it.
+ *
  * @param {boolean} [opts.debug] - When true, enables debug logging. Default false.
  *
  * @param {Function} [opts.encode] - The function to encode outgoing messages.

--- a/installer/templates/phx_static/robots.txt
+++ b/installer/templates/phx_static/robots.txt
@@ -3,3 +3,9 @@
 # To ban all spiders from the entire site uncomment the next two lines:
 # User-agent: *
 # Disallow: /
+
+# /live/longpoll is LiveView's fallback transport for clients that can't open a
+# WebSocket, which includes search engine crawlers. It carries no indexable
+# content, so disallow it to keep crawlers from spending crawl budget there.
+User-agent: *
+Disallow: /live/longpoll

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -141,6 +141,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       # assets
       assert_file("phx_blog/priv/static/images/logo.svg")
+      assert_file("phx_blog/priv/static/robots.txt", ~r"Disallow: /live/longpoll")
 
       assert_file("phx_blog/.gitignore", fn file ->
         assert file =~ "/priv/static/assets/"


### PR DESCRIPTION
New LiveView apps enable a longpoll fallback by default, but the generated
`robots.txt` is empty — so search engine crawlers spend crawl budget polling a
transport endpoint that has no indexable content.

The chain:

- The generated endpoint mounts `socket "/live"` with `longpoll:` enabled, and the
  generated `app.js` sets `longPollFallbackMs: 2500`.
- Googlebot's renderer doesn't open WebSockets, so on every render it falls back to
  longpoll and fetches `/live/longpoll`.
- That endpoint is transport-only — it returns serialized socket messages, not HTML.
  Every fetch is wasted crawl budget.

I ran into this on a production LiveView site:

<img width="2065" height="1260" alt="image" src="https://github.com/user-attachments/assets/48c7f693-c72f-4c5e-b743-7584056bb508" />

This PR adds `Disallow: /live/longpoll` to the scaffolded `robots.txt`, and documents
the behavior on `longPollFallbackMs` in `Phoenix.Socket`.

### Why robots.txt is the right lever

The renderer honors `robots.txt` for the resources it fetches *during* rendering
(JS/CSS/XHR), so the `Disallow` actually stops the longpoll fetch — it doesn't merely
deindex it.

It also can't hide content. LiveView's disconnected ("dead") render already emits the
page's server-rendered HTML; the socket is for interactivity, not first-paint content.
So for apps that render in `mount`/`render` (the disconnected pass), nothing indexable
lives behind the socket. The one exception is an app that gates indexable content behind
`connected?(socket)` — it serves that content only over the socket, and this rule removes
the renderer's last path to it (WebSocket was already unavailable). That's a discouraged
pattern for SEO and such content indexes poorly today regardless, but it's worth calling
out.

### Scope (a deliberate default)

`/live/longpoll` is correct for the default socket mount (`Phoenix.LiveView.Socket` at
`/live`). An app that remounts the socket, runs multiple sockets, or uses a plain
`Phoenix.Socket` with longpoll would need to adjust the rule. Since this is a scaffolded
file that bakes in the generator's own defaults, I kept it as a single unconditional line
rather than templating it: it matches the existing "one shared static `robots.txt`"
approach, and it's a harmless no-op for `--no-html`/`--no-live` apps where the `/live`
socket is commented out anyway.

The two commits are split so the `Phoenix.Socket` doc change can stand on its own if you'd
rather take them separately.

### Refs

- Googlebot doesn't support WebSockets; provide an HTTP fallback —
  https://developers.google.com/search/docs/crawling-indexing/javascript/fix-search-javascript
- `robots.txt` governs the resources the renderer fetches —
  https://developers.google.com/search/blog/2024/12/crawling-december-resources