### PR TITLE
Split route match clauses into sub-modules to parallelize compile-time type-checking

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -485,6 +485,9 @@ defmodule Phoenix.Router do
   end
 
   @doc false
+  @routes_per_module 250
+  @checks_per_module 400
+
   defmacro __before_compile__(env) do
     routes = env.module |> Module.get_attribute(:phoenix_routes) |> Enum.reverse()
     routes_with_exprs = Enum.map(routes, &{&1, Route.exprs(&1)})
@@ -494,18 +497,15 @@ defmodule Phoenix.Router do
         Helpers.define(env, routes_with_exprs)
       end
 
-    # Group routes by verb making sure the ones that match all are handled last
-    {matches, {pipelines, _}} =
-      routes_with_exprs
-      |> Enum.group_by(&elem(&1, 0).verb)
-      |> Map.pop(:*, [])
-      |> then(fn {match_routes_exprs, map} ->
-        Map.to_list(map) ++ [{:*, match_routes_exprs}]
-      end)
-      |> Enum.map_reduce({[], %{}}, &build_match_verb/2)
+    {pipelines, pipe_index} = build_pipelines(routes_with_exprs)
 
-    routes_per_path =
-      Enum.group_by(routes_with_exprs, &elem(&1, 1).path, &elem(&1, 0))
+    # Emit the match clauses into sub-modules: the type checker's per-module
+    # cost is super-linear in the number of clauses, so splitting the match
+    # table across modules is where the compile-time speedup comes from.
+    {match_modules, match_module_names} =
+      build_match_modules(env.module, routes_with_exprs, pipe_index)
+
+    routes_per_path = Enum.group_by(routes_with_exprs, &elem(&1, 1).path, &elem(&1, 0))
 
     verifies =
       routes_with_exprs
@@ -527,15 +527,38 @@ defmodule Phoenix.Router do
         def __forward__(_), do: nil
       end
 
-    checks =
-      routes
-      |> Enum.map(fn %{line: line, metadata: metadata, plug: plug} ->
-        {line, Map.get(metadata, :mfa, {plug, :init, 1})}
-      end)
-      |> Enum.uniq()
-      |> Enum.map(fn {line, {module, function, arity}} ->
-        quote line: line, do: _ = &(unquote(module).unquote(function) / unquote(arity))
-      end)
+    check_modules = build_check_modules(routes, env.module)
+
+    match =
+      if match_module_names == [] do
+        quote do
+          @doc false
+          def __match_route__(_method, _path, _host), do: :error
+        end
+      else
+        quote do
+          @doc false
+          def __match_route__(method, path, host) do
+            __match_route__(unquote(match_module_names), method, path, host)
+          end
+
+          # The dispatch is deliberately dynamic: because the module is a
+          # variable, the type checker treats `match/3` as an unknown call
+          # rather than re-aggregating every route's return type into this
+          # module — which is the cost the sub-modules exist to avoid.
+          defp __match_route__([module | modules], method, path, host) do
+            case module.match(method, path, host) do
+              {metadata, prepare, pipeline, plug_opts} ->
+                {metadata, prepare, __pipeline__(pipeline), plug_opts}
+
+              :error ->
+                __match_route__(modules, method, path, host)
+            end
+          end
+
+          defp __match_route__([], _method, _path, _host), do: :error
+        end
+      end
 
     keys = [:verb, :path, :plug, :plug_opts, :helper, :metadata]
     routes = Enum.map(routes, &Map.take(&1, keys))
@@ -545,9 +568,6 @@ defmodule Phoenix.Router do
       def __routes__, do: unquote(Macro.escape(routes))
 
       @doc false
-      def __checks__, do: unquote({:__block__, [], checks})
-
-      @doc false
       def __helpers__, do: unquote(helpers)
 
       defp prepare(conn) do
@@ -555,10 +575,12 @@ defmodule Phoenix.Router do
       end
 
       unquote(pipelines)
+      unquote(match)
       unquote(verifies)
       unquote(verify_catch_all)
-      unquote(matches)
       unquote(forward_catch_all)
+      unquote(match_modules)
+      unquote(check_modules)
     end
   end
 
@@ -625,52 +647,71 @@ defmodule Phoenix.Router do
     forward
   end
 
-  defp build_match_verb({:*, routes_exprs}, acc) do
-    name = :__match_route_catch_all__
-    {clauses, acc} = Enum.map_reduce(routes_exprs, acc, &build_match_path(name, &1, &2))
+  # Pipelines are defined on the router, but match clauses live in sub-modules
+  # and cannot capture private functions, so each clause carries the pipeline
+  # index that __pipeline__/1 resolves back into a capture.
+  defp build_pipelines(routes_with_exprs) do
+    {defs, index} =
+      Enum.reduce(routes_with_exprs, {[], %{}}, fn {route, _expr}, {defs, index} ->
+        pipe_through = route.pipe_through
 
-    dispatch =
-      quote generated: true do
-        unquote({:__block__, [], clauses})
+        if Map.has_key?(index, pipe_through) do
+          {defs, index}
+        else
+          i = map_size(index)
 
-        defp __match_route_catch_all__(_path, _host) do
-          :error
+          {[build_pipes(:"__pipe_through#{i}__", pipe_through) | defs],
+           Map.put(index, pipe_through, i)}
         end
+      end)
 
