### PR TITLE
Remove unused @epoch module attribute in integration test

### DIFF
--- a/integration_test/test/code_generation/app_with_no_options_test.exs
+++ b/integration_test/test/code_generation/app_with_no_options_test.exs
@@ -1,8 +1,6 @@
 defmodule Phoenix.Integration.CodeGeneration.AppWithNoOptionsTest do
   use Phoenix.Integration.CodeGeneratorCase, async: true
 
-  @epoch {{1970, 1, 1}, {0, 0, 0}}
-
   test "newly generated app has no warnings or errors" do
     with_installer_tmp("app_with_no_options", fn tmp_dir ->
       {app_root_path, _} =


### PR DESCRIPTION
In #6764, the test "development workflow works as expected" was updated to "generated app boots with mix phx.server", removing the `File.touch!` and `File.stat!` assertions on non-existent HTML templates in an app generated with `--no-html`.

However, the `@epoch` module attribute definition at the top of the file was left behind, causing the compiler warning:
```
  "warning: module attribute @epoch was set but never used"
```

This removes the unused `@epoch` definition.