### PR TITLE
Fix running installer tests twice for Elixir 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         include:
           - elixir: "1.15.8"
             otp: "25.3.2.21"
+            installer: true
 
           - elixir: "1.18.4"
             otp: "27.3.4.13"

--- a/integration_test/test.sh
+++ b/integration_test/test.sh
@@ -11,13 +11,7 @@ socat TCP-LISTEN:5432,fork TCP-CONNECT:postgres:5432&
 socat TCP-LISTEN:3306,fork TCP-CONNECT:mysql:3306&
 socat TCP-LISTEN:1433,fork TCP-CONNECT:mssql:1433&
 
-# Run installer tests
-echo "Running installer tests"
-cd installer
-mix deps.get
-mix test
-
 echo "Running integration tests"
-cd ../integration_test
+cd integration_test
 mix deps.get
 mix test --include database


### PR DESCRIPTION
Both the integration test script and the ci.yml mix_test job were responsible for running installer tests, such that the same tests were run twice for Elixir 1.19.

Since running the tests as part of a job provides better visibility, remove the installer test execution from the integration test script and opt-in to run the installer tests also on Elixir 1.15 as part of the mix_test job (previously was run by the test.sh script).

---

Extracted from bumping requirement for new apps (1.15->1.17) https://github.com/phoenixframework/phoenix/pull/6713#issuecomment-4705690380, so as to keep the diff focused and easier to review.