### PR TITLE
fix: add missing websocket options to Endpoint validation

### DIFF
--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -725,7 +725,10 @@ defmodule Phoenix.Endpoint do
             :fullsweep_after,
             :compress,
             :subprotocols,
-            :error_handler
+            :error_handler,
+            :validate_utf8,
+            :active_n,
+            :deflate_options
           ]
       )
 


### PR DESCRIPTION
Valid options from websock_adapter:

https://github.com/phoenixframework/websock_adapter/blob/80901f46c8864cb8bd5231c32b7171b9d0e330ce/lib/websock_adapter.ex#L84-L89


```
  {:timeout, timeout} -> [idle_timeout: timeout]
  {:compress, _} = opt -> [opt]
  {:max_frame_size, _} = opt -> [opt]
  {:validate_utf8, _} = opt -> [opt]
  {:active_n, _} = opt -> [opt]
  {:deflate_options, deflate_options} -> [deflate_opts: deflate_options]
```