### PR TITLE
Fix build phoenix.js instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ mix archive.build
 To build Phoenix.js:
 
 ```bash
-cd assets
-npm install
+mix assets.build
 ```
 
 ## Important links


### PR DESCRIPTION
Running `mix assets.build` is enough. Installing npm dependencies is not required, as there are only dev dependencies that do not affect `esbuild` bundler calls.