### PR TITLE
Wait for the server ack when leaving channels

### DIFF
--- a/assets/js/phoenix/channel.js
+++ b/assets/js/phoenix/channel.js
@@ -207,6 +207,7 @@ export default class Channel {
     this.rejoinTimer.reset()
     this.joinPush.cancelTimeout()
 
+    let canPush = this.canPush()
     this.state = CHANNEL_STATES.leaving
     let onClose = () => {
       if(this.socket.hasLogger()) this.socket.log("channel", `leave ${this.topic}`)
@@ -216,7 +217,7 @@ export default class Channel {
     leavePush.receive("ok", () => onClose())
       .receive("timeout", () => onClose())
     leavePush.send()
-    if(!this.canPush()){ leavePush.trigger("ok", {}) }
+    if(!canPush){ leavePush.trigger("ok", {}) }
 
     return leavePush
   }

--- a/assets/test/channel_test.js
+++ b/assets/test/channel_test.js
@@ -1041,11 +1041,7 @@ describe("with transport", function (){
       expect(channel.state).toBe("closed")
     })
 
-    // TODO - the following tests are skipped until Channel.leave
-    // behavior can be fixed; currently, 'ok' is triggered immediately
-    // within Channel.leave so timeout callbacks are never reached
-    //
-    it.skip("sets state to leaving initially", function (){
+    it("sets state to leaving initially", function (){
       expect(channel.state).not.toBe("leaving")
 
       channel.leave()
@@ -1053,7 +1049,7 @@ describe("with transport", function (){
       expect(channel.state).toBe("leaving")
     })
 
-    it.skip("closes channel on 'timeout'", function (){
+    it("closes channel on 'timeout'", function (){
       channel.leave()
 
       jest.advanceTimersByTime(channel.timeout)
@@ -1061,7 +1057,7 @@ describe("with transport", function (){
       expect(channel.state).toBe("closed")
     })
 
-    it.skip("accepts timeout arg", function (){
+    it("accepts timeout arg", function (){
       channel.leave(channel.timeout * 2)
 
       jest.advanceTimersByTime(channel.timeout)


### PR DESCRIPTION
I ran into this while looking at channel cleanup in an app

`leave()` was returning `"ok"` before the server had actually replied.

`leave()` changes the channel state to `leaving` and then checks `canPush()`, but `canPush()` only returns true when the channel is still joined so at that point it always returns `false`

Then, the fallback runs right away and the channel closes locally instead of waiting for the server reply or the leave timeout

The fix is just to check `canPush()` before changing the state to `leaving`

If the channel can still push, it sends the leave request and waits for either the reply or the timeout. If it cant, it keeps the existing behavior and closes immediately

I also re-enabled the tests for the leaving state and leave timeout

Tested with:

* `npm test -- --runInBand`
* `npx eslint assets/js/phoenix/channel.js assets/test/channel_test.js`
