### PR TITLE
Refactor CI workflow to isolate installer tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
           - elixir: "1.19.5"
             otp: "28.5.0.2"
             lint: true
-            installer: true
 
     runs-on: ubuntu-24.04
 
@@ -60,12 +59,57 @@ jobs:
       - name: Run tests
         run: mix test
 
-      - name: Run installer test
-        run: |
-          cd installer
-          mix deps.get
-          mix test
-        if: ${{ matrix.installer }}
+  installer_test:
+    name: installer test (OTP ${{matrix.otp}} | Elixir ${{matrix.elixir}})
+
+    env:
+      MIX_ENV: test
+      PHX_CI: true
+
+    strategy:
+      matrix:
+        include:
+          - elixir: "1.15.8"
+            otp: "25.3.2.21"
+
+          - elixir: "1.19.5"
+            otp: "28.5.0.2"
+
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
+        with:
+          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ matrix.otp }}
+
+      - name: Restore deps and _build cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            deps
+            _build
+          key: deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            deps-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}
+
+      - name: Install installer dependencies
+        run: mix deps.get
+        working-directory: installer
+
+      - name: Run installer unit tests
+        run: mix test
+        working-directory: installer
+
+      - name: Install root dependencies
+        run: mix deps.get --only test
+
+      - name: Run mix_phx_new generator integration tests
+        run: mix test --only mix_phx_new
 
   npm_test:
     name: npm test

--- a/integration_test/test.sh
+++ b/integration_test/test.sh
@@ -11,13 +11,9 @@ socat TCP-LISTEN:5432,fork TCP-CONNECT:postgres:5432&
 socat TCP-LISTEN:3306,fork TCP-CONNECT:mysql:3306&
 socat TCP-LISTEN:1433,fork TCP-CONNECT:mssql:1433&
 
-# Run installer tests
-echo "Running installer tests"
-cd installer
-mix deps.get
-mix test
+# Navigate to the integration_test directory relative to the script location
+cd "$(dirname "$0")"
 
 echo "Running integration tests"
-cd ../integration_test
 mix deps.get
 mix test --include database

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -25,11 +25,6 @@ assert_timeout = String.to_integer(
   System.get_env("ELIXIR_ASSERT_TIMEOUT") || "200"
 )
 
-excludes =
-  if Version.match?(System.version(), "~> 1.15") do
-    []
-  else
-    [:mix_phx_new]
-  end
+excludes = [:mix_phx_new]
 
 ExUnit.start(assert_receive_timeout: assert_timeout, exclude: excludes)


### PR DESCRIPTION
Separate installer tests out of the `mix_test` job and the `integration_test/test.sh` script (`integration-test-elixir` job), such that the Elixir version matrix for the installer tests can evolve independent of the matrix of supported versions for Phoenix itself as a library.

Notes:
- Fixes running the installer unit tests twice for Elixir 1.19 during CI: previously they were executed both as part of the main `mix_test` job (when matrix.installer was true) and also inside the `integration-test-elixir` job via `test.sh`.
- Update `integration_test/test.sh` to resolve the correct directory based on the script path, so that running the script works as expected regardless of the current working directory.
- Simplifies `test/test_helper.exs` exclusions, defaulting to always skipping `:mix_phx_new` integration tests, unless explicitly enabled (`--only mix_phx_new`) in the CI `installer_test` job. These tests are now run for all Elixir versions in the `installer_test` job matrix.

---

Alternative to / closes #6724.

This would allow us to bump the Elixir version requirement for the installer without changing the supported Elixir versions for Phoenix https://github.com/phoenixframework/phoenix/pull/6713#issuecomment-4705690380.