### PR TITLE
Add markdown formatter to docs output

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -156,7 +156,7 @@ defmodule Phoenix.MixProject do
       logo: "logo.png",
       extra_section: "GUIDES",
       assets: %{"guides/assets" => "assets"},
-      formatters: ["html", "epub"],
+      formatters: ["html", "markdown", "epub"],
       groups_for_modules: groups_for_modules(),
       extras: extras(),
       groups_for_extras: groups_for_extras(),


### PR DESCRIPTION
## Summary

- add the Markdown formatter to Phoenix's existing ExDoc formatter list
- preserve the existing HTML and EPUB outputs

This follows up on #6076. That discussion preferred an ecosystem-wide ExDoc solution over a Phoenix-specific `llms.txt`; ExDoc v0.40.0 subsequently added the Markdown formatter and `llms.txt` generation. Phoenix already resolves ExDoc 0.40.3, but its explicit formatter list prevents that new default from applying.

This PR was generated from [Elixir's retrieval gap is a rollout problem, not an access problem](https://phxagents.dev/research/elixir-retrieval-gap/).

## Verification

- unmodified baseline: `MIX_ENV=docs mix docs` passed and produced HTML and EPUB, with no `llms.txt` or Markdown pages
- changed build: `MIX_ENV=docs mix docs` passed and produced HTML, EPUB, `llms.txt`, and 102 Markdown pages
- `mix format --check-formatted mix.exs`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test` — 1,079 passed, 33 excluded

— Oliver’s AMP