-        @doc false
-        def __match_route__(_, path, host) do
-          __match_route_catch_all__(path, host)
-        end
-      end
+    resolvers =
+      for {_pipe_through, i} <- Enum.sort_by(index, &elem(&1, 1)) do
+        name = :"__pipe_through#{i}__"
 
-    {dispatch, acc}
-  end
-
-  defp build_match_verb({verb, routes_exprs}, acc) do
-    pattern = verb |> to_string() |> String.upcase()
-    name = :"__match_route_#{verb}__"
-
-    {clauses, acc} = Enum.map_reduce(routes_exprs, acc, &build_match_path(name, &1, &2))
-
-    dispatch =
-      quote generated: true do
-        unquote({:__block__, [], clauses})
-
-        defp unquote(name)(path, host) do
-          __match_route_catch_all__(path, host)
-        end
-
-        def __match_route__(unquote(pattern), path, host) do
-          unquote(name)(path, host)
+        quote generated: true do
+          defp __pipeline__(unquote(i)), do: &(unquote(Macro.var(name, __MODULE__)) / 1)
         end
       end
 
-    {dispatch, acc}
+    {Enum.reverse(defs) ++ resolvers, index}
   end
 
-  defp build_match_path(name, {route, expr}, {acc_pipes, known_pipes}) do
-    {pipe_name, acc_pipes, known_pipes} = build_match_pipes(route, acc_pipes, known_pipes)
+  # Group routes by verb (the ones that match all come last) and chunk each
+  # group into its own sub-module, returning the module ASTs and their names
+  # in dispatch order.
+  defp build_match_modules(router, routes_with_exprs, pipe_index) do
+    {wildcard, by_verb} =
+      routes_with_exprs
+      |> Enum.group_by(&elem(&1, 0).verb)
+      |> Map.pop(:*, [])
 
+    groups = Map.to_list(by_verb) ++ [{:*, wildcard}]
+
+    {modules, names, _count} =
+      Enum.reduce(groups, {[], [], 0}, fn {_verb, routes_exprs}, acc ->
+        routes_exprs
+        |> Enum.chunk_every(@routes_per_module)
+        |> Enum.reduce(acc, fn chunk, {modules, names, count} ->
+          name = Module.concat(router, :"Match#{count}")
+
+          module =
+            quote generated: true do
+              defmodule unquote(name) do
+                @moduledoc false
+                unquote(Enum.flat_map(chunk, &build_match_path(&1, pipe_index)))
+                def match(_method, _path, _host), do: :error
+              end
+            end
+
+          {[module | modules], [name | names], count + 1}
+        end)
+      end)
+
+    {Enum.reverse(modules), Enum.reverse(names)}
+  end
+
+  defp build_match_path({route, expr}, pipe_index) do
     %{
       prepare: prepare,
       dispatch: dispatch,
@@ -679,34 +720,46 @@ defmodule Phoenix.Router do
       path: path
     } = expr
 
-    clauses =
-      for host <- hosts do
-        quote line: route.line do
-          defp unquote(name)(unquote(path), unquote(host)) do
-            {unquote(build_metadata(route, path_params)),
-             fn var!(conn, :conn), %{path_params: var!(path_params, :conn)} ->
-               unquote(prepare)
-             end, &(unquote(Macro.var(pipe_name, __MODULE__)) / 1), unquote(dispatch)}
-          end
-        end
+    verb =
+      case route.verb do
+        :* -> quote(do: _method)
+        verb -> verb |> to_string() |> String.upcase()
       end
 
-    {clauses, {acc_pipes, known_pipes}}
+    pipeline = Map.fetch!(pipe_index, route.pipe_through)
+    metadata = build_metadata(route, path_params)
+
+    for host <- hosts do
+      quote line: route.line, generated: true do
+        def match(unquote(verb), unquote(path), unquote(host)) do
+          {unquote(metadata),
+           fn var!(conn, :conn), %{path_params: var!(path_params, :conn)} ->
+             unquote(prepare)
+           end, unquote(pipeline), unquote(dispatch)}
+        end
+      end
+    end
   end
 
