### PR TITLE
Avoid blank line with leading whitespace in root layout template

### DIFF
--- a/installer/templates/phx_web/components/layouts/root.html.heex.eex
+++ b/installer/templates/phx_web/components/layouts/root.html.heex.eex
@@ -28,8 +28,7 @@
           setTheme(localStorage.getItem("phx:theme") || "system");
         }
         window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "system"));
-        <%= if not @live do %>
-        document.addEventListener("DOMContentLoaded", () => {
+        <%= if not @live do %>document.addEventListener("DOMContentLoaded", () => {
           document
             .querySelectorAll("button[data-phx-theme]")
             .forEach((el) => {
@@ -37,8 +36,7 @@
                 setTheme(el.dataset.phxTheme)
               })
             })
-        })<% else %>
-        window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));<% end %>
+        })<% else %>window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));<% end %>
 
         matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
           if (document.documentElement.getAttribute("data-theme-source") === "system") {


### PR DESCRIPTION
## Before (live, default)

Leading whitespace replaced with `_` for visibility:

```html
    <script>
      (() => {
        // ...
        if (!document.documentElement.hasAttribute("data-theme")) {
          setTheme(localStorage.getItem("phx:theme") || "system");
        }
        window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "system"));
 ______ 
        window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));

        matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
          if (document.documentElement.getAttribute("data-theme-source") === "system") {
            document.documentElement.setAttribute("data-theme", systemTheme());
          }
        });
      })();
    </script>
```

## Resulting root.html

### Live (default)

```html
    <script>
      (() => {
        // ...
        if (!document.documentElement.hasAttribute("data-theme")) {
          setTheme(localStorage.getItem("phx:theme") || "system");
        }
        window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "system"));
        window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));

        matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
          if (document.documentElement.getAttribute("data-theme-source") === "system") {
            document.documentElement.setAttribute("data-theme", systemTheme());
          }
        });
      })();
    </script>
```

### With `--no-live` flag

```html
    <script>
      (() => {
        // ...
        if (!document.documentElement.hasAttribute("data-theme")) {
          setTheme(localStorage.getItem("phx:theme") || "system");
        }
        window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "system"));
        document.addEventListener("DOMContentLoaded", () => {
          document
            .querySelectorAll("button[data-phx-theme]")
            .forEach((el) => {
              el.addEventListener("click", () => {
                setTheme(el.dataset.phxTheme)
              })
            })
        })

        matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
          if (document.documentElement.getAttribute("data-theme-source") === "system") {
            document.documentElement.setAttribute("data-theme", systemTheme());
          }
        });
      })();
    </script>
```