### PR TITLE
presence: Fix get_by_key documentation and typespec inconsistencies

### DIFF
--- a/lib/phoenix/presence.ex
+++ b/lib/phoenix/presence.ex
@@ -312,12 +312,12 @@ defmodule Phoenix.Presence do
   devices, could return:
 
       iex> MyPresence.get_by_key("room:1", "user1")
-      [%{name: "User 1", metas: [%{device: "Desktop"}, %{device: "Mobile"}]}]
+      %{name: "User 1", metas: [%{device: "Desktop"}, %{device: "Mobile"}]}
 
   Like `c:list/1`, the presence metadata is passed to the `fetch`
   callback of your presence module to fetch any additional information.
   """
-  @callback get_by_key(Phoenix.Socket.t() | topic, key :: String.t()) :: [presence]
+  @callback get_by_key(Phoenix.Socket.t() | topic, key :: String.t()) :: map() | []
 
   @doc """
   Extend presence information with additional data.


### PR DESCRIPTION
Fixes #5759 and #4514. The `get_by_key/2` function was incorrectly documented as returning a list of maps, and the typespec reflected this, but the implementation actually returns a map (or an empty list if not found). This PR updates the typespec and example in the documentation to accurately match the implementation without introducing breaking changes.