### PR TITLE
Allow configuring LongPoll to send its token via headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog for v1.9
 
-Nothing, so far.
+## Enhancements
+
+  * [Transports] Allow the longpoll session token to be sent in the
+    `x-phoenix-longpoll-token` header instead of the query string, via
+    `longpoll: [token_location: :header]`.
+    Longpoll responses are now also sent with `cache-control: no-store`.
+
+    Because the setting is negotiated per session and the server keeps
+    accepting both, it can be flipped with a rolling deploy. Deploy a
+    version that accepts both first, then switch to `:header` once no
+    node predates it:
+
+        socket "/socket", MyAppWeb.UserSocket,
+          longpoll: [token_location: :header]
+
+    Older clients that do not understand the negotiation keep using
+    params and continue to work.
 
 ## v1.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,10 @@
 
 ## Enhancements
 
-  * [Transports] Allow the longpoll session token to be sent in the
-    `x-phoenix-longpoll-token` header instead of the query string, via
-    `longpoll: [token_location: :header]`.
-    Longpoll responses are now also sent with `cache-control: no-store`.
-
-    Because the setting is negotiated per session and the server keeps
-    accepting both, it can be flipped with a rolling deploy. Deploy a
-    version that accepts both first, then switch to `:header` once no
-    node predates it:
-
-        socket "/socket", MyAppWeb.UserSocket,
-          longpoll: [token_location: :header]
-
-    Older clients that do not understand the negotiation keep using
-    params and continue to work.
+  * The longpoll session token is now sent in a `x-phoenix-longpoll-token`
+    header instead of the query string. If you do rolling deploys where both
+    old and new nodes are active at the same time, ensure that you deploy
+    Phoenix v1.8.10 or a later v1.8 release first.
 
 ## v1.8
 

--- a/assets/js/phoenix/longpoll.js
+++ b/assets/js/phoenix/longpoll.js
@@ -25,6 +25,9 @@ export default class LongPoll {
     }
     this.endPoint = null
     this.token = null
+    // Where to send the session token. The server tells us when it establishes
+    // the session; servers that predate that continue to receive it in params.
+    this.tokenLocation = "params"
     this.skipHeartbeat = true
     this.reqs = new Set()
     this.awaitingBatchAck = false
@@ -49,6 +52,7 @@ export default class LongPoll {
   }
 
   endpointURL(){
+    if(this.tokenLocation === "header"){ return this.pollEndpoint }
     return Ajax.appendParams(this.pollEndpoint, {token: this.token})
   }
 
