### PR TITLE
phx.gen.release: use Bob API structured filters and sorting for Docker tags

### DIFF
--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -238,25 +238,23 @@ defmodule Mix.Tasks.Phx.Gen.Release do
     |> map_size() > 0
   end
 
-  @bob_docker_api "https://bob.hex.pm/api/docker"
-  @bob_docker_url "https://bob.hex.pm/docker"
-  @docker_repo "hexpm/elixir"
-  @debian "trixie"
+  defp bob_url, do: "https://bob.hex.pm"
+  defp docker_repo, do: "hexpm/elixir"
+  defp debian, do: "trixie"
+
   defp elixir_otp_and_debian_vsn(elixir_vsn, otp_vsn) do
     elixir_vsn
     |> docker_tag_searches(otp_vsn)
     |> Enum.find_value(:error, fn search ->
-      candidates =
-        for tag <- fetch_bob_docker_tags(search.params),
-            candidate = docker_tag_candidate(tag),
-            candidate && docker_tag_matches?(candidate, search) do
-          candidate
-        end
+      tags = fetch_bob_docker_tags(search.params)
 
-      case best_docker_tag(candidates) do
-        nil -> nil
-        candidate -> {:ok, candidate.elixir, candidate.otp, candidate.debian_vsn}
-      end
+      Enum.find_value(tags, fn tag ->
+        candidate = docker_tag_candidate(tag)
+
+        if candidate && docker_tag_matches?(candidate, search) do
+          {:ok, candidate.elixir, candidate.otp, candidate.debian_vsn}
+        end
+      end)
     end)
   end
 