-  defp build_match_pipes(route, acc_pipes, known_pipes) do
-    %{pipe_through: pipe_through} = route
-
-    case known_pipes do
-      %{^pipe_through => name} ->
-        {name, acc_pipes, known_pipes}
-
-      %{} ->
-        name = :"__pipe_through#{map_size(known_pipes)}__"
-        acc_pipes = [build_pipes(name, pipe_through) | acc_pipes]
-        known_pipes = Map.put(known_pipes, pipe_through, name)
-        {name, acc_pipes, known_pipes}
-    end
+  defp build_check_modules(routes, router) do
+    routes
+    |> Enum.map(fn %{line: line, metadata: metadata, plug: plug} ->
+      {line, Map.get(metadata, :mfa, {plug, :init, 1})}
+    end)
+    |> Enum.uniq()
+    |> Enum.map(fn {line, {module, function, arity}} ->
+      quote line: line, do: _ = &(unquote(module).unquote(function) / unquote(arity))
+    end)
+    |> Enum.chunk_every(@checks_per_module)
+    |> Enum.with_index()
+    |> Enum.map(fn {checks, i} ->
+      quote generated: true do
+        defmodule unquote(Module.concat(router, :"Checks#{i}")) do
+          @moduledoc false
+          def __checks__, do: unquote({:__block__, [], checks})
+        end
+      end
+    end)
   end
 
   defp build_metadata(route, path_params) do


### PR DESCRIPTION
## Context

This builds on #6739 (`jv-router-split`), which splits routes by verb during compilation. That change reorganizes the match clauses into per-verb functions *within* the router module, improving runtime dispatch.

While benchmarking #6739 against a large production Phoenix application (~4,100 routes across ~1,350 controllers) on Elixir 1.20, I found that the new set-theoretic type checker's "group pass check" phase did **not** improve: the router module still took ~420s to type-check, essentially unchanged from before #6739.

## Root cause

The set-theoretic type checker's unit of work is the **module** (`Module.ParallelChecker.check_module/3`), and per-module verification cost is strongly **super-linear** in the number of route clauses. Splitting the same app's routes into separate modules by verb and measuring each in isolation:

| module | routes | type-check |
|---|---|---|
| GET | 1,972 | 65.1s |
| POST | 1,070 | 12.3s |
| PUT | 449 | 1.7s |
| PATCH | 404 | 1.3s |
| DELETE | 241 | 0.65s |
| **single module, all verbs** | **4,145** | **450s** |

GET has ~2× the routes of POST but ~5× the type-check time. Because all match clauses (and the `&Controller.action/arity` compile-time checks) live in one module, the checker processes them as a single serial pass whose cost grows super-linearly.

Splitting into per-verb *functions* within the same module (as #6739 does) doesn't move this number, because the **module** is the granularity the checker operates on — not the function.

## Change

Emit the generated route artifacts into sub-modules instead of in-module functions:

- **Match clauses** go into per-verb-chunked sub-modules `Router.Match{N}` (bounded at 250 routes per module). The parent's `__match_route__/3` delegates across them.
- **The compile-time action references** (`&Controller.action/arity`) go into `Router.Checks{N}` sub-modules (bounded at 400). These exist only to be type-checked, so they parallelize cleanly.
- **Pipelines stay in the parent.** The match clauses can't capture the parent's private pipeline functions, so each clause carries a pipeline index that the parent resolves back to a capture via a generated `__pipeline__/1`.

Each sub-module is verified in its own `check_module` pass, so the work both parallelizes across cores and — because of the super-linearity — drops in total CPU.

## Results

Same app, same Elixir 1.20.1, only the codegen differs:

| phase | #6739 (per-verb functions) | this change (sub-modules) |
|---|---|---|
| group pass check (whole app) | 422.0s | **17.4s** |
| full compilation cycle | 537.0s | **93.6s** |
| router module compile | 450.7s | **17.5s** |

The 17.4s whole-app type-check is below this app's pre-1.20 baseline (~86s), so this recovers the full 1.20 type-checker cost on large routers.

Correctness verified: the route table is identical (all 4,145 routes preserved), and dispatch semantics are unchanged — verb disambiguation, path params, multi-pipeline resolution, wildcard-any-method matching, and no-match fallthrough all check out. The existing Phoenix router/routing/verified-routes suites pass (195 tests). No new compiler warnings.

## Caveats / open questions

This is a proof-of-concept demonstrating the mechanism, not necessarily merge-ready:

- **Dispatch is dynamic by design.** `__match_route__/3` walks the chunk modules with a dynamic `module.match(...)` call. This is load-bearing, not a shortcut: a *static* per-verb jump table (`def __match_route__("GET", ...)` calling `Match0.match(...)` directly) makes the type checker re-aggregate every route's return type back into the router module — I measured ~198s that way, i.e. it defeats the split. So the win requires the dispatch to stay opaque to the checker. The trade-off is a per-request walk of the chunk list; if that cost matters, verb-keying can be reintroduced as dynamic per-verb module *lists* (still an opaque `module.match(...)`), never static calls.
- **Chunk sizes** (250 / 400) are arbitrary knobs and should be tuned, or made configurable.
- `__verify_route__` and `__forward__` were left whole in the parent; they weren't a bottleneck on this app.

Happy to iterate on the dispatch structure if the direction is interesting.
