### PR TITLE
Restrict CI push triggers to main and release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - main
+      - "v*.*"
+  pull_request:
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Previously, the CI workflow triggered on all pushes (`[push, pull_request]`). When maintainers push feature branches directly to the upstream repository and open a pull request, GitHub Actions triggers two concurrent workflow runs for every commit, doubling CI runner consumption.

This restricts the `push` event to `main` and `"v*.*"`, matching `.github/workflows/assets.yml`:

- PRs continue to trigger CI via `pull_request` (exactly once per update).
- Direct pushes and merges to `main` or release maintenance branches continue to run full CI.
- Pushing feature branches to the repository no longer duplicates CI runs.

Addresses https://github.com/phoenixframework/phoenix/pull/6834#issuecomment-5542175849