### PR TITLE
Remove unused installer template bindings

### DIFF
--- a/installer/lib/phx_new/generator.ex
+++ b/installer/lib/phx_new/generator.ex
@@ -274,8 +274,6 @@ defmodule Phx.New.Generator do
     {web_adapter_app, web_adapter_vsn, web_adapter_module, web_adapter_docs} =
       get_web_adapter(web_adapter)
 
-    pubsub_server = get_pubsub_server(project.app_mod)
-
     adapter_config =
       case Keyword.fetch(opts, :binary_id) do
         {:ok, value} -> Keyword.put_new(adapter_config, :binary_id, value)
@@ -285,7 +283,6 @@ defmodule Phx.New.Generator do
     binding = [
       app_name: project.app,
       app_module: inspect(project.app_mod),
-      root_app_name: project.root_app,
       root_app_module: inspect(project.root_mod),
       lib_web_name: project.lib_web_name,
       web_app_name: project.web_app,
@@ -295,7 +292,6 @@ defmodule Phx.New.Generator do
       phoenix_dep_umbrella_root: phoenix_dep(phoenix_path_umbrella_root),
       phoenix_js_path: phoenix_js_path(phoenix_path),
       phoenix_version: @phoenix_version,
-      pubsub_server: pubsub_server,
       secret_key_base_dev: random_string(64),
       secret_key_base_test: random_string(64),
       signing_salt: random_string(8),
@@ -382,13 +378,6 @@ defmodule Phx.New.Generator do
     config :#{binding[:app_name]}, #{binding[:app_module]}.Repo,
       #{adapter_config[:prod_config]}
     """)
-  end
-
-  defp get_pubsub_server(module) do
-    module
-    |> Module.split()
-    |> hd()
-    |> Module.concat(PubSub)
   end
 
   defp get_ecto_adapter("mssql", app, module) do

--- a/installer/lib/phx_new/project.ex
+++ b/installer/lib/phx_new/project.ex
@@ -7,7 +7,6 @@ defmodule Phx.New.Project do
             app_mod: nil,
             app_path: nil,
             lib_web_name: nil,
-            root_app: nil,
             root_mod: nil,
             project_path: nil,
             web_app: nil,
@@ -28,7 +27,6 @@ defmodule Phx.New.Project do
       base_path: project_path,
       app: app,
       app_mod: app_mod,
-      root_app: app,
       root_mod: app_mod,
       opts: opts
     }

--- a/installer/lib/phx_new/single.ex
+++ b/installer/lib/phx_new/single.ex
@@ -110,20 +110,11 @@ defmodule Phx.New.Single do
       %{project | in_umbrella?: false, project_path: base_path}
     end
     |> put_app()
-    |> put_root_app()
     |> put_web_app()
   end
 
   defp put_app(%Project{base_path: base_path} = project) do
     %{project | app_path: base_path}
-  end
-
-  defp put_root_app(%Project{app: app, opts: opts} = project) do
-    %{
-      project
-      | root_app: app,
-        root_mod: Module.concat([opts[:module] || Macro.camelize(app)])
-    }
   end
 
   defp put_web_app(%Project{app: app} = project) do

--- a/installer/lib/phx_new/umbrella.ex
+++ b/installer/lib/phx_new/umbrella.ex
@@ -21,7 +21,7 @@ defmodule Phx.New.Umbrella do
     project
     |> put_app()
     |> put_web()
-    |> put_root_app()
+    |> put_root_mod()
   end
 
   defp put_app(project) do
@@ -45,11 +45,10 @@ defmodule Phx.New.Umbrella do
     }
   end
 
-  defp put_root_app(%Project{app: app} = project) do
+  defp put_root_mod(%Project{} = project) do
     %{
       project
-      | root_app: :"#{app}_umbrella",
-        root_mod: Module.concat(project.app_mod, "Umbrella")
+      | root_mod: Module.concat(project.app_mod, "Umbrella")
     }
   end
 


### PR DESCRIPTION
Following up on unifying `.gitignore` templates into a static file, an audit of all installer bindings was conducted to see if any variables eliminated from `.gitignore.eex` became unused repo-wide.

While all variables from `.gitignore.eex` remain required by other templates, the audit uncovered two pre-existing unused bindings (`pubsub_server` and `root_app_name`), allowing us to clean them up along with their supporting code:

- `pubsub_server`: Stopped being used in templates in commit 04398b60e (June 2019) when PubSub was moved into the application supervision tree and templates switched to referencing `<%= web_namespace %>.PubSub` directly. Remove `pubsub_server` from binding and delete the helper `get_pubsub_server/1`.

- `root_app_name` / `root_app`: `root_app_name` was defined when umbrella generators were added in commit dad413ff2 (Jan 2017), but templates have always used `@root_app_module` (`MyApp.Umbrella`) instead. Remove `root_app_name` from binding and drop the `root_app` struct field from `%Phx.New.Project{}`.

- Helper cleanup: `Project.new/2` already initializes `root_mod` to `app_mod` (`Module.concat([opts[:module] || Macro.camelize(app)])`). In `Phx.New.Single`, `put_root_app/1` was computing the exact same value a second time to assign `root_mod`, making it a no-op. Remove `put_root_app/1` from `Single`, and rename `put_root_app/1` to `put_root_mod/1` in `Phx.New.Umbrella` where it actually overrides `root_mod` with the `MyApp.Umbrella` module name.