@@ -113,6 +117,7 @@ export default class LongPoll {
           this.poll()
           break
         case 410:
+          this.tokenLocation = resp.token_location === "header" ? "header" : "params"
           this.readyState = SOCKET_STATES.open
           this.onopen({})
           this.poll()
@@ -189,6 +194,9 @@ export default class LongPoll {
     let ontimeout = () => {
       this.reqs.delete(req)
       onCallerTimeout()
+    }
+    if(this.tokenLocation === "header" && this.token !== null){
+      headers = Object.assign({}, headers, {"X-Phoenix-Longpoll-Token": this.token})
     }
     req = Ajax.request(method, this.endpointURL(), headers, body, this.timeout, ontimeout, resp => {
       this.reqs.delete(req)

--- a/assets/js/phoenix/longpoll.js
+++ b/assets/js/phoenix/longpoll.js
@@ -25,9 +25,6 @@ export default class LongPoll {
     }
     this.endPoint = null
     this.token = null
-    // Where to send the session token. The server tells us when it establishes
-    // the session; servers that predate that continue to receive it in params.
-    this.tokenLocation = "params"
     this.skipHeartbeat = true
     this.reqs = new Set()
     this.awaitingBatchAck = false
@@ -52,8 +49,7 @@ export default class LongPoll {
   }
 
   endpointURL(){
-    if(this.tokenLocation === "header"){ return this.pollEndpoint }
-    return Ajax.appendParams(this.pollEndpoint, {token: this.token})
+    return this.pollEndpoint
   }
 
   closeAndRetry(code, reason, wasClean){
@@ -117,7 +113,6 @@ export default class LongPoll {
           this.poll()
           break
         case 410:
-          this.tokenLocation = resp.token_location === "header" ? "header" : "params"
           this.readyState = SOCKET_STATES.open
           this.onopen({})
           this.poll()
@@ -195,7 +190,7 @@ export default class LongPoll {
       this.reqs.delete(req)
       onCallerTimeout()
     }
-    if(this.tokenLocation === "header" && this.token !== null){
+    if(this.token !== null){
       headers = Object.assign({}, headers, {"X-Phoenix-Longpoll-Token": this.token})
     }
     req = Ajax.request(method, this.endpointURL(), headers, body, this.timeout, ontimeout, resp => {

--- a/assets/test/longpoll_test.js
+++ b/assets/test/longpoll_test.js
@@ -117,6 +117,71 @@ describe("LongPoll", () => {
       )
     })
 
+    it("should keep the token in params when the server does not advertise the header", () => {
+      const longpoll = new LongPoll("http://localhost/socket/longpoll", undefined)
+      longpoll.timeout = 1000
+
+      Ajax.request.mockImplementationOnce((method, url, headers, body, timeout, ontimeout, callback) => {
+        callback({status: 410, token: "token123", messages: []})
+        return {abort: jest.fn()}
+      })
+
+      longpoll.poll()
+
+      expect(longpoll.tokenLocation).toBe("params")
+      expect(Ajax.request).toHaveBeenLastCalledWith(
+        "GET",
+        "http://localhost/socket/longpoll?token=token123",
+        {"Accept": "application/json"},
+        null,
+        expect.any(Number),
+        expect.any(Function),
+        expect.any(Function)
+      )
+    })
+
+    it("should move the token to a header when the server advertises it", () => {
+      const longpoll = new LongPoll("http://localhost/socket/longpoll", undefined)
+      longpoll.timeout = 1000
+
+      Ajax.request.mockImplementationOnce((method, url, headers, body, timeout, ontimeout, callback) => {
+        callback({status: 410, token: "token123", messages: [], token_location: "header"})
+        return {abort: jest.fn()}
+      })
+
+      longpoll.poll()
+
+      expect(longpoll.tokenLocation).toBe("header")
+      expect(Ajax.request).toHaveBeenLastCalledWith(
+        "GET",
+        "http://localhost/socket/longpoll",
+        {"Accept": "application/json", "X-Phoenix-Longpoll-Token": "token123"},
+        null,
+        expect.any(Number),
+        expect.any(Function),
+        expect.any(Function)
+      )
+    })
+
+    it("should send the token header on batched pushes", () => {
+      const longpoll = new LongPoll("http://localhost/socket/longpoll", undefined)
+      longpoll.timeout = 1000
+      longpoll.token = "token123"
+      longpoll.tokenLocation = "header"
+
+      longpoll.batchSend(["msg1"])
+
+      expect(Ajax.request).toHaveBeenLastCalledWith(
+        "POST",
+        "http://localhost/socket/longpoll",
+        {"Content-Type": "application/x-ndjson", "X-Phoenix-Longpoll-Token": "token123"},
+        "msg1",
+        expect.any(Number),
+        expect.any(Function),
+        expect.any(Function)
+      )
+    })
+
     it("should treat 410 as error when token already exists", () => {
       const longpoll = new LongPoll("http://localhost/socket/longpoll", undefined)
       longpoll.timeout = 1000

--- a/assets/test/longpoll_test.js
+++ b/assets/test/longpoll_test.js
@@ -117,7 +117,7 @@ describe("LongPoll", () => {
       )
     })
 
-    it("should keep the token in params when the server does not advertise the header", () => {
+    it("should send the session token in a header", () => {
       const longpoll = new LongPoll("http://localhost/socket/longpoll", undefined)
       longpoll.timeout = 1000
 
@@ -128,30 +128,6 @@ describe("LongPoll", () => {
 
       longpoll.poll()
 
-      expect(longpoll.tokenLocation).toBe("params")
-      expect(Ajax.request).toHaveBeenLastCalledWith(
-        "GET",
-        "http://localhost/socket/longpoll?token=token123",
-        {"Accept": "application/json"},
-        null,
-        expect.any(Number),
-        expect.any(Function),
-        expect.any(Function)
-      )
-    })
-
-    it("should move the token to a header when the server advertises it", () => {
-      const longpoll = new LongPoll("http://localhost/socket/longpoll", undefined)
-      longpoll.timeout = 1000
-
-      Ajax.request.mockImplementationOnce((method, url, headers, body, timeout, ontimeout, callback) => {
-        callback({status: 410, token: "token123", messages: [], token_location: "header"})
-        return {abort: jest.fn()}
-      })
-
-      longpoll.poll()
-
-      expect(longpoll.tokenLocation).toBe("header")
       expect(Ajax.request).toHaveBeenLastCalledWith(
         "GET",
         "http://localhost/socket/longpoll",
@@ -167,7 +143,6 @@ describe("LongPoll", () => {
       const longpoll = new LongPoll("http://localhost/socket/longpoll", undefined)
       longpoll.timeout = 1000
       longpoll.token = "token123"
-      longpoll.tokenLocation = "header"
 
       longpoll.batchSend(["msg1"])
 

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -740,7 +740,8 @@ defmodule Phoenix.Endpoint do
           [
             :window_ms,
             :pubsub_timeout_ms,
-            :crypto
+            :crypto,
+            :token_location
           ]
       )
 
@@ -1063,6 +1064,13 @@ defmodule Phoenix.Endpoint do
 
     * `:crypto` - options for verifying and signing the token, accepted
       by `Phoenix.Token`. By default tokens are valid for 2 weeks
+
+    * `:token_location` - where clients should send the session token,
+      either `:params` (default) or `:header`. The server always accepts
+      the token from both locations; this option only controls which one
+      it tells clients to use when a session is established. Sending the
+      token in the `x-phoenix-longpoll-token` header keeps it out of URLs,
+      and therefore out of access logs.
 
   """
   defmacro socket(path, module, opts \\ []) do

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -740,8 +740,7 @@ defmodule Phoenix.Endpoint do
           [
             :window_ms,
             :pubsub_timeout_ms,
-            :crypto,
-            :token_location
+            :crypto
           ]
       )
 
@@ -1064,13 +1063,6 @@ defmodule Phoenix.Endpoint do
 
     * `:crypto` - options for verifying and signing the token, accepted
       by `Phoenix.Token`. By default tokens are valid for 2 weeks
-
-    * `:token_location` - where clients should send the session token,
-      either `:params` (default) or `:header`. The server always accepts
-      the token from both locations; this option only controls which one
-      it tells clients to use when a session is established. Sending the
-      token in the `x-phoenix-longpoll-token` header keeps it out of URLs,
-      and therefore out of access logs.
 
   """
   defmacro socket(path, module, opts \\ []) do

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -7,6 +7,7 @@ defmodule Phoenix.Transports.LongPoll do
   @max_base64_size 10_000_000
   @max_poll_batch_size 100
   @connect_info_opts [:check_csrf]
+  @token_header "x-phoenix-longpoll-token"
 
   import Plug.Conn
   alias Phoenix.Socket.{V1, V2, Transport}
@@ -18,7 +19,8 @@ defmodule Phoenix.Transports.LongPoll do
       pubsub_timeout_ms: 2_000,
       serializer: [{V1.JSONSerializer, "~> 1.0.0"}, {V2.JSONSerializer, "~> 2.0.0"}],
       transport_log: false,
-      crypto: [max_age: 1_209_600]
+      crypto: [max_age: 1_209_600],
+      token_location: :params
     ]
   end
 
@@ -52,9 +54,9 @@ defmodule Phoenix.Transports.LongPoll do
 
   # Starts a new session or listen to a message if one already exists.
   defp dispatch(%{method: "GET"} = conn, endpoint, handler, opts) do
-    case resume_session(conn, conn.params, endpoint, opts) do
-      {:ok, new_conn, server_ref} ->
-        listen(new_conn, server_ref, endpoint, opts)
+    case resume_session(conn, endpoint, opts) do
+      {:ok, new_conn, server_ref, token} ->
+        listen(new_conn, server_ref, token, endpoint, opts)
 
       :error ->
         new_session(conn, endpoint, handler, opts)
@@ -63,8 +65,8 @@ defmodule Phoenix.Transports.LongPoll do
 
   # Publish the message.
   defp dispatch(%{method: "POST"} = conn, endpoint, _, opts) do
-    case resume_session(conn, conn.params, endpoint, opts) do
-      {:ok, new_conn, server_ref} ->
+    case resume_session(conn, endpoint, opts) do
+      {:ok, new_conn, server_ref, _token} ->
         publish(new_conn, server_ref, endpoint, opts)
 
       :error ->
@@ -153,11 +155,21 @@ defmodule Phoenix.Transports.LongPoll do
       {:ok, server_pid} ->
         data = {:v1, endpoint.config(:endpoint_id), server_pid, priv_topic}
         token = sign_token(endpoint, data, opts)
-        conn |> put_status(:gone) |> status_token_messages_json(token, [])
+
+        # A new session is always established before the client holds a token,
+        # so this response tells the client where to send it from now on. Clients
+        # that predate this default to params, which we keep accepting.
+        extra =
+          case opts[:token_location] do
+            :header -> %{"token_location" => "header"}
+            _ -> %{}
+          end
+
+        conn |> put_status(:gone) |> status_token_messages_json(token, [], extra)
     end
   end
 
-  defp listen(conn, server_ref, endpoint, opts) do
+  defp listen(conn, server_ref, token, endpoint, opts) do
     ref = make_ref()
     client_ref = client_ref(server_ref)
     broadcast_from!(endpoint, server_ref, {:flush, client_ref, ref})
@@ -185,38 +197,44 @@ defmodule Phoenix.Transports.LongPoll do
 
     conn
     |> put_status(status)
-    |> status_token_messages_json(conn.params["token"], messages)
+    |> status_token_messages_json(token, messages)
+  end
+
+  # The token is accepted from either location regardless of :token_location,
+  # so that clients and servers can be rolled out independently.
+  defp fetch_token(conn) do
+    case get_req_header(conn, @token_header) do
+      [token | _] -> token
+      [] -> conn.params["token"]
+    end
   end
 
   # Retrieves the serialized `Phoenix.LongPoll.Server` pid
   # by publishing a message in the encrypted private topic.
-  defp resume_session(%Plug.Conn{} = conn, %{"token" => token}, endpoint, opts) do
-    case verify_token(endpoint, token, opts) do
-      {:ok, {:v1, id, pid, priv_topic}} ->
-        server_ref = server_ref(endpoint.config(:endpoint_id), id, pid, priv_topic)
+  defp resume_session(%Plug.Conn{} = conn, endpoint, opts) do
+    with token when is_binary(token) <- fetch_token(conn),
+         {:ok, {:v1, id, pid, priv_topic}} <- verify_token(endpoint, token, opts) do
+      server_ref = server_ref(endpoint.config(:endpoint_id), id, pid, priv_topic)
 
-        new_conn =
-          Plug.Conn.register_before_send(conn, fn conn ->
-            unsubscribe(endpoint, server_ref)
-            conn
-          end)
+      new_conn =
+        Plug.Conn.register_before_send(conn, fn conn ->
+          unsubscribe(endpoint, server_ref)
+          conn
+        end)
 
-        ref = make_ref()
-        :ok = subscribe(endpoint, server_ref)
-        broadcast_from!(endpoint, server_ref, {:subscribe, client_ref(server_ref), ref})
+      ref = make_ref()
+      :ok = subscribe(endpoint, server_ref)
+      broadcast_from!(endpoint, server_ref, {:subscribe, client_ref(server_ref), ref})
 
-        receive do
-          {:subscribe, ^ref} -> {:ok, new_conn, server_ref}
-        after
-          opts[:pubsub_timeout_ms] -> :error
-        end
-
-      _ ->
-        :error
+      receive do
+        {:subscribe, ^ref} -> {:ok, new_conn, server_ref, token}
+      after
+        opts[:pubsub_timeout_ms] -> :error
+      end
+    else
+      _ -> :error
     end
   end
-
-  defp resume_session(%Plug.Conn{}, _params, _endpoint, _opts), do: :error
 
   ## Helpers
 
@@ -283,13 +301,17 @@ defmodule Phoenix.Transports.LongPoll do
     send_json(conn, %{"status" => conn.status || 200})
   end
 
-  defp status_token_messages_json(conn, token, messages) do
-    send_json(conn, %{"status" => conn.status || 200, "token" => token, "messages" => messages})
+  defp status_token_messages_json(conn, token, messages, extra \\ %{}) do
+    body = %{"status" => conn.status || 200, "token" => token, "messages" => messages}
+    send_json(conn, Map.merge(body, extra))
   end
 
   defp send_json(conn, data) do
     conn
     |> put_resp_header("content-type", "application/json; charset=utf-8")
+    # When the token travels in a header, the poll URL is identical for every
+    # session, so responses must never be stored or shared by a cache.
+    |> put_resp_header("cache-control", "no-store")
     |> send_resp(200, Phoenix.json_library().encode_to_iodata!(data))
   end
 end

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -19,8 +19,7 @@ defmodule Phoenix.Transports.LongPoll do
       pubsub_timeout_ms: 2_000,
       serializer: [{V1.JSONSerializer, "~> 1.0.0"}, {V2.JSONSerializer, "~> 2.0.0"}],
       transport_log: false,
-      crypto: [max_age: 1_209_600],
-      token_location: :params
+      crypto: [max_age: 1_209_600]
     ]
   end
 
@@ -155,17 +154,7 @@ defmodule Phoenix.Transports.LongPoll do
       {:ok, server_pid} ->
         data = {:v1, endpoint.config(:endpoint_id), server_pid, priv_topic}
         token = sign_token(endpoint, data, opts)
-
-        # A new session is always established before the client holds a token,
-        # so this response tells the client where to send it from now on. Clients
-        # that predate this default to params, which we keep accepting.
-        extra =
-          case opts[:token_location] do
-            :header -> %{"token_location" => "header"}
-            _ -> %{}
-          end
-
-        conn |> put_status(:gone) |> status_token_messages_json(token, [], extra)
+        conn |> put_status(:gone) |> status_token_messages_json(token, [])
     end
   end
 
@@ -200,8 +189,8 @@ defmodule Phoenix.Transports.LongPoll do
     |> status_token_messages_json(token, messages)
   end
 
-  # The token is accepted from either location regardless of :token_location,
-  # so that clients and servers can be rolled out independently.
+  # Accept the token from either location so that newer clients can use the
+  # header while older clients continue to use params.
   defp fetch_token(conn) do
     case get_req_header(conn, @token_header) do
       [token | _] -> token

--- a/test/phoenix/integration/long_poll_socket_test.exs
+++ b/test/phoenix/integration/long_poll_socket_test.exs
@@ -72,6 +72,15 @@ defmodule Phoenix.Integration.LongPollSocketTest do
     socket "/custom/:socket_var", UserSocket,
       longpoll: [path: ":path_var/path", check_origin: ["//example.com"], pubsub_timeout_ms: 200],
       custom: :value
+
+    socket "/header-token", UserSocket,
+      longpoll: [
+        window_ms: 200,
+        pubsub_timeout_ms: 200,
+        check_origin: ["//example.com"],
+        token_location: :header
+      ],
+      custom: :value
   end
 
   setup %{adapter: adapter} do
@@ -141,6 +150,65 @@ defmodule Phoenix.Integration.LongPollSocketTest do
         assert params =~ ~s("key" => "value")
         assert params =~ ~s("socket_var" => "123")
         assert params =~ ~s(path_var" => "456")
+      end
+
+      test "does not advertise the token header by default" do
+        resp = poll(:get, "ws/longpoll", %{}, nil)
+        refute Map.has_key?(resp.body, "token_location")
+      end
+
+      test "accepts the token from a header even when it is not advertised" do
+        resp = poll(:get, "ws/longpoll", %{"hello" => "world"}, nil)
+        token = %{"x-phoenix-longpoll-token" => resp.body["token"]}
+
+        resp = poll(:post, "ws/longpoll", %{}, "params", token)
+        assert resp.body["status"] == 200
+
+        resp = poll(:get, "ws/longpoll", %{}, nil, token)
+        assert resp.body["messages"] == [~s(%{"hello" => "world"})]
+      end
+
+      test "advertises the token header when token_location: :header" do
+        resp = poll(:get, "header-token/longpoll", %{"hello" => "world"}, nil)
+        assert resp.body["status"] == 410
+        assert resp.body["token_location"] == "header"
+        token = %{"x-phoenix-longpoll-token" => resp.body["token"]}
+
+        resp = poll(:post, "header-token/longpoll", %{}, "params", token)
+        assert resp.body["status"] == 200
+
+        resp = poll(:get, "header-token/longpoll", %{}, nil, token)
+        assert resp.body["status"] == 200
+        assert resp.body["token"] == token["x-phoenix-longpoll-token"]
+        assert resp.body["messages"] == [~s(%{"hello" => "world"})]
+      end
+
+      test "still accepts the token from params when token_location: :header" do
+        resp = poll(:get, "header-token/longpoll", %{"hello" => "world"}, nil)
+        secret = Map.take(resp.body, ["token"])
+
+        resp = poll(:post, "header-token/longpoll", secret, "params")
+        assert resp.body["status"] == 200
+
+        resp = poll(:get, "header-token/longpoll", secret, nil)
+        assert resp.body["messages"] == [~s(%{"hello" => "world"})]
+      end
+
+      test "the header takes precedence over a stale params token" do
+        resp = poll(:get, "ws/longpoll", %{"hello" => "world"}, nil)
+        token = resp.body["token"]
+
+        resp =
+          poll(:post, "ws/longpoll", %{"token" => "bogus"}, "params", %{
+            "x-phoenix-longpoll-token" => token
+          })
+
+        assert resp.body["status"] == 200
+      end
+
+      test "responses are never cached" do
+        resp = poll(:get, "ws/longpoll", %{}, nil)
+        assert {_, ~c"no-store"} = List.keyfind(resp.headers, ~c"cache-control", 0)
       end
 
       test "returns pong from async request" do

--- a/test/phoenix/integration/long_poll_socket_test.exs
+++ b/test/phoenix/integration/long_poll_socket_test.exs
@@ -12,6 +12,7 @@ defmodule Phoenix.Integration.LongPollSocketTest do
   @moduletag :capture_log
   @port 5908
   @pool_size 1
+  @token_header "x-phoenix-longpoll-token"
 
   Application.put_env(
     :phoenix,
@@ -72,15 +73,6 @@ defmodule Phoenix.Integration.LongPollSocketTest do
     socket "/custom/:socket_var", UserSocket,
       longpoll: [path: ":path_var/path", check_origin: ["//example.com"], pubsub_timeout_ms: 200],
       custom: :value
-
-    socket "/header-token", UserSocket,
-      longpoll: [
-        window_ms: 200,
-        pubsub_timeout_ms: 200,
-        check_origin: ["//example.com"],
-        token_location: :header
-      ],
-      custom: :value
   end
 
   setup %{adapter: adapter} do
@@ -100,6 +92,23 @@ defmodule Phoenix.Integration.LongPollSocketTest do
   end
 
   def poll(method, path, params, body \\ nil, headers \\ %{}) do
+    {token, params} = Map.pop(params, "token")
+
+    headers =
+      if token do
+        Map.put(headers, @token_header, token)
+      else
+        headers
+      end
+
+    do_poll(method, path, params, body, headers)
+  end
+
+  def poll_with_token_in_params(method, path, params, body \\ nil, headers \\ %{}) do
+    do_poll(method, path, params, body, headers)
+  end
+
+  defp do_poll(method, path, params, body, headers) do
     headers = Map.merge(%{"content-type" => "application/json"}, headers)
     url = "http://127.0.0.1:#{@port}/#{path}?" <> URI.encode_query(params)
     {:ok, resp} = HTTPClient.request(method, url, headers, body)
@@ -152,45 +161,14 @@ defmodule Phoenix.Integration.LongPollSocketTest do
         assert params =~ ~s(path_var" => "456")
       end
 
-      test "does not advertise the token header by default" do
-        resp = poll(:get, "ws/longpoll", %{}, nil)
-        refute Map.has_key?(resp.body, "token_location")
-      end
-
-      test "accepts the token from a header even when it is not advertised" do
+      test "accepts the token from params" do
         resp = poll(:get, "ws/longpoll", %{"hello" => "world"}, nil)
-        token = %{"x-phoenix-longpoll-token" => resp.body["token"]}
-
-        resp = poll(:post, "ws/longpoll", %{}, "params", token)
-        assert resp.body["status"] == 200
-
-        resp = poll(:get, "ws/longpoll", %{}, nil, token)
-        assert resp.body["messages"] == [~s(%{"hello" => "world"})]
-      end
-
-      test "advertises the token header when token_location: :header" do
-        resp = poll(:get, "header-token/longpoll", %{"hello" => "world"}, nil)
-        assert resp.body["status"] == 410
-        assert resp.body["token_location"] == "header"
-        token = %{"x-phoenix-longpoll-token" => resp.body["token"]}
-
-        resp = poll(:post, "header-token/longpoll", %{}, "params", token)
-        assert resp.body["status"] == 200
-
-        resp = poll(:get, "header-token/longpoll", %{}, nil, token)
-        assert resp.body["status"] == 200
-        assert resp.body["token"] == token["x-phoenix-longpoll-token"]
-        assert resp.body["messages"] == [~s(%{"hello" => "world"})]
-      end
-
-      test "still accepts the token from params when token_location: :header" do
-        resp = poll(:get, "header-token/longpoll", %{"hello" => "world"}, nil)
         secret = Map.take(resp.body, ["token"])
 
-        resp = poll(:post, "header-token/longpoll", secret, "params")
+        resp = poll_with_token_in_params(:post, "ws/longpoll", secret, "params")
         assert resp.body["status"] == 200
 
-        resp = poll(:get, "header-token/longpoll", secret, nil)
+        resp = poll_with_token_in_params(:get, "ws/longpoll", secret)
         assert resp.body["messages"] == [~s(%{"hello" => "world"})]
       end
 
@@ -199,9 +177,13 @@ defmodule Phoenix.Integration.LongPollSocketTest do
         token = resp.body["token"]
 
         resp =
-          poll(:post, "ws/longpoll", %{"token" => "bogus"}, "params", %{
-            "x-phoenix-longpoll-token" => token
-          })
+          poll_with_token_in_params(
+            :post,
+            "ws/longpoll",
+            %{"token" => "bogus"},
+            "params",
+            %{@token_header => token}
+          )
 
         assert resp.body["status"] == 200
       end


### PR DESCRIPTION
This changes the longpoll client to send its token in a header instead of query parameters. The server still accepts old clients.

Closes https://github.com/phoenixframework/phoenix/issues/6761.