### PR TITLE
Include per-mount :check_origin in the origin policy cache key

### DIFF
--- a/lib/phoenix/socket/transport.ex
+++ b/lib/phoenix/socket/transport.ex
@@ -570,7 +570,13 @@ defmodule Phoenix.Socket.Transport do
   end
 
   defp check_origin_config(handler, endpoint, opts) do
-    Phoenix.Config.cache(endpoint, {:check_origin, handler}, fn _ ->
+    # The same handler may be mounted several times with different
+    # :check_origin options, so the option must be part of the cache key.
+    # Otherwise the first mount to be reached decides the policy for all
+    # of them.
+    key = {:check_origin, handler, Keyword.get(opts, :check_origin)}
+
+    Phoenix.Config.cache(endpoint, key, fn _ ->
       check_origin =
         case Keyword.get(opts, :check_origin, endpoint.config(:check_origin)) do
           origins when is_list(origins) ->

--- a/test/phoenix/socket/transport_test.exs
+++ b/test/phoenix/socket/transport_test.exs
@@ -238,6 +238,33 @@ defmodule Phoenix.Socket.TransportTest do
       # an allowed host
       refute check_origin("https://host.com/", check_origin: mfa).halted
     end
+
+    test "does not share the origin policy between mounts of the same handler" do
+      # The helper above passes a fresh make_ref/0 as the handler on every
+      # call, so it never exercises the policy cache. A single handler mounted
+      # twice with different :check_origin options must not have the first
+      # mount's policy applied to the second.
+      handler = __MODULE__.MultiMount
+      mount_a = [check_origin: ["//a.example"]]
+      mount_b = [check_origin: ["//b.example"]]
+
+      check = fn origin, opts ->
+        conn(:get, "/")
+        |> put_req_header("origin", origin)
+        |> Transport.check_origin(handler, Endpoint, opts)
+      end
+
+      # Mount A is reached first and populates the cache.
+      refute check.("http://a.example", mount_a).halted
+
+      # Mount B must apply its own allowlist, not mount A's.
+      assert check.("http://a.example", mount_b).halted
+      refute check.("http://b.example", mount_b).halted
+
+      # Mount A keeps its own allowlist too.
+      refute check.("http://a.example", mount_a).halted
+      assert check.("http://b.example", mount_a).halted
+    end
   end
 
   ## Check subprotocols


### PR DESCRIPTION
Fixes #6773.

## Problem

`check_origin_config/3` caches the parsed origin policy under
`{:check_origin, handler}`, where `handler` is the socket module. The key does
not include the per-mount `:check_origin` option, even though that option is
what the cached value is computed from:

```elixir
defp check_origin_config(handler, endpoint, opts) do
  Phoenix.Config.cache(endpoint, {:check_origin, handler}, fn _ ->
    check_origin =
      case Keyword.get(opts, :check_origin, endpoint.config(:check_origin)) do
      ...
```

`opts` is only read inside the cache callback, and that callback runs once per
handler module. So when the same socket module is mounted more than once with
different `:check_origin` values, whichever mount serves the first handshake
populates the cache and its policy is then applied to every other mount of that
module for the rest of the endpoint's lifetime.

Given:

```elixir
socket "/a_socket", MyApp.UserSocket, websocket: [check_origin: ["//a.example"]]
socket "/b_socket", MyApp.UserSocket, websocket: [check_origin: ["//b.example"]]
```

after a request reaches `/a_socket` first:

| mount | allowlist | Origin | expected | actual |
|---|---|---|---|---|
| `/a_socket` | `["//a.example"]` | `http://a.example` | allowed | allowed |
| `/b_socket` | `["//b.example"]` | `http://a.example` | **rejected** | **allowed** |
| `/b_socket` | `["//b.example"]` | `http://b.example` | **allowed** | **rejected** |

`/b_socket` accepts a cross-origin WebSocket from an origin its allowlist
excludes, and rejects the only origin it permits. Restart the endpoint and reach
`/b_socket` first and the two mounts swap symptoms, so which mount ends up
unprotected depends on request ordering after boot.

The practical impact is on endpoints that mount one socket module at several
paths with different origin policies — e.g. a strict internal mount next to a
looser public one. If the looser mount wins the race, the stricter mount's
origin check is effectively disabled.

## Fix

Include the effective per-mount option in the cache key:

```elixir
key = {:check_origin, handler, Keyword.get(opts, :check_origin)}
```

Mounts that do not set `:check_origin` still share a single entry (key
`{:check_origin, handler, nil}`) and continue to resolve through
`endpoint.config(:check_origin)`, so there is no behaviour change for the common
single-mount case. The number of distinct keys is bounded by the number of
socket mounts, which is static configuration, so this does not grow the config
table at runtime.

## Why the suite did not catch this

The existing `check_origin/4` tests pass a fresh `make_ref()` as the handler on
every call:

```elixir
defp check_origin(%Plug.Conn{} = conn, origin, opts) do
  conn = put_req_header(conn, "origin", origin)
  Transport.check_origin(conn, make_ref(), Endpoint, opts)
end
```

Every call therefore gets a unique cache key and the caching path is never
exercised. The added test uses one fixed handler module across calls, which is
what a real endpoint does.

## Verification

- Added `test "does not share the origin policy between mounts of the same handler"`
  to `test/phoenix/socket/transport_test.exs`. It fails on `main` at the first
  `assert` (mount B accepting `a.example`) and passes with this change.
- Also reproduced end to end in Chrome against a generated app, with the two
  mounts above and real WebSocket handshakes from `a.localhost` / `b.localhost`
  origins: repro app and instructions are linked from #6773.
