### PR TITLE
Eliminate Process.sleep from integration tests

### DIFF
--- a/integration_test/test/code_generation/app_with_mysql_adapter_scopes_test.exs
+++ b/integration_test/test/code_generation/app_with_mysql_adapter_scopes_test.exs
@@ -10,8 +10,7 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithMySQLAdapterScopesTest do
 
         mix_run!(~w(phx.gen.auth Accounts User users --live), app_root_path)
 
-        # we need to wait, otherwise we'd generate two migrations with the same version...
-        Process.sleep(1500)
+        adjust_migration_timestamps(app_root_path)
 
         mix_run!(
           ~w(phx.gen.live Blog Post posts title:string),

--- a/integration_test/test/code_generation/app_with_scopes_custom_routes_test.exs
+++ b/integration_test/test/code_generation/app_with_scopes_custom_routes_test.exs
@@ -10,8 +10,8 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithScopesCustomRoutesTest do
         # First generate authentication system
         mix_run!(~w(phx.gen.auth Accounts User users --live), app_root_path)
 
-        # sleep to have fresh migration name
-        Process.sleep(1500)
+        adjust_migration_timestamps(app_root_path)
+
         mix_run!(~w(ecto.gen.migration AddOrganizationAndOrgUser), app_root_path)
 
         assert [migration] =
@@ -337,21 +337,22 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithScopesCustomRoutesTest do
         end)
 
         # Generate resources with all three generators - use different contexts to avoid naming conflicts
-        Process.sleep(1500)
+
+        adjust_migration_timestamps(app_root_path)
 
         mix_run!(
           ~w(phx.gen.html Blog1 Article articles title:string --scope organization),
           app_root_path
         )
 
-        Process.sleep(1500)
+        adjust_migration_timestamps(app_root_path)
 
         mix_run!(
           ~w(phx.gen.live Blog2 Post posts title:string --scope organization),
           app_root_path
         )
 
-        Process.sleep(1500)
+        adjust_migration_timestamps(app_root_path)
 
         mix_run!(
           ~w(phx.gen.json Blog3 Comment comments content:string --scope organization),

--- a/integration_test/test/code_generation/app_with_scopes_html_test.exs
+++ b/integration_test/test/code_generation/app_with_scopes_html_test.exs
@@ -8,8 +8,9 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithScopesHtmlTest do
         {app_root_path, _} = generate_phoenix_app(tmp_dir, "sc_html")
 
         mix_run!(~w(phx.gen.auth Accounts User users --no-live), app_root_path)
-        # we need to wait, otherwise we would generate two migrations with the same version...
-        Process.sleep(1500)
+
+        adjust_migration_timestamps(app_root_path)
+
         mix_run!(~w(phx.gen.html Blog Post posts title:string), app_root_path)
 
         modify_file(Path.join(app_root_path, "lib/sc_html_web/router.ex"), fn file ->

--- a/integration_test/test/code_generation/app_with_scopes_json_test.exs
+++ b/integration_test/test/code_generation/app_with_scopes_json_test.exs
@@ -8,8 +8,9 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithScopesJsonTest do
         {app_root_path, _} = generate_phoenix_app(tmp_dir, "sc_json")
 
         mix_run!(~w(phx.gen.auth Accounts User users --no-live), app_root_path)
-        # we need to wait, otherwise we'd generate two migrations with the same version...
-        Process.sleep(1500)
+
+        adjust_migration_timestamps(app_root_path)
+
         mix_run!(~w(phx.gen.json Blog Post posts title:string), app_root_path)
 
         modify_file(Path.join(app_root_path, "lib/sc_json_web/router.ex"), fn file ->

--- a/integration_test/test/code_generation/app_with_scopes_live_test.exs
+++ b/integration_test/test/code_generation/app_with_scopes_live_test.exs
@@ -8,8 +8,9 @@ defmodule Phoenix.Integration.CodeGeneration.AppWithScopesLiveTest do
         {app_root_path, _} = generate_phoenix_app(tmp_dir, "sc_live")
 
         mix_run!(~w(phx.gen.auth Accounts User users --live), app_root_path)
-        # we need to wait, otherwise we would generate two migrations with the same version...
-        Process.sleep(1500)
+
+        adjust_migration_timestamps(app_root_path)
+
         mix_run!(~w(phx.gen.live Blog Post posts title:string), app_root_path)
 
         modify_file(Path.join(app_root_path, "lib/sc_live_web/router.ex"), fn file ->

--- a/integration_test/test/support/code_generator_case.ex
+++ b/integration_test/test/support/code_generator_case.ex
@@ -103,6 +103,39 @@ defmodule Phoenix.Integration.CodeGeneratorCase do
     mix_run!(["ecto.drop"], app_path, env: [{"MIX_ENV", "test"}])
   end
 
+  # Renames existing migration files in `app_path` to deterministic, sequentially ordered
+  # timestamps in the past (starting at 2000-01-01 00:00:00).
+  #
+  # Consecutive generator invocations in tests (e.g. `phx.gen.auth` followed by `phx.gen.live`)
+  # run fast enough to generate migrations within the same second, leading to timestamp
+  # collisions or unexpected execution order. Calling this helper between generator runs
+  # shifts existing migrations to earlier timestamps so subsequent generators can produce
+  # fresh, non-colliding migration versions with current timestamps immediately without sleeping.
+  #
+  # Preconditions & Limitations:
+  #
+  # - Must be called before migrations are executed against the database.
+  # - Only looks for migrations under `priv/repo/migrations`.
+  def adjust_migration_timestamps(app_path) when is_binary(app_path) do
+    [
+      Path.join(app_path, "priv/repo/migrations/*_*.exs"),
+      Path.join(app_path, "apps/*/priv/repo/migrations/*_*.exs")
+    ]
+    |> Enum.flat_map(&Path.wildcard/1)
+    |> Enum.with_index()
+    |> Enum.each(fn {path, idx} ->
+      dir = Path.dirname(path)
+      name = Path.basename(path)
+      [_, rest] = Regex.run(~r"^\d{14}_(.+)$", name)
+      new_timestamp = Integer.to_string(20_000_101_000_000 + idx)
+      new_path = Path.join(dir, "#{new_timestamp}_#{rest}")
+
+      if path != new_path do
+        File.rename!(path, new_path)
+      end
+    end)
+  end
+
   def with_installer_tmp(name, opts \\ [], function)
       when is_list(opts) and is_function(function, 1) do
     autoremove? = Keyword.get(opts, :autoremove?, true)


### PR DESCRIPTION
Previously, consecutive generator commands in integration tests (such as `phx.gen.auth` followed by `phx.gen.live` or multiple scoped generators) invoked `Process.sleep(1500)` to ensure that newly generated migrations received distinct 1-second timestamp versions.

In aggregate across all tests, these blind sleeps introduced unnecessary idle latency to test runs.

This adds `adjust_migration_timestamps/1`:

- Adjusts timestamps of existing migration files on disk to deterministic, sequentially ordered timestamps in the past.
- Allows subsequent generators to produce fresh, non-colliding migration versions immediately without sleeping.
- Removes all 8 instances of `Process.sleep(1500)` across integration tests.