### PR TITLE
Move generated live_reload patterns to runtime config

### DIFF
--- a/installer/templates/phx_single/config/dev.exs.eex
+++ b/installer/templates/phx_single/config/dev.exs.eex
@@ -44,22 +44,7 @@ config :<%= @app_name %>, <%= @endpoint_module %>,<%= if @inside_docker_env? do 
 #
 # If desired, both `http:` and `https:` keys can be
 # configured to run both http and https servers on
-# different ports.<%= if @html do %>
-
-# Reload browser tabs when matching files change.
-config :<%= @app_name %>, <%= @endpoint_module %>,
-  live_reload: [
-    web_console_logger: true,
-    patterns: [
-      # Static assets, except user uploads
-      ~r"priv/static/(?!uploads/).*\.(js|css|png|jpeg|jpg|gif|svg)$"<%= @config_regex_E %>,<%= if @gettext do %>
-      # Gettext translations
-      ~r"priv/gettext/.*\.po$"<%= @config_regex_E %>,<% end %>
-      # Router, Controllers, LiveViews and LiveComponents
-      ~r"lib/<%= @lib_web_name %>/router\.ex$"<%= @config_regex_E %>,
-      ~r"lib/<%= @lib_web_name %>/(controllers|live|components)/.*\.(ex|heex)$"<%= @config_regex_E %>
-    ]
-  ]<% end %>
+# different ports.
 
 # Enable dev routes for dashboard and mailbox
 config :<%= @app_name %>, dev_routes: true

--- a/installer/templates/phx_single/config/runtime.exs.eex
+++ b/installer/templates/phx_single/config/runtime.exs.eex
@@ -22,7 +22,24 @@ end
 
 config :<%= @app_name %>, <%= @endpoint_module %>,
   http: [port: String.to_integer(System.get_env("PORT", "4000"))]
-
+<%= if @html do %>
+if config_env() == :dev do
+  # Reload browser tabs when matching files change.
+  config :<%= @app_name %>, <%= @endpoint_module %>,
+    live_reload: [
+      web_console_logger: true,
+      patterns: [
+        # Static assets, except user uploads
+        ~r"priv/static/(?!uploads/).*\.(js|css|png|jpeg|jpg|gif|svg)$"<%= @config_regex_E %>,<%= if @gettext do %>
+        # Gettext translations
+        ~r"priv/gettext/.*\.po$"<%= @config_regex_E %>,<% end %>
+        # Router, Controllers, LiveViews and LiveComponents
+        ~r"lib/<%= @lib_web_name %>/router\.ex$"<%= @config_regex_E %>,
+        ~r"lib/<%= @lib_web_name %>/(controllers|live|components)/.*\.(ex|heex)$"<%= @config_regex_E %>
+      ]
+    ]
+end
+<% end %>
 if config_env() == :prod do
   # The secret key base is used to sign/encrypt cookies and other secrets.
   # A default value is used in config/dev.exs and config/test.exs but you

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs.eex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/dev.exs.eex
@@ -44,22 +44,7 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,<%= if @inside_docker_env?
 #
 # If desired, both `http:` and `https:` keys can be
 # configured to run both http and https servers on
-# different ports.<%= if @html do %>
-
-# Reload browser tabs when matching files change.
-config :<%= @web_app_name %>, <%= @endpoint_module %>,
-  live_reload: [
-    web_console_logger: true,
-    patterns: [
-      # Static assets, except user uploads
-      ~r"priv/static/(?!uploads/).*\.(js|css|png|jpeg|jpg|gif|svg)$"<%= @config_regex_E %>,<%= if @gettext do %>
-      # Gettext translations
-      ~r"priv/gettext/.*\.po$"<%= @config_regex_E %>,<% end %>
-      # Router, Controllers, LiveViews and LiveComponents
-      ~r"lib/<%= @web_app_name %>/router\.ex$"<%= @config_regex_E %>,
-      ~r"lib/<%= @web_app_name %>/(controllers|live|components)/.*\.(ex|heex)$"<%= @config_regex_E %>
-    ]
-  ]<% end %>
+# different ports.
 
 # Enable dev routes for dashboard and mailbox
 config :<%= @web_app_name %>, dev_routes: true

