### PR TITLE
Fix logger failing when connection is upgraded to websocket

### DIFF
--- a/lib/phoenix/logger.ex
+++ b/lib/phoenix/logger.ex
@@ -287,6 +287,8 @@ defmodule Phoenix.Logger do
     end)
   end
 
+  defp status_to_string(nil), do: "unknown"
+
   defp status_to_string(status) do
     status |> Plug.Conn.Status.code() |> Integer.to_string()
   end


### PR DESCRIPTION
Fixes

```
[error] Handler {Phoenix.Logger, [:phoenix, :endpoint, :stop]} has failed and has been detached. Class=:error
Reason=:function_clause
Stacktrace=[
  {Plug.Conn.Status, :code, [nil],
   [file: ~c"lib/plug/conn/status.ex", line: 118]},
  {Phoenix.Logger, :status_to_string, 1,
   [file: ~c"lib/phoenix/logger.ex", line: 293]},
  {Phoenix.Logger, :"-phoenix_endpoint_stop/4-fun-0-", 2,
   [file: ~c"lib/phoenix/logger.ex", line: 262]},
  {Logger, :__do_log__, 4, [file: ~c"lib/logger.ex", line: 1029]},
  {:telemetry, :do_execute, 4,
   [file: ~c"/home/steffen/dayzee/deps/telemetry/src/telemetry.erl", line: 202]},
  {Plug.Telemetry, :"-call/2-fun-0-", 4,
   [file: ~c"lib/plug/telemetry.ex", line: 76]},
  {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: ~c"lib/enum.ex", line: 2520]},
  {Plug.Conn, :run_before_send, 2, [file: ~c"lib/plug/conn.ex", line: 1918]},
  {Plug.Conn, :upgrade_adapter, 3, [file: ~c"lib/plug/conn.ex", line: 1476]},
  {DayzeeWeb.WebsocketUpgrade, :call, 2,
   [file: ~c"lib/dayzee_web/websocketupgrade.ex", line: 13]},
  {Phoenix.Router, :__call__, 5, [file: ~c"lib/phoenix/router.ex", line: 416]},
  {DayzeeWeb.Endpoint, :plug_builder_call, 2,
   [file: ~c"lib/dayzee_web/endpoint.ex", line: 1]},
  {DayzeeWeb.Endpoint, :"call (overridable 3)", 2,
   [file: ~c"deps/plug/lib/plug/debugger.ex", line: 155]},
  {DayzeeWeb.Endpoint, :call, 2,
   [file: ~c"lib/dayzee_web/endpoint.ex", line: 1]},
  {...},
  ...
]
```

when using WebSockAdapter.upgrade. In that case status is nil.