### PR TITLE
Replace internal docs references .html -> .md

### DIFF
--- a/lib/mix/tasks/phx.gen.auth.ex
+++ b/lib/mix/tasks/phx.gen.auth.ex
@@ -20,12 +20,12 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
 
   Will generate an `Identity` context with `Client` and `ClientToken` inside.
   Additional information and security considerations are detailed in the
-  [`mix phx.gen.auth` guide](mix_phx_gen_auth.html).
+  [`mix phx.gen.auth` guide](mix_phx_gen_auth.md).
 
   > #### A note on scopes {: .info}
   >
   > `mix phx.gen.auth` creates a scope named after the schema by default.
-  > You can read more about scopes in the [Scopes guide](scopes.html).
+  > You can read more about scopes in the [Scopes guide](scopes.md).
 
   ## LiveView vs conventional Controllers & Views
 
@@ -138,7 +138,7 @@ defmodule Mix.Tasks.Phx.Gen.Auth do
   $ mix phx.gen.auth Accounts User users --scope app_user
   ```
 
-  This will generate a scope named `app_user` instead of `user`. You can read more about scopes in the [Scopes guide](scopes.html).
+  This will generate a scope named `app_user` instead of `user`. You can read more about scopes in the [Scopes guide](scopes.md).
 
   Additionally, the scope's assign key can be customized by passing the `--assign-key` option. For example:
 

--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -2,7 +2,7 @@ defmodule Phoenix do
   @moduledoc """
   This is the documentation for the Phoenix project.
 
-  To get started, see our [overview guides](overview.html).
+  To get started, see our [overview guides](overview.md).
   """
   use Application
 

--- a/lib/phoenix/channel.ex
+++ b/lib/phoenix/channel.ex
@@ -5,7 +5,7 @@ defmodule Phoenix.Channel do
   Channels provide a means for bidirectional communication from clients that
   integrate with the `Phoenix.PubSub` layer for soft-realtime functionality.
 
-  For a conceptual overview, see the [Channels guide](channels.html).
+  For a conceptual overview, see the [Channels guide](channels.md).
 
   ## Topics & Callbacks
 
@@ -354,7 +354,7 @@ defmodule Phoenix.Channel do
   >
   > The `payload` contains untrusted data from the client. You must authorize
   > and validate this data before using it. See the ["Security"
-  > guide](security.html) for more information.
+  > guide](security.md) for more information.
 
   ## Example
 
@@ -381,8 +381,7 @@ defmodule Phoenix.Channel do
   >
   > The event `payload` contains untrusted data from the client. You must
   > authorize and validate this data before using it to fetch or modify
-  > resources. See the ["Security" guide](security.html) for more
-  > information.
+  > resources. See the ["Security" guide](security.md) for more information.
 
   ## Example
 

--- a/lib/phoenix/debug.ex
+++ b/lib/phoenix/debug.ex
@@ -81,7 +81,8 @@ defmodule Phoenix.Debug do
   @doc """
   Checks if the given pid is a `Phoenix.Channel` process.
 
-  Note: this function returns false for [custom channels](https://phoenix.hexdocs.pm/Phoenix.Socket.html#module-custom-channels).
+  > ### Custom channels {: .info}
+  > This function always returns `false` for [custom channels](`m:Phoenix.Socket#module-custom-channels`).
   """
   def channel_process?(pid) do
     # Phoenix.Channel sets the "$process_label" to {Phoenix.Socket, handler_module, id}
@@ -104,9 +105,10 @@ defmodule Phoenix.Debug do
     - `:status` - the status of the channel
     - `:topic` - the topic of the channel
 
-  Note that this list also contains [custom channels](https://phoenix.hexdocs.pm/Phoenix.Socket.html#module-custom-channels)
-  like LiveViews. You can check if a channel is a custom channel by using the `channel?/1`
-  function, which returns `false` for custom channels.
+  > ### Custom channels {: .info}
+  > Note that the list also contains [custom channels](`m:Phoenix.Socket#module-custom-channels`)
+  > like LiveViews. You can check if a channel is a custom channel by using the
+  > `channel_process?/1` function, which returns `false` for custom channels.
 
   ## Examples
 

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -213,8 +213,7 @@ defmodule Phoenix.Socket do
 
   To deny connection, return `:error` or `{:error, term}`. To control the
   response the client receives in that case, [define an error handler in the
-  websocket
-  configuration](https://phoenix.hexdocs.pm/Phoenix.Endpoint.html#socket/3-websocket-configuration).
+  websocket configuration](`Phoenix.Endpoint.socket/3#websocket-configuration`).
 
   See `Phoenix.Token` documentation for examples in
   performing token verification on connect.


### PR DESCRIPTION
See https://ex-doc.hexdocs.pm/readme.html#auto-linking.

In addition, replace external references to Phoenix with internal ones, such that following links remain on the same version of the documentation.