### PR TITLE
phx.gen.release: simplify Debian version parsing and usage

### DIFF
--- a/lib/mix/tasks/phx.gen.release.ex
+++ b/lib/mix/tasks/phx.gen.release.ex
@@ -252,7 +252,7 @@ defmodule Mix.Tasks.Phx.Gen.Release do
         candidate = docker_tag_candidate(tag)
 
         if candidate && docker_tag_matches?(candidate, search) do
-          {:ok, candidate.elixir, candidate.otp, candidate.debian_vsn}
+          {:ok, candidate}
         end
       end)
     end)
@@ -355,16 +355,12 @@ defmodule Mix.Tasks.Phx.Gen.Release do
 
   # Ensure we only select multi-arch manifest images
   defp docker_tag_candidate(%{"archs" => [_, _ | _], "tag" => tag}) do
-    with [elixir, rest] <- String.split(tag, "-erlang-", parts: 2),
-         [otp, debian_vsn] <- String.split(rest, "-debian-#{debian()}-", parts: 2),
-         true <- String.ends_with?(debian_vsn, "-slim") do
-      %{
-        elixir: elixir,
-        otp: otp,
-        debian_vsn: String.replace_suffix(debian_vsn, "-slim", "")
-      }
-    else
-      _ -> nil
+    case Regex.run(~r/\A([\w.-]+?)-erlang-([\w.-]+?)-debian-([\w.-]+-slim)\z/, tag) do
+      [_, elixir_vsn, otp_vsn, debian_vsn] ->
+        %{elixir_vsn: elixir_vsn, otp_vsn: otp_vsn, debian_vsn: debian_vsn}
+
+      _ ->
+        nil
     end
   end
 
@@ -373,8 +369,8 @@ defmodule Mix.Tasks.Phx.Gen.Release do
   end
 
   defp docker_tag_matches?(candidate, search) do
-    version_matches?(candidate.elixir, search.elixir_match) and
-      version_matches?(candidate.otp, search.otp_match)
+    version_matches?(candidate.elixir_vsn, search.elixir_match) and
+      version_matches?(candidate.otp_vsn, search.otp_match)
   end
 
   defp version_matches?(_version, :any), do: true
@@ -419,37 +415,27 @@ defmodule Mix.Tasks.Phx.Gen.Release do
           _ -> System.version()
         end
 
-    otp_vsn = opts[:otp] || otp_vsn()
+    wanted_otp_vsn = opts[:otp] || otp_vsn()
 
-    vsns =
-      case elixir_otp_and_debian_vsn(wanted_elixir_vsn, otp_vsn) do
-        {:ok, elixir_vsn, image_otp_vsn, debian_vsn} ->
-          if elixir_vsn != wanted_elixir_vsn do
-            Logger.warning(
-              "Docker image for Elixir #{wanted_elixir_vsn} not found, defaulting to Elixir #{elixir_vsn}"
-            )
-          end
+    case elixir_otp_and_debian_vsn(wanted_elixir_vsn, wanted_otp_vsn) do
+      {:ok, %{elixir_vsn: elixir_vsn, otp_vsn: otp_vsn, debian_vsn: debian_vsn}} ->
+        if elixir_vsn != wanted_elixir_vsn do
+          Logger.warning(
+            "Docker image for Elixir #{wanted_elixir_vsn} not found, defaulting to Elixir #{elixir_vsn}"
+          )
+        end
 
-          if image_otp_vsn != otp_vsn do
-            Logger.warning(
-              "Docker image for Erlang/OTP #{otp_vsn} not found, defaulting to Erlang/OTP #{image_otp_vsn}"
-            )
-          end
+        if otp_vsn != wanted_otp_vsn do
+          Logger.warning(
+            "Docker image for Erlang/OTP #{wanted_otp_vsn} not found, defaulting to Erlang/OTP #{otp_vsn}"
+          )
+        end
 
-          {:ok, elixir_vsn, image_otp_vsn, debian_vsn}
-
-        :error ->
-          :error
-      end
-
-    case vsns do
-      {:ok, elixir_vsn, otp_vsn, debian_vsn} ->
         binding =
           Keyword.merge(binding,
-            debian: debian(),
-            debian_vsn: debian_vsn,
             elixir_vsn: elixir_vsn,
-            otp_vsn: otp_vsn
+            otp_vsn: otp_vsn,
+            debian_vsn: debian_vsn
           )
 
         Mix.Phoenix.copy_from(paths(), "priv/templates/phx.gen.release", binding, [
@@ -458,10 +444,10 @@ defmodule Mix.Tasks.Phx.Gen.Release do
         ])
 
       :error ->
-        params = docker_tag_filters(%{erlang_version: version_major_prefix(otp_vsn)})
+        params = docker_tag_filters(%{erlang_version: version_major_prefix(wanted_otp_vsn)})
 
         raise """
-        unable to fetch supported Docker image for Elixir #{wanted_elixir_vsn} and Erlang #{otp_vsn}.
+        unable to fetch supported Docker image for Elixir #{wanted_elixir_vsn} and Erlang #{wanted_otp_vsn}.
         Please check #{bob_docker_ui_url(params)} for a suitable Elixir version
         """
     end

