### PR TITLE
Fix release date for v1.8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ This release introduces deprecation warnings for several features that have been
 
   * The `config` variable is no longer available in `Phoenix.Endpoint`. In the past, it was possible to read your endpoint configuration at compile-time via an injected variable named `config`, which is no longer supported. Use `Application.compile_env/3` instead, which is tracked by the Elixir compiler and lead to a better developer experience. This may also lead to errors on application boot if you were previously incorrectly setting compile time config at runtime.
 
-## v1.8.11 (2028-08-12)
+## v1.8.11 (2026-08-12)
 
 ### Bug fixes
 


### PR DESCRIPTION
Correct the release date for version 1.8.11 in the changelog (2026 rather than 2028...).

This was thrown up by a deps upgrade audit at my end, so I thought I'd flag it. Totally understand if it's dismissed.