### PR TITLE
phx.gen.release: Document new Bob Web UI

### DIFF
--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -1,16 +1,22 @@
-# Find eligible builder and runner images on Docker Hub. We use Ubuntu/Debian
-# instead of Alpine to avoid DNS resolution issues in production.
-#
-# https://hub.docker.com/r/hexpm/elixir/tags?name=ubuntu
-# https://hub.docker.com/_/ubuntu/tags
-#
 # This file is based on these images:
 #
-#   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
-#   - https://hub.docker.com/_/debian/tags?name=<%= debian %>-<%= debian_vsn %>-slim - for the release image
-#   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: docker.io/hexpm/elixir:<%= elixir_vsn %>-erlang-<%= otp_vsn %>-debian-<%= debian %>-<%= debian_vsn %>-slim
+#   - https://hub.docker.com/r/hexpm/elixir/tags - for the builder image
+#     E.g.: docker.io/hexpm/elixir:<%= elixir_vsn %>-erlang-<%= otp_vsn %>-debian-<%= debian %>-<%= debian_vsn %>-slim
+#   - https://hub.docker.com/_/debian/tags?name=<%= debian %>-<%= debian_vsn %>-slim - for the runner image
+#     E.g.: docker.io/debian:<%= debian %>-<%= debian_vsn %>-slim
 #
+# Find builder and runner images on Docker Hub or on Hex's Build Server (Bob).
+# We recommend using Bob's Web UI to find recent tags:
+#
+#   - https://bob.hex.pm/docker
+#
+# We suggest using the same Debian version for both the builder and runner images.
+#
+# We suggest Debian/Ubuntu instead of Alpine to avoid production compatibility issues
+# (such as DNS resolution failures, and dynamically linked NIFs/precompiled binaries).
+#
+# For finding packages in Debian, search on https://packages.debian.org/.
+
 ARG ELIXIR_VERSION=<%= elixir_vsn %>
 ARG OTP_VERSION=<%= otp_vsn %>
 ARG DEBIAN_VERSION=<%= debian %>-<%= debian_vsn %>-slim


### PR DESCRIPTION
A frequent pain point with phx.gen.release and updating image versions is that Docker Hub's UI is slow and the API often times out. Search for relevant images is far from ideal.

Now the Hex team has given us a new tool, a read-only Web UI that gives us insight on the latest images without depending on Docker Hub.

In updating the Dockerfile header commentary, replace reference to pkgs.org (filled with ads) with the official Debian package index.

See https://github.com/hexpm/bob/issues/185 and https://github.com/hexpm/bob/pull/256.