### PR TITLE
Raise when `:router` given to use Phoenix.VerifiedRoutes is not a literal

### DIFF
--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -229,6 +229,12 @@ defmodule Phoenix.VerifiedRoutes do
           if Macro.quoted_literal?(v) do
             {k, Macro.prewalk(v, &expand_alias(&1, __CALLER__))}
           else
+            if k == :router do
+              IO.warn(
+                ":router option in VerifiedRoutes must be a literal module, got: #{Macro.to_string(v)}",
+                __CALLER__
+              )
+            end
             {k, v}
           end
         end

--- a/lib/phoenix/verified_routes.ex
+++ b/lib/phoenix/verified_routes.ex
@@ -226,16 +226,16 @@ defmodule Phoenix.VerifiedRoutes do
     opts =
       if Keyword.keyword?(opts) do
         for {k, v} <- opts do
-          if Macro.quoted_literal?(v) do
-            {k, Macro.prewalk(v, &expand_alias(&1, __CALLER__))}
-          else
-            if k == :router do
-              IO.warn(
-                ":router option in VerifiedRoutes must be a literal module, got: #{Macro.to_string(v)}",
-                __CALLER__
-              )
-            end
-            {k, v}
+          cond do
+            Macro.quoted_literal?(v) ->
+              {k, Macro.prewalk(v, &expand_alias(&1, __CALLER__))}
+
+            k == :router ->
+              raise ArgumentError,
+                ":router option in VerifiedRoutes must be a literal module, got: #{Macro.to_string(v)}"
+
+            true ->
+              {k, v}
           end
         end
       else

--- a/test/phoenix/verified_routes_test.exs
+++ b/test/phoenix/verified_routes_test.exs
@@ -695,5 +695,36 @@ defmodule Phoenix.VerifiedRoutesTest do
       :code.purge(__MODULE__.VerifyForwardedRouter)
       :code.delete(__MODULE__.VerifyForwardedRouter)
     end
+
+    test "warns when :router is not a literal module" do
+      warnings =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          defmodule DynamicRouter do
+            use Phoenix.VerifiedRoutes,
+              endpoint: unquote(@endpoint),
+              router: Module.concat([unquote(@router)])
+          end
+        end)
+
+      assert warnings =~
+               ":router option in VerifiedRoutes must be a literal module"
+    after
+      :code.purge(__MODULE__.DynamicRouter)
+      :code.delete(__MODULE__.DynamicRouter)
+    end
+
+    test "does not warn when :router is a literal module" do
+      warnings =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          defmodule LiteralRouter do
+            use Phoenix.VerifiedRoutes, endpoint: unquote(@endpoint), router: unquote(@router)
+          end
+        end)
+
+      assert warnings == ""
+    after
+      :code.purge(__MODULE__.LiteralRouter)
+      :code.delete(__MODULE__.LiteralRouter)
+    end
   end
 end

--- a/test/phoenix/verified_routes_test.exs
+++ b/test/phoenix/verified_routes_test.exs
@@ -700,8 +700,7 @@ defmodule Phoenix.VerifiedRoutesTest do
       assert_raise ArgumentError, ~r/:router option in VerifiedRoutes must be a literal module/, fn ->
         defmodule DynamicRouter do
           use Phoenix.VerifiedRoutes,
-            endpoint: unquote(@endpoint),
-            router: Module.concat([unquote(@router)])
+            router: Module.concat(["My", "Router"])
         end
       end
     after

--- a/test/phoenix/verified_routes_test.exs
+++ b/test/phoenix/verified_routes_test.exs
@@ -696,35 +696,17 @@ defmodule Phoenix.VerifiedRoutesTest do
       :code.delete(__MODULE__.VerifyForwardedRouter)
     end
 
-    test "warns when :router is not a literal module" do
-      warnings =
-        ExUnit.CaptureIO.capture_io(:stderr, fn ->
-          defmodule DynamicRouter do
-            use Phoenix.VerifiedRoutes,
-              endpoint: unquote(@endpoint),
-              router: Module.concat([unquote(@router)])
-          end
-        end)
-
-      assert warnings =~
-               ":router option in VerifiedRoutes must be a literal module"
+    test "raises when :router is not a literal module" do
+      assert_raise ArgumentError, ~r/:router option in VerifiedRoutes must be a literal module/, fn ->
+        defmodule DynamicRouter do
+          use Phoenix.VerifiedRoutes,
+            endpoint: unquote(@endpoint),
+            router: Module.concat([unquote(@router)])
+        end
+      end
     after
       :code.purge(__MODULE__.DynamicRouter)
       :code.delete(__MODULE__.DynamicRouter)
-    end
-
-    test "does not warn when :router is a literal module" do
-      warnings =
-        ExUnit.CaptureIO.capture_io(:stderr, fn ->
-          defmodule LiteralRouter do
-            use Phoenix.VerifiedRoutes, endpoint: unquote(@endpoint), router: unquote(@router)
-          end
-        end)
-
-      assert warnings == ""
-    after
-      :code.purge(__MODULE__.LiteralRouter)
-      :code.delete(__MODULE__.LiteralRouter)
     end
   end
 end


### PR DESCRIPTION
### What is this

~Warn~ Raises when non-literal modules are passed for the `:router` option with VerifiedRoutes

### Background

In an effort to avoid compilation-cycles, we had code where the VerifiedRoutes router was being created dynamically. 
While it technically worked, that could create scenarios where it looked like routes were being enforced/verified at compile time when they really weren't, as the compiler was not aware of the dependencies between the modules.

I've since updated our code to not have that problem, but thought it might be worth having a warning come out of Phoenix itself.

There's already existing code that does similar work within the private `build_route` function:

https://github.com/phoenixframework/phoenix/blob/cb69bb890acbd728b6a81da6bceb039df3e9be94/lib/phoenix/verified_routes.ex#L932-L943

I'm wondering if the intention there was the same as what i have here, save that that missed cases like this where the value could be expanded into a module.

### Example

Given a dynamically resolved router:

```elixir
defmodule MyAppWeb.SubMod.NeatCode do
  use Phoenix.VerifiedRoutes,
    router: __MODULE__ |> Module.split() |> List.replace_at(-1, "Router") |> Module.concat()

  def my_path, do: ~p"/my_path"
end
```

in our setup, I could get this buggy behaviour due to the missing explicit compile-time dependency:

1. have the example code above
2. delete the relevant action from the router
3. compile & get a warning about the invalid `~p"/my_path"` route
4. restore the route to the router
5. compile, and still get the warning

Assisted by: claude-sonnet-5