### PR TITLE
join_ref can be nil on non-join messages

### DIFF
--- a/guides/howto/writing_a_channels_client.md
+++ b/guides/howto/writing_a_channels_client.md
@@ -34,7 +34,7 @@ The general format for messages a client sends to a Phoenix Channel is as follow
 [join_reference, message_reference, topic_name, event_name, payload]
 ```
 
-- The `join_reference` is also chosen by the client and should also be a unique value. It only needs to be sent for a `"phx_join"` event; for other messages it can be `null`. It is used as a message reference for `push` messages from the server, meaning those that are not replies to a specific client message. For example, imagine something like "a new user just joined the chat room".
+- The `join_reference` is also chosen by the client and should be a unique value. It must be sent for a `"phx_join"` event. Clients should also send the current `join_reference` with subsequent messages to the channel so the server can discard stale messages from a previous join. The server accepts `null` for backwards compatibility. The `join_reference` is also used as a message reference for `push` messages from the server, meaning those that are not replies to a specific client message. For example, imagine something like "a new user just joined the chat room".
 - The `message_reference` is chosen by the client and should be a unique value. The server includes it in its reply so that the client knows which message the reply is for.
 - The `topic_name` must be a known topic for the socket endpoint, and a client must join that topic before sending any messages on it.
 - The `event_name` must match the first argument of a `handle_in` function on the server channel module.
@@ -51,7 +51,7 @@ First, `phx_join` is used join a channel. For example, to join the `miami:weathe
 Second, `phx_leave` is used to leave a channel. For example, to leave the `miami:weather` channel:
 
 ```json
-[null, "1", "miami:weather", "phx_leave", {}]
+["0", "1", "miami:weather", "phx_leave", {}]
 ```
 
 Third, `heartbeat` is used to maintain the WebSocket connection. For example:
@@ -77,5 +77,5 @@ end
 ...a client could send:
 
 ```json
-[null, "3", "miami:weather", "report_emergency", {"category": "sharknado"}]
+["0", "3", "miami:weather", "report_emergency", {"category": "sharknado"}]
 ```

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -791,8 +791,8 @@ defmodule Phoenix.Socket do
     %{topic: topic, join_ref: join_ref} = msg
 
     case state.channels_inverse do
-      # we need to match on nil to handle v1 protocol
-      %{^pid => {^topic, existing_join_ref}} when existing_join_ref in [join_ref, nil] ->
+      %{^pid => {^topic, existing_join_ref}}
+      when is_nil(join_ref) or join_ref === existing_join_ref ->
         send(pid, msg)
         {:ok, {update_channel_status(state, pid, topic, :leaving), socket}}
 
@@ -806,8 +806,11 @@ defmodule Phoenix.Socket do
     %{topic: topic, join_ref: join_ref} = msg
 
     case state.channels_inverse do
-      # we need to match on nil to handle v1 protocol
-      %{^pid => {^topic, existing_join_ref}} when existing_join_ref in [join_ref, nil] ->
+      # a nil join_ref is valid on non-join messages;
+      # phoenix.js also sends it on each message, but the protocol does not
+      # require it. Also, v1 protocol clients may send nil.
+      %{^pid => {^topic, existing_join_ref}}
+      when is_nil(join_ref) or join_ref === existing_join_ref ->
         send(pid, msg)
         {:ok, {state, socket}}
 

--- a/test/phoenix/integration/long_poll_channels_test.exs
+++ b/test/phoenix/integration/long_poll_channels_test.exs
@@ -534,8 +534,7 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
 
         test "#{@mode}: publishing events" do
           Phoenix.PubSub.subscribe(__MODULE__, "room:lobby")
-          join_ref = "1"
-          session = join("/ws", "room:lobby", @vsn, join_ref, @mode)
+          session = join("/ws", "room:lobby", @vsn, "1", @mode)
 
           # Publish successfully
           resp =
@@ -543,7 +542,7 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
               "topic" => "room:lobby",
               "event" => "new_msg",
               "ref" => "1",
-              "join_ref" => join_ref,
+              # no join_ref required on regular messages
               "payload" => %{"body" => "hi!"}
             })
 
@@ -594,6 +593,23 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
           end)
         end
 
+        test "#{@mode}: no join_ref is required on non-join messages" do
+          vsn = "2.0.0"
+          Phoenix.PubSub.subscribe(__MODULE__, "room:lobby")
+          session = join("/ws", "room:lobby", vsn, "1", @mode)
+
+          resp =
+            poll(:post, "/ws", vsn, session, %{
+              "topic" => "room:lobby",
+              "event" => "new_msg",
+              "ref" => "2",
+              "payload" => %{"body" => "hi!"}
+            })
+
+          assert resp.body["status"] == 200
+          assert_receive %Broadcast{event: "new_msg", payload: %{"body" => "hi!"}}
+        end
+
         test "#{@mode}: lonpoll publishing batch events on v2 protocol" do
           vsn = "2.0.0"
           Phoenix.PubSub.subscribe(__MODULE__, "room:lobby")
@@ -614,12 +630,20 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
                 "ref" => "3",
                 "join_ref" => "1",
                 "payload" => %{"body" => "hi2"}
+              },
+              %{
+                "topic" => "room:lobby",
+                "event" => "new_msg",
+                "ref" => "stale",
+                "join_ref" => "stale",
+                "payload" => %{"body" => "stale"}
               }
             ])
 
           assert resp.body["status"] == 200
           assert_receive %Broadcast{event: "new_msg", payload: %{"body" => "hi1"}}
           assert_receive %Broadcast{event: "new_msg", payload: %{"body" => "hi2"}}
+          refute_receive %Broadcast{event: "new_msg", payload: %{"body" => "stale"}}
 
           # Publish base64 binary successfully
           resp =
@@ -825,14 +849,25 @@ defmodule Phoenix.Integration.LongPollChannelsTest do
                  }
         end
 
-        test "sends phx_close if a channel server normally exits" do
+        test "ignores stale join refs and accepts a nil join ref on phx_leave" do
           session = join("/ws", "room:lobby", @vsn, @join_ref)
 
           resp =
             poll(:post, "/ws", @vsn, session, %{
               "topic" => "room:lobby",
               "event" => "phx_leave",
-              "join_ref" => @join_ref,
+              "join_ref" => "stale",
+              "ref" => "stale",
+              "payload" => %{}
+            })
+
+          assert resp.body["status"] == 200
+          assert resp.status == 200
+
+          resp =
+            poll(:post, "/ws", @vsn, session, %{
+              "topic" => "room:lobby",
+              "event" => "phx_leave",
               "ref" => "2",
               "payload" => %{}
             })


### PR DESCRIPTION
We still drop messages with a stale (non-nil) join_ref.

Fixup for c73bbfcfeafce3d42cb270a7ecb41a4ca39ae393.

The protocol explicitly allows non join messages to omit the join_ref, see

https://phoenix.hexdocs.pm/1.8.11/writing_a_channels_client.html#message-format

Note: this also updates to docs to say clients **should** include the join ref for non join messages, as it allows staleness detection. We cannot make it required though, because it was allowed and explicitly documented in the past, so we allow it for backwards compatibility.