### PR TITLE
Add filter and sort query parameters to Bob Web UI links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       matrix:
         include:
-          # look for latest alpine image here: https://bob.hex.pm/docker
+          # look for latest alpine image here: https://bob.hex.pm/docker?repo=hexpm/elixir&os=alpine&sort=elixir_version,erlang_version,os_version
           - elixir: "1.17.3"
             otp: "25.3.2.21"
             suffix: "alpine-3.22.4"

--- a/guides/deployment/releases.md
+++ b/guides/deployment/releases.md
@@ -169,7 +169,7 @@ If you call `mix phx.gen.release --docker`, you'll see a new file with content s
 # Find builder and runner images on Docker Hub or on Hex's Build Server (Bob).
 # We recommend using Bob's Web UI to find recent tags:
 #
-#   - https://bob.hex.pm/docker
+#   - https://bob.hex.pm/docker?repo=hexpm/elixir&os=debian&sort=elixir_version,erlang_version,os_version
 #
 # We suggest using the same Debian version for both the builder and runner images.
 #

--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -8,7 +8,7 @@
 # Find builder and runner images on Docker Hub or on Hex's Build Server (Bob).
 # We recommend using Bob's Web UI to find recent tags:
 #
-#   - https://bob.hex.pm/docker
+#   - https://bob.hex.pm/docker?repo=hexpm/elixir&os=debian&sort=elixir_version,erlang_version,os_version
 #
 # We suggest using the same Debian version for both the builder and runner images.
 #

--- a/test/mix/tasks/phx.gen.release_test.exs
+++ b/test/mix/tasks/phx.gen.release_test.exs
@@ -150,6 +150,9 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
       Gen.Release.run(["--docker", "--elixir", "1.18.4", "--otp", "27.0.3"])
 
       assert_file("Dockerfile", fn file ->
+        assert file =~
+                 "https://bob.hex.pm/docker?repo=hexpm/elixir&os=debian&sort=elixir_version,erlang_version,os_version"
+
         assert file =~ ~S|ARG ELIXIR_VERSION=1.18.4|
         assert file =~ ~S|ARG OTP_VERSION=27.0.3|
         assert file =~ ~S|ARG DEBIAN_VERSION=trixie-20251117-slim|


### PR DESCRIPTION
Previously, Bob Web UI links referenced in Dockerfile templates, release guides, and CI workflows pointed to the root https://bob.hex.pm/docker URL without filter or sorting parameters.

Following Bob's support for structured query filters and server-side natural sorting (https://github.com/hexpm/bob/pull/286), improve the suggested links to pre-filter by repo and OS (`repo=hexpm/elixir` and `os=debian` or `os=alpine`) and sort newest first with `sort=elixir_version,erlang_version,os_version`.