### PR TITLE
Explicitly require :tailwind >= 0.5 for ColocatedCSS

### DIFF
--- a/installer/templates/phx_single/mix.exs.eex
+++ b/installer/templates/phx_single/mix.exs.eex
@@ -54,7 +54,7 @@ defmodule <%= @app_module %>.MixProject do
       {:lazy_html, ">= 0.1.0", only: :test},<% end %><%= if @dashboard do %>
       {:phoenix_live_dashboard, "~> 0.8.3"},<% end %><%= if @javascript do %>
       {:esbuild, "~> 0.10", runtime: Mix.env() == :dev},<% end %><%= if @css do %>
-      {:tailwind, "~> 0.3", runtime: Mix.env() == :dev},
+      {:tailwind, "~> 0.5", runtime: Mix.env() == :dev},
       {:heroicons,
        github: "tailwindlabs/heroicons",
        tag: "v2.2.0",

--- a/installer/templates/phx_umbrella/apps/app_name_web/mix.exs.eex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/mix.exs.eex
@@ -46,7 +46,7 @@ defmodule <%= @web_namespace %>.MixProject do
       {:lazy_html, ">= 0.1.0", only: :test},<% end %><%= if @dashboard do %>
       {:phoenix_live_dashboard, "~> 0.8.3"},<% end %><%= if @javascript do %>
       {:esbuild, "~> 0.10", runtime: Mix.env() == :dev},<% end %><%= if @css do %>
-      {:tailwind, "~> 0.3", runtime: Mix.env() == :dev},
+      {:tailwind, "~> 0.5", runtime: Mix.env() == :dev},
       {:heroicons,
        github: "tailwindlabs/heroicons",
        tag: "v2.2.0",

--- a/integration_test/mix.exs
+++ b/integration_test/mix.exs
@@ -55,7 +55,7 @@ defmodule Phoenix.Integration.MixProject do
       {:bcrypt_elixir, "~> 3.0"},
       {:argon2_elixir, "~> 4.0"},
       {:pbkdf2_elixir, "~> 2.0"},
-      {:tailwind, "~> 0.3"},
+      {:tailwind, "~> 0.5"},
       {:heroicons,
        github: "tailwindlabs/heroicons",
        tag: "v2.2.0",


### PR DESCRIPTION
ColocatedCSS new in 1.8.8 requires passing env as a list to phoenix/tailwind config, supported from version 0.5.

To prevent new apps from going into an unsupported state, explicitly bump the version range to require at least 0.5.

See #6706 and https://github.com/phoenixframework/phoenix_live_view/issues/4295.