### PR TITLE
Fix phx.new.web generator referencing Ecto

### DIFF
--- a/installer/lib/mix/tasks/phx.new.web.ex
+++ b/installer/lib/mix/tasks/phx.new.web.ex
@@ -39,6 +39,6 @@ defmodule Mix.Tasks.Phx.New.Web do
       Mix.raise "The web task can only be run within an umbrella's apps directory"
     end
 
-    Mix.Tasks.Phx.New.run(args, Phx.New.Web, :web_path)
+    Mix.Tasks.Phx.New.run(args ++ ["--no-ecto"], Phx.New.Web, :web_path)
   end
 end

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -832,9 +832,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
           File.cd!(dir, fn ->
             assert_raise Mix.Error,
                          ~r"The web task can only be run within an umbrella's apps directory",
-                         fn ->
-                           Mix.Tasks.Phx.New.Web.run(["valid"])
-                         end
+                         fn -> Mix.Tasks.Phx.New.Web.run(["web_app"]) end
           end)
         end
       end)
@@ -859,7 +857,9 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         end)
 
         assert_file("../config/config.exs", fn file ->
-          assert file =~ "ecto_repos: [Another.Repo]"
+          assert file =~ "config :another,\n  generators: [context_app: false]"
+          assert file =~ "config :another, Another.Endpoint,"
+          refute file =~ "ecto_repos: [Another.Repo]"
         end)
 
         assert_file("../config/prod.exs", fn file ->
@@ -876,7 +876,13 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         assert_file("another/test/another/controllers/page_controller_test.exs")
         assert_file("another/test/another/controllers/error_html_test.exs", "async: true")
         assert_file("another/test/another/controllers/error_json_test.exs", "async: true")
-        assert_file("another/test/support/conn_case.ex")
+
+        assert_file("another/test/support/conn_case.ex", fn file ->
+          assert file =~ "defmodule Another.ConnCase do"
+          assert file =~ "setup _tags do\n    {:ok, conn: Phoenix.ConnTest.build_conn()}\n  end"
+          refute file =~ "DataCase.setup_sandbox"
+        end)
+
         assert_file("another/test/test_helper.exs")
 
         assert_file(
@@ -906,7 +912,9 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
         # Ecto
         assert_file("another/mix.exs", fn file ->
-          assert file =~ "{:phoenix_ecto,"
+          assert file =~ "{:phoenix,"
+          refute file =~ "{:phoenix_ecto,"
+          refute file =~ "ecto.create"
         end)
 
         assert_file("another/lib/another.ex", ~r"defmodule Another")

--- a/installer/test/phx_new_web_test.exs
+++ b/installer/test/phx_new_web_test.exs
@@ -1,4 +1,4 @@
-Code.require_file "mix_helper.exs", __DIR__
+Code.require_file("mix_helper.exs", __DIR__)
 
 defmodule Mix.Tasks.Phx.New.WebTest do
   use ExUnit.Case
@@ -10,41 +10,56 @@ defmodule Mix.Tasks.Phx.New.WebTest do
   setup do
     # The shell asks to install deps.
     # We will politely say not.
-    send self(), {:mix_shell_input, :yes?, false}
+    send(self(), {:mix_shell_input, :yes?, false})
     :ok
   end
 
   test "new without args" do
     assert capture_io(fn -> Mix.Tasks.Phx.New.Web.run([]) end) =~
-           "Creates a new Phoenix web project within an umbrella project."
+             "Creates a new Phoenix web project within an umbrella project."
   end
 
   test "new with barebones umbrella" do
-    in_tmp_umbrella_project "new with barebones umbrella", fn ->
+    in_tmp_umbrella_project("new with barebones umbrella", fn ->
       files = ~w[../config/dev.exs ../config/test.exs ../config/prod.exs ../config/runtime.exs]
       Enum.each(files, &File.rm/1)
 
-      assert_file "../config/config.exs", &refute(&1 =~ ~S[import_config "#{config_env()}.exs"])
+      assert_file("../config/config.exs", &refute(&1 =~ ~S[import_config "#{config_env()}.exs"]))
       Mix.Tasks.Phx.New.Web.run([@app_name])
-      assert_file "../config/config.exs", &assert(&1 =~ ~S[import_config "#{config_env()}.exs"])
-    end
+      assert_file("../config/config.exs", &assert(&1 =~ ~S[import_config "#{config_env()}.exs"]))
+    end)
   end
 
   test "new outside umbrella", config do
-    in_tmp config.test, fn ->
-      assert_raise Mix.Error, ~r"The web task can only be run within an umbrella's apps directory", fn ->
-        Mix.Tasks.Phx.New.Web.run ["007invalid"]
-      end
-    end
+    in_tmp(config.test, fn ->
+      assert_raise Mix.Error,
+                   ~r"The web task can only be run within an umbrella's apps directory",
+                   fn -> Mix.Tasks.Phx.New.Web.run(["web_app"]) end
+    end)
   end
 
   test "new with defaults" do
-    in_tmp_umbrella_project "new with defaults", fn ->
+    in_tmp_umbrella_project("new with defaults", fn ->
       Mix.Tasks.Phx.New.Web.run([@app_name])
 
-      assert_file "../config/config.exs", fn file ->
-        assert file =~ "generators: [context_app: false]"
-      end
+      assert_file("../config/config.exs", fn file ->
+        assert file =~ "config :#{@app_name},\n  generators: [context_app: false]"
+        assert file =~ "config :#{@app_name}, PhxWeb.Endpoint,"
+        refute file =~ "ecto_repos:"
+      end)
+
+      assert_file("#{@app_name}/mix.exs", fn file ->
+        assert file =~ "app: :#{@app_name}"
+        assert file =~ "{:phoenix,"
+        refute file =~ "{:phoenix_ecto,"
+        refute file =~ "ecto.create"
+      end)
+
+      assert_file("#{@app_name}/test/support/conn_case.ex", fn file ->
+        assert file =~ "defmodule PhxWeb.ConnCase do"
+        assert file =~ "setup _tags do\n    {:ok, conn: Phoenix.ConnTest.build_conn()}\n  end"
+        refute file =~ "DataCase.setup_sandbox"
+      end)
 
       # Install dependencies?
       assert_received {:mix_shell, :yes?, ["\nFetch and install dependencies?"]}
@@ -54,19 +69,20 @@ defmodule Mix.Tasks.Phx.New.WebTest do
       assert msg =~ "$ cd phx_web"
       assert msg =~ "$ mix deps.get"
 
-      assert_received {:mix_shell, :info, ["Your web app requires a PubSub server to be running." <> _]}
+      assert_received {:mix_shell, :info,
+                       ["Your web app requires a PubSub server to be running." <> _]}
 
       assert_received {:mix_shell, :info, ["Start your Phoenix app" <> _]}
-    end
+    end)
   end
 
   test "app_name is included in tailwind config" do
-    in_tmp_umbrella_project "new with defaults", fn ->
+    in_tmp_umbrella_project("new with defaults", fn ->
       Mix.Tasks.Phx.New.Web.run(["testweb"])
 
-      assert_file "testweb/assets/vendor/heroicons.js", fn file ->
+      assert_file("testweb/assets/vendor/heroicons.js", fn file ->
         assert file =~ "/deps/heroicons/optimized"
-      end
-    end
+      end)
+    end)
   end
 end


### PR DESCRIPTION
The `phx.new.web` task is documented to create a bare Phoenix web project without database integration inside an umbrella. However, because it did not pass `--no-ecto`, it inherited the generator's default `ecto: true` setting, generating invalid references to a non-existent `<App>.Repo` and `<App>.DataCase`.

This passes `--no-ecto` by default when running `phx.new.web`.

Fixes #5690.
Closes #5691.