### PR TITLE
Fix timer leak in Ajax fetch requests

### DIFF
--- a/assets/js/phoenix/ajax.js
+++ b/assets/js/phoenix/ajax.js
@@ -27,16 +27,21 @@ export default class Ajax {
       body,
     }
     let controller = null
+    let timeoutId = null
     if(timeout){
       controller = new AbortController()
-      const _timeoutId = setTimeout(() => controller.abort(), timeout)
+      timeoutId = setTimeout(() => controller.abort(), timeout)
       options.signal = controller.signal
     }
     global.fetch(endPoint, options)
       .then(response => response.text())
       .then(data => this.parseJSON(data))
-      .then(data => callback && callback(data))
+      .then(data => {
+        if(timeoutId){ clearTimeout(timeoutId) }
+        callback && callback(data)
+      })
       .catch(err => {
+        if(timeoutId){ clearTimeout(timeoutId) }
         if(err.name === "AbortError" && ontimeout){
           ontimeout()
         } else {

--- a/assets/test/longpoll_test.js
+++ b/assets/test/longpoll_test.js
@@ -450,4 +450,87 @@ describe("Ajax.request", () => {
       })
     )
   })
+
+  it("clears the timeout timer when fetch completes successfully", () => {
+    global.XMLHttpRequest = undefined
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout")
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout")
+
+    return new Promise((resolve, reject) => {
+      Ajax.request("GET", "/test-endpoint", {}, null, 5000, null, (response) => {
+        try {
+          expect(response).toEqual({success: true})
+          const timerId = setTimeoutSpy.mock.results[0].value
+          expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId)
+          resolve()
+        } catch(err){
+          reject(err)
+        }
+      })
+    })
+  })
+
+  it("clears the timeout timer when fetch errors", () => {
+    global.XMLHttpRequest = undefined
+    global.fetch = jest.fn(() => Promise.reject(new Error("Network error")))
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout")
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout")
+
+    return new Promise((resolve, reject) => {
+      Ajax.request("GET", "/test-endpoint", {}, null, 5000, null, (response) => {
+        try {
+          expect(response).toBeNull()
+          const timerId = setTimeoutSpy.mock.results[0].value
+          expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId)
+          resolve()
+        } catch(err){
+          reject(err)
+        }
+      })
+    })
+  })
+
+  it("does not set or clear timeout timer when timeout is 0 or not specified", () => {
+    global.XMLHttpRequest = undefined
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout")
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout")
+
+    return new Promise((resolve, reject) => {
+      Ajax.request("GET", "/test-endpoint", {}, null, 0, null, (response) => {
+        try {
+          expect(response).toEqual({success: true})
+          expect(setTimeoutSpy).not.toHaveBeenCalled()
+          expect(clearTimeoutSpy).not.toHaveBeenCalled()
+          resolve()
+        } catch(err){
+          reject(err)
+        }
+      })
+    })
+  })
+
+  it("invokes ontimeout and clears timer when fetch rejects with AbortError", () => {
+    global.XMLHttpRequest = undefined
+    const abortError = new Error("The user aborted a request.")
+    abortError.name = "AbortError"
+    global.fetch = jest.fn(() => Promise.reject(abortError))
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout")
+    const clearTimeoutSpy = jest.spyOn(global, "clearTimeout")
+
+    return new Promise((resolve, reject) => {
+      const callback = jest.fn(() => reject(new Error("callback should not be called on AbortError")))
+      const ontimeout = () => {
+        try {
+          expect(callback).not.toHaveBeenCalled()
+          const timerId = setTimeoutSpy.mock.results[0].value
+          expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId)
+          resolve()
+        } catch(err){
+          reject(err)
+        }
+      }
+
+      Ajax.request("GET", "/test-endpoint", {}, null, 5000, ontimeout, callback)
+    })
+  })
 })


### PR DESCRIPTION
When fetchRequest support was originally introduced to support Service Workers in #6181, a setTimeout timer was created as `const timeoutId` to trigger `controller.abort()` when the duration expired. In a subsequent linter update in #6283, `timeoutId` was renamed to `_timeoutId` to silence an unused variable warning, masking the fact that the pending timer was never cleared upon request completion.

Because ServiceWorkerGlobalScope omits both WebSocket and XMLHttpRequest APIs, Service Workers cannot establish WebSocket connections and rely on LongPoll with Ajax.fetchRequest as their primary transport.

In LongPoll mode, each polling request configures a timeout (defaulting to 20,000ms via `this.longpollerTimeout`). When requests resolve with data or fail before the timeout, the pending timer remains active in the host runtime's timer queue until its full duration elapses. For active connections with frequent polling, uncleared timers accumulate, retaining memory references to AbortController closures and preventing ephemeral runtimes like Service Workers from entering idle states.

Fix:
1. Track `timeoutId` when setting up AbortController in `Ajax.fetchRequest`.
2. Clear `timeoutId` upon promise fulfillment (`.then`) before invoking the response callback.
3. Clear `timeoutId` upon promise rejection or abort (`.catch`).

Tests:
- Added unit tests in `longpoll_test.js` verifying `clearTimeout` is called with the exact timer ID on success, network error, and AbortError.
- Configured fail-fast rejection callbacks to catch unexpected invocations without timing out.
- Verified neither `setTimeout` nor `clearTimeout` is called when no timeout (or 0) is specified.

---

Disclaimer

- Found while reviewing #5984
- Assisted by Google Antigravity CLI with Gemini 3.7 Flash