--- a/priv/templates/phx.gen.release/Dockerfile.eex
+++ b/priv/templates/phx.gen.release/Dockerfile.eex
@@ -1,9 +1,9 @@
 # This file is based on these images:
 #
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the builder image
-#     E.g.: docker.io/hexpm/elixir:<%= elixir_vsn %>-erlang-<%= otp_vsn %>-debian-<%= debian %>-<%= debian_vsn %>-slim
-#   - https://hub.docker.com/_/debian/tags?name=<%= debian %>-<%= debian_vsn %>-slim - for the runner image
-#     E.g.: docker.io/debian:<%= debian %>-<%= debian_vsn %>-slim
+#     E.g.: docker.io/hexpm/elixir:<%= elixir_vsn %>-erlang-<%= otp_vsn %>-debian-<%= debian_vsn %>
+#   - https://hub.docker.com/_/debian/tags?name=<%= debian_vsn %> - for the runner image
+#     E.g.: docker.io/debian:<%= debian_vsn %>
 #
 # Find builder and runner images on Docker Hub or on Hex's Build Server (Bob).
 # We recommend using Bob's Web UI to find recent tags:
@@ -19,7 +19,7 @@
 
 ARG ELIXIR_VERSION=<%= elixir_vsn %>
 ARG OTP_VERSION=<%= otp_vsn %>
-ARG DEBIAN_VERSION=<%= debian %>-<%= debian_vsn %>-slim
+ARG DEBIAN_VERSION=<%= debian_vsn %>
 
 ARG BUILDER_IMAGE="docker.io/hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="docker.io/debian:${DEBIAN_VERSION}"

--- a/test/mix/tasks/phx.gen.release_test.exs
+++ b/test/mix/tasks/phx.gen.release_test.exs
@@ -282,6 +282,27 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
               archs: ["amd64", "arm64"],
               built_at: "2025-11-17T00:00:00Z"
             },
+            # non-debian tag (should be ignored)
+            %{
+              repo: "hexpm/elixir",
+              tag: "1.18.4-erlang-27.0.3-alpine-3.20-slim",
+              archs: ["amd64", "arm64"],
+              built_at: "2025-11-17T00:00:00Z"
+            },
+            # tag with newline (should be ignored)
+            %{
+              repo: "hexpm/elixir",
+              tag: "1.18.4\nRUN evil-erlang-27.0.3-debian-trixie-20251117-slim",
+              archs: ["amd64", "arm64"],
+              built_at: "2025-11-17T00:00:00Z"
+            },
+            # malformed tag (should be ignored)
+            %{
+              repo: "hexpm/elixir",
+              tag: "malformed-tag",
+              archs: ["amd64", "arm64"],
+              built_at: "2025-11-17T00:00:00Z"
+            },
             # first valid multi-arch slim tag (should be selected)
             %{
               repo: "hexpm/elixir",
@@ -297,7 +318,7 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
               built_at: "2025-10-01T00:00:00Z"
             }
           ],
-          total: 4,
+          total: 7,
           offset: 0,
           page_size: 100
         })
@@ -312,6 +333,28 @@ defmodule Mix.Tasks.Phx.Gen.ReleaseTest do
       assert_file("Dockerfile", fn file ->
         assert file =~ ~S|ARG ELIXIR_VERSION=1.18.4|
         assert file =~ ~S|ARG OTP_VERSION=27.0.3|
+        assert file =~ ~S|ARG DEBIAN_VERSION=trixie-20251117-slim|
+      end)
+    end)
+  end
+
+  test "supports pre-release versions with hyphens in tag candidate matching", config do
+    Process.put({Mix.Tasks.Phx.Gen.Release, :http_client}, fn url ->
+      uri = URI.parse(to_string(url))
+
+      if uri.host == "bob.hex.pm" and uri.path == "/api/docker" do
+        bob_tags_response(["1.19.0-rc.0-erlang-27.1-rc.1-debian-trixie-20251117-slim"])
+      else
+        raise "unexpected URL #{url}"
+      end
+    end)
+
+    in_tmp_project(config.test, fn ->
+      Gen.Release.run(["--docker", "--elixir", "1.19.0-rc.0", "--otp", "27.1-rc.1"])
+
+      assert_file("Dockerfile", fn file ->
+        assert file =~ ~S|ARG ELIXIR_VERSION=1.19.0-rc.0|
+        assert file =~ ~S|ARG OTP_VERSION=27.1-rc.1|
         assert file =~ ~S|ARG DEBIAN_VERSION=trixie-20251117-slim|
       end)
     end)


### PR DESCRIPTION
Consolidate the Debian tag into a single `debian_vsn` binding instead of splitting it into `debian` and `debian_vsn` and stripping/re-appending `-slim`.

Key changes:
* Use an inline regex in `docker_tag_candidate/1` to declaratively parse Docker tags according to the tag specification while enforcing the `-slim` suffix. Compared to string splitting, the regex match is more concise while strictly validating accepted tag characters.
* Keep `debian_vsn` as the complete Debian tag (e.g. `trixie-20251117-slim`), removing the redundant `debian` template binding and aligning `ARG DEBIAN_VERSION=<%= debian_vsn %>` symmetrically with `elixir_vsn` and `otp_vsn`.
* Streamline candidate data flow and unify `_vsn` naming, removing redundant tuple conversions and duplicate `case` expressions in `gen_docker/2`.
* Add test coverage for pre-release versions with hyphens, non-slim/non-Debian tags, and malformed inputs.

---

Follows up on #6802.