### PR TITLE
Follow-up to moving from Jason to JSON

### DIFF
--- a/guides/deployment/gigalixir.md
+++ b/guides/deployment/gigalixir.md
@@ -80,7 +80,7 @@ Note: the app name cannot be changed afterwards. A random name is used if you do
 Gigalixir requires that you specify the Erlang and Elixir versions you intend to use. It's generally a good idea to run the same version in production as you do in development. For example:
 
 ```console
-$ echo 'elixir_version=1.17.2' > elixir_buildpack.config
+$ echo 'elixir_version=1.18.4' > elixir_buildpack.config
 $ echo 'erlang_version=27.0' >> elixir_buildpack.config
 $ git add elixir_buildpack.config
 ```

--- a/guides/deployment/heroku.md
+++ b/guides/deployment/heroku.md
@@ -95,11 +95,11 @@ The buildpack uses a predefined Elixir and Erlang version, but to avoid surprise
 
 ```console
 # Elixir version
-elixir_version=1.15.0
+elixir_version=1.18.4
 
 # Erlang version
 # https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
-erlang_version=25.3
+erlang_version=27.0
 
 # Invoke assets.deploy defined in your mix.exs to deploy assets with esbuild
 # Note we nuke the esbuild executable from the image

--- a/installer/templates/phx_single/config/config.exs.eex
+++ b/installer/templates/phx_single/config/config.exs.eex
@@ -75,7 +75,8 @@ config :logger, :default_formatter,
 
 # Use built-in `JSON` module
 config :phoenix, :json_library, JSON<%= if @ecto do %>
-config :<%= @adapter_app %>, :json_library, JSON<% end %>
+config :<%= @adapter_app %>, :json_library, JSON<% end %><%= if @mailer do %>
+config :swoosh, :json_library, JSON<% end %>
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/installer/templates/phx_single/config/prod.exs.eex
+++ b/installer/templates/phx_single/config/prod.exs.eex
@@ -21,10 +21,10 @@ config :<%= @web_app_name %>, <%= @endpoint_module %>,
   ]<%= if @mailer do %>
 
 # Configure Swoosh API Client
-config :swoosh, api_client: Swoosh.ApiClient.Req
+config :swoosh, :api_client, Swoosh.ApiClient.Req
 
 # Disable Swoosh Local Memory Storage
-config :swoosh, local: false<% end %>
+config :swoosh, :local, false<% end %>
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/installer/templates/phx_umbrella/config/extra_config.exs.eex
+++ b/installer/templates/phx_umbrella/config/extra_config.exs.eex
@@ -7,7 +7,8 @@ config :logger, :default_formatter,
 
 # Use built-in `JSON` module
 config :phoenix, :json_library, JSON<%= if @ecto do %>
-config :<%= @adapter_app %>, :json_library, JSON<% end %>
+config :<%= @adapter_app %>, :json_library, JSON<% end %><%= if @mailer do %>
+config :swoosh, :json_library, JSON<% end %>
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/installer/templates/phx_umbrella/config/prod.exs.eex
+++ b/installer/templates/phx_umbrella/config/prod.exs.eex
@@ -5,7 +5,7 @@ import Config
 config :swoosh, :api_client, Swoosh.ApiClient.Req
 
 # Disable Swoosh Local Memory Storage
-config :swoosh, local: false<% end %>
+config :swoosh, :local, false<% end %>
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/installer/test/phx_new_test.exs
+++ b/installer/test/phx_new_test.exs
@@ -55,6 +55,8 @@ defmodule Mix.Tasks.Phx.NewTest do
         assert file =~ "ecto_repos: [PhxBlog.Repo]"
         assert file =~ "generators: [timestamp_type: :utc_datetime]"
         assert file =~ "config :phoenix, :json_library, JSON"
+        assert file =~ "config :postgrex, :json_library, JSON"
+        assert file =~ "config :swoosh, :json_library, JSON"
         assert file =~ ~s[cd: Path.expand("../assets", __DIR__),]
         refute file =~ "namespace: PhxBlog"
         refute file =~ "config :phx_blog, :generators"
@@ -281,8 +283,8 @@ defmodule Mix.Tasks.Phx.NewTest do
       end)
 
       assert_file("phx_blog/config/prod.exs", fn file ->
-        assert file =~
-                 "config :swoosh, api_client: Swoosh.ApiClient.Req"
+        assert file =~ "config :swoosh, :api_client, Swoosh.ApiClient.Req"
+        assert file =~ "config :swoosh, :local, false"
       end)
 
       # Install dependencies?
@@ -354,6 +356,9 @@ defmodule Mix.Tasks.Phx.NewTest do
       assert_file("phx_blog/mix.exs", &refute(&1 =~ ~r":phoenix_ecto"))
 
       assert_file("phx_blog/config/config.exs", fn file ->
+        assert file =~ "config :phoenix, :json_library, JSON"
+        refute file =~ "config :postgrex, :json_library, JSON"
+        refute file =~ "config :swoosh, :json_library, JSON"
         refute file =~ "config :esbuild"
         refute file =~ "config :phx_blog, :generators"
         refute file =~ "ecto_repos:"
@@ -553,6 +558,12 @@ defmodule Mix.Tasks.Phx.NewTest do
         refute file =~ "subdirectories:"
       end)
 
+      assert_file("phx_blog/config/config.exs", fn file ->
+        assert file =~ "config :phoenix, :json_library, JSON"
+        refute file =~ "config :postgrex, :json_library, JSON"
+        assert file =~ "config :swoosh, :json_library, JSON"
+      end)
+
       assert_file("phx_blog/test/phx_blog_web/controllers/error_html_test.exs", "async: true")
       assert_file("phx_blog/test/phx_blog_web/controllers/error_json_test.exs", "async: true")
     end)
@@ -672,6 +683,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       Mix.Tasks.Phx.New.run([project_path, "--database", "mysql"])
 
       assert_file("custom_path/mix.exs", ":myxql")
+      assert_file("custom_path/config/config.exs", "config :myxql, :json_library, JSON")
       assert_file("custom_path/config/dev.exs", [~r/username: "root"/, ~r/password: ""/])
       assert_file("custom_path/config/test.exs", [~r/username: "root"/, ~r/password: ""/])
       assert_file("custom_path/config/runtime.exs", [~r/url: database_url/])
@@ -700,6 +712,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       Mix.Tasks.Phx.New.run([project_path, "--database", "sqlite3"])
 
       assert_file("custom_path/mix.exs", ":ecto_sqlite3")
+      assert_file("custom_path/config/config.exs", "config :ecto_sqlite3, :json_library, JSON")
       assert_file("custom_path/config/dev.exs", [~r/database: .*_dev.db/])
       assert_file("custom_path/config/test.exs", [~r/database: .*_test.db/])
       assert_file("custom_path/config/runtime.exs", [~r/database: database_path/])
@@ -742,6 +755,7 @@ defmodule Mix.Tasks.Phx.NewTest do
       Mix.Tasks.Phx.New.run([project_path, "--database", "mssql"])
 
       assert_file("custom_path/mix.exs", ":tds")
+      assert_file("custom_path/config/config.exs", "config :tds, :json_library, JSON")
 
       assert_file("custom_path/config/dev.exs", [
         ~r/username: "sa"/,

--- a/installer/test/phx_new_umbrella_test.exs
+++ b/installer/test/phx_new_umbrella_test.exs
@@ -65,6 +65,8 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
         assert file =~ "cd: Path.expand(\"../apps/phx_umb_web/assets\", __DIR__)"
         assert file =~ ~S[import_config "#{config_env()}.exs"]
         assert file =~ "config :phoenix, :json_library, JSON"
+        assert file =~ "config :postgrex, :json_library, JSON"
+        assert file =~ "config :swoosh, :json_library, JSON"
         assert file =~ "ecto_repos: [PhxUmb.Repo]"
         assert file =~ ":phx_umb_web, PhxUmbWeb.Endpoint"
         assert file =~ "generators: [context_app: :phx_umb]\n"
@@ -313,6 +315,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
 
       assert_file(root_path(@app, "config/prod.exs"), fn file ->
         assert file =~ "config :swoosh, :api_client, Swoosh.ApiClient.Req"
+        assert file =~ "config :swoosh, :local, false"
       end)
 
       # Install dependencies?
@@ -367,6 +370,9 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       assert_file(app_path(@app, "mix.exs"), &refute(&1 =~ ~r":phoenix_ecto"))
 
       assert_file(root_path(@app, "config/config.exs"), fn file ->
+        assert file =~ "config :phoenix, :json_library, JSON"
+        refute file =~ "config :postgrex, :json_library, JSON"
+        refute file =~ "config :swoosh, :json_library, JSON"
         refute file =~ "config :esbuild"
         refute file =~ "config :phx_blog_web, :generators"
         refute file =~ "ecto_repos:"
@@ -626,6 +632,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       Mix.Tasks.Phx.New.run([project_path, "--umbrella", "--database", "mysql"])
 
       assert_file(app_path(app, "mix.exs"), ":myxql")
+      assert_file(root_path(app, "config/config.exs"), "config :myxql, :json_library, JSON")
       assert_file(app_path(app, "lib/custom_path/repo.ex"), "Ecto.Adapters.MyXQL")
 
       assert_file(root_path(app, "config/dev.exs"), [~r/username: "root"/, ~r/password: ""/])
@@ -653,6 +660,12 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       Mix.Tasks.Phx.New.run([project_path, "--umbrella", "--database", "sqlite3"])
 
       assert_file(app_path(app, "mix.exs"), ":ecto_sqlite3")
+
+      assert_file(
+        root_path(app, "config/config.exs"),
+        "config :ecto_sqlite3, :json_library, JSON"
+      )
+
       assert_file(app_path(app, "lib/custom_path/repo.ex"), "Ecto.Adapters.SQLite3")
 
       assert_file(app_path(app, "lib/custom_path/application.ex"), fn file ->
@@ -692,6 +705,7 @@ defmodule Mix.Tasks.Phx.New.UmbrellaTest do
       Mix.Tasks.Phx.New.run([project_path, "--umbrella", "--database", "mssql"])
 
       assert_file(app_path(app, "mix.exs"), ":tds")
+      assert_file(root_path(app, "config/config.exs"), "config :tds, :json_library, JSON")
       assert_file(app_path(app, "lib/custom_path/repo.ex"), "Ecto.Adapters.Tds")
 
       assert_file(root_path(app, "config/dev.exs"), [

--- a/integration_test/config/config.exs
+++ b/integration_test/config/config.exs
@@ -2,7 +2,8 @@ import Config
 
 config :phoenix, :json_library, JSON
 
-config :swoosh, api_client: false
+config :swoosh, :json_library, JSON
+config :swoosh, :api_client, false
 
 config :tailwind, :version, "4.1.12"
 

--- a/lib/phoenix.ex
+++ b/lib/phoenix.ex
@@ -38,7 +38,7 @@ defmodule Phoenix do
   @doc """
   Returns the configured JSON encoding library for Phoenix.
 
-  To customize the JSON library, including the following
+  To customize the JSON library, include the following
   in your `config/config.exs`:
 
       config :phoenix, :json_library, AlternativeJsonLibrary


### PR DESCRIPTION
Follows up on #6481.

- Configure Swoosh to use JSON instead of Jason when mailer is enabled
- Standardize `:swoosh` configuration to use `config/3`
- Add installer test assertions for adapter and swoosh config
- Update Elixir version in deployment guides
- Fix typo in `Phoenix.json_library/0` docstring

---

## Note for future work

When I looked at the final `mix.lock` of a newly generated app, I noticed `:jason` is still there. Preliminary investigation points to these dependencies:

1. [phoenixframework/esbuild](https://github.com/phoenixframework/esbuild): Either make `json_library` configurable like other packages, or directly replace `Jason.decode!` with `JSON.decode!`, then make `jason` optional (tracking issue https://github.com/phoenixframework/esbuild/issues/83).
2. [swoosh/swoosh](https://github.com/swoosh/swoosh): Make `jason` optional (already acknowledged in https://swoosh.hexdocs.pm/1.28.0/Swoosh.html#module-custom-json-library and part of a list of several items in https://github.com/swoosh/swoosh/issues/556).
3. [wojtekmach/req](https://github.com/wojtekmach/req): coming soon as per https://github.com/wojtekmach/req/issues/386, to be released in v0.8 entirely dropping Jason and requiring Elixir 1.18+ ([v0.8.0-rc.0 (2026-08-18) changelog](https://github.com/wojtekmach/req/blob/58e94146b446205a4db2ebcacbe8e918fc691a6a/CHANGELOG.md#changelog)).

Once new versions of `esbuild`, `swoosh`, and `req` are published with optional `jason`, a newly generated Phoenix app will have a `mix.lock` free of `Jason`.