### PR TITLE
Make pipe_through accepts pipelines and all plug forms

### DIFF
--- a/lib/phoenix/router.ex
+++ b/lib/phoenix/router.ex
@@ -820,7 +820,7 @@ defmodule Phoenix.Router do
       pipe_through
       |> Enum.reverse()
       |> Enum.map(fn
-        {module, opts} -> {module, opts, true}
+        {plug, opts} -> {plug, opts, true}
         plug -> {plug, [], true}
       end)
 
@@ -1035,18 +1035,26 @@ defmodule Phoenix.Router do
   @doc """
   Defines a list of plugs (and pipelines) to send the connection through.
 
-  Plugs are specified using the atom name of any imported 2-arity function
-  which takes a `Plug.Conn` and options and returns a `Plug.Conn`. For
-  example, `:require_authenticated_user`.
+  Function plugs are specified using the atom name of functions. For example,
+  `:require_authenticated_user`.
+
+  Module plugs are specified using the module name. For example,
+  `MyAppWeb.UserAuth`.
+
+  And, the plugs can also be given options via `{plug, opts}`. For example,
+  `{:require_authenticated_user, opts}`, or `{MyAppWeb.UserAuth, opts}`
 
   Pipelines are defined in the router, see `pipeline/2` for more information.
 
-      pipe_through [:require_authenticated_user, :my_browser_pipeline]
+  ## Examples
 
-  A module plug may also be given, optionally with a tuple of `{plug, opts}`
-  to pass options to it:
-
-      pipe_through [:browser, MyApp.Plugs.Locale, {MyApp.Plugs.Feature, flag: :beta}]
+      pipe_through [
+        :browser,
+        :require_authenticated_user,
+        {:trace_user, prefix: :authenticated},
+        MyAppWeb.Plugs.Locale,
+        {MyAppWeb.Plugs.Feature, flag: :beta}
+      ]
 
   ## Multiple invocations
 

--- a/test/phoenix/router/pipeline_test.exs
+++ b/test/phoenix/router/pipeline_test.exs
@@ -175,34 +175,55 @@ defmodule Phoenix.Router.PipelineTest do
     end
   end
 
-  test "pipe_through with module plug and options" do
-    defmodule ModulePlugRouter do
+  test "pipe_through accepts pipelines and all plug forms" do
+    defmodule PassThroughRouter do
       use Phoenix.Router
 
-      defmodule GreetingPlug do
+      def push_stack(conn, value) do
+        assign(conn, :stack, [value | conn.assigns[:stack] || []])
+      end
+
+      def function_plug(conn, opts) do
+        PassThroughRouter.push_stack(conn, {:function_plug, opts})
+      end
+
+      defmodule ModulePlug do
         def init(opts), do: opts
 
         def call(conn, opts) do
-          Plug.Conn.assign(conn, :greeting, Keyword.fetch!(opts, :greeting))
+          PassThroughRouter.push_stack(conn, {:module_plug, opts})
         end
       end
 
-      pipeline :api do
-        plug :put_assign, "api"
+      pipeline :pipeline1 do
+        plug :push_stack, :pipeline1
       end
 
       scope "/" do
-        pipe_through [:api, {GreetingPlug, greeting: "Hey there"}]
-        get "/hello", SampleController, :index
-      end
+        pipe_through [
+          :pipeline1,
+          :function_plug,
+          {:function_plug, []},
+          {:function_plug, [:opt1]},
+          ModulePlug,
+          {ModulePlug, []},
+          {ModulePlug, [:opt1]}
+        ]
 
-      defp put_assign(conn, value) do
-        assign(conn, :stack, [value | conn.assigns[:stack] || []])
+        get "/hello", SampleController, :index
       end
     end
 
-    conn = call(ModulePlugRouter, :get, "/hello")
-    assert conn.assigns[:greeting] == "Hey there"
-    assert conn.assigns[:stack] == ["api"]
+    conn = call(PassThroughRouter, :get, "/hello")
+
+    assert Enum.reverse(conn.assigns[:stack]) == [
+             :pipeline1,
+             {:function_plug, []},
+             {:function_plug, []},
+             {:function_plug, [:opt1]},
+             {:module_plug, []},
+             {:module_plug, []},
+             {:module_plug, [:opt1]}
+           ]
   end
 end


### PR DESCRIPTION
This is a rework of #6755.

I think, the missing feature is not about module plugs, it's about plugs and **plugs with options**. 

We need to build and test it around all plug forms, not just limit it to module plug with options.

This PR is trying make it clearer that `pipe_through` supports pipelines and all plug forms.
