### PR TITLE
Add security notes for Channel join / handle_in payload

### DIFF
--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -350,6 +350,12 @@ defmodule Phoenix.Channel do
 
   Payloads are serialized before sending with the configured serializer.
 
+  > #### Security Note {: .warning}
+  >
+  > The `payload` contains untrusted data from the client. You must authorize
+  > and validate this data before using it. See the ["Security"
+  > guide](security.html) for more information.
+
   ## Example
 
       def join("room:lobby", payload, socket) do
@@ -370,6 +376,13 @@ defmodule Phoenix.Channel do
   Handle incoming `event`s.
 
   Payloads are serialized before sending with the configured serializer.
+
+  > #### Security Note {: .warning}
+  >
+  > The event `payload` contains untrusted data from the client. You must
+  > authorize and validate this data before using it to fetch or modify
+  > resources. See the ["Security" guide](security.html) for more
+  > information.
 
   ## Example
 


### PR DESCRIPTION
They contain client-controlled data, and must be handled with that in mind.

Phoenix's counterpart to https://github.com/phoenixframework/phoenix_live_view/pull/4284.

See conversation in https://github.com/phoenixframework/phoenix_live_view/pull/4268#issuecomment-4631233965.