### PR TITLE
Fix tiny typo in phx.gen.auth scope.ex.eex

### DIFF
--- a/priv/templates/phx.gen.auth/scope.ex.eex
+++ b/priv/templates/phx.gen.auth/scope.ex.eex
@@ -5,8 +5,8 @@ defmodule <%= inspect scope_config.scope.module %> do
   The `<%= inspect scope_config.scope.module %>` allows public interfaces to receive
   information about the caller, such as if the call is initiated from an
   end-user, and if so, which user. Additionally, such a scope can carry fields
-  such as "super user" or other privileges for use as authorization, or to
-  ensure specific code paths can only be access for a given scope.
+  such as "super user" or other privileges for use in authorization checks,
+  or to ensure specific code paths can only be accessed for a given scope.
 
   It is useful for logging as well as for scoping pubsub subscriptions and
   broadcasts when a caller subscribes to an interface or performs a particular


### PR DESCRIPTION
It should be "accessed".  I made one other tiny change while I was in here that I believe reads better.