@@ -264,7 +262,10 @@ defmodule Mix.Tasks.Phx.Gen.Release do
     [
       # prefer an exact match first
       docker_tag_search(
-        %{repo: @docker_repo, tag: "#{elixir_vsn}-erlang-#{otp_vsn}-debian-#{@debian}-"},
+        docker_tag_filters(%{
+          elixir_version: elixir_vsn,
+          erlang_version: otp_vsn
+        }),
         {:exact, elixir_vsn},
         {:exact, otp_vsn}
       ),
@@ -326,42 +327,40 @@ defmodule Mix.Tasks.Phx.Gen.Release do
   defp docker_tag_filters(params) do
     Map.merge(
       %{
-        repo: @docker_repo,
+        repo: docker_repo(),
         os: "debian",
-        os_version: "#{@debian}-"
+        os_version: "#{debian()}-",
+        sort: "elixir_version,erlang_version,os_version"
       },
       params
     )
   end
 
-  defp fetch_bob_docker_tags(params, offset \\ 0, acc \\ []) do
+  defp fetch_bob_docker_tags(params) do
     body =
       params
-      |> bob_docker_tags_url(offset)
+      |> bob_docker_tags_url()
       |> fetch_body!()
       |> Phoenix.json_library().decode!()
 
-    tags = Map.fetch!(body, "tags")
-    next_offset = offset + length(tags)
-
-    if length(tags) > 0 and next_offset < Map.get(body, "total", next_offset) do
-      fetch_bob_docker_tags(params, next_offset, acc ++ tags)
-    else
-      acc ++ tags
-    end
+    Map.get(body, "tags", [])
   end
 
-  defp bob_docker_tags_url(params, offset) do
-    @bob_docker_api <> "?" <> URI.encode_query(Map.put(params, :offset, offset))
+  defp bob_docker_tags_url(params), do: bob_docker_url("/api/docker", params)
+  defp bob_docker_ui_url(params), do: bob_docker_url("/docker", params)
+
+  defp bob_docker_url(path, params) do
+    bob_url() <> path <> "?" <> URI.encode_query(params)
   end
 
-  defp bob_docker_url(params) do
-    @bob_docker_url <> "?" <> URI.encode_query(params)
-  end
-
-  defp docker_tag_candidate(%{"repo" => @docker_repo, "tag" => tag}) do
-    with [elixir, rest] <- String.split(tag, "-erlang-", parts: 2),
-         [otp, debian_vsn] <- String.split(rest, "-debian-#{@debian}-", parts: 2),
+  defp docker_tag_candidate(%{"repo" => repo, "tag" => tag} = candidate) do
+    # Bob API filters `repo` using a prefix match, so querying `hexpm/elixir` also returns
+    # single-arch `hexpm/elixir-amd64` and `hexpm/elixir-arm64` tags. We check exact equality
+    # and multiple architectures to ensure we only select multi-arch manifest images.
+    with true <- repo == docker_repo(),
+         true <- match?(%{"archs" => [_, _ | _]}, candidate),
+         [elixir, rest] <- String.split(tag, "-erlang-", parts: 2),
+         [otp, debian_vsn] <- String.split(rest, "-debian-#{debian()}-", parts: 2),
          true <- String.ends_with?(debian_vsn, "-slim") do
       %{
         elixir: elixir,
@@ -389,87 +388,6 @@ defmodule Mix.Tasks.Phx.Gen.Release do
     do: same_version_prefix?(version, wanted, 2)
 
   defp version_matches?(version, {:major, wanted}), do: same_version_prefix?(version, wanted, 1)
-
-  defp best_docker_tag([]), do: nil
-
-  defp best_docker_tag([candidate | candidates]) do
-    Enum.reduce(candidates, candidate, fn candidate, best ->
-      if compare_docker_tags(candidate, best) == :gt, do: candidate, else: best
-    end)
-  end
-
-  defp compare_docker_tags(left, right) do
-    compare_versions(left.elixir, right.elixir, &compare_elixir_versions/2) ||
-      compare_versions(left.otp, right.otp, &compare_otp_versions/2) ||
-      compare_strings(left.debian_vsn, right.debian_vsn)
-  end
-
-  defp compare_versions(left, right, compare) do
-    case compare.(left, right) do
-      :eq -> nil
-      result -> result
-    end
-  end
-
-  defp compare_strings(left, right) do
-    cond do
-      left > right -> :gt
-      left < right -> :lt
-      true -> :eq
-    end
-  end
-
-  defp compare_elixir_versions(left, right) do
-    Version.compare(normalize_elixir_version(left), normalize_elixir_version(right))
-  end
-
-  defp normalize_elixir_version(version) do
-    case String.split(version, ".") do
-      [major, minor] -> "#{major}.#{minor}.0"
-      [_major, _minor | _rest] -> version
-      _ -> version
-    end
-  end
-
-  defp compare_otp_versions(left, right) do
-    compare_otp_components(otp_matchable(left), otp_matchable(right))
-  end
-
-  defp compare_otp_components({[left | lefts], left_pre}, {[right | rights], right_pre}) do
-    cond do
-      left > right -> :gt
-      left < right -> :lt
-      true -> compare_otp_components({lefts, left_pre}, {rights, right_pre})
-    end
-  end
-
-  defp compare_otp_components({[], left_pre}, {[], right_pre}) do
-    cond do
-      left_pre == [] and right_pre != [] -> :gt
-      left_pre != [] and right_pre == [] -> :lt
-      left_pre > right_pre -> :gt
-      left_pre < right_pre -> :lt
-      true -> :eq
-    end
-  end
-
-  defp compare_otp_components({[], _left_pre}, {_rights, _right_pre}), do: :lt
-  defp compare_otp_components({_lefts, _left_pre}, {[], _right_pre}), do: :gt
-
-  defp otp_matchable(version) do
-    [version, pre] =
-      case String.split(version, "-", parts: 2) do
-        [version, pre] -> [version, pre]
-        [version] -> [version, []]
-      end
-
-    components =
-      version
-      |> String.split(".")
-      |> Enum.map(&String.to_integer/1)
-
-    {components, pre}
-  end
 
   defp version_major_prefix(version), do: version_prefix(version, 1)
   defp version_major_minor_prefix(version), do: version_prefix(version, 2)
@@ -532,7 +450,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
       {:ok, elixir_vsn, otp_vsn, debian_vsn} ->
         binding =
           Keyword.merge(binding,
-            debian: @debian,
+            debian: debian(),
             debian_vsn: debian_vsn,
             elixir_vsn: elixir_vsn,
             otp_vsn: otp_vsn
@@ -548,7 +466,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
 
         raise """
         unable to fetch supported Docker image for Elixir #{wanted_elixir_vsn} and Erlang #{otp_vsn}.
-        Please check #{bob_docker_url(params)} for a suitable Elixir version
+        Please check #{bob_docker_ui_url(params)} for a suitable Elixir version
         """
     end
   end

--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -353,13 +353,9 @@ defmodule Mix.Tasks.Phx.Gen.Release do
     bob_url() <> path <> "?" <> URI.encode_query(params)
   end
 
-  defp docker_tag_candidate(%{"repo" => repo, "tag" => tag} = candidate) do
-    # Bob API filters `repo` using a prefix match, so querying `hexpm/elixir` also returns
-    # single-arch `hexpm/elixir-amd64` and `hexpm/elixir-arm64` tags. We check exact equality
-    # and multiple architectures to ensure we only select multi-arch manifest images.
-    with true <- repo == docker_repo(),
-         true <- match?(%{"archs" => [_, _ | _]}, candidate),
-         [elixir, rest] <- String.split(tag, "-erlang-", parts: 2),
+  # Ensure we only select multi-arch manifest images
+  defp docker_tag_candidate(%{"archs" => [_, _ | _], "tag" => tag}) do
+    with [elixir, rest] <- String.split(tag, "-erlang-", parts: 2),
          [otp, debian_vsn] <- String.split(rest, "-debian-#{debian()}-", parts: 2),
          true <- String.ends_with?(debian_vsn, "-slim") do
       %{

--- a/test/mix/tasks/phx.gen.release_test.exs
+++ b/test/mix/tasks/phx.gen.release_test.exs
@@ -13,10 +13,11 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
     Process.put({Mix.Tasks.Phx.Gen.Release, :http_client}, fn url ->
       uri = URI.parse(to_string(url))
       params = URI.decode_query(uri.query || "")
-      tag = params["tag"] || "1.18.4-erlang-25.3.2.17-debian-trixie-"
+      elixir_vsn = params["elixir_version"] || "1.18.4"
+      otp_vsn = params["erlang_version"] || "25.3.2.17"
 
       if uri.host == "bob.hex.pm" and uri.path == "/api/docker" do
-        bob_tags_response([tag <> "20251117-slim"])
+        bob_tags_response(["#{elixir_vsn}-erlang-#{otp_vsn}-debian-trixie-20251117-slim"])
       else
         raise "unexpected URL #{url}"
       end
@@ -156,7 +157,13 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
       end)
 
       assert_receive {:docker_url, %URI{query: query}}
-      assert URI.decode_query(query)["tag"] == "1.18.4-erlang-27.0.3-debian-trixie-"
+      params = URI.decode_query(query)
+      assert params["repo"] == "hexpm/elixir"
+      assert params["elixir_version"] == "1.18.4"
+      assert params["erlang_version"] == "27.0.3"
+      assert params["os"] == "debian"
+      assert params["os_version"] == "trixie-"
+      assert params["sort"] == "elixir_version,erlang_version,os_version"
     end)
   end
 
@@ -166,14 +173,14 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
       params = URI.decode_query(uri.query || "")
 
       tags =
-        case {params["tag"], params["elixir_version"], params["erlang_version"]} do
-          {"1.18.3-erlang-27.0.0-debian-trixie-", _, _} ->
+        case {params["elixir_version"], params["erlang_version"]} do
+          {"1.18.3", "27.0.0"} ->
             []
 
-          {_, "1.18.3", _} ->
+          {"1.18.3", "27.0"} ->
             []
 
-          {_, "1.18", "27.0"} ->
+          {"1.18", "27.0"} ->
             ["1.18.4-erlang-27.0.3-debian-trixie-20251117-slim"]
 
           _ ->
@@ -218,6 +225,89 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
         refute file =~ ~S|RUN mix assets.setup|
         refute file =~ ~S|COPY assets assets|
         refute file =~ ~S|RUN mix assets.deploy|
+      end)
+    end)
+  end
+
+  test "raises when no matching docker image is found", config do
+    Process.put({Mix.Tasks.Phx.Gen.Release, :http_client}, fn url ->
+      uri = URI.parse(to_string(url))
+
+      if uri.host == "bob.hex.pm" and uri.path == "/api/docker" do
+        bob_tags_response([])
+      else
+        raise "unexpected URL #{url}"
+      end
+    end)
+
+    in_tmp_project(config.test, fn ->
+      error =
+        assert_raise RuntimeError, fn ->
+          Gen.Release.run(["--docker", "--elixir", "1.18.4", "--otp", "27.0.3"])
+        end
+
+      assert error.message =~ "unable to fetch supported Docker image for Elixir 1.18.4 and Erlang 27.0.3."
+      assert error.message =~ "https://bob.hex.pm/docker?"
+      assert error.message =~ "erlang_version=27"
+      assert error.message =~ "repo=hexpm%2Felixir"
+      assert error.message =~ "for a suitable Elixir version"
+    end)
+  end
+
+  # Bob API sorts descending by (elixir_version, erlang_version, os_version, built_at).
+  # The task selects the first candidate that is a multi-arch slim image.
+  test "selects first matching multi-arch slim tag from sorted results", config do
+    Process.put({Mix.Tasks.Phx.Gen.Release, :http_client}, fn url ->
+      uri = URI.parse(to_string(url))
+
+      if uri.host == "bob.hex.pm" and uri.path == "/api/docker" do
+        Phoenix.json_library().encode!(%{
+          tags: [
+            # single-arch tag (should be ignored)
+            %{
+              repo: "hexpm/elixir-amd64",
+              tag: "1.18.4-erlang-27.0.3-debian-trixie-20251117-slim",
+              archs: ["amd64"],
+              built_at: "2025-11-17T00:00:00Z"
+            },
+            # non-slim tag (should be ignored)
+            %{
+              repo: "hexpm/elixir",
+              tag: "1.18.4-erlang-27.0.3-debian-trixie-20251117",
+              archs: ["amd64", "arm64"],
+              built_at: "2025-11-17T00:00:00Z"
+            },
+            # first valid multi-arch slim tag (should be selected)
+            %{
+              repo: "hexpm/elixir",
+              tag: "1.18.4-erlang-27.0.3-debian-trixie-20251117-slim",
+              archs: ["amd64", "arm64"],
+              built_at: "2025-11-17T00:00:00Z"
+            },
+            # older multi-arch slim tag
+            %{
+              repo: "hexpm/elixir",
+              tag: "1.18.4-erlang-27.0.3-debian-trixie-20251001-slim",
+              archs: ["amd64", "arm64"],
+              built_at: "2025-10-01T00:00:00Z"
+            }
+          ],
+          total: 4,
+          offset: 0,
+          page_size: 100
+        })
+      else
+        raise "unexpected URL #{url}"
+      end
+    end)
+
+    in_tmp_project(config.test, fn ->
+      Gen.Release.run(["--docker", "--elixir", "1.18.4", "--otp", "27.0.3"])
+
+      assert_file("Dockerfile", fn file ->
+        assert file =~ ~S|ARG ELIXIR_VERSION=1.18.4|
+        assert file =~ ~S|ARG OTP_VERSION=27.0.3|
+        assert file =~ ~S|ARG DEBIAN_VERSION=trixie-20251117-slim|
       end)
     end)
   end

--- a/test/mix/tasks/phx.gen.release_test.exs
+++ b/test/mix/tasks/phx.gen.release_test.exs
@@ -246,7 +246,9 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
           Gen.Release.run(["--docker", "--elixir", "1.18.4", "--otp", "27.0.3"])
         end
 
-      assert error.message =~ "unable to fetch supported Docker image for Elixir 1.18.4 and Erlang 27.0.3."
+      assert error.message =~
+               "unable to fetch supported Docker image for Elixir 1.18.4 and Erlang 27.0.3."
+
       assert error.message =~ "https://bob.hex.pm/docker?"
       assert error.message =~ "erlang_version=27"
       assert error.message =~ "repo=hexpm%2Felixir"
@@ -265,7 +267,7 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
           tags: [
             # single-arch tag (should be ignored)
             %{
-              repo: "hexpm/elixir-amd64",
+              repo: "hexpm/elixir",
               tag: "1.18.4-erlang-27.0.3-debian-trixie-20251117-slim",
               archs: ["amd64"],
               built_at: "2025-11-17T00:00:00Z"


### PR DESCRIPTION
Previously, `phx.gen.release` fetched all Docker tags matching an initial prefix from Bob across paginated requests and ran custom client-side version comparison logic (`best_docker_tag`, `compare_docker_tags`, `compare_otp_versions`, etc.) to select the newest compatible image.

With Bob's `/api/docker` endpoint now supporting structured filter parameters and numeric-aware natural sorting (https://github.com/hexpm/bob/pull/286), we can delegate the tag filtering and ranking directly to the server:

1. Pass `elixir_version`, `erlang_version`, `os`, `os_version`, and `sort=elixir_version,erlang_version,os_version` to `/api/docker`.

2. Select the first matching multi-arch slim tag directly from the sorted response, removing pagination and ~87 lines of hand-rolled version comparison logic.

3. Retain the `repo == docker_repo()` check with an explicit multi-arch `archs` guard to filter out single-arch `-amd64` and `-arm64` images returned by Bob's prefix-matched `repo` query.

4. Unify Bob URL helpers under `bob_docker_url/2`, providing `bob_docker_tags_url/1` for the API and `bob_docker_ui_url/1` for the human-facing Web UI link in failure messages.

5. Add tests covering multi-arch slim tag selection from sorted API results and asserting both the error message and the Web UI fallback link when no compatible image is found.

---

The non-exact match for `repo` may change in the future, see https://github.com/hexpm/bob/issues/289, which would reduce even further the number of candidate images we fetch from the API.

---

Changes assisted by Google Antigravity CLI (Gemini 3.7), but intently driven and reviewed by myself.