### PR TITLE
Support module plugs with options in pipe_through

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -816,7 +816,14 @@ defmodule Phoenix.Router do
   end
 
   defp build_pipes(name, pipe_through) do
-    plugs = pipe_through |> Enum.reverse() |> Enum.map(&{&1, [], true})
+    plugs =
+      pipe_through
+      |> Enum.reverse()
+      |> Enum.map(fn
+        {module, opts} -> {module, opts, true}
+        plug -> {plug, [], true}
+      end)
+
     opts = [init_mode: Phoenix.plug_init_mode(), log_on_halt: :debug]
     {conn, body} = Plug.Builder.compile(__ENV__, plugs, opts)
 
@@ -1035,6 +1042,11 @@ defmodule Phoenix.Router do
   Pipelines are defined in the router, see `pipeline/2` for more information.
 
       pipe_through [:require_authenticated_user, :my_browser_pipeline]
+
+  A module plug may also be given, optionally with a tuple of `{plug, opts}`
+  to pass options to it:
+
+      pipe_through [:browser, MyApp.Plugs.Locale, {MyApp.Plugs.Feature, flag: :beta}]
 
   ## Multiple invocations
 

--- a/test/phoenix/router/pipeline_test.exs
+++ b/test/phoenix/router/pipeline_test.exs
@@ -174,4 +174,35 @@ defmodule Phoenix.Router.PipelineTest do
       end
     end
   end
+
+  test "pipe_through with module plug and options" do
+    defmodule ModulePlugRouter do
+      use Phoenix.Router
+
+      defmodule GreetingPlug do
+        def init(opts), do: opts
+
+        def call(conn, opts) do
+          Plug.Conn.assign(conn, :greeting, Keyword.fetch!(opts, :greeting))
+        end
+      end
+
+      pipeline :api do
+        plug :put_assign, "api"
+      end
+
+      scope "/" do
+        pipe_through [:api, {GreetingPlug, greeting: "Hey there"}]
+        get "/hello", SampleController, :index
+      end
+
+      defp put_assign(conn, value) do
+        assign(conn, :stack, [value | conn.assigns[:stack] || []])
+      end
+    end
+
+    conn = call(ModulePlugRouter, :get, "/hello")
+    assert conn.assigns[:greeting] == "Hey there"
+    assert conn.assigns[:stack] == ["api"]
+  end
 end


### PR DESCRIPTION
Closes #6711.

Using a module plug with options as a `{plug, opts}` tuple in `pipe_through`
raised at compile time:

    pipe_through [:api, {MyPlug, greeting: "hey"}]

    ** (ArgumentError) errors were found at the given arguments:
      * 1st argument: not an atom

`build_pipes/2` mapped every entry to `{plug, [], true}`, so a bare atom
(function plug, pipeline, or bare module plug) worked, but a `{plug, opts}`
tuple was passed through as the plug itself, which `Plug.Builder` then tried
to treat as an atom. This maps `{plug, opts}` tuples to `{plug, opts, true}`
and keeps the existing behaviour for bare entries.

Added a test covering the mixed case (a pipeline plus a module plug with
options) and documented the form in `pipe_through/1`.

Note: the route's `pipe_through` metadata (used by telemetry/logging) may now
contain a `{plug, opts}` tuple in addition to atoms. Happy to adjust if you'd
prefer that field to stay atoms-only.