### PR TITLE
Write test-generated apps to installer/tmp and fix leak

### DIFF
--- a/installer/test/mix_helper.exs
+++ b/installer/test/mix_helper.exs
@@ -7,7 +7,7 @@ defmodule MixHelper do
   import ExUnit.CaptureIO
 
   def tmp_path do
-    Path.expand("../../tmp", __DIR__)
+    Path.expand("../tmp", __DIR__)
   end
 
   defp random_string(len) do

--- a/integration_test/test/support/code_generator_case.ex
+++ b/integration_test/test/support/code_generator_case.ex
@@ -106,14 +106,15 @@ defmodule Phoenix.Integration.CodeGeneratorCase do
   def with_installer_tmp(name, opts \\ [], function)
       when is_list(opts) and is_function(function, 1) do
     autoremove? = Keyword.get(opts, :autoremove?, true)
-    path = Path.join([installer_tmp_path(), random_string(10), to_string(name)])
+    base = Path.join([installer_tmp_path(), random_string(10)])
+    path = Path.join([base, to_string(name)])
 
     try do
       File.rm_rf!(path)
       File.mkdir_p!(path)
       function.(path)
     after
-      if autoremove?, do: File.rm_rf!(path)
+      if autoremove?, do: File.rm_rf!(base)
     end
   end
 


### PR DESCRIPTION
Consolidate all temporary Phoenix application generation across test suites into `installer/tmp/`, and fix the accumulation of empty directories created by integration tests.

Git archaeology:

- In 2014 (3db60a5ed), when `phoenix.new` was part of the root `phoenix` package, `tmp_path/0` resolved to `<repo_root>/tmp/`.
- In 2015 (a049adba8), the installer was extracted into it's own package in `installer/`, and `/installer/tmp/` was added to `.gitignore`. However, because of a change in directory structure, the helper accidentally continued to resolve to `<repo_root>/tmp/`. This oversight probably went unnoticed because the root `/tmp/` was already gitignored.
- In 2020 (83cb53ba0), `integration_test/` was introduced. It used `installer/tmp/` to satisfy the `phx.new --dev` requirement. However, `with_installer_tmp/3` only deleted the inner project path and left behind empty 10-character random directories.

With this change:

1. Both `phx.new` (`installer/test/`) and `phx.gen.*` tests (`test/mix/tasks/`) now write to `installer/tmp/` instead of `<repo_root>/tmp/`.
2. Integration tests continue writing to `installer/tmp/`, and leave no dangling directories behind.

This enables uniform `tmpfs` mounting in CI (https://github.com/phoenixframework/phoenix/pull/6831#issuecomment-5528339147).