### PR TITLE
Use npm ci to build JS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ To create projects outside of the `installer/` directory, add the latest archive
 To build the documentation:
 
 ```bash
-npm install
 MIX_ENV=docs mix docs
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -286,7 +286,7 @@ defmodule Phoenix.MixProject do
 
   defp generate_js_docs(_) do
     Mix.Task.run("app.start")
-    {_, 0} = System.cmd("npm", ["install"], into: IO.stream())
+    {_, 0} = System.cmd("npm", ["ci"], into: IO.stream())
     {_, 0} = System.cmd("npm", ["run", "docs"], into: IO.stream())
   end
 


### PR DESCRIPTION
This ensures we're always using the pinned versions from package-lock.json.

Since `mix docs` takes care of installing npm dependencies, we don't need that step in the README.md.