### PR TITLE
Fix xref exclude deprecation (Elixir 1.20)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,8 +24,8 @@ defmodule Phoenix.MixProject do
       deps: deps(),
       package: package(),
       consolidate_protocols: Mix.env() != :test,
-      xref: [
-        exclude: [
+      elixirc_options: [
+        no_warn_undefined: [
           {IEx, :started?, 0},
           Ecto.Type,
           :ranch,


### PR DESCRIPTION
Use elixirc_options: [no_warn_undefined: ...] instead of xref: [exclude: ...]

The `xref: [exclude: ...]` project option has been deprecated in Elixir 1.20 in favor of `elixirc_options: [no_warn_undefined: ...]`. This silences the deprecation warning emitted by `mix compile` while preserving the existing behaviour of suppressing undefined-module warnings for optional/dynamic dependencies.