### PR TITLE
Improve integration test CI visibility, healthchecks, and reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,17 +232,23 @@ jobs:
           # look for latest alpine image here: https://bob.hex.pm/docker?repo=hexpm/elixir&os=alpine&sort=elixir_version,erlang_version,os_version
           - elixir: "1.18.4"
             otp: "27.3.4.3"
-            suffix: "alpine-3.22.4"
+            alpine: "3.22.4"
 
           - elixir: "1.20.4"
             otp: "29.0.5"
-            suffix: "alpine-3.23.5"
+            alpine: "3.23.5"
 
     container:
-      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-${{ matrix.suffix }}
+      image: hexpm/elixir:${{ matrix.elixir }}-erlang-${{ matrix.otp }}-alpine-${{ matrix.alpine }}
       env:
         ELIXIR_ASSERT_TIMEOUT: 10000
         PHX_CI: true
+        # Set to half of the runner vCPU cores to compile deps/NIFs
+        # concurrently across OS processes without CPU oversubscription.
+        # See https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        # and https://elixir-lang.org/blog/2025/10/16/elixir-v1-19-0-released/
+        MIX_OS_DEPS_COMPILE_PARTITION_COUNT: 2
+        MAKEFLAGS: "-j2"
     services:
       postgres:
         image: postgres:18
@@ -250,12 +256,22 @@ jobs:
           - 5432:5432
         env:
           POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 10
       mysql:
         image: mysql:26
         ports:
           - 3306:3306
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 10
       mssql:
         image: mcr.microsoft.com/mssql/server:2019-latest
         env:
@@ -263,9 +279,44 @@ jobs:
           SA_PASSWORD: some!Password
         ports:
           - 1433:1433
+        options: >-
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$SA_PASSWORD\" -C -Q 'SELECT 1' 2>/dev/null || /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P \"$SA_PASSWORD\" -Q 'SELECT 1' 2>/dev/null"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 25
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Run test script
-        run: ./integration_test/test.sh
+
+      - name: Install system packages
+        run: apk add --no-progress --update git socat make gcc libc-dev cmake g++
+
+      - name: Set up Hex and Rebar
+        run: |
+          mix local.rebar --force
+          mix local.hex --force
+
+      - name: Start database proxy bridges
+        run: |
+          socat TCP-LISTEN:5432,fork TCP-CONNECT:postgres:5432 > /dev/null 2>&1 &
+          socat TCP-LISTEN:3306,fork TCP-CONNECT:mysql:3306 > /dev/null 2>&1 &
+          socat TCP-LISTEN:1433,fork TCP-CONNECT:mssql:1433 > /dev/null 2>&1 &
+
+      - name: Fetch dependencies
+        working-directory: integration_test
+        run: mix deps.get
+
+      - name: Compile dependencies
+        working-directory: integration_test
+        run: mix deps.compile
+        env:
+          MIX_ENV: test
+
+      - name: Run integration tests
+        working-directory: integration_test
+        run: |
+          mix test --include database \
+            --formatter ExUnit.CLIFormatter \
+            --formatter Phoenix.Integration.SummaryFormatter


### PR DESCRIPTION
Previously, the integration test CI job ran entirely within a monolithic `integration_test/test.sh` script inside an Alpine container. Bundling system package installation, Hex/Rebar setup, proxy startup, dependency compilation, and test execution into a single script obscured the duration of each phase in CI metrics. CI also lacked explicit database readiness checks, relying solely on the duration of preceding commands to avoid connection failures.

This updates `.github/workflows/ci.yml` with the following improvements:

- Decompose monolithic test execution into discrete, individually timed CI steps (package installation, Hex/Rebar setup, proxy bridges, dependency fetching, MIX_ENV=test dependency compilation, and test execution) to surface exact phase timings in GitHub Actions UI.
- Add explicit container healthcheck probes (`--health-cmd`) for Postgres, MySQL, and MSSQL services to eliminate startup race conditions before tests begin.
- Detach background `socat` proxy streams (`> /dev/null 2>&1 &`) so the proxy step completes immediately without blocking the runner's step listener.
- Enable concurrent dependency and NIF compilation (`MIX_OS_DEPS_COMPILE_PARTITION_COUNT: 2` and `MAKEFLAGS: "-j2"`) tuned to runner vCPU capacity without CPU oversubscription.
- Standardize Alpine matrix parameterization by separating the `alpine` version tag from string suffixes.

---

I intend to suggest similar improvements for the local integration tests workflow as a separate PR.