### PR TITLE
Fix broken doc reference in Phoenix.Debug

### DIFF
--- a/lib/phoenix/debug.ex
+++ b/lib/phoenix/debug.ex
@@ -26,7 +26,7 @@ defmodule Phoenix.Debug do
   For example, when using Phoenix LiveView, the browser establishes a socket
   connection when initially navigating to the page, and each live navigation
   retains the same socket connection. Nested LiveViews also share the same
-  connection, each being a different channel. See `Phoenix.Debug.channels/1`.
+  connection, each being a different channel. See `Phoenix.Debug.list_channels/1`.
 
   ## Examples
 


### PR DESCRIPTION
The `@doc` for `Phoenix.Debug.list_sockets/0` ends with:

> Nested LiveViews also share the same connection, each being a different channel.
> See `Phoenix.Debug.channels/1`.

`Phoenix.Debug` exports `list_sockets/0`, `list_channels/1`, `socket/1`,
`socket_process?/1` and `channel_process?/1`. There is no `channels/1`, so the
reference does not resolve. The function that lists the channels of a socket
process is `list_channels/1`.

```
iex> function_exported?(Phoenix.Debug, :channels, 1)
false
iex> function_exported?(Phoenix.Debug, :list_channels, 1)
true
```

Docs-only change.