### PR TITLE
Prioritize project-local build path in NODE_PATH config templates

### DIFF
--- a/installer/templates/phx_single/config/config.exs.eex
+++ b/installer/templates/phx_single/config/config.exs.eex
@@ -45,7 +45,7 @@ config :esbuild,
     args:
       ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
     cd: Path.expand("..<%= if @in_umbrella, do: "/apps/#{@app_name}" %>/assets", __DIR__),
-    env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+    env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
   ]<% end %><%= if @css do %>
 
 # Configure tailwind (the version is required)
@@ -57,7 +57,7 @@ config :tailwind,
       --output=priv/static/assets/css/app.css
     ),
     cd: Path.expand("..<%= if @in_umbrella, do: "/apps/#{@app_name}" %>", __DIR__),
-    env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+    env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
   ]<% end %>
 
 # Configure Elixir's Logger

--- a/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs.eex
+++ b/installer/templates/phx_umbrella/apps/app_name_web/config/config.exs.eex
@@ -24,7 +24,7 @@ config :esbuild,
     args:
       ~w(js/app.js --bundle --target=es2022 --outdir=../priv/static/assets/js --external:/fonts/* --external:/images/* --alias:@=.),
     cd: Path.expand("../apps/<%= @web_app_name %>/assets", __DIR__),
-    env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+    env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
   ]<% end %><%= if @css do %>
 
 # Configure tailwind (the version is required)
@@ -36,5 +36,5 @@ config :tailwind,
       --output=priv/static/assets/css/app.css
     ),
     cd: Path.expand("../apps/<%= @web_app_name %>", __DIR__),
-    env: %{"NODE_PATH" => [Path.expand("../deps", __DIR__), Mix.Project.build_path()]}
+    env: %{"NODE_PATH" => [Mix.Project.build_path(), Path.expand("../deps", __DIR__)]}
   ]<% end %>


### PR DESCRIPTION
For security, ensure that project-local files (`Mix.Project.build_path()`) have priority over dependency-controlled directories (`Path.expand("../deps", __DIR__)`) in the `NODE_PATH` environment variable for esbuild and tailwind configs. This prevents dependencies from overriding project-local assets/files.