### PR TITLE
Create GitHub releases with changelog

### DIFF
--- a/.github/extract-changelog.sh
+++ b/.github/extract-changelog.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Extract changelog for a specific version from CHANGELOG.md
+#
+# Usage: ./extract-changelog.sh <version>
+# Example: ./extract-changelog.sh v1.8.9
+
+set -euo pipefail
+
+VERSION="${1:-}"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: $0 <version>" >&2
+    echo "Example: $0 v1.8.9" >&2
+    exit 1
+fi
+
+# Normalize version to drop the 'v' prefix, since Phoenix changelog headers
+# are written without it (e.g. "## 1.8.9 (2026-07-07)").
+VERSION="${VERSION#v}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHANGELOG_PATH="${SCRIPT_DIR}/../CHANGELOG.md"
+
+if [[ ! -f "$CHANGELOG_PATH" ]]; then
+    echo "Error: CHANGELOG.md not found at $CHANGELOG_PATH" >&2
+    exit 1
+fi
+
+# Extract the section for the specified version
+# Match from "## X.Y.Z" until the next "## X.Y.Z" header
+awk -v version="$VERSION" '
+    BEGIN { found = 0; printing = 0 }
+
+    # Match the start of a numbered version section
+    /^## [0-9]/ {
+        if (printing) {
+            # We hit the next version, stop printing
+            exit
+        }
+        # Check if this line contains our version
+        if (index($0, "## " version " ") > 0) {
+            found = 1
+            printing = 1
+            next  # Skip the version header line
+        }
+    }
+
+    printing { print }
+
+    END {
+        if (!found) {
+            print "Error: Version " version " not found in changelog" > "/dev/stderr"
+            exit 1
+        }
+    }
+' "$CHANGELOG_PATH"

--- a/.github/extract-changelog.sh
+++ b/.github/extract-changelog.sh
@@ -15,9 +15,9 @@ if [[ -z "$VERSION" ]]; then
     exit 1
 fi
 
-# Normalize version to drop the 'v' prefix, since Phoenix changelog headers
-# are written without it (e.g. "## 1.8.9 (2026-07-07)").
-VERSION="${VERSION#v}"
+# Normalize version to include 'v' prefix
+VERSION="${VERSION#v}"  # Remove 'v' if present
+VERSION="v${VERSION}"   # Add 'v' prefix
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHANGELOG_PATH="${SCRIPT_DIR}/../CHANGELOG.md"
@@ -28,12 +28,12 @@ if [[ ! -f "$CHANGELOG_PATH" ]]; then
 fi
 
 # Extract the section for the specified version
-# Match from "## X.Y.Z" until the next "## X.Y.Z" header
+# Match from "## vX.Y.Z" until the next "## v" header
 awk -v version="$VERSION" '
     BEGIN { found = 0; printing = 0 }
 
-    # Match the start of a numbered version section
-    /^## [0-9]/ {
+    # Match the start of our target version section
+    /^## v[0-9]/ {
         if (printing) {
             # We hit the next version, stop printing
             exit

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,35 @@
+name: Creates a GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog for version
+        run: bash .github/extract-changelog.sh "${{ steps.version.outputs.version }}" > release_notes.md
+
+      - name: Create GitHub Release
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ steps.version.outputs.version }}" == *-rc* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "${{ steps.version.outputs.version }}" \
+            --title "${{ steps.version.outputs.version }}" \
+            --notes-file release_notes.md \
+            $PRERELEASE_FLAG


### PR DESCRIPTION
Automatically creates a GitHub release with the matching changelog entry
whenever a `v*` tag is pushed.

- Add `.github/extract-changelog.sh` to extract a specific version's section
  from `CHANGELOG.md`
- Add `.github/workflows/github_release.yml` to create the release on tag
  push, using the extracted entry as the release notes (marks `-rc` tags as
  prereleases)

Same feature I contributed to LiveView in https://github.com/phoenixframework/phoenix_live_view/pull/4135
(issue [phoenixframework/phoenix_live_view#4126](https://github.com/phoenixframework/phoenix_live_view/issues/4126)).

This way, Renovate will show the changelog entries in version updates (see LiveView issue for details).