### PR TITLE
Add class support for col item

### DIFF
--- a/installer/templates/phx_web/components/core_components.ex.eex
+++ b/installer/templates/phx_web/components/core_components.ex.eex
@@ -357,6 +357,7 @@ defmodule <%= @web_namespace %>.CoreComponents do
 
   slot :col, required: true do
     attr :label, :string
+    attr :class, :any
   end
 
   slot :action, doc: "the slot for showing user actions in the last table column"
@@ -382,7 +383,11 @@ defmodule <%= @web_namespace %>.CoreComponents do
           <td
             :for={col <- @col}
             phx-click={@row_click && @row_click.(row)}
-            class={@row_click && "hover:cursor-pointer"}
+            class={
+              [@row_click && "hover:cursor-pointer", col[:class]]
+              |> Enum.reject(& !&1)
+              |> Enum.join(" ")
+            }
           >
             {render_slot(col, @row_item.(row))}
           </td>


### PR DESCRIPTION
My first PR. Any feedback or guidelines would be greatly appreciated.

### Purpose

Add support for a `class` attribute on `<.col>` components in `Phoenix.CoreComponents` (`installer/templates/phx_web/components/core_components.ex`).

This allows styling individual table cells using either a single CSS class (for example, `"text-right"`) or multiple classes (for example, `"text-right font-bold"`), and still resoect existing implementation.

### Motivation

The generated `<.table>` component already supports several customization options, but `<.col>` doesn't currently allow passing a class attribute. I needed this to apply custom styling to individual table cells without modifying the generated component.

### What this supports

1. Having a `row_click` attribute in `<.table />`:

`<.table id="products" rows={@products} row_click={&JS.navigate(~p"/products/#{&1}")}>`

and a `class` in col item:

`<:col :let={product} label="Price" class="text-right">`

Result:

<img width="566" height="150" alt="01-row_click_class" src="https://github.com/user-attachments/assets/94648a84-9e47-4c4d-9aa6-ff2e1a7a2aaa" />



2. Without a `row_click` attribute in `<.table />`:

`<.table id="products" rows={@products}>`

but with a `class` attribute in col item:

<:col :let={product} label="Price" class="text-right font-bold">

Result:

<img width="566" height="148" alt="02-row_click_nil_with_class" src="https://github.com/user-attachments/assets/ebdae670-5e06-469c-a55a-e8d7eeb67853" />



3. without a `row_click` attribute in `<.table />`:

`<.table id="products" rows={@products}>`

as well as no `class` attribute:

`<:col :let={product} label="Price">`

Result:

<img width="566" height="195" alt="03-row_click_nil-and-class-nil" src="https://github.com/user-attachments/assets/108fe3a4-c4f3-41b9-8cf3-036a98f8b0d2" />

### Backward compatibility

This change is fully backward compatible; existing templates continue to behave as before.