### PR TITLE
Close and retry the longpoll transport when a batch POST times out

### DIFF
--- a/assets/js/phoenix/longpoll.js
+++ b/assets/js/phoenix/longpoll.js
@@ -154,12 +154,7 @@ export default class LongPoll {
     this.awaitingBatchAck = true
     const next = offset + MAX_LONGPOLL_BATCH_SIZE
     const batch = messages.slice(offset, next)
-    // a timed out batch is a failed batch: without resetting the ack, every
-    // later send would be buffered forever on a transport that looks alive
-    this.ajax("POST", {"Content-Type": "application/x-ndjson"}, batch.join("\n"), () => {
-      this.awaitingBatchAck = false
-      this.ontimeout()
-    }, resp => {
+    this.ajax("POST", {"Content-Type": "application/x-ndjson"}, batch.join("\n"), () => this.ontimeout(), resp => {
       if(!resp || resp.status !== 200){
         this.awaitingBatchAck = false
         this.onerror(resp && resp.status)
@@ -180,6 +175,7 @@ export default class LongPoll {
     this.readyState = SOCKET_STATES.closed
     let opts = Object.assign({code: 1000, reason: undefined, wasClean: true}, {code, reason, wasClean})
     this.batchBuffer = []
+    this.awaitingBatchAck = false
     clearTimeout(this.currentBatchTimer)
     this.currentBatchTimer = null
     if(typeof(CloseEvent) !== "undefined"){

--- a/assets/js/phoenix/longpoll.js
+++ b/assets/js/phoenix/longpoll.js
@@ -154,7 +154,12 @@ export default class LongPoll {
     this.awaitingBatchAck = true
     const next = offset + MAX_LONGPOLL_BATCH_SIZE
     const batch = messages.slice(offset, next)
-    this.ajax("POST", {"Content-Type": "application/x-ndjson"}, batch.join("\n"), () => this.onerror("timeout"), resp => {
+    // a timed out batch is a failed batch: without resetting the ack, every
+    // later send would be buffered forever on a transport that looks alive
+    this.ajax("POST", {"Content-Type": "application/x-ndjson"}, batch.join("\n"), () => {
+      this.awaitingBatchAck = false
+      this.ontimeout()
+    }, resp => {
       if(!resp || resp.status !== 200){
         this.awaitingBatchAck = false
         this.onerror(resp && resp.status)

--- a/assets/test/longpoll_test.js
+++ b/assets/test/longpoll_test.js
@@ -1,7 +1,7 @@
 import {jest} from "@jest/globals"
 import {LongPoll} from "../js/phoenix"
 import {Socket} from "../js/phoenix"
-import {AUTH_TOKEN_PREFIX} from "../js/phoenix/constants"
+import {AUTH_TOKEN_PREFIX, SOCKET_STATES} from "../js/phoenix/constants"
 import Ajax from "../js/phoenix/ajax"
 
 describe("LongPoll", () => {
@@ -249,6 +249,51 @@ describe("LongPoll", () => {
         calls[1].callback({status: 200})
         expect(calls).toHaveLength(2)
         expect(longpoll.awaitingBatchAck).toBe(false)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+
+    it("closes and retries when a batch POST times out", () => {
+      jest.useFakeTimers()
+      try {
+        const longpoll = new LongPoll("http://localhost/socket/longpoll", undefined)
+        longpoll.timeout = 1000
+        longpoll.poll = jest.fn()
+        longpoll.readyState = SOCKET_STATES.open
+
+        const onerror = jest.fn()
+        const onclose = jest.fn()
+        longpoll.onerror = onerror
+        longpoll.onclose = onclose
+
+        const calls = []
+        Ajax.request.mockImplementation((method, url, headers, body, timeout, ontimeout, callback) => {
+          calls.push({method, body, ontimeout, callback})
+          return {abort: jest.fn()}
+        })
+
+        longpoll.send("a")
+        jest.runOnlyPendingTimers()
+
+        expect(calls).toHaveLength(1)
+        expect(longpoll.awaitingBatchAck).toBe(true)
+
+        // the POST times out on the caller side
+        calls[0].ontimeout()
+
+        expect(onerror).toHaveBeenCalledWith("timeout")
+        expect(onclose).toHaveBeenCalled()
+        expect(longpoll.readyState).toBe(SOCKET_STATES.connecting)
+        expect(longpoll.awaitingBatchAck).toBe(false)
+
+        // later sends must not be silently buffered on the dead batch
+        longpoll.send("b")
+        jest.runOnlyPendingTimers()
+
+        expect(longpoll.batchBuffer).toEqual([])
+        expect(calls).toHaveLength(2)
+        expect(calls[1].body).toBe("b")
       } finally {
         jest.useRealTimers()
       }


### PR DESCRIPTION
Fixes #6767.

### The bug

`LongPoll.batchSend` resets `awaitingBatchAck` in its response callback and again on the non-200 branch, but its caller-timeout argument is only `() => this.onerror("timeout")`. Nothing resets the ack, nothing retries, and the transport is not closed. From then on every `send()` takes the `else if(this.awaitingBatchAck)` branch and appends to `batchBuffer`, which is never flushed again. The GET poll keeps working, so the transport still looks open, but no client message — including the channel join — ever leaves the browser on that instance.

### The fix

Make the timeout path do what the non-200 path in the same function already does: reset `awaitingBatchAck` and close and retry, reusing the existing `ontimeout` that the poll side already uses for its own caller timeout.

### On "if it holds POST requests, how would reconnecting help?"

@SteffenDE — fair challenge. A few parts to the answer:

1. **A network that blackholes every POST is unrecoverable, and nothing here claims otherwise.** If the appliance holds every POST forever, longpoll is dead and the user needs a different network. And yes — a middlebox that breaks both transports puts you in a bad spot no matter what the client does.

2. **But it does work sometimes.** The case we traced is a dual-WAN branch office whose two uplinks are not equal: one path runs through the inspecting appliance, the other doesn't, and the router picks per connection. A fresh connection is therefore a fresh draw. In one production session the POSTs began flowing 8.5 minutes in, on the same page, with nothing else changed. A transport that closes and retries gets those draws; the zombie instance never does, by construction — it holds one bad connection forever.

3. **Where nothing helps, the fix buys honest failure instead of a silent freeze.** Today the failure is invisible: the transport reports itself open, the poll loop keeps ticking, and sends pile into `batchBuffer` with no error, no backoff, no fallback memory, and a join that stays in flight forever. Nothing above the transport can react to a failure it is never told about. With the fix the socket layer learns the transport failed and does its usual work — channel error, reconnect backoff, and the application's own failure handling finally gets a chance to run.

4. And the small one: **the non-200 branch of this same function already does exactly this**, so the timeout path diverging reads more like an oversight than a decision.

### Tests

One test added to `assets/test/longpoll_test.js`: a batch POST that times out on the caller side now fires `onerror("timeout")`, closes the transport (`readyState` back to `connecting`), clears `awaitingBatchAck`, and a subsequent `send()` goes out as a new POST rather than disappearing into `batchBuffer`. It fails on `main` (the transport is never closed).

`npm test` is green (179 passing, 3 skipped).

### Reproduction

We have a harness — a node middlebox proxy that forwards `GET /longpoll` normally and holds `POST /longpoll` open forever, plus a Playwright driver — and are glad to share it or run a patch through it.

---
*Submitted on behalf of Rupert Deese by Claude, the AI engineering assistant at Gearflow.*