--- a/installer/templates/phx_umbrella/config/runtime.exs.eex
+++ b/installer/templates/phx_umbrella/config/runtime.exs.eex
@@ -9,7 +9,24 @@ import Config
 
 config :<%= @web_app_name %>, <%= @endpoint_module %>,
   http: [port: String.to_integer(System.get_env("PORT", "4000"))]
-
+<%= if @html do %>
+if config_env() == :dev do
+  # Reload browser tabs when matching files change.
+  config :<%= @web_app_name %>, <%= @endpoint_module %>,
+    live_reload: [
+      web_console_logger: true,
+      patterns: [
+        # Static assets, except user uploads
+        ~r"priv/static/(?!uploads/).*\.(js|css|png|jpeg|jpg|gif|svg)$"<%= @config_regex_E %>,<%= if @gettext do %>
+        # Gettext translations
+        ~r"priv/gettext/.*\.po$"<%= @config_regex_E %>,<% end %>
+        # Router, Controllers, LiveViews and LiveComponents
+        ~r"lib/<%= @web_app_name %>/router\.ex$"<%= @config_regex_E %>,
+        ~r"lib/<%= @web_app_name %>/(controllers|live|components)/.*\.(ex|heex)$"<%= @config_regex_E %>
+      ]
+    ]
+end
+<% end %>
 if config_env() == :prod do
   config :<%= @app_name %>, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 end

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -68,6 +68,8 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~
                  ~r/^  http: \[port: String.to_integer\(System.get_env\("PORT", "4000"\)\)\]$/m
 
+        assert file =~ "lib/phx_blog_web/router\\.ex$"
+        assert file =~ "lib/phx_blog_web/(controllers|live|components)/.*\\.(ex|heex)$"
         assert file =~ ~r/^\s+ip: {0, 0, 0, 0, 0, 0, 0, 0}$/m
       end)
 
@@ -150,8 +152,7 @@ defmodule Mix.Tasks.Phx.NewTest do
 
       assert_file("phx_blog/config/dev.exs", fn file ->
         assert file =~ "esbuild: {Esbuild,"
-        assert file =~ "lib/phx_blog_web/router\\.ex$"
-        assert file =~ "lib/phx_blog_web/(controllers|live|components)/.*\\.(ex|heex)$"
+        refute file =~ "live_reload"
         assert file =~ "http: [ip: {127, 0, 0, 1}]"
       end)
 

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -72,8 +72,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file(root_path(@app, "config/dev.exs"), fn file ->
         assert file =~ ~r[esbuild: {Esbuild]
-        assert file =~ "lib/#{@app}_web/router\\.ex$"
-        assert file =~ "lib/#{@app}_web/(controllers|live|components)/.*\\.(ex|heex)$"
+        refute file =~ "live_reload"
         assert file =~ "config :#{@app}_web, dev_routes: true"
       end)
 
@@ -85,6 +84,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         assert file =~
                  ~r/^\s+config :phx_umb_web, PhxUmbWeb.Endpoint,\n\s+http: \[port: String\.to_integer\(System\.get_env\("PORT", "4000"\)\)\]$/m
 
+        assert file =~ "lib/#{@app}_web/router\\.ex$"
+        assert file =~ "lib/#{@app}_web/(controllers|live|components)/.*\\.(ex|heex)$"
         assert file =~ ~r/^\s+ip: {0, 0, 0, 0, 0, 0, 0, 0}$/m
       end)
 


### PR DESCRIPTION
`phx.new` currently generates `live_reload` patterns in `config/dev.exs`.

Those patterns are runtime-only endpoint configuration, read by `Phoenix.LiveReloader` from the endpoint config when the live reload socket joins. They do not need to be part of compile-time configuration.

Keeping them in compile config can lead to unnecessary recompilation because Mix stores compile config in the Elixir compiler manifest, and equivalent regex literals are not term-equal across evaluations:

```elixir
~r/foo/ == ~r/foo/
#=> false
```

If a config file is touched, Mix may re-check compile config and see the newly evaluated regex values as changed even when the config source did not meaningfully change.

This moves the generated `live_reload` config to `runtime.exs` under the development environment, preserving behavior while avoiding unstable regex terms in compile config.
