### PR TITLE
Fix Elixir 1.20 warnings in installer cache dir tests

### DIFF
--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -957,7 +957,20 @@ defmodule Mix.Tasks.Phx.NewTest do
   end
 
   describe "PHX_NEW_CACHE_DIR" do
-    @phx_new_cache_dir System.get_env("PHX_NEW_CACHE_DIR")
+    setup do
+      phx_new_cache_dir = System.get_env("PHX_NEW_CACHE_DIR")
+
+      on_exit(fn ->
+        if phx_new_cache_dir do
+          System.put_env("PHX_NEW_CACHE_DIR", phx_new_cache_dir)
+        else
+          System.delete_env("PHX_NEW_CACHE_DIR")
+        end
+      end)
+
+      :ok
+    end
+
     test "new with PHX_NEW_CACHE_DIR" do
       System.put_env("PHX_NEW_CACHE_DIR", __DIR__)
       cache_files = File.ls!(__DIR__)
@@ -971,12 +984,6 @@ defmodule Mix.Tasks.Phx.NewTest do
           assert file in project_files, "#{file} not copied to new project"
         end
       end)
-    after
-      if @phx_new_cache_dir do
-        System.put_env("PHX_NEW_CACHE_DIR", @phx_new_cache_dir)
-      else
-        System.delete_env("PHX_NEW_CACHE_DIR")
-      end
     end
 
     test "new with PHX_NEW_CACHE_DIR that doesn't exist" do
@@ -989,12 +996,6 @@ defmodule Mix.Tasks.Phx.NewTest do
         project_files = File.ls!(Path.join(File.cwd!(), @app_name))
         assert "mix.exs" in project_files
       end)
-    after
-      if @phx_new_cache_dir do
-        System.put_env("PHX_NEW_CACHE_DIR", @phx_new_cache_dir)
-      else
-        System.delete_env("PHX_NEW_CACHE_DIR")
-      end
     end
   end
 end


### PR DESCRIPTION
<details>

```
❯ mix test
Compiling 5 files (.ex)
Running ExUnit with seed: 45773, max_cases: 20

     warning: incompatible types given to System.put_env/2:

         System.put_env("PHX_NEW_CACHE_DIR", nil)

     given types:

         binary(), nil

     but expected one of:

         binary(), binary()

     type warning found at:
     │
 976 │         System.put_env("PHX_NEW_CACHE_DIR", @phx_new_cache_dir)
     │                ~
     │
     └─ test/phx_new_test.exs:976:16: Mix.Tasks.Phx.NewTest."test PHX_NEW_CACHE_DIR new with PHX_NEW_CACHE_DIR"/1

     warning: incompatible types given to System.put_env/2:

         System.put_env("PHX_NEW_CACHE_DIR", nil)

     given types:

         binary(), nil

     but expected one of:

         binary(), binary()

     type warning found at:
     │
 994 │         System.put_env("PHX_NEW_CACHE_DIR", @phx_new_cache_dir)
     │                ~
     │
     └─ test/phx_new_test.exs:994:16: Mix.Tasks.Phx.NewTest."test PHX_NEW_CACHE_DIR new with PHX_NEW_CACHE_DIR that doesn't exist"/1

...............................................................
Finished in 2.1 seconds (0.00s async, 2.1s sync)

Result: 63 passed
```

</details>