### PR TITLE
Revert "Drop incoming messages with stale join refs"

### DIFF
--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -802,19 +802,9 @@ defmodule Phoenix.Socket do
     end
   end
 
-  defp handle_in({pid, _ref, _status}, msg, state, socket) do
-    %{topic: topic, join_ref: join_ref} = msg
-
-    case state.channels_inverse do
-      # we need to match on nil to handle v1 protocol
-      %{^pid => {^topic, existing_join_ref}} when existing_join_ref in [join_ref, nil] ->
-        send(pid, msg)
-        {:ok, {state, socket}}
-
-      # the client has sent a stale message to a previous join_ref, ignore
-      %{^pid => {^topic, _old_join_ref}} ->
-        {:ok, {state, socket}}
-    end
+  defp handle_in({pid, _ref, _status}, message, state, socket) do
+    send(pid, message)
+    {:ok, {state, socket}}
   end
 
   defp handle_in(

--- a/test/phoenix/integration/long_poll_channels_test.exs
+++ b/test/phoenix/integration/long_poll_channels_test.exs
@@ -534,8 +534,7 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
 
         test "#{@mode}: publishing events" do
           Phoenix.PubSub.subscribe(__MODULE__, "room:lobby")
-          join_ref = "1"
-          session = join("/ws", "room:lobby", @vsn, join_ref, @mode)
+          session = join("/ws", "room:lobby", @vsn, "1", @mode)
 
           # Publish successfully
           resp =
@@ -543,7 +542,6 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
               "topic" => "room:lobby",
               "event" => "new_msg",
               "ref" => "1",
-              "join_ref" => join_ref,
               "payload" => %{"body" => "hi!"}
             })
 


### PR DESCRIPTION
_please ignore 😭 _

~~This reverts commit https://github.com/phoenixframework/phoenix/commit/c73bbfcfeafce3d42cb270a7ecb41a4ca39ae393.~~

~~We have some SDKs faulty in their implementation of the protocol.~~
~~Hence, revert this one commit but keep the CVEs and other fixes~~
~~until we remedy it.~~

~~See REAL-981.~~

~~PR not to be merged, just for running tests and showing off purposes.~~