### PR TITLE
Fix Elixir 1.15 compiler warnings

### DIFF
--- a/lib/phoenix/code_reloader/server.ex
+++ b/lib/phoenix/code_reloader/server.ex
@@ -2,9 +2,6 @@ defmodule Phoenix.CodeReloader.Server do
   @moduledoc false
   use GenServer
 
-  # Elixir v1.19 bundles consolidation into compile.elixir
-  # so we no longer need to trigger it manually
-  @requires_consolidation not Version.match?(System.version(), ">= 1.19.0")
 
   require Logger
   alias Phoenix.CodeReloader.Proxy
@@ -259,6 +256,33 @@ defmodule Phoenix.CodeReloader.Server do
     end
   end
 
+  # Elixir v1.19 bundles consolidation into compile.elixir
+  # so we no longer need to trigger it manually
+  if Version.match?(System.version(), "< 1.19.0") do
+    defp maybe_purge_consolidated_modules(config, path) do
+      if config[:consolidate_protocols] do
+        # If we are consolidating protocols, we need to purge all of its modules
+        # to ensure the consolidated versions are loaded. "mix compile" performs
+        # a similar task.
+        Code.prepend_path(path)
+        purge_modules(path)
+      end
+    end
+
+    defp maybe_compile_protocols(config) do
+      if config[:consolidate_protocols] do
+        # Calling compile.protocols is not required from Elixir v1.19
+        Mix.Task.reenable("compile.protocols")
+        Mix.Task.run("compile.protocols", [])
+      end
+
+      :ok
+    end
+  else
+    defp maybe_purge_consolidated_modules(_config, _path), do: :ok
+    defp maybe_compile_protocols(_config), do: :ok
+  end
+
   defp mix_compile(
          {:module, Mix.Task},
          compilers,
@@ -298,13 +322,7 @@ defmodule Phoenix.CodeReloader.Server do
       purge_fallback?
     )
 
-    if @requires_consolidation && config[:consolidate_protocols] do
-      # If we are consolidating protocols, we need to purge all of its modules
-      # to ensure the consolidated versions are loaded. "mix compile" performs
-      # a similar task.
-      Code.prepend_path(path)
-      purge_modules(path)
-    end
+    maybe_purge_consolidated_modules(config, path)
 
     :ok
   end
@@ -411,11 +429,10 @@ defmodule Phoenix.CodeReloader.Server do
           exit({:shutdown, 1})
         end
 
-      @requires_consolidation && status == :ok && config[:consolidate_protocols] ->
-        # TODO: Calling compile.protocols is no longer be required from Elixir v1.19
-        Mix.Task.reenable("compile.protocols")
-        Mix.Task.run("compile.protocols", [])
         :ok
+
+      status == :ok ->
+        maybe_compile_protocols(config)
 
       true ->
         :ok


### PR DESCRIPTION
Address compiler warnings emitted in `Phoenix.CodeReloader.Server` when compiling Phoenix on Elixir < 1.19 (such as Elixir 1.15 on CI):

- What: Replace the `@requires_consolidation` module attribute with version-gated helper functions.
- Why: On Elixir < 1.19 (e.g. 1.15.8), `@requires_consolidation` evaluated to `true` at compile time. Using it in `&&` checks inside `if` and `cond` clauses triggered "this check/guard will always yield the same result" compiler warnings.
- Tradeoff: Adds a couple of small conditionally defined private functions instead of inline attribute checks, cleanly isolating version branching and eliminating boolean literal warnings in Phoenix core.

Note on installer `JSON.decode!/1` warning: When running the root test suite on Elixir 1.15 in CI, compiling `Mix.Tasks.Phx.New` emits an undefined module warning for `JSON.decode!/1` (introduced in Elixir 1.18). We intentionally omit conditional shims in `installer/` because `phx_new` officially requires Elixir ~> 1.18 and is never installed or executed on older Elixir versions in production. CI enforces `--warnings-as-errors` on the latest Elixir version, so this test-only warning on older matrix runs is accepted to keep the installer codebase clean.

---

Example:

https://github.com/phoenixframework/phoenix/actions/runs/33614222960

### Annotations
3 warnings
- mix test (OTP 25.3.2.21 | Elixir 1.15.8): lib/phoenix/code_reloader/server.ex#L414
this check/guard will always yield the same result
- mix test (OTP 25.3.2.21 | Elixir 1.15.8): lib/phoenix/code_reloader/server.ex#L301
this check/guard will always yield the same result
- mix test (OTP 25.3.2.21 | Elixir 1.15.8)
JSON.decode!/1 is undefined (module JSON is not available or is yet to be defined)