### PR TITLE
Bind longpoll session tokens to their socket handler (#6791)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
     old and new nodes are active at the same time, ensure that you deploy
     Phoenix v1.8.10 or a later v1.8 release first.
 
+## Bug fixes
+
+  * Longpoll session tokens are now bound to the socket handler that minted
+    them, so a token from one `socket/3` mount can no longer be used to
+    resume a session on another mount of the same endpoint. This changes the
+    signing salt for longpoll tokens: tokens issued before upgrading will fail
+    verification after upgrading and the client will transparently start a
+    new session, the same as it does for any other expired/invalid token.
+
 ## v1.8
 
 The CHANGELOG for v1.8 releases can be found in the [v1.8 branch](https://github.com/phoenixframework/phoenix/blob/v1.8/CHANGELOG.md).

--- a/lib/phoenix/transports/long_poll.ex
+++ b/lib/phoenix/transports/long_poll.ex
@@ -53,7 +53,7 @@ defmodule Phoenix.Transports.LongPoll do
 
   # Starts a new session or listen to a message if one already exists.
   defp dispatch(%{method: "GET"} = conn, endpoint, handler, opts) do
-    case resume_session(conn, endpoint, opts) do
+    case resume_session(conn, endpoint, handler, opts) do
       {:ok, new_conn, server_ref, token} ->
         listen(new_conn, server_ref, token, endpoint, opts)
 
@@ -63,8 +63,8 @@ defmodule Phoenix.Transports.LongPoll do
   end
 
   # Publish the message.
-  defp dispatch(%{method: "POST"} = conn, endpoint, _, opts) do
-    case resume_session(conn, endpoint, opts) do
+  defp dispatch(%{method: "POST"} = conn, endpoint, handler, opts) do
+    case resume_session(conn, endpoint, handler, opts) do
       {:ok, new_conn, server_ref, _token} ->
         publish(new_conn, server_ref, endpoint, opts)
 
@@ -153,7 +153,7 @@ defmodule Phoenix.Transports.LongPoll do
 
       {:ok, server_pid} ->
         data = {:v1, endpoint.config(:endpoint_id), server_pid, priv_topic}
-        token = sign_token(endpoint, data, opts)
+        token = sign_token(endpoint, handler, data, opts)
         conn |> put_status(:gone) |> status_token_messages_json(token, [])
     end
   end
@@ -200,9 +200,14 @@ defmodule Phoenix.Transports.LongPoll do
 
   # Retrieves the serialized `Phoenix.LongPoll.Server` pid
   # by publishing a message in the encrypted private topic.
-  defp resume_session(%Plug.Conn{} = conn, endpoint, opts) do
+  #
+  # The token is signed with a salt derived from the socket `handler` that
+  # minted it, so a token can only be resumed at the same handler/mount that
+  # created it. Tokens signed before this binding existed (or signed by a
+  # different handler) fail signature verification here and are rejected.
+  defp resume_session(%Plug.Conn{} = conn, endpoint, handler, opts) do
     with token when is_binary(token) <- fetch_token(conn),
-         {:ok, {:v1, id, pid, priv_topic}} <- verify_token(endpoint, token, opts) do
+         {:ok, {:v1, id, pid, priv_topic}} <- verify_token(endpoint, handler, token, opts) do
       server_ref = server_ref(endpoint.config(:endpoint_id), id, pid, priv_topic)
 
       new_conn =
@@ -256,22 +261,36 @@ defmodule Phoenix.Transports.LongPoll do
   defp broadcast_from!(_endpoint, pid, msg) when is_pid(pid),
     do: send(pid, msg)
 
-  defp sign_token(endpoint, data, opts) do
+  defp sign_token(endpoint, handler, data, opts) do
     Phoenix.Token.sign(
       endpoint,
-      Atom.to_string(endpoint.config(:pubsub_server)),
+      token_salt(endpoint, handler),
       data,
       opts[:crypto]
     )
   end
 
-  defp verify_token(endpoint, signed, opts) do
+  defp verify_token(endpoint, handler, signed, opts) do
     Phoenix.Token.verify(
       endpoint,
-      Atom.to_string(endpoint.config(:pubsub_server)),
+      token_salt(endpoint, handler),
       signed,
       opts[:crypto]
     )
+  end
+
+  # Binds the token to both the pubsub server and the socket handler that
+  # minted it. Using `:erlang.term_to_binary/1` over a tuple (rather than
+  # string concatenation) avoids any ambiguity between different
+  # server/handler pairs producing the same salt.
+  #
+  # This is a breaking change to the salt used for existing longpoll session
+  # tokens: tokens signed before this change (which do not carry a handler
+  # binding) will fail verification here and be treated the same as any
+  # other invalid/expired token (the client transparently starts a new
+  # session).
+  defp token_salt(endpoint, handler) do
+    :erlang.term_to_binary({endpoint.config(:pubsub_server), handler})
   end
 
   defp maybe_auth_token_from_header(conn, true) do

--- a/test/phoenix/integration/long_poll_channels_test.exs
+++ b/test/phoenix/integration/long_poll_channels_test.exs
@@ -324,12 +324,15 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
   def join(path, topic, vsn, join_ref, :pubsub, payload, params, headers) do
     session = join(path, topic, vsn, join_ref, :local, payload, params, headers)
 
+    # All :pubsub-mode callers in this test module join through "/ws", which
+    # is mounted with the `UserSocket` handler, hence the hardcoded salt below.
+    salt = :erlang.term_to_binary({__MODULE__, UserSocket})
+
     {:ok, {:v1, _id, pid, topic}} =
-      Phoenix.Token.verify(Endpoint, Atom.to_string(__MODULE__), session["token"])
+      Phoenix.Token.verify(Endpoint, salt, session["token"])
 
     %{
-      "token" =>
-        Phoenix.Token.sign(Endpoint, Atom.to_string(__MODULE__), {:v1, "unknown", pid, topic})
+      "token" => Phoenix.Token.sign(Endpoint, salt, {:v1, "unknown", pid, topic})
     }
   end
 
@@ -694,6 +697,60 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
           resp = poll(:post, "/ws", @vsn, session)
           assert resp.body["status"] == 410
         end
+      end
+
+      test "resumes a session at the same handler/mount that minted it" do
+        session = join("/ws", "room:lobby", "2.0.0", "1")
+
+        resp = poll(:get, "/ws", "2.0.0", session)
+        assert resp.body["status"] == 200
+      end
+
+      test "rejects a session token minted by a different socket handler" do
+        resp = poll(:get, "/ws", "2.0.0", %{}, nil)
+        assert resp.body["status"] == 410
+        session = Map.take(resp.body, ["token"])
+
+        # "/ws" is mounted with `UserSocket`, "/ws/connect_info" is mounted
+        # with the distinct `UserSocketConnectInfo` handler. A token minted
+        # at one must not be usable to resume a session at the other.
+        resp =
+          poll(:post, "/ws/connect_info", "2.0.0", session, %{
+            "topic" => "room:lobby",
+            "event" => "phx_join",
+            "ref" => "1",
+            "join_ref" => "1",
+            "payload" => %{}
+          })
+
+        assert resp.body["status"] == 410
+
+        resp = poll(:get, "/ws/connect_info", "2.0.0", session)
+        assert resp.body["status"] == 410
+      end
+
+      test "rejects a token signed under the legacy (pre-handler-binding) salt" do
+        resp = poll(:get, "/ws", "2.0.0", %{}, nil)
+        assert resp.body["status"] == 410
+
+        new_salt = :erlang.term_to_binary({__MODULE__, UserSocket})
+        legacy_salt = Atom.to_string(__MODULE__)
+
+        {:ok, {:v1, id, pid, priv_topic}} =
+          Phoenix.Token.verify(Endpoint, new_salt, resp.body["token"])
+
+        legacy_token = Phoenix.Token.sign(Endpoint, legacy_salt, {:v1, id, pid, priv_topic})
+
+        resp =
+          poll(:post, "/ws", "2.0.0", %{"token" => legacy_token}, %{
+            "topic" => "room:lobby",
+            "event" => "phx_join",
+            "ref" => "1",
+            "join_ref" => "1",
+            "payload" => %{}
+          })
+
+        assert resp.body["status"] == 410
       end
 
       test "publish responds with 408 when transport_dispatch times out" do


### PR DESCRIPTION
Fixes #6791

## Problem

A longpoll session token is signed as `{:v1, endpoint_id, server_pid, priv_topic}` using a crypto salt derived only from `endpoint.config(:pubsub_server)`. Neither the payload nor the salt encodes which socket handler (or mount) issued the token. As a result, a session token minted at one `socket/3` mount is accepted to resume a session at *any other* longpoll mount on the same endpoint, regardless of which handler module owns it — the resuming mount's `handler` is never consulted during verification. The reporter's linked repro (two sockets, `PublicSocket` and `PrivateSocket`, sharing a channel) demonstrates a token minted by the permissive `PublicSocket` being accepted for resumption at the `PrivateSocket` mount, whose `connect/3` always rejects new connections.

## Fix

- Thread the `handler` argument (already available in `call/4`/`dispatch/4`) into `resume_session/4` and `verify_token/4`.
- Derive the `Phoenix.Token` salt from **both** the pubsub server and the handler module: `:erlang.term_to_binary({pubsub_server, handler})`, used symmetrically by `sign_token/4` and `verify_token/4`. `term_to_binary/1` over a tuple is used instead of string concatenation to avoid any ambiguity between distinct `{server, handler}` pairs.
- A session can now only be resumed at the same handler that minted it. Resuming at a different handler fails `Phoenix.Token.verify/4` (bad HMAC) and is treated as an ordinary invalid/expired token — normal 410 behavior, client starts a new session.

## Backward compatibility (please review closely — this is an auth-boundary change)

This changes the salt used to sign/verify **every** longpoll token, so it deserves explicit scrutiny:

- **New tokens** carry the handler binding via the salt (not the payload, so there is no attacker-controlled field to omit/downgrade — the salt is entirely server-derived from static endpoint/handler config).
- **Old-format tokens** (signed before this change) were signed with the old salt (`pubsub_server` only). After upgrading, verifying them with the new salt fails signature verification outright — `Phoenix.Token.verify/4` returns `{:error, :invalid}`, which `resume_session/4`'s `with` already treats as `:error` → the existing 410 "expired/invalid" path. This is a **fail-closed** migration: there is no code path where an old-format token is silently accepted post-upgrade, and no way for a client to opt out of the new check by shaping its request.
- Practically, an in-flight long-poll session that straddles the deploy will see its next poll/publish come back as `410`, exactly as it already would for any expired or otherwise invalid token; the JS client already handles this by transparently starting a new session (see `assets/js/phoenix/longpoll.js`).
- This mirrors the precedent set by the `x-phoenix-longpoll-token` header change noted in the v1.9 CHANGELOG, which also calls out rolling-deploy behavior for a longpoll transport-level change. I added a similar CHANGELOG entry here.

I did not change the token *payload* shape (still `{:v1, endpoint_id, server_pid, priv_topic}`) — binding via the salt achieves the same guarantee with a smaller, more mechanically-obvious diff, and avoids adding a new payload field that a hypothetical alternate signing path could omit.

## Out of scope

The issue also notes that `:max_age` is taken from the *resuming* mount's `opts[:crypto]`, so a token rejected as "expired" at a short-`max_age` mount can still be accepted at a longer-`max_age` mount **sharing the same handler module**. The reporter explicitly said they don't consider this a vulnerability, and fixing it would require threading the full configured mount path (not just the handler module) through `Phoenix.Endpoint`'s socket-route macro into the transport's plug init, which is a larger, more invasive change than the handler-binding fix. I left it out to keep this PR narrowly scoped to the reported cross-handler session hijack; happy to follow up separately if maintainers want the mount-path binding too.

## Testing

- Added to `test/phoenix/integration/long_poll_channels_test.exs`:
  - a token minted at one handler (`UserSocket` via `/ws`) is rejected when replayed at a different handler (`UserSocketConnectInfo` via `/ws/connect_info`) — the reported vulnerability.
  - a session still resumes normally at the same handler/mount that minted it.
  - a token re-signed under the legacy (pre-handler-binding) salt is rejected rather than silently accepted.
  - updated the existing `:pubsub`-mode test helper, which hand-rolled `Phoenix.Token.sign/verify` with the old salt, to use the new handler-bound salt.

**I was unable to run these tests.** This environment does not have Elixir/Erlang or `mix` installed, so I could not execute `mix test` or verify compilation. I've reviewed the diff carefully by hand and traced every caller of the changed private functions (`sign_token/4`, `verify_token/4`, `resume_session/4`), but please treat the test results as unverified until CI